### PR TITLE
Switch moxygen submodule from orly-integration to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "deps/moxygen"]
 	path = deps/moxygen
 	url = git@github.com:openmoq/moxygen.git
-	branch = orly-integration
+	branch = main


### PR DESCRIPTION
All orly-integration changes have been incorporated into the openmoq/moxygen main branch. Track main going forward.