### PR TITLE
Reformat

### DIFF
--- a/include/o_rly/ORelay.h
+++ b/include/o_rly/ORelay.h
@@ -21,14 +21,11 @@ class ORelay : public moxygen::Publisher,
                public moxygen::Subscriber,
                public std::enable_shared_from_this<ORelay>,
                public moxygen::MoQForwarder::Callback {
- public:
-  explicit ORelay(
-      size_t maxCachedTracks = moxygen::kDefaultMaxCachedTracks,
-      size_t maxCachedGroupsPerTrack =
-          moxygen::kDefaultMaxCachedGroupsPerTrack) {
+public:
+  explicit ORelay(size_t maxCachedTracks = moxygen::kDefaultMaxCachedTracks,
+                  size_t maxCachedGroupsPerTrack = moxygen::kDefaultMaxCachedGroupsPerTrack) {
     if (maxCachedTracks > 0) {
-      cache_ = std::make_unique<moxygen::MoQCache>(
-          maxCachedTracks, maxCachedGroupsPerTrack);
+      cache_ = std::make_unique<moxygen::MoQCache>(maxCachedTracks, maxCachedGroupsPerTrack);
     }
   }
 
@@ -36,35 +33,31 @@ class ORelay : public moxygen::Publisher,
     allowedNamespacePrefix_ = std::move(allowed);
   }
 
-  folly::coro::Task<SubscribeResult> subscribe(
-      moxygen::SubscribeRequest subReq,
-      std::shared_ptr<moxygen::TrackConsumer> consumer) override;
+  folly::coro::Task<SubscribeResult>
+  subscribe(moxygen::SubscribeRequest subReq,
+            std::shared_ptr<moxygen::TrackConsumer> consumer) override;
 
-  folly::coro::Task<FetchResult> fetch(
-      moxygen::Fetch fetch,
-      std::shared_ptr<moxygen::FetchConsumer> consumer) override;
+  folly::coro::Task<FetchResult> fetch(moxygen::Fetch fetch,
+                                       std::shared_ptr<moxygen::FetchConsumer> consumer) override;
 
-  folly::coro::Task<SubscribeNamespaceResult> subscribeNamespace(
-      moxygen::SubscribeNamespace subAnn,
-      std::shared_ptr<NamespacePublishHandle> namespacePublishHandle)
-      override;
+  folly::coro::Task<SubscribeNamespaceResult>
+  subscribeNamespace(moxygen::SubscribeNamespace subAnn,
+                     std::shared_ptr<NamespacePublishHandle> namespacePublishHandle) override;
 
   folly::coro::Task<moxygen::Subscriber::PublishNamespaceResult>
-  publishNamespace(
-      moxygen::PublishNamespace ann,
-      std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback>) override;
+  publishNamespace(moxygen::PublishNamespace ann,
+                   std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback>) override;
 
-  PublishResult publish(
-      moxygen::PublishRequest pubReq,
-      std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle =
-          nullptr) override;
+  PublishResult
+  publish(moxygen::PublishRequest pubReq,
+          std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle = nullptr) override;
 
   void goaway(moxygen::Goaway goaway) override {
     XLOG(INFO) << "Processing goaway uri=" << goaway.newSessionUri;
   }
 
-  std::shared_ptr<moxygen::MoQSession> findPublishNamespaceSession(
-      const moxygen::TrackNamespace& ns);
+  std::shared_ptr<moxygen::MoQSession>
+  findPublishNamespaceSession(const moxygen::TrackNamespace& ns);
 
   // Wrapper for compatibility - returns single session as vector
   std::vector<std::shared_ptr<moxygen::MoQSession>>
@@ -83,44 +76,36 @@ class ORelay : public moxygen::Publisher,
   };
   PublishState findPublishState(const moxygen::FullTrackName& ftn);
 
- private:
+private:
   class NamespaceSubscription;
   class TerminationFilter;
 
-  void unsubscribeNamespace(
-      const moxygen::TrackNamespace& prefix,
-      std::shared_ptr<moxygen::MoQSession> session);
+  void unsubscribeNamespace(const moxygen::TrackNamespace& prefix,
+                            std::shared_ptr<moxygen::MoQSession> session);
 
   void onPublishDone(const moxygen::FullTrackName& ftn);
 
-  struct NamespaceNode
-      : public moxygen::Subscriber::PublishNamespaceHandle {
+  struct NamespaceNode : public moxygen::Subscriber::PublishNamespaceHandle {
     explicit NamespaceNode(ORelay& relay, NamespaceNode* parent = nullptr)
         : relay_(relay), parent_(parent) {}
 
-    void publishNamespaceDone() override {
-      relay_.publishNamespaceDone(trackNamespace_, this);
-    }
+    void publishNamespaceDone() override { relay_.publishNamespaceDone(trackNamespace_, this); }
 
-    folly::coro::Task<RequestUpdateResult> requestUpdate(
-        moxygen::RequestUpdate reqUpdate) override {
+    folly::coro::Task<RequestUpdateResult>
+    requestUpdate(moxygen::RequestUpdate reqUpdate) override {
       co_return folly::makeUnexpected(
-          moxygen::RequestError{
-              reqUpdate.requestID,
-              moxygen::RequestErrorCode::NOT_SUPPORTED,
-              "REQUEST_UPDATE not supported for relay PUBLISH_NAMESPACE"});
+          moxygen::RequestError{reqUpdate.requestID, moxygen::RequestErrorCode::NOT_SUPPORTED,
+                                "REQUEST_UPDATE not supported for relay PUBLISH_NAMESPACE"});
     }
 
     // Helper to check if THIS node (excluding children) has content
     bool hasLocalSessions() const {
-      return !publishes.empty() || !sessions.empty() ||
-          !namespacesPublished.empty() || sourceSession != nullptr;
+      return !publishes.empty() || !sessions.empty() || !namespacesPublished.empty() ||
+             sourceSession != nullptr;
     }
 
     // Check if node should be kept (has content OR non-empty children)
-    bool shouldKeep() const {
-      return hasLocalSessions() || activeChildCount_ > 0;
-    }
+    bool shouldKeep() const { return hasLocalSessions() || activeChildCount_ > 0; }
 
     using moxygen::Subscriber::PublishNamespaceHandle::setPublishNamespaceOk;
 
@@ -128,15 +113,12 @@ class ORelay : public moxygen::Publisher,
     folly::F14FastMap<std::string, std::shared_ptr<NamespaceNode>> children;
 
     // Maps a track name to a the session performing the PUBLISH
-    folly::F14FastMap<std::string, std::shared_ptr<moxygen::MoQSession>>
-        publishes;
+    folly::F14FastMap<std::string, std::shared_ptr<moxygen::MoQSession>> publishes;
     // Sessions with a SUBSCRIBE_NAMESPACE here, with their forward preference
     // Key: session, Value: forward (true = forward data, false = don't forward)
     folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, bool> sessions;
     // All active PUBLISH_NAMESPACEs for this node (includes prefix sessions)
-    folly::F14FastMap<
-        std::shared_ptr<moxygen::MoQSession>,
-        std::shared_ptr<PublishNamespaceHandle>>
+    folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, std::shared_ptr<PublishNamespaceHandle>>
         namespacesPublished;
     // The session that PUBLISH_NAMESPACEd this node
     std::shared_ptr<moxygen::MoQSession> sourceSession;
@@ -158,16 +140,13 @@ class ORelay : public moxygen::Publisher,
   NamespaceNode publishNamespaceRoot_{*this};
   enum class MatchType { Exact, Prefix };
   std::shared_ptr<NamespaceNode> findNamespaceNode(
-      const moxygen::TrackNamespace& ns,
-      bool createMissingNodes = false,
+      const moxygen::TrackNamespace& ns, bool createMissingNodes = false,
       MatchType matchType = MatchType::Exact,
-      std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>>*
-          sessions = nullptr);
+      std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>>* sessions = nullptr);
 
   struct RelaySubscription {
-    RelaySubscription(
-        std::shared_ptr<moxygen::MoQForwarder> f,
-        std::shared_ptr<moxygen::MoQSession> u)
+    RelaySubscription(std::shared_ptr<moxygen::MoQForwarder> f,
+                      std::shared_ptr<moxygen::MoQSession> u)
         : forwarder(std::move(f)), upstream(std::move(u)) {}
 
     std::shared_ptr<moxygen::MoQForwarder> forwarder;
@@ -181,35 +160,26 @@ class ORelay : public moxygen::Publisher,
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
   void forwardChanged(moxygen::MoQForwarder* forwarder) override;
 
-  folly::coro::Task<void> publishNamespaceToSession(
-      std::shared_ptr<moxygen::MoQSession> session,
-      moxygen::PublishNamespace ann,
-      std::shared_ptr<NamespaceNode> nodePtr);
+  folly::coro::Task<void> publishNamespaceToSession(std::shared_ptr<moxygen::MoQSession> session,
+                                                    moxygen::PublishNamespace ann,
+                                                    std::shared_ptr<NamespaceNode> nodePtr);
 
-  folly::coro::Task<void> publishToSession(
-      std::shared_ptr<moxygen::MoQSession> session,
-      std::shared_ptr<moxygen::MoQForwarder> forwarder,
-      moxygen::PublishRequest pub,
-      bool forward);
+  folly::coro::Task<void> publishToSession(std::shared_ptr<moxygen::MoQSession> session,
+                                           std::shared_ptr<moxygen::MoQForwarder> forwarder,
+                                           moxygen::PublishRequest pub, bool forward);
 
-  folly::coro::Task<void> doSubscribeUpdate(
-      std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
-      bool forward);
+  folly::coro::Task<void>
+  doSubscribeUpdate(std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle, bool forward);
 
-  void publishNamespaceDone(
-      const moxygen::TrackNamespace& trackNamespace,
-      NamespaceNode* node);
+  void publishNamespaceDone(const moxygen::TrackNamespace& trackNamespace, NamespaceNode* node);
 
   moxygen::TrackNamespace allowedNamespacePrefix_;
-  folly::F14FastMap<
-      moxygen::FullTrackName,
-      RelaySubscription,
-      moxygen::FullTrackName::hash>
+  folly::F14FastMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
       subscriptions_;
 
-  std::shared_ptr<moxygen::TrackConsumer> getSubscribeWriteback(
-      const moxygen::FullTrackName& ftn,
-      std::shared_ptr<moxygen::TrackConsumer> consumer);
+  std::shared_ptr<moxygen::TrackConsumer>
+  getSubscribeWriteback(const moxygen::FullTrackName& ftn,
+                        std::shared_ptr<moxygen::TrackConsumer> consumer);
   std::unique_ptr<moxygen::MoQCache> cache_;
 };
 

--- a/include/o_rly/ORelayServer.h
+++ b/include/o_rly/ORelayServer.h
@@ -1,37 +1,28 @@
 #pragma once
 
-#include <o_rly/ORelay.h>
 #include <moxygen/MoQServer.h>
+#include <o_rly/ORelay.h>
 
 namespace openmoq::o_rly {
 
 class ORelayServer : public moxygen::MoQServer {
- public:
+public:
   // Used when the insecure flag is false
-  ORelayServer(
-      const std::string& cert,
-      const std::string& key,
-      const std::string& endpoint,
-      const std::string& versions,
-      size_t maxCachedTracks,
-      size_t maxCachedGroupsPerTrack);
+  ORelayServer(const std::string& cert, const std::string& key, const std::string& endpoint,
+               const std::string& versions, size_t maxCachedTracks, size_t maxCachedGroupsPerTrack);
 
   // Used when the insecure flag is true
-  ORelayServer(
-      const std::string& endpoint,
-      const std::string& versions,
-      size_t maxCachedTracks,
-      size_t maxCachedGroupsPerTrack);
+  ORelayServer(const std::string& endpoint, const std::string& versions, size_t maxCachedTracks,
+               size_t maxCachedGroupsPerTrack);
 
-  void onNewSession(
-      std::shared_ptr<moxygen::MoQSession> clientSession) override;
+  void onNewSession(std::shared_ptr<moxygen::MoQSession> clientSession) override;
 
- protected:
-  std::shared_ptr<moxygen::MoQSession> createSession(
-      folly::MaybeManagedPtr<proxygen::WebTransport> wt,
-      std::shared_ptr<moxygen::MoQExecutor> executor) override;
+protected:
+  std::shared_ptr<moxygen::MoQSession>
+  createSession(folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+                std::shared_ptr<moxygen::MoQExecutor> executor) override;
 
- private:
+private:
   std::shared_ptr<ORelay> relay_;
 };
 

--- a/src/ORelay.cpp
+++ b/src/ORelay.cpp
@@ -6,9 +6,9 @@
  * Copyright (c) OpenMOQ contributors.
  */
 
-#include <o_rly/ORelay.h>
 #include <moxygen/MoQFilters.h>
 #include <moxygen/MoQTrackProperties.h>
+#include <o_rly/ORelay.h>
 
 using namespace moxygen;
 
@@ -24,28 +24,21 @@ namespace openmoq::o_rly {
 // - subscribe: first forwarding subscriber added (forward=true)
 // - onEmpty: last subscriber left a publish subscription (forward=false)
 // - forwardChanged: forwarding subscriber count changed
-folly::coro::Task<void> ORelay::doSubscribeUpdate(
-    std::shared_ptr<Publisher::SubscriptionHandle> handle,
-    bool forward) {
-  auto updateRes = co_await handle->requestUpdate(
-      {RequestID(0),
-       handle->subscribeOk().requestID,
-       kLocationMin,
-       kLocationMax.group,
-       kDefaultPriority,
-       /*forward=*/forward});
+folly::coro::Task<void>
+ORelay::doSubscribeUpdate(std::shared_ptr<Publisher::SubscriptionHandle> handle, bool forward) {
+  auto updateRes =
+      co_await handle->requestUpdate({RequestID(0), handle->subscribeOk().requestID, kLocationMin,
+                                      kLocationMax.group, kDefaultPriority,
+                                      /*forward=*/forward});
   if (updateRes.hasError()) {
     XLOG(ERR) << "requestUpdate failed: " << updateRes.error().reasonPhrase;
   }
 }
 
-std::shared_ptr<ORelay::NamespaceNode> ORelay::findNamespaceNode(
-    const TrackNamespace& ns,
-    bool createMissingNodes,
-    MatchType matchType,
-    std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>* sessions) {
-  std::shared_ptr<NamespaceNode> nodePtr(
-      std::shared_ptr<void>(), &publishNamespaceRoot_);
+std::shared_ptr<ORelay::NamespaceNode>
+ORelay::findNamespaceNode(const TrackNamespace& ns, bool createMissingNodes, MatchType matchType,
+                          std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>* sessions) {
+  std::shared_ptr<NamespaceNode> nodePtr(std::shared_ptr<void>(), &publishNamespaceRoot_);
   for (auto i = 0ul; i < ns.size(); i++) {
     if (sessions) {
       // Extract session pointers with their forward preferences from the map
@@ -61,9 +54,7 @@ std::shared_ptr<ORelay::NamespaceNode> ORelay::findNamespaceNode(
         nodePtr->children.emplace(name, node);
         // Don't increment yet - only when content is actually added
         nodePtr = std::move(node);
-      } else if (
-          matchType == MatchType::Prefix &&
-          nodePtr.get() != &publishNamespaceRoot_) {
+      } else if (matchType == MatchType::Prefix && nodePtr.get() != &publishNamespaceRoot_) {
         return nodePtr;
       } else {
         XLOG(ERR) << "prefix not found in publishNamespace tree";
@@ -77,31 +68,22 @@ std::shared_ptr<ORelay::NamespaceNode> ORelay::findNamespaceNode(
 }
 
 folly::coro::Task<Subscriber::PublishNamespaceResult>
-ORelay::publishNamespace(
-    PublishNamespace ann,
-    std::shared_ptr<Subscriber::PublishNamespaceCallback> callback) {
+ORelay::publishNamespace(PublishNamespace ann,
+                         std::shared_ptr<Subscriber::PublishNamespaceCallback> callback) {
   XLOG(DBG1) << __func__ << " ns=" << ann.trackNamespace;
   // check auth
   if (!ann.trackNamespace.startsWith(allowedNamespacePrefix_)) {
-    co_return folly::makeUnexpected(
-        PublishNamespaceError{
-            ann.requestID,
-            PublishNamespaceErrorCode::UNINTERESTED,
-            "bad namespace"});
+    co_return folly::makeUnexpected(PublishNamespaceError{
+        ann.requestID, PublishNamespaceErrorCode::UNINTERESTED, "bad namespace"});
   }
   std::vector<std::pair<std::shared_ptr<MoQSession>, bool>> sessions;
-  auto nodePtr = findNamespaceNode(
-      ann.trackNamespace,
-      /*createMissingNodes=*/true,
-      MatchType::Exact,
-      &sessions);
+  auto nodePtr = findNamespaceNode(ann.trackNamespace,
+                                   /*createMissingNodes=*/true, MatchType::Exact, &sessions);
 
   // Log if there is already a session that has publishNamespace-d this track
   if (nodePtr->sourceSession) {
-    XLOG(WARNING) << "PublishNamespace: Existing session ("
-                  << nodePtr->sourceSession.get()
-                  << ") has already published trackNamespace="
-                  << ann.trackNamespace;
+    XLOG(WARNING) << "PublishNamespace: Existing session (" << nodePtr->sourceSession.get()
+                  << ") has already published trackNamespace=" << ann.trackNamespace;
     // Since we don't fully support multiple publishers -- cancel the old
     // publishNamespace and remove ongoing subscriptions to this publisher
     // in that namespace.  Note: it could have publishNamespace-d a more
@@ -141,25 +123,21 @@ ORelay::publishNamespace(
   for (auto& [outSession, forward] : sessions) {
     if (outSession != session) {
       auto exec = outSession->getExecutor();
-      co_withExecutor(exec, publishNamespaceToSession(outSession, ann, nodePtr))
-          .start();
+      co_withExecutor(exec, publishNamespaceToSession(outSession, ann, nodePtr)).start();
     }
   }
   co_return nodePtr;
 }
 
-folly::coro::Task<void> ORelay::publishNamespaceToSession(
-    std::shared_ptr<MoQSession> session,
-    PublishNamespace ann,
-    std::shared_ptr<NamespaceNode> nodePtr) {
+folly::coro::Task<void> ORelay::publishNamespaceToSession(std::shared_ptr<MoQSession> session,
+                                                          PublishNamespace ann,
+                                                          std::shared_ptr<NamespaceNode> nodePtr) {
   auto publishNamespaceHandle = co_await session->publishNamespace(ann);
   if (publishNamespaceHandle.hasError()) {
-    XLOG(ERR) << "PublishNamespace failed err="
-              << publishNamespaceHandle.error().reasonPhrase;
+    XLOG(ERR) << "PublishNamespace failed err=" << publishNamespaceHandle.error().reasonPhrase;
   } else {
     // This can race with unsubscribeNamespace
-    nodePtr->namespacesPublished[session] =
-        std::move(publishNamespaceHandle.value());
+    nodePtr->namespacesPublished[session] = std::move(publishNamespaceHandle.value());
   }
 }
 
@@ -229,9 +207,7 @@ void ORelay::NamespaceNode::tryPruneChild(const std::string& childKey) {
   parentOfNodeToRemove->children.erase(keyToRemove);
 }
 
-void ORelay::publishNamespaceDone(
-    const TrackNamespace& trackNamespace,
-    NamespaceNode*) {
+void ORelay::publishNamespaceDone(const TrackNamespace& trackNamespace, NamespaceNode*) {
   XLOG(DBG1) << __func__ << " ns=" << trackNamespace;
   // Node would be useful if there were back links
   auto nodePtr = findNamespaceNode(trackNamespace);
@@ -286,8 +262,7 @@ void ORelay::onPublishDone(const FullTrackName& ftn) {
         // Prune if node became empty and has a parent
         if (hadLocalContent && !nodePtr->shouldKeep() && nodePtr->parent_ &&
             !ftn.trackNamespace.trackNamespace.empty()) {
-          nodePtr->parent_->tryPruneChild(
-              ftn.trackNamespace.trackNamespace.back());
+          nodePtr->parent_->tryPruneChild(ftn.trackNamespace.trackNamespace.back());
         }
       }
     }
@@ -301,39 +276,31 @@ void ORelay::onPublishDone(const FullTrackName& ftn) {
     // If forwarder has no subscribers, clean up immediately
     // Otherwise onEmpty will be called when last subscriber leaves
     if (it->second.forwarder->empty()) {
-      XLOG(DBG1) << "Publisher terminated with no subscribers, cleaning up "
-                 << ftn;
+      XLOG(DBG1) << "Publisher terminated with no subscribers, cleaning up " << ftn;
       subscriptions_.erase(it);
     }
   }
 }
 
-Subscriber::PublishResult ORelay::publish(
-    PublishRequest pub,
-    std::shared_ptr<Publisher::SubscriptionHandle> handle) {
+Subscriber::PublishResult ORelay::publish(PublishRequest pub,
+                                          std::shared_ptr<Publisher::SubscriptionHandle> handle) {
   XLOG(DBG1) << __func__ << " ftn=" << pub.fullTrackName;
   XCHECK(handle) << "Publish handle cannot be null";
   if (!pub.fullTrackName.trackNamespace.startsWith(allowedNamespacePrefix_)) {
     return folly::makeUnexpected(
-        PublishError{
-            pub.requestID, PublishErrorCode::UNINTERESTED, "bad namespace"});
+        PublishError{pub.requestID, PublishErrorCode::UNINTERESTED, "bad namespace"});
   }
 
   if (pub.fullTrackName.trackNamespace.empty()) {
-    return folly::makeUnexpected(PublishError(
-        {pub.requestID,
-         PublishErrorCode::INTERNAL_ERROR,
-         "namespace required"}));
+    return folly::makeUnexpected(
+        PublishError({pub.requestID, PublishErrorCode::INTERNAL_ERROR, "namespace required"}));
   }
 
   // Find All Nodes that Subscribed to this namespace (including
   // prefix ns)
   std::vector<std::pair<std::shared_ptr<MoQSession>, bool>> sessions = {};
-  auto nodePtr = findNamespaceNode(
-      pub.fullTrackName.trackNamespace,
-      /*createMissingNodes=*/true,
-      MatchType::Exact,
-      &sessions);
+  auto nodePtr = findNamespaceNode(pub.fullTrackName.trackNamespace,
+                                   /*createMissingNodes=*/true, MatchType::Exact, &sessions);
   // Extract session pointers with their forward preferences from the map
   for (const auto& [sessionPtr, forward] : nodePtr->sessions) {
     sessions.emplace_back(sessionPtr, forward);
@@ -349,11 +316,9 @@ Subscriber::PublishResult ORelay::publish(
     XLOG(DBG1) << "New publisher for existing subscription";
     nodePtr->publishes.erase(pub.fullTrackName.trackName);
     it->second.handle->unsubscribe();
-    it->second.forwarder->publishDone(
-        {RequestID(0),
-         PublishDoneStatusCode::SUBSCRIPTION_ENDED,
-         0, // filled in by session
-         "upstream disconnect"});
+    it->second.forwarder->publishDone({RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+                                       0, // filled in by session
+                                       "upstream disconnect"});
     XLOG(DBG4) << "Erasing subscription to " << it->first;
     subscriptions_.erase(it);
   }
@@ -366,8 +331,7 @@ Subscriber::PublishResult ORelay::publish(
   }
 
   // Create Forwarder for this publish
-  auto forwarder =
-      std::make_shared<MoQForwarder>(pub.fullTrackName, std::nullopt);
+  auto forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, std::nullopt);
 
   // Set Forwarder Params
   forwarder->setGroupOrder(pub.groupOrder);
@@ -379,10 +343,9 @@ Subscriber::PublishResult ORelay::publish(
     forwarder->setDeliveryTimeout(deliveryTimeout->count());
   }
 
-  auto subRes = subscriptions_.emplace(
-      std::piecewise_construct,
-      std::forward_as_tuple(pub.fullTrackName),
-      std::forward_as_tuple(forwarder, session));
+  auto subRes =
+      subscriptions_.emplace(std::piecewise_construct, std::forward_as_tuple(pub.fullTrackName),
+                             std::forward_as_tuple(forwarder, session));
   auto& rsub = subRes.first->second;
   rsub.promise.setValue(folly::unit);
   rsub.requestID = pub.requestID;
@@ -394,41 +357,32 @@ Subscriber::PublishResult ORelay::publish(
     if (outSession != session) {
       nSubscribers++;
       auto exec = outSession->getExecutor();
-      co_withExecutor(
-          exec, publishToSession(outSession, forwarder, pub, forward))
-          .start();
+      co_withExecutor(exec, publishToSession(outSession, forwarder, pub, forward)).start();
     }
   }
   forwarder->setCallback(shared_from_this());
 
   // Wrap forwarder in filter to intercept publishDone
-  auto filterImpl = std::make_shared<TerminationFilter>(
-      shared_from_this(), pub.fullTrackName, forwarder);
-  std::shared_ptr<TrackConsumer> filter =
-      std::static_pointer_cast<TrackConsumer>(filterImpl);
+  auto filterImpl =
+      std::make_shared<TerminationFilter>(shared_from_this(), pub.fullTrackName, forwarder);
+  std::shared_ptr<TrackConsumer> filter = std::static_pointer_cast<TrackConsumer>(filterImpl);
 
   return PublishConsumerAndReplyTask{
       filter, // Return filter, not forwarder directly
-      folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(PublishOk{
-          pub.requestID,
-          /*forward=*/(nSubscribers > 0),
-          kDefaultPriority,
-          pub.groupOrder,
-          LocationType::AbsoluteRange,
-          kLocationMin,
-          kLocationMax.group})};
+      folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(
+          PublishOk{pub.requestID,
+                    /*forward=*/(nSubscribers > 0), kDefaultPriority, pub.groupOrder,
+                    LocationType::AbsoluteRange, kLocationMin, kLocationMax.group})};
 }
 
-folly::coro::Task<void> ORelay::publishToSession(
-    std::shared_ptr<MoQSession> session,
-    std::shared_ptr<MoQForwarder> forwarder,
-    PublishRequest pub,
-    bool forward) {
+folly::coro::Task<void> ORelay::publishToSession(std::shared_ptr<MoQSession> session,
+                                                 std::shared_ptr<MoQForwarder> forwarder,
+                                                 PublishRequest pub, bool forward) {
   pub.forward = forward;
   auto subscriber = forwarder->addSubscriber(session, pub);
   if (!subscriber) {
-    XLOG(ERR) << "Subscribe failed: addSubscriber returned null for "
-              << forwarder->fullTrackName() << " reqID=" << pub.requestID;
+    XLOG(ERR) << "Subscribe failed: addSubscriber returned null for " << forwarder->fullTrackName()
+              << " reqID=" << pub.requestID;
     co_return;
   }
   XLOG(DBG4) << "added subscriber for ftn=" << pub.fullTrackName;
@@ -450,8 +404,7 @@ folly::coro::Task<void> ORelay::publishToSession(
     co_return;
   }
   if (pubResult.value().hasError()) {
-    XLOG(ERR) << "Publish failed err="
-              << pubResult.value().error().reasonPhrase;
+    XLOG(ERR) << "Publish failed err=" << pubResult.value().error().reasonPhrase;
     co_return;
   }
   guard.dismiss();
@@ -461,23 +414,16 @@ folly::coro::Task<void> ORelay::publishToSession(
   if (pubOk.endGroup) {
     end = AbsoluteLocation{*pubOk.endGroup, 0};
   }
-  subscriber->range =
-      toSubscribeRange(pubOk.start, end, pubOk.locType, forwarder->largest());
+  subscriber->range = toSubscribeRange(pubOk.start, end, pubOk.locType, forwarder->largest());
   subscriber->shouldForward = pubOk.forward;
 }
 
-class ORelay::NamespaceSubscription
-    : public Publisher::SubscribeNamespaceHandle {
- public:
-  NamespaceSubscription(
-      std::shared_ptr<ORelay> relay,
-      std::shared_ptr<MoQSession> session,
-      SubscribeNamespaceOk ok,
-      TrackNamespace trackNamespacePrefix)
-      : Publisher::SubscribeNamespaceHandle(std::move(ok)),
-        relay_(std::move(relay)),
-        session_(std::move(session)),
-        trackNamespacePrefix_(std::move(trackNamespacePrefix)) {}
+class ORelay::NamespaceSubscription : public Publisher::SubscribeNamespaceHandle {
+public:
+  NamespaceSubscription(std::shared_ptr<ORelay> relay, std::shared_ptr<MoQSession> session,
+                        SubscribeNamespaceOk ok, TrackNamespace trackNamespacePrefix)
+      : Publisher::SubscribeNamespaceHandle(std::move(ok)), relay_(std::move(relay)),
+        session_(std::move(session)), trackNamespacePrefix_(std::move(trackNamespacePrefix)) {}
 
   void unsubscribeNamespace() override {
     if (relay_) {
@@ -486,16 +432,13 @@ class ORelay::NamespaceSubscription
     }
   }
 
-  folly::coro::Task<RequestUpdateResult> requestUpdate(
-      RequestUpdate reqUpdate) override {
+  folly::coro::Task<RequestUpdateResult> requestUpdate(RequestUpdate reqUpdate) override {
     co_return folly::makeUnexpected(
-        RequestError{
-            reqUpdate.requestID,
-            RequestErrorCode::NOT_SUPPORTED,
-            "REQUEST_UPDATE not supported for relay SUBSCRIBE_NAMESPACE"});
+        RequestError{reqUpdate.requestID, RequestErrorCode::NOT_SUPPORTED,
+                     "REQUEST_UPDATE not supported for relay SUBSCRIBE_NAMESPACE"});
   }
 
- private:
+private:
   std::shared_ptr<ORelay> relay_;
   std::shared_ptr<MoQSession> session_;
   TrackNamespace trackNamespacePrefix_;
@@ -503,17 +446,13 @@ class ORelay::NamespaceSubscription
 
 // Filter TrackConsumer that intercepts publishDone to clean up relay state
 class ORelay::TerminationFilter : public TrackConsumerFilter {
- public:
-  TerminationFilter(
-      std::shared_ptr<ORelay> relay,
-      FullTrackName ftn,
-      std::shared_ptr<TrackConsumer> downstream)
-      : TrackConsumerFilter(std::move(downstream)),
-        relay_(std::move(relay)),
-        ftn_(std::move(ftn)) {}
+public:
+  TerminationFilter(std::shared_ptr<ORelay> relay, FullTrackName ftn,
+                    std::shared_ptr<TrackConsumer> downstream)
+      : TrackConsumerFilter(std::move(downstream)), relay_(std::move(relay)), ftn_(std::move(ftn)) {
+  }
 
-  folly::Expected<folly::Unit, MoQPublishError> publishDone(
-      PublishDone pubDone) override {
+  folly::Expected<folly::Unit, MoQPublishError> publishDone(PublishDone pubDone) override {
     // Notify relay that publisher is done - this will:
     // 1. Remove from nodePtr->publishes
     // 2. Clear subscription.handle
@@ -524,38 +463,31 @@ class ORelay::TerminationFilter : public TrackConsumerFilter {
     return TrackConsumerFilter::publishDone(std::move(pubDone));
   }
 
- private:
+private:
   std::shared_ptr<ORelay> relay_;
   FullTrackName ftn_;
 };
 
-std::shared_ptr<TrackConsumer> ORelay::getSubscribeWriteback(
-    const FullTrackName& ftn,
-    std::shared_ptr<TrackConsumer> consumer) {
-  auto baseConsumer = cache_
-      ? cache_->getSubscribeWriteback(ftn, std::move(consumer))
-      : std::move(consumer);
-  auto filterConsumer = std::make_shared<TerminationFilter>(
-      shared_from_this(), ftn, std::move(baseConsumer));
+std::shared_ptr<TrackConsumer>
+ORelay::getSubscribeWriteback(const FullTrackName& ftn, std::shared_ptr<TrackConsumer> consumer) {
+  auto baseConsumer =
+      cache_ ? cache_->getSubscribeWriteback(ftn, std::move(consumer)) : std::move(consumer);
+  auto filterConsumer =
+      std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(baseConsumer));
   return std::static_pointer_cast<TrackConsumer>(filterConsumer);
 }
 
 folly::coro::Task<Publisher::SubscribeNamespaceResult>
-ORelay::subscribeNamespace(
-    SubscribeNamespace subNs,
-    std::shared_ptr<NamespacePublishHandle> namespacePublishHandle) {
+ORelay::subscribeNamespace(SubscribeNamespace subNs,
+                           std::shared_ptr<NamespacePublishHandle> namespacePublishHandle) {
   XLOG(DBG1) << __func__ << " nsp=" << subNs.trackNamespacePrefix;
   // check auth
   if (subNs.trackNamespacePrefix.empty()) {
-    co_return folly::makeUnexpected(
-        SubscribeNamespaceError{
-            subNs.requestID,
-            SubscribeNamespaceErrorCode::NAMESPACE_PREFIX_UNKNOWN,
-            "empty"});
+    co_return folly::makeUnexpected(SubscribeNamespaceError{
+        subNs.requestID, SubscribeNamespaceErrorCode::NAMESPACE_PREFIX_UNKNOWN, "empty"});
   }
   auto session = MoQSession::getRequestSession();
-  auto nodePtr = findNamespaceNode(
-      subNs.trackNamespacePrefix, /*createMissingNodes=*/true);
+  auto nodePtr = findNamespaceNode(subNs.trackNamespacePrefix, /*createMissingNodes=*/true);
 
   // Check if this is the first session subscriber for this node
   bool wasEmpty = !nodePtr->hasLocalSessions();
@@ -575,42 +507,33 @@ ORelay::subscribeNamespace(
     nodes.pop_front();
     if (nodePtr->sourceSession && nodePtr->sourceSession != session) {
       // TODO: Auth/params
-      co_withExecutor(
-          exec,
-          publishNamespaceToSession(
-              session, {subNs.requestID, prefix}, nodePtr))
+      co_withExecutor(exec, publishNamespaceToSession(session, {subNs.requestID, prefix}, nodePtr))
           .start();
     }
-    PublishRequest pub{
-        0,
-        FullTrackName{prefix, ""},
-        TrackAlias(0), // filled in by library
-        GroupOrder::Default,
-        std::nullopt,
-        /*forward=*/false};
+    PublishRequest pub{0,
+                       FullTrackName{prefix, ""},
+                       TrackAlias(0), // filled in by library
+                       GroupOrder::Default,
+                       std::nullopt,
+                       /*forward=*/false};
     for (auto& publishEntry : nodePtr->publishes) {
       auto& publishSession = publishEntry.second;
       pub.fullTrackName.trackName = publishEntry.first;
       auto subscriptionIt = subscriptions_.find(pub.fullTrackName);
       if (subscriptionIt == subscriptions_.end()) {
-        XLOG(ERR) << "Invalid state, no subscription for publish ftn="
-                  << pub.fullTrackName;
+        XLOG(ERR) << "Invalid state, no subscription for publish ftn=" << pub.fullTrackName;
         continue;
       }
       auto& forwarder = subscriptionIt->second.forwarder;
       if (forwarder->empty()) {
         // Use forward value from this namespace subscription
-        co_withExecutor(
-            exec,
-            doSubscribeUpdate(subscriptionIt->second.handle, subNs.forward))
+        co_withExecutor(exec, doSubscribeUpdate(subscriptionIt->second.handle, subNs.forward))
             .start();
       }
       pub.groupOrder = forwarder->groupOrder();
       pub.largest = forwarder->largest();
       if (publishSession != session) {
-        co_withExecutor(
-            exec, publishToSession(session, forwarder, pub, subNs.forward))
-            .start();
+        co_withExecutor(exec, publishToSession(session, forwarder, pub, subNs.forward)).start();
       }
     }
     for (auto& nextNodeIt : nodePtr->children) {
@@ -619,16 +542,13 @@ ORelay::subscribeNamespace(
       nodes.emplace_back(std::forward_as_tuple(nodePrefix, nextNodeIt.second));
     }
   }
-  co_return std::make_shared<NamespaceSubscription>(
-      shared_from_this(),
-      std::move(session),
-      SubscribeNamespaceOk{subNs.requestID},
-      subNs.trackNamespacePrefix);
+  co_return std::make_shared<NamespaceSubscription>(shared_from_this(), std::move(session),
+                                                    SubscribeNamespaceOk{subNs.requestID},
+                                                    subNs.trackNamespacePrefix);
 }
 
-void ORelay::unsubscribeNamespace(
-    const TrackNamespace& trackNamespacePrefix,
-    std::shared_ptr<MoQSession> session) {
+void ORelay::unsubscribeNamespace(const TrackNamespace& trackNamespacePrefix,
+                                  std::shared_ptr<MoQSession> session) {
   XLOG(DBG1) << __func__ << " nsp=" << trackNamespacePrefix;
   auto nodePtr = findNamespaceNode(trackNamespacePrefix);
   if (!nodePtr) {
@@ -646,8 +566,7 @@ void ORelay::unsubscribeNamespace(
     // Prune if node became empty and has a parent
     if (hadLocalContent && !nodePtr->shouldKeep() && nodePtr->parent_ &&
         !trackNamespacePrefix.trackNamespace.empty()) {
-      nodePtr->parent_->tryPruneChild(
-          trackNamespacePrefix.trackNamespace.back());
+      nodePtr->parent_->tryPruneChild(trackNamespacePrefix.trackNamespace.back());
     }
     return;
   }
@@ -655,16 +574,14 @@ void ORelay::unsubscribeNamespace(
   XLOG(DBG1) << "Namespace prefix was not subscribed by this session";
 }
 
-std::shared_ptr<MoQSession> ORelay::findPublishNamespaceSession(
-    const TrackNamespace& ns) {
+std::shared_ptr<MoQSession> ORelay::findPublishNamespaceSession(const TrackNamespace& ns) {
   /*
    * This function is called from subscribe() and fetch().
    * We use MatchType::Prefix here because the relay routes SUBSCRIBE and FETCH
    * to the publisher who published the closest matching broader
    * namespace, not necessarily the exact match.
    */
-  auto nodePtr =
-      findNamespaceNode(ns, /*createMissingNodes=*/false, MatchType::Prefix);
+  auto nodePtr = findNamespaceNode(ns, /*createMissingNodes=*/false, MatchType::Prefix);
   if (!nodePtr) {
     return nullptr;
   }
@@ -673,8 +590,8 @@ std::shared_ptr<MoQSession> ORelay::findPublishNamespaceSession(
 
 ORelay::PublishState ORelay::findPublishState(const FullTrackName& ftn) {
   PublishState state;
-  auto nodePtr = findNamespaceNode(
-      ftn.trackNamespace, /*createMissingNodes=*/false, MatchType::Exact);
+  auto nodePtr =
+      findNamespaceNode(ftn.trackNamespace, /*createMissingNodes=*/false, MatchType::Exact);
 
   if (!nodePtr) {
     // Node doesn't exist - tree was properly pruned
@@ -691,9 +608,8 @@ ORelay::PublishState ORelay::findPublishState(const FullTrackName& ftn) {
   return state;
 }
 
-folly::coro::Task<Publisher::SubscribeResult> ORelay::subscribe(
-    SubscribeRequest subReq,
-    std::shared_ptr<TrackConsumer> consumer) {
+folly::coro::Task<Publisher::SubscribeResult>
+ORelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
   auto subscriptionIt = subscriptions_.find(subReq.fullTrackName);
   if (subscriptionIt == subscriptions_.end()) {
@@ -704,31 +620,24 @@ folly::coro::Task<Publisher::SubscribeResult> ORelay::subscribe(
     if (subReq.fullTrackName.trackNamespace.empty()) {
       // message error?
       co_return folly::makeUnexpected(SubscribeError(
-          {subReq.requestID,
-           SubscribeErrorCode::TRACK_NOT_EXIST,
-           "namespace required"}));
+          {subReq.requestID, SubscribeErrorCode::TRACK_NOT_EXIST, "namespace required"}));
     }
-    auto upstreamSession =
-        findPublishNamespaceSession(subReq.fullTrackName.trackNamespace);
+    auto upstreamSession = findPublishNamespaceSession(subReq.fullTrackName.trackNamespace);
     if (!upstreamSession) {
       // no such namespace has been published
       co_return folly::makeUnexpected(SubscribeError(
-          {subReq.requestID,
-           SubscribeErrorCode::TRACK_NOT_EXIST,
-           "no such namespace or track"}));
+          {subReq.requestID, SubscribeErrorCode::TRACK_NOT_EXIST, "no such namespace or track"}));
     }
     subReq.priority = kDefaultUpstreamPriority;
     subReq.groupOrder = GroupOrder::Default;
     // We only subscribe upstream with LargestObject. This is to satisfy other
     // subscribers that join with narrower filters
     subReq.locType = LocationType::LargestObject;
-    auto forwarder =
-        std::make_shared<MoQForwarder>(subReq.fullTrackName, std::nullopt);
+    auto forwarder = std::make_shared<MoQForwarder>(subReq.fullTrackName, std::nullopt);
     forwarder->setCallback(shared_from_this());
-    auto emplaceRes = subscriptions_.emplace(
-        std::piecewise_construct,
-        std::forward_as_tuple(subReq.fullTrackName),
-        std::forward_as_tuple(forwarder, upstreamSession));
+    auto emplaceRes = subscriptions_.emplace(std::piecewise_construct,
+                                             std::forward_as_tuple(subReq.fullTrackName),
+                                             std::forward_as_tuple(forwarder, upstreamSession));
     // The iterator returned from emplace does not survive across coroutine
     // resumption, so both the guard and updating the RelaySubscription below
     // require another lookup in the subscriptions_ map.
@@ -741,16 +650,12 @@ folly::coro::Task<Publisher::SubscribeResult> ORelay::subscribe(
       }
     });
     // Add subscriber first in case objects come before subscribe OK.
-    auto subscriber = forwarder->addSubscriber(
-        std::move(session), subReq, std::move(consumer));
+    auto subscriber = forwarder->addSubscriber(std::move(session), subReq, std::move(consumer));
     if (!subscriber) {
-      XLOG(ERR) << "addSubscriber returned null (draining?) for "
-                << subReq.fullTrackName << " reqID=" << subReq.requestID;
-      co_return folly::makeUnexpected(
-          SubscribeError{
-              subReq.requestID,
-              SubscribeErrorCode::INTERNAL_ERROR,
-              "failed to add subscriber"});
+      XLOG(ERR) << "addSubscriber returned null (draining?) for " << subReq.fullTrackName
+                << " reqID=" << subReq.requestID;
+      co_return folly::makeUnexpected(SubscribeError{
+          subReq.requestID, SubscribeErrorCode::INTERNAL_ERROR, "failed to add subscriber"});
     }
     XLOG(DBG4) << "added subscriber for ftn=" << subReq.fullTrackName;
     // As per the spec, we must set forward = true in the subscribe request
@@ -763,10 +668,8 @@ folly::coro::Task<Publisher::SubscribeResult> ORelay::subscribe(
         subReq, getSubscribeWriteback(subReq.fullTrackName, forwarder));
     if (subRes.hasError()) {
       co_return folly::makeUnexpected(SubscribeError(
-          {subReq.requestID,
-           subRes.error().errorCode,
-           folly::to<std::string>(
-               "upstream subscribe failed: ", subRes.error().reasonPhrase)}));
+          {subReq.requestID, subRes.error().errorCode,
+           folly::to<std::string>("upstream subscribe failed: ", subRes.error().reasonPhrase)}));
     }
     // is it more correct to co_await folly::coro::co_safe_point here?
     g.dismiss();
@@ -779,16 +682,14 @@ folly::coro::Task<Publisher::SubscribeResult> ORelay::subscribe(
     forwarder->setGroupOrder(pubGroupOrder);
 
     // Store upstream delivery timeout in forwarder
-    auto deliveryTimeout =
-        getPublisherDeliveryTimeout(subRes.value()->subscribeOk());
+    auto deliveryTimeout = getPublisherDeliveryTimeout(subRes.value()->subscribeOk());
 
     // Add delivery timeout to downstream subscriber explicitly as this is the
     // first subscriber. Forwarder can add it to subsequent subscribers
     if (deliveryTimeout && deliveryTimeout->count() > 0) {
       forwarder->setDeliveryTimeout(deliveryTimeout->count());
-      subscriber->setParam(
-          {folly::to_underlying(TrackRequestParamKey::DELIVERY_TIMEOUT),
-           static_cast<uint64_t>(deliveryTimeout->count())});
+      subscriber->setParam({folly::to_underlying(TrackRequestParamKey::DELIVERY_TIMEOUT),
+                            static_cast<uint64_t>(deliveryTimeout->count())});
     }
 
     subscriber->setPublisherGroupOrder(pubGroupOrder);
@@ -798,8 +699,7 @@ folly::coro::Task<Publisher::SubscribeResult> ORelay::subscribe(
     // and then gets flushed
     if (it == subscriptions_.end()) {
       XLOG(ERR) << "Subscription is GONE, returning exception";
-      co_yield folly::coro::co_error(
-          std::runtime_error("subscription is gone"));
+      co_yield folly::coro::co_error(std::runtime_error("subscription is gone"));
     }
     auto& rsub = it->second;
     rsub.requestID = subRes.value()->subscribeOk().requestID;
@@ -815,51 +715,38 @@ folly::coro::Task<Publisher::SubscribeResult> ORelay::subscribe(
     auto& forwarder = subscriptionIt->second.forwarder;
     if (forwarder->largest() && subReq.locType == LocationType::AbsoluteRange &&
         subReq.endGroup < forwarder->largest()->group) {
-      co_return folly::makeUnexpected(
-          SubscribeError{
-              subReq.requestID,
-              SubscribeErrorCode::INVALID_RANGE,
-              "Range in the past, use FETCH"});
+      co_return folly::makeUnexpected(SubscribeError{
+          subReq.requestID, SubscribeErrorCode::INVALID_RANGE, "Range in the past, use FETCH"});
       // start may be in the past, it will get adjusted forward to largest
     }
-    bool forwarding =
-        subscriptionIt->second.forwarder->numForwardingSubscribers() > 0;
-    auto subscriber = subscriptionIt->second.forwarder->addSubscriber(
-        std::move(session), subReq, std::move(consumer));
+    bool forwarding = subscriptionIt->second.forwarder->numForwardingSubscribers() > 0;
+    auto subscriber = subscriptionIt->second.forwarder->addSubscriber(std::move(session), subReq,
+                                                                      std::move(consumer));
     if (!subscriber) {
-      XLOG(ERR) << "addSubscriber returned null (draining?) for "
-                << subReq.fullTrackName << " reqID=" << subReq.requestID;
-      co_return folly::makeUnexpected(
-          SubscribeError{
-              subReq.requestID,
-              SubscribeErrorCode::INTERNAL_ERROR,
-              "failed to add subscriber"});
+      XLOG(ERR) << "addSubscriber returned null (draining?) for " << subReq.fullTrackName
+                << " reqID=" << subReq.requestID;
+      co_return folly::makeUnexpected(SubscribeError{
+          subReq.requestID, SubscribeErrorCode::INTERNAL_ERROR, "failed to add subscriber"});
     }
     XLOG(DBG4) << "added subscriber for ftn=" << subReq.fullTrackName;
-    if (!forwarding &&
-        subscriptionIt->second.forwarder->numForwardingSubscribers() > 0) {
+    if (!forwarding && subscriptionIt->second.forwarder->numForwardingSubscribers() > 0) {
       auto exec = subscriptionIt->second.upstream->getExecutor();
-      co_withExecutor(
-          exec,
-          doSubscribeUpdate(subscriptionIt->second.handle, /*forward=*/true))
+      co_withExecutor(exec, doSubscribeUpdate(subscriptionIt->second.handle, /*forward=*/true))
           .start();
     }
     co_return subscriber;
   }
 }
 
-folly::coro::Task<Publisher::FetchResult> ORelay::fetch(
-    Fetch fetch,
-    std::shared_ptr<FetchConsumer> consumer) {
+folly::coro::Task<Publisher::FetchResult> ORelay::fetch(Fetch fetch,
+                                                        std::shared_ptr<FetchConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
 
   // check auth
   // get trackNamespace
   if (fetch.fullTrackName.trackNamespace.empty()) {
-    co_return folly::makeUnexpected(FetchError(
-        {fetch.requestID,
-         FetchErrorCode::TRACK_NOT_EXIST,
-         "namespace required"}));
+    co_return folly::makeUnexpected(
+        FetchError({fetch.requestID, FetchErrorCode::TRACK_NOT_EXIST, "namespace required"}));
   }
 
   auto [standalone, joining] = fetchType(fetch);
@@ -869,12 +756,9 @@ folly::coro::Task<Publisher::FetchResult> ORelay::fetch(
       XLOG(ERR) << "No subscription for joining fetch";
       // message error
       co_return folly::makeUnexpected(FetchError(
-          {fetch.requestID,
-           FetchErrorCode::TRACK_NOT_EXIST,
-           "No subscription for joining fetch"}));
+          {fetch.requestID, FetchErrorCode::TRACK_NOT_EXIST, "No subscription for joining fetch"}));
     } else if (subscriptionIt->second.promise.isFulfilled()) {
-      auto res = subscriptionIt->second.forwarder->resolveJoiningFetch(
-          session, *joining);
+      auto res = subscriptionIt->second.forwarder->resolveJoiningFetch(session, *joining);
       if (res.hasError()) {
         co_return folly::makeUnexpected(res.error());
       }
@@ -886,8 +770,7 @@ folly::coro::Task<Publisher::FetchResult> ORelay::fetch(
     }
   }
 
-  auto upstreamSession =
-      findPublishNamespaceSession(fetch.fullTrackName.trackNamespace);
+  auto upstreamSession = findPublishNamespaceSession(fetch.fullTrackName.trackNamespace);
   if (!upstreamSession) {
     // Attempt to find matching upstream subscription (from publish)
     auto subscriptionIt = subscriptions_.find(fetch.fullTrackName);
@@ -895,15 +778,13 @@ folly::coro::Task<Publisher::FetchResult> ORelay::fetch(
       upstreamSession = subscriptionIt->second.upstream;
     } else {
       // no such namespace has been published
-      co_return folly::makeUnexpected(FetchError(
-          {fetch.requestID,
-           FetchErrorCode::TRACK_NOT_EXIST,
-           "no such namespace"}));
+      co_return folly::makeUnexpected(
+          FetchError({fetch.requestID, FetchErrorCode::TRACK_NOT_EXIST, "no such namespace"}));
     }
   }
   if (session.get() == upstreamSession.get()) {
-    co_return folly::makeUnexpected(FetchError(
-        {fetch.requestID, FetchErrorCode::INTERNAL_ERROR, "self fetch"}));
+    co_return folly::makeUnexpected(
+        FetchError({fetch.requestID, FetchErrorCode::INTERNAL_ERROR, "self fetch"}));
   }
   fetch.priority = kDefaultUpstreamPriority;
   if (!cache_ || joining) {
@@ -911,14 +792,12 @@ folly::coro::Task<Publisher::FetchResult> ORelay::fetch(
     // which objects are being requested.  However, once we have that resolved,
     // we SHOULD be able to serve from cache.
     if (standalone) {
-      XLOG(DBG1) << "Upstream fetch {" << standalone->start.group << ","
-                 << standalone->start.object << "}.." << standalone->end.group
-                 << "," << standalone->end.object << "}";
+      XLOG(DBG1) << "Upstream fetch {" << standalone->start.group << "," << standalone->start.object
+                 << "}.." << standalone->end.group << "," << standalone->end.object << "}";
     }
     co_return co_await upstreamSession->fetch(fetch, std::move(consumer));
   }
-  co_return co_await cache_->fetch(
-      fetch, std::move(consumer), std::move(upstreamSession));
+  co_return co_await cache_->fetch(fetch, std::move(consumer), std::move(upstreamSession));
 }
 
 void ORelay::onEmpty(MoQForwarder* forwarder) {
@@ -941,9 +820,7 @@ void ORelay::onEmpty(MoQForwarder* forwarder) {
     // if it's publish, don't unsubscribe, just subscribeUpdate forward=false
     XLOG(DBG1) << "Updating upstream subscription forward=false";
     auto exec = subscription.upstream->getExecutor();
-    co_withExecutor(
-        exec, doSubscribeUpdate(subscription.handle, /*forward=*/false))
-        .start();
+    co_withExecutor(exec, doSubscribeUpdate(subscription.handle, /*forward=*/false)).start();
   } else {
     subscription.handle->unsubscribe();
     XLOG(DBG4) << "Erasing subscription to " << subscriptionIt->first;
@@ -965,11 +842,8 @@ void ORelay::forwardChanged(MoQForwarder* forwarder) {
              << " numForwardingSubs=" << forwarder->numForwardingSubscribers();
 
   auto exec = subscription.upstream->getExecutor();
-  co_withExecutor(
-      exec,
-      doSubscribeUpdate(
-          subscription.handle,
-          /*forward=*/forwarder->numForwardingSubscribers() > 0))
+  co_withExecutor(exec, doSubscribeUpdate(subscription.handle,
+                                          /*forward=*/forwarder->numForwardingSubscribers() > 0))
       .start();
 }
 

--- a/src/ORelayServer.cpp
+++ b/src/ORelayServer.cpp
@@ -1,67 +1,47 @@
-#include <o_rly/ORelayServer.h>
 #include <moxygen/MoQRelaySession.h>
+#include <o_rly/ORelayServer.h>
 
 using namespace moxygen;
 
 namespace openmoq::o_rly {
 
-ORelayServer::ORelayServer(
-    const std::string& cert,
-    const std::string& key,
-    const std::string& endpoint,
-    const std::string& versions,
-    size_t maxCachedTracks,
-    size_t maxCachedGroupsPerTrack)
-    : MoQServer(
-          quic::samples::createFizzServerContext(
-              [&versions]() {
-                std::vector<std::string> alpns = {"h3"};
-                auto moqt = getMoqtProtocols(versions, true);
-                alpns.insert(alpns.end(), moqt.begin(), moqt.end());
-                return alpns;
-              }(),
-              fizz::server::ClientAuthMode::Optional,
-              cert,
-              key),
-          endpoint),
-      relay_(std::make_shared<ORelay>(
-          maxCachedTracks,
-          maxCachedGroupsPerTrack)) {}
+ORelayServer::ORelayServer(const std::string& cert, const std::string& key,
+                           const std::string& endpoint, const std::string& versions,
+                           size_t maxCachedTracks, size_t maxCachedGroupsPerTrack)
+    : MoQServer(quic::samples::createFizzServerContext(
+                    [&versions]() {
+                      std::vector<std::string> alpns = {"h3"};
+                      auto moqt = getMoqtProtocols(versions, true);
+                      alpns.insert(alpns.end(), moqt.begin(), moqt.end());
+                      return alpns;
+                    }(),
+                    fizz::server::ClientAuthMode::Optional, cert, key),
+                endpoint),
+      relay_(std::make_shared<ORelay>(maxCachedTracks, maxCachedGroupsPerTrack)) {}
 
-ORelayServer::ORelayServer(
-    const std::string& endpoint,
-    const std::string& versions,
-    size_t maxCachedTracks,
-    size_t maxCachedGroupsPerTrack)
-    : MoQServer(
-          quic::samples::createFizzServerContextWithInsecureDefault(
-              [&versions]() {
-                std::vector<std::string> alpns = {"h3"};
-                auto moqt = getMoqtProtocols(versions, true);
-                alpns.insert(alpns.end(), moqt.begin(), moqt.end());
-                return alpns;
-              }(),
-              fizz::server::ClientAuthMode::None,
-              "" /* cert */,
-              "" /* key */),
-          endpoint),
-      relay_(std::make_shared<ORelay>(
-          maxCachedTracks,
-          maxCachedGroupsPerTrack)) {}
+ORelayServer::ORelayServer(const std::string& endpoint, const std::string& versions,
+                           size_t maxCachedTracks, size_t maxCachedGroupsPerTrack)
+    : MoQServer(quic::samples::createFizzServerContextWithInsecureDefault(
+                    [&versions]() {
+                      std::vector<std::string> alpns = {"h3"};
+                      auto moqt = getMoqtProtocols(versions, true);
+                      alpns.insert(alpns.end(), moqt.begin(), moqt.end());
+                      return alpns;
+                    }(),
+                    fizz::server::ClientAuthMode::None, "" /* cert */, "" /* key */),
+                endpoint),
+      relay_(std::make_shared<ORelay>(maxCachedTracks, maxCachedGroupsPerTrack)) {}
 
-void ORelayServer::onNewSession(
-    std::shared_ptr<MoQSession> clientSession) {
+void ORelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
   clientSession->setPublishHandler(relay_);
   clientSession->setSubscribeHandler(relay_);
 }
 
-std::shared_ptr<MoQSession> ORelayServer::createSession(
-    folly::MaybeManagedPtr<proxygen::WebTransport> wt,
-    std::shared_ptr<MoQExecutor> executor) {
+std::shared_ptr<MoQSession>
+ORelayServer::createSession(folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+                            std::shared_ptr<MoQExecutor> executor) {
   return std::make_shared<MoQRelaySession>(
-      folly::MaybeManagedPtr<proxygen::WebTransport>(std::move(wt)),
-      *this,
-      std::move(executor));
+      folly::MaybeManagedPtr<proxygen::WebTransport>(std::move(wt)), *this, std::move(executor));
 }
 
 } // namespace openmoq::o_rly

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,23 +9,12 @@ DEFINE_string(key, "", "Key path");
 DEFINE_string(endpoint, "/moq-relay", "End point");
 DEFINE_int32(port, 9668, "Relay Server Port");
 DEFINE_bool(enable_cache, true, "Enable relay cache");
-DEFINE_bool(
-    insecure,
-    false,
-    "Use insecure verifier (skip certificate validation)");
-DEFINE_string(
-    versions,
-    "",
-    "Comma-separated MoQ draft versions (e.g. \"14,16\"). Empty = all "
-    "supported.");
-DEFINE_int32(
-    max_cached_tracks,
-    100,
-    "Maximum number of cached tracks (0 to disable caching)");
-DEFINE_int32(
-    max_cached_groups_per_track,
-    3,
-    "Maximum groups per track in cache");
+DEFINE_bool(insecure, false, "Use insecure verifier (skip certificate validation)");
+DEFINE_string(versions, "",
+              "Comma-separated MoQ draft versions (e.g. \"14,16\"). Empty = all "
+              "supported.");
+DEFINE_int32(max_cached_tracks, 100, "Maximum number of cached tracks (0 to disable caching)");
+DEFINE_int32(max_cached_groups_per_track, 3, "Maximum groups per track in cache");
 
 int main(int argc, char* argv[]) {
 
@@ -33,10 +22,8 @@ int main(int argc, char* argv[]) {
   // CLI args, config files, env vars
   folly::Init init(&argc, &argv, true);
 
-  size_t maxCachedTracks =
-      FLAGS_enable_cache ? static_cast<size_t>(FLAGS_max_cached_tracks) : 0;
-  size_t maxCachedGroupsPerTrack =
-      static_cast<size_t>(FLAGS_max_cached_groups_per_track);
+  size_t maxCachedTracks = FLAGS_enable_cache ? static_cast<size_t>(FLAGS_max_cached_tracks) : 0;
+  size_t maxCachedGroupsPerTrack = static_cast<size_t>(FLAGS_max_cached_groups_per_track);
 
   // === 2. Set up logging/observability ===
   // TODO: logging framework, log levels, structured logging
@@ -59,18 +46,11 @@ int main(int argc, char* argv[]) {
   std::shared_ptr<openmoq::o_rly::ORelayServer> server = nullptr;
   if (FLAGS_insecure) {
     server = std::make_shared<openmoq::o_rly::ORelayServer>(
-        FLAGS_endpoint,
-        FLAGS_versions,
-        maxCachedTracks,
-        maxCachedGroupsPerTrack);
+        FLAGS_endpoint, FLAGS_versions, maxCachedTracks, maxCachedGroupsPerTrack);
   } else {
-    server = std::make_shared<openmoq::o_rly::ORelayServer>(
-        FLAGS_cert,
-        FLAGS_key,
-        FLAGS_endpoint,
-        FLAGS_versions,
-        maxCachedTracks,
-        maxCachedGroupsPerTrack);
+    server = std::make_shared<openmoq::o_rly::ORelayServer>(FLAGS_cert, FLAGS_key, FLAGS_endpoint,
+                                                            FLAGS_versions, maxCachedTracks,
+                                                            maxCachedGroupsPerTrack);
   }
 
   // === 7. Start health checks / admin endpoints ===

--- a/tests/ORelayTest.cpp
+++ b/tests/ORelayTest.cpp
@@ -12,10 +12,10 @@
 #include <folly/portability/GTest.h>
 #include <moxygen/events/MoQFollyExecutorImpl.h>
 #include <moxygen/relay/MoQForwarder.h>
-#include <o_rly/ORelay.h>
 #include <moxygen/test/MockMoQSession.h>
 #include <moxygen/test/Mocks.h>
 #include <moxygen/test/TestUtils.h>
+#include <o_rly/ORelay.h>
 
 using namespace testing;
 using namespace moxygen;
@@ -28,15 +28,12 @@ const TrackNamespace kAllowedPrefix{{"test"}};
 const FullTrackName kTestTrackName{kTestNamespace, "track1"};
 
 // TestMoQExecutor that can be driven for tests
-class TestMoQExecutor : public MoQFollyExecutorImpl,
-                        public folly::DrivableExecutor {
- public:
+class TestMoQExecutor : public MoQFollyExecutorImpl, public folly::DrivableExecutor {
+public:
   explicit TestMoQExecutor() : MoQFollyExecutorImpl(&evb_) {}
   ~TestMoQExecutor() override = default;
 
-  void add(folly::Func func) override {
-    MoQFollyExecutorImpl::add(std::move(func));
-  }
+  void add(folly::Func func) override { MoQFollyExecutorImpl::add(std::move(func)); }
 
   // Implements DrivableExec::drive
   void drive() override {
@@ -47,7 +44,7 @@ class TestMoQExecutor : public MoQFollyExecutorImpl,
     }
   }
 
- private:
+private:
   folly::EventBase evb_;
 };
 
@@ -56,16 +53,14 @@ class TestMoQExecutor : public MoQFollyExecutorImpl,
 // Full integration tests with real sessions will be added when implementing
 // multi-publisher support.
 class ORelayTest : public ::testing::Test {
- protected:
+protected:
   void SetUp() override {
     exec_ = std::make_shared<TestMoQExecutor>();
     relay_ = std::make_shared<ORelay>(/*enableCache=*/false);
     relay_->setAllowedNamespacePrefix(kAllowedPrefix);
   }
 
-  void TearDown() override {
-    relay_.reset();
-  }
+  void TearDown() override { relay_.reset(); }
 
   // Helper to create a mock session
   std::shared_ptr<MockMoQSession> createMockSession() {
@@ -77,43 +72,35 @@ class ORelayTest : public ::testing::Test {
   }
 
   // Helper to create a mock subscription handle for publish calls
-  std::shared_ptr<Publisher::SubscriptionHandle>
-  createMockSubscriptionHandle() {
+  std::shared_ptr<Publisher::SubscriptionHandle> createMockSubscriptionHandle() {
     SubscribeOk ok;
     ok.requestID = RequestID(0);
     ok.trackAlias = TrackAlias(0);
     ok.expires = std::chrono::milliseconds(0);
     ok.groupOrder = GroupOrder::Default;
-    auto handle =
-        std::make_shared<NiceMock<MockSubscriptionHandle>>(std::move(ok));
+    auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(std::move(ok));
     return handle;
   }
 
   // Helper to remove a session from the relay and clean up mock state
-  void removeSession(std::shared_ptr<MoQSession> sess) {
-    cleanupMockSession(std::move(sess));
-  }
+  void removeSession(std::shared_ptr<MoQSession> sess) { cleanupMockSession(std::move(sess)); }
 
   // Helper to create a mock consumer with default actions
   std::shared_ptr<MockTrackConsumer> createMockConsumer() {
     auto consumer = std::make_shared<NiceMock<MockTrackConsumer>>();
     ON_CALL(*consumer, setTrackAlias(_))
-        .WillByDefault(
-            Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
     ON_CALL(*consumer, publishDone(_))
-        .WillByDefault(
-            Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
     return consumer;
   }
 
   // Helper to subscribe a session to a track
-  std::shared_ptr<SubscriptionHandle> subscribeToTrack(
-      std::shared_ptr<MoQSession> session,
-      const FullTrackName& trackName,
-      std::shared_ptr<TrackConsumer> consumer,
-      RequestID requestID = RequestID(0),
-      bool addToState = true,
-      folly::Optional<SubscribeErrorCode> expectedError = folly::none) {
+  std::shared_ptr<SubscriptionHandle>
+  subscribeToTrack(std::shared_ptr<MoQSession> session, const FullTrackName& trackName,
+                   std::shared_ptr<TrackConsumer> consumer, RequestID requestID = RequestID(0),
+                   bool addToState = true,
+                   folly::Optional<SubscribeErrorCode> expectedError = folly::none) {
     SubscribeRequest sub;
     sub.fullTrackName = trackName;
     sub.requestID = requestID;
@@ -144,13 +131,11 @@ class ORelayTest : public ::testing::Test {
 
   // Helper to set up RequestContext for a session (simulates incoming request)
   template <typename Func>
-  auto withSessionContext(std::shared_ptr<MoQSession> session, Func&& func)
-      -> decltype(func()) {
+  auto withSessionContext(std::shared_ptr<MoQSession> session, Func&& func) -> decltype(func()) {
     folly::RequestContextScopeGuard guard;
     folly::RequestContext::get()->setContextData(
         sessionRequestToken(),
-        std::make_unique<MoQSession::MoQSessionRequestData>(
-            std::move(session)));
+        std::make_unique<MoQSession::MoQSessionRequestData>(std::move(session)));
     return func();
   }
 
@@ -167,12 +152,9 @@ class ORelayTest : public ::testing::Test {
     std::vector<std::shared_ptr<TrackConsumer>> publishConsumers;
     // Handles for results from publishNamespace, subscribeNamespace,
     // and subscribe
-    std::vector<std::shared_ptr<Subscriber::PublishNamespaceHandle>>
-        publishNamespaceHandles;
-    std::vector<std::shared_ptr<Publisher::SubscribeNamespaceHandle>>
-        subscribeNamespaceHandles;
-    std::vector<std::shared_ptr<Publisher::SubscriptionHandle>>
-        subscribeHandles;
+    std::vector<std::shared_ptr<Subscriber::PublishNamespaceHandle>> publishNamespaceHandles;
+    std::vector<std::shared_ptr<Publisher::SubscribeNamespaceHandle>> subscribeNamespaceHandles;
+    std::vector<std::shared_ptr<Publisher::SubscriptionHandle>> subscribeHandles;
 
     void cleanup() {
       // Simulate MoQSession::cleanup() for publish tracks
@@ -180,10 +162,7 @@ class ORelayTest : public ::testing::Test {
       // FilterConsumer callbacks that properly clean up relay state
       for (auto& consumer : publishConsumers) {
         consumer->publishDone(
-            {RequestID(0),
-             PublishDoneStatusCode::SESSION_CLOSED,
-             0,
-             "mock session cleanup"});
+            {RequestID(0), PublishDoneStatusCode::SESSION_CLOSED, 0, "mock session cleanup"});
       }
       publishConsumers.clear();
 
@@ -215,8 +194,7 @@ class ORelayTest : public ::testing::Test {
 
   std::map<MoQSession*, std::shared_ptr<MockSessionState>> mockSessions_;
 
-  std::shared_ptr<MockSessionState> getOrCreateMockState(
-      std::shared_ptr<MoQSession> session) {
+  std::shared_ptr<MockSessionState> getOrCreateMockState(std::shared_ptr<MoQSession> session) {
     auto it = mockSessions_.find(session.get());
     if (it == mockSessions_.end()) {
       auto state = std::make_shared<MockSessionState>();
@@ -240,10 +218,9 @@ class ORelayTest : public ::testing::Test {
   // Returns the PublishNamespaceHandle so tests can use it for manual cleanup
   // if needed If addToState is true, the handle is automatically saved for
   // cleanup
-  std::shared_ptr<Subscriber::PublishNamespaceHandle> doPublishNamespace(
-      std::shared_ptr<MoQSession> session,
-      const TrackNamespace& ns,
-      bool addToState = true) {
+  std::shared_ptr<Subscriber::PublishNamespaceHandle>
+  doPublishNamespace(std::shared_ptr<MoQSession> session, const TrackNamespace& ns,
+                     bool addToState = true) {
     PublishNamespace ann;
     ann.trackNamespace = ns;
     return withSessionContext(session, [&]() {
@@ -252,8 +229,7 @@ class ORelayTest : public ::testing::Test {
       EXPECT_TRUE(res.hasValue());
       if (res.hasValue()) {
         if (addToState) {
-          getOrCreateMockState(session)->publishNamespaceHandles.push_back(
-              *res);
+          getOrCreateMockState(session)->publishNamespaceHandles.push_back(*res);
         }
         return *res;
       }
@@ -265,20 +241,16 @@ class ORelayTest : public ::testing::Test {
   // Returns the TrackConsumer so tests can use it for manual operations if
   // needed If addToState is true, the consumer is automatically saved for
   // cleanup
-  std::shared_ptr<TrackConsumer> doPublish(
-      std::shared_ptr<MoQSession> session,
-      const FullTrackName& trackName,
-      bool addToState = true) {
+  std::shared_ptr<TrackConsumer> doPublish(std::shared_ptr<MoQSession> session,
+                                           const FullTrackName& trackName, bool addToState = true) {
     PublishRequest pub;
     pub.fullTrackName = trackName;
     return withSessionContext(session, [&]() {
-      auto res =
-          relay_->publish(std::move(pub), createMockSubscriptionHandle());
+      auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
       EXPECT_TRUE(res.hasValue());
       if (res.hasValue()) {
         if (addToState) {
-          getOrCreateMockState(session)->publishConsumers.push_back(
-              res->consumer);
+          getOrCreateMockState(session)->publishConsumers.push_back(res->consumer);
         }
         return res->consumer;
       }
@@ -290,10 +262,9 @@ class ORelayTest : public ::testing::Test {
   // Returns the SubscribeNamespaceHandle so tests can use it for manual cleanup
   // if needed If addToState is true, the handle is automatically saved for
   // cleanup
-  std::shared_ptr<Publisher::SubscribeNamespaceHandle> doSubscribeNamespace(
-      std::shared_ptr<MoQSession> session,
-      const TrackNamespace& nsPrefix,
-      bool addToState = true) {
+  std::shared_ptr<Publisher::SubscribeNamespaceHandle>
+  doSubscribeNamespace(std::shared_ptr<MoQSession> session, const TrackNamespace& nsPrefix,
+                       bool addToState = true) {
     SubscribeNamespace subNs;
     subNs.trackNamespacePrefix = nsPrefix;
     return withSessionContext(session, [&]() {
@@ -302,8 +273,7 @@ class ORelayTest : public ::testing::Test {
       EXPECT_TRUE(res.hasValue());
       if (res.hasValue()) {
         if (addToState) {
-          getOrCreateMockState(session)->subscribeNamespaceHandles.push_back(
-              *res);
+          getOrCreateMockState(session)->subscribeNamespaceHandles.push_back(*res);
         }
         return *res;
       }
@@ -315,21 +285,16 @@ class ORelayTest : public ::testing::Test {
   std::shared_ptr<MockSubgroupConsumer> createMockSubgroupConsumer() {
     auto sg = std::make_shared<NiceMock<MockSubgroupConsumer>>();
     ON_CALL(*sg, beginObject(_, _, _, _))
-        .WillByDefault(
-            Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
     ON_CALL(*sg, objectPayload(_, _))
-        .WillByDefault(Return(
-            folly::makeExpected<MoQPublishError>(
-                ObjectPublishStatus::IN_PROGRESS)));
+        .WillByDefault(
+            Return(folly::makeExpected<MoQPublishError>(ObjectPublishStatus::IN_PROGRESS)));
     ON_CALL(*sg, endOfSubgroup())
-        .WillByDefault(
-            Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
     ON_CALL(*sg, endOfGroup(_))
-        .WillByDefault(
-            Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
     ON_CALL(*sg, endOfTrackAndGroup(_))
-        .WillByDefault(
-            Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
     return sg;
   }
 
@@ -382,16 +347,14 @@ TEST_F(ORelayTest, PruneLeafKeepSiblings) {
   // PublishNamespace test/A/B/C (don't add to state because we
   // publishNamespaceDone manually)
   TrackNamespace nsABC{{"test", "A", "B", "C"}};
-  auto handleABC =
-      doPublishNamespace(publisherABC, nsABC, /*addToState=*/false);
+  auto handleABC = doPublishNamespace(publisherABC, nsABC, /*addToState=*/false);
 
   // PublishNamespace test/A/D
   TrackNamespace nsAD{{"test", "A", "D"}};
   doPublishNamespace(publisherAD, nsAD);
 
   // PublishNamespaceDone test/A/B/C - should prune B (and C) but keep A and D
-  withSessionContext(
-      publisherABC, [&]() { handleABC->publishNamespaceDone(); });
+  withSessionContext(publisherABC, [&]() { handleABC->publishNamespaceDone(); });
 
   // Verify test/A/D still exists using findPublishNamespaceSessions
   auto sessions = relay_->findPublishNamespaceSessions(nsAD);
@@ -485,9 +448,7 @@ TEST_F(ORelayTest, PruneOnPublishDoneBug) {
 
   // PublishNamespaceDone - node should stay because publish is still active
   withSessionContext(publisher, [&]() {
-    getOrCreateMockState(publisher)
-        ->publishNamespaceHandles[0]
-        ->publishNamespaceDone();
+    getOrCreateMockState(publisher)->publishNamespaceHandles[0]->publishNamespaceDone();
     getOrCreateMockState(publisher)->publishNamespaceHandles.clear();
   });
 
@@ -499,10 +460,7 @@ TEST_F(ORelayTest, PruneOnPublishDoneBug) {
   // End the publish - onPublishDone gets called
   withSessionContext(publisher, [&]() {
     consumer->publishDone(
-        {RequestID(0),
-         PublishDoneStatusCode::SUBSCRIPTION_ENDED,
-         0,
-         "publisher done"});
+        {RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher done"});
   });
 
   // BUG EXPOSED: The publish is removed from the map but the node still exists
@@ -532,9 +490,7 @@ TEST_F(ORelayTest, MixedContentPublishNamespaceAndPublish) {
 
   // PublishNamespaceDone - should NOT prune because publish still exists
   withSessionContext(publisher, [&]() {
-    getOrCreateMockState(publisher)
-        ->publishNamespaceHandles[0]
-        ->publishNamespaceDone();
+    getOrCreateMockState(publisher)->publishNamespaceHandles[0]->publishNamespaceDone();
     getOrCreateMockState(publisher)->publishNamespaceHandles.clear();
   });
 
@@ -675,8 +631,7 @@ TEST_F(ORelayTest, StalePublishNamespaceDoneDoesNotAffectNewOwner) {
   EXPECT_EQ(sessions.size(), 1)
       << "Ownership check failed: findPublishNamespaceSessions returned wrong count";
   if (!sessions.empty()) {
-    EXPECT_EQ(sessions[0], publisher1)
-        << "Ownership check failed: wrong session returned";
+    EXPECT_EQ(sessions[0], publisher1) << "Ownership check failed: wrong session returned";
   }
 
   // Publisher1 should still be able to properly publishNamespaceDone its own
@@ -739,8 +694,7 @@ TEST_F(ORelayTest, EmptyNamespacePublishNamespaceDone) {
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     // Don't assert on success/failure, just verify no crash
     if (res.hasValue()) {
-      getOrCreateMockState(publisher)->publishNamespaceHandles.push_back(
-          res.value());
+      getOrCreateMockState(publisher)->publishNamespaceHandles.push_back(res.value());
     }
   });
 
@@ -822,15 +776,12 @@ TEST_F(ORelayTest, ForwarderOnlyCreatesSubgroupsBeforeObjectData) {
 
   auto setupSubgroupConsumer = [](auto& sg) {
     ON_CALL(*sg, beginObject(_, _, _, _))
-        .WillByDefault(
-            Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
     ON_CALL(*sg, objectPayload(_, _))
-        .WillByDefault(Return(
-            folly::makeExpected<MoQPublishError>(
-                ObjectPublishStatus::IN_PROGRESS)));
-    ON_CALL(*sg, endOfSubgroup())
         .WillByDefault(
-            Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+            Return(folly::makeExpected<MoQPublishError>(ObjectPublishStatus::IN_PROGRESS)));
+    ON_CALL(*sg, endOfSubgroup())
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
   };
 
   // Subscriber 1 and 2 should get beginSubgroup
@@ -838,18 +789,14 @@ TEST_F(ORelayTest, ForwarderOnlyCreatesSubgroupsBeforeObjectData) {
       .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
         auto sg = std::make_shared<NiceMock<MockSubgroupConsumer>>();
         setupSubgroupConsumer(sg);
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
       });
 
   EXPECT_CALL(*mockConsumer2, beginSubgroup(_, _, _, _))
       .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
         auto sg = std::make_shared<NiceMock<MockSubgroupConsumer>>();
         setupSubgroupConsumer(sg);
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
       });
 
   // Subscriber 3 joins mid-object and should NOT get beginSubgroup
@@ -868,8 +815,7 @@ TEST_F(ORelayTest, ForwarderOnlyCreatesSubgroupsBeforeObjectData) {
 
   // First object -> goes to subscriber 1
   EXPECT_TRUE(subgroup->beginObject(0, 4, 0).hasValue());
-  EXPECT_TRUE(subgroup->objectPayload(folly::IOBuf::copyBuffer("test"), false)
-                  .hasValue());
+  EXPECT_TRUE(subgroup->objectPayload(folly::IOBuf::copyBuffer("test"), false).hasValue());
 
   // Subscriber 2 joins after first object
   subscribeToTrack(subscriber2, kTestTrackName, mockConsumer2, RequestID(2));
@@ -881,9 +827,7 @@ TEST_F(ORelayTest, ForwarderOnlyCreatesSubgroupsBeforeObjectData) {
   subscribeToTrack(subscriber3, kTestTrackName, mockConsumer3, RequestID(3));
 
   // Payload and endOfSubgroup -> only to subscribers 1, 2 (NOT 3)
-  EXPECT_TRUE(
-      subgroup->objectPayload(folly::IOBuf::copyBuffer("more data"), false)
-          .hasValue());
+  EXPECT_TRUE(subgroup->objectPayload(folly::IOBuf::copyBuffer("more data"), false).hasValue());
   EXPECT_TRUE(subgroup->endOfSubgroup().hasValue());
 
   removeSession(publisherSession);
@@ -921,9 +865,8 @@ TEST_F(ORelayTest, GracefulSessionDraining) {
     EXPECT_CALL(*consumers[0], beginSubgroup(i, 0, _, _))
         .WillOnce([this, i, &sub0_sgs](uint64_t, uint64_t, uint8_t, bool) {
           sub0_sgs[i] = createMockSubgroupConsumer();
-          return folly::
-              makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                  sub0_sgs[i]);
+          return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
+              sub0_sgs[i]);
         });
   }
 
@@ -931,9 +874,7 @@ TEST_F(ORelayTest, GracefulSessionDraining) {
   EXPECT_CALL(*consumers[1], beginSubgroup(1, 0, _, _))
       .WillOnce([this, &sub1_sg0](uint64_t, uint64_t, uint8_t, bool) {
         sub1_sg0 = createMockSubgroupConsumer();
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sub1_sg0);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sub1_sg0);
       });
 
   std::array<std::shared_ptr<SubgroupConsumer>, 2> sgs;
@@ -957,11 +898,7 @@ TEST_F(ORelayTest, GracefulSessionDraining) {
   EXPECT_CALL(*sub1_sg0, reset(_)).Times(0);
 
   publishConsumer->publishDone(
-      PublishDone{
-          RequestID(0),
-          PublishDoneStatusCode::SUBSCRIPTION_ENDED,
-          0,
-          "publisher ended"});
+      PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher ended"});
 
   // At this point:
   // - subscriber3 removed (had no subgroups)
@@ -996,14 +933,12 @@ TEST_F(ORelayTest, RemoveSessionResetsOpenSubgroups) {
           sgs[i] = createMockSubgroupConsumer();
           EXPECT_CALL(*sgs[i], object(0, testing::_, testing::_, false))
               .WillOnce(testing::Return(folly::unit));
-          return folly::
-              makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                  sgs[i]);
+          return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sgs[i]);
         });
   }
 
-  auto subHandle = subscribeToTrack(
-      subscriber, kTestTrackName, consumer, RequestID(1), /*addToState=*/false);
+  auto subHandle =
+      subscribeToTrack(subscriber, kTestTrackName, consumer, RequestID(1), /*addToState=*/false);
 
   // Publish data to create subgroups and first objects
   std::array<std::shared_ptr<SubgroupConsumer>, 2> pubSgs;
@@ -1046,9 +981,7 @@ TEST_F(ORelayTest, DrainingSubscriberRemovedOnSubgroupError) {
     EXPECT_CALL(*consumer, beginSubgroup(i, 0, _, _))
         .WillOnce([this, i, &sgs](uint64_t, uint64_t, uint8_t, bool) {
           sgs[i] = createMockSubgroupConsumer();
-          return folly::
-              makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                  sgs[i]);
+          return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sgs[i]);
         });
   }
 
@@ -1065,8 +998,7 @@ TEST_F(ORelayTest, DrainingSubscriberRemovedOnSubgroupError) {
   // Note: publishDone may be called multiple times (during drain and cleanup)
   EXPECT_CALL(*consumer, publishDone(_))
       .Times(AtLeast(1))
-      .WillRepeatedly(
-          Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+      .WillRepeatedly(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
 
   // Subgroups should NOT be reset during drain
   EXPECT_CALL(*sgs[0], reset(_)).Times(0);
@@ -1074,11 +1006,7 @@ TEST_F(ORelayTest, DrainingSubscriberRemovedOnSubgroupError) {
   EXPECT_CALL(*sgs[2], reset(_)).Times(0);
 
   publishConsumer->publishDone(
-      PublishDone{
-          RequestID(0),
-          PublishDoneStatusCode::SUBSCRIPTION_ENDED,
-          0,
-          "publisher ended"});
+      PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher ended"});
 
   // Now close subgroups one by one
   // Test 1: Send error on subgroup 0 -> subscriber NOT removed (still has 1, 2)
@@ -1114,17 +1042,14 @@ TEST_F(ORelayTest, SubscriberUnsubscribeDoesNotReceiveNewObjects) {
         auto sg = std::make_shared<NiceMock<MockSubgroupConsumer>>();
         EXPECT_CALL(*sg, beginObject(_, _, _, _)).WillOnce(Return(folly::unit));
         EXPECT_CALL(*sg, reset(_));
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
       });
 
   // Sub2 should also get beginSubgroup
   EXPECT_CALL(*mockConsumer2, beginSubgroup(_, _, _, _)).Times(0);
 
   // Publish track
-  auto publishConsumer =
-      doPublish(publisherSession, kTestTrackName, /*addToState=*/false);
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName, /*addToState=*/false);
 
   // Subscriber 1 joins
   subscribeToTrack(subscriber1, kTestTrackName, mockConsumer1, RequestID(1));
@@ -1136,22 +1061,14 @@ TEST_F(ORelayTest, SubscriberUnsubscribeDoesNotReceiveNewObjects) {
 
   // publisher ends subscription
   EXPECT_CALL(*mockConsumer1, publishDone(testing::_));
-  EXPECT_TRUE(publishConsumer
-                  ->publishDone(
-                      {RequestID(1),
-                       PublishDoneStatusCode::TRACK_ENDED,
-                       0,
-                       "track ended"})
-                  .hasValue());
+  EXPECT_TRUE(
+      publishConsumer
+          ->publishDone({RequestID(1), PublishDoneStatusCode::TRACK_ENDED, 0, "track ended"})
+          .hasValue());
 
   // Subscriber 2 joins after publishDone
-  subscribeToTrack(
-      subscriber2,
-      kTestTrackName,
-      mockConsumer2,
-      RequestID(2),
-      /*addToState=*/false,
-      SubscribeErrorCode::INTERNAL_ERROR);
+  subscribeToTrack(subscriber2, kTestTrackName, mockConsumer2, RequestID(2),
+                   /*addToState=*/false, SubscribeErrorCode::INTERNAL_ERROR);
 
   // Send object - should only go to subscriber 1 (sub2 is gone)
   EXPECT_TRUE(subgroup->beginObject(0, 4, 0).hasValue());
@@ -1172,43 +1089,34 @@ TEST_F(ORelayTest, SubscribeNamespaceDoesntAddDrainingPublish) {
   auto subscriber2 = createMockSession();
 
   // Subscriber 1 subscribes to publishNamespaces
-  auto handle1 =
-      doSubscribeNamespace(subscriber1, kTestNamespace, /*addToState=*/false);
+  auto handle1 = doSubscribeNamespace(subscriber1, kTestNamespace, /*addToState=*/false);
 
   // Publish first track - subscriber 1 should receive it
   auto mockConsumer1 = createMockConsumer();
   EXPECT_CALL(*subscriber1, publish(testing::_, testing::_))
       .WillOnce([mockConsumer1](auto pubReq, auto subHandle) {
-        return Subscriber::PublishResult(
-            Subscriber::PublishConsumerAndReplyTask{
-                mockConsumer1,
-                []() -> folly::coro::Task<
-                         folly::Expected<PublishOk, PublishError>> {
-                  co_return PublishOk{/*requestID=*/RequestID(1),
-                                      /*forward=*/true,
-                                      /*subscriberPriority=*/0,
-                                      /*groupOrder=*/GroupOrder::OldestFirst,
-                                      /*locType=*/LocationType::LargestObject,
-                                      /*start=*/std::nullopt,
-                                      /*endGroup=*/std::nullopt};
-                }()});
+        return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
+            mockConsumer1, []() -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
+              co_return PublishOk{/*requestID=*/RequestID(1),
+                                  /*forward=*/true,
+                                  /*subscriberPriority=*/0,
+                                  /*groupOrder=*/GroupOrder::OldestFirst,
+                                  /*locType=*/LocationType::LargestObject,
+                                  /*start=*/std::nullopt,
+                                  /*endGroup=*/std::nullopt};
+            }()});
       });
 
   EXPECT_CALL(*mockConsumer1, beginSubgroup(_, _, _, _))
       .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
         auto sg = std::make_shared<NiceMock<MockSubgroupConsumer>>();
-        EXPECT_CALL(*sg, endOfSubgroup())
-            .WillOnce(testing::Return(folly::unit));
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg);
+        EXPECT_CALL(*sg, endOfSubgroup()).WillOnce(testing::Return(folly::unit));
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
       });
 
   // Begin a subgroup for ongoing publish activity
-  auto pubConsumer = doPublish(
-      publisherSession,
-      FullTrackName{kTestNamespace, "track_stream"},
-      /*addToState=*/false);
+  auto pubConsumer = doPublish(publisherSession, FullTrackName{kTestNamespace, "track_stream"},
+                               /*addToState=*/false);
   // TODO: bug subscriber not added until next loop?
   exec_->drive();
   auto subgroupRes = pubConsumer->beginSubgroup(0, 0, 0);
@@ -1217,13 +1125,9 @@ TEST_F(ORelayTest, SubscribeNamespaceDoesntAddDrainingPublish) {
 
   // publisher ends subscription
   EXPECT_CALL(*mockConsumer1, publishDone(testing::_));
-  EXPECT_TRUE(pubConsumer
-                  ->publishDone(
-                      {RequestID(1),
-                       PublishDoneStatusCode::TRACK_ENDED,
-                       0,
-                       "track ended"})
-                  .hasValue());
+  EXPECT_TRUE(
+      pubConsumer->publishDone({RequestID(1), PublishDoneStatusCode::TRACK_ENDED, 0, "track ended"})
+          .hasValue());
   subgroup->endOfSubgroup();
 
   // Subscriber 2 subscribes to publishNamespaces but doesn't get finished track
@@ -1242,8 +1146,7 @@ TEST_F(ORelayTest, SubscribeNamespaceDoesntAddDrainingPublish) {
         return folly::makeUnexpected(PublishError{});
       });
 
-  auto pubConsumer2 = doPublish(
-      publisherSession, FullTrackName{kTestNamespace, "track_stream_2"});
+  auto pubConsumer2 = doPublish(publisherSession, FullTrackName{kTestNamespace, "track_stream_2"});
   exec_->drive();
 
   removeSession(publisherSession);
@@ -1274,23 +1177,18 @@ TEST_F(ORelayTest, DataOperationCancelledWhenAllSubscribersFail) {
         .WillOnce([this, i, &sgs](uint64_t, uint64_t, uint8_t, bool) {
           sgs[i] = createMockSubgroupConsumer();
           EXPECT_CALL(*sgs[i], objectPayload(_, false))
-              .WillOnce(Return(
-                  folly::makeExpected<MoQPublishError>(
-                      ObjectPublishStatus::IN_PROGRESS)))
-              .WillOnce(Return(
-                  folly::makeUnexpected(MoQPublishError(
-                      MoQPublishError::WRITE_ERROR, "write failed"))));
-          return folly::
-              makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                  sgs[i]);
+              .WillOnce(
+                  Return(folly::makeExpected<MoQPublishError>(ObjectPublishStatus::IN_PROGRESS)))
+              .WillOnce(Return(folly::makeUnexpected(
+                  MoQPublishError(MoQPublishError::WRITE_ERROR, "write failed"))));
+          return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sgs[i]);
         });
   }
 
   // Publish track and add subscribers
   auto publishConsumer = doPublish(publisherSession, kTestTrackName);
   for (size_t i = 0; i < 2; ++i) {
-    subscribeToTrack(
-        subscribers[i], kTestTrackName, consumers[i], RequestID(i + 1));
+    subscribeToTrack(subscribers[i], kTestTrackName, consumers[i], RequestID(i + 1));
   }
 
   // Begin subgroup and object
@@ -1340,17 +1238,13 @@ TEST_F(ORelayTest, PartialSubscriberFailureDoesNotCancelData) {
       .WillOnce([this, &sgs](uint64_t, uint64_t, uint8_t, bool) {
         sgs[0] = createMockSubgroupConsumer();
         EXPECT_CALL(*sgs[0], objectPayload(_, false))
-            .WillOnce(Return(
-                folly::makeExpected<MoQPublishError>(
-                    ObjectPublishStatus::IN_PROGRESS)))
-            .WillOnce(Return(
-                folly::makeUnexpected(MoQPublishError(
-                    MoQPublishError::WRITE_ERROR, "write failed"))));
+            .WillOnce(
+                Return(folly::makeExpected<MoQPublishError>(ObjectPublishStatus::IN_PROGRESS)))
+            .WillOnce(Return(folly::makeUnexpected(
+                MoQPublishError(MoQPublishError::WRITE_ERROR, "write failed"))));
         // Expect reset when subscriber is removed
         EXPECT_CALL(*sgs[0], reset(_)).Times(1);
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sgs[0]);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sgs[0]);
       });
 
   // Setup subscribers 1 and 2 - will succeed on objectPayload
@@ -1360,23 +1254,18 @@ TEST_F(ORelayTest, PartialSubscriberFailureDoesNotCancelData) {
         .WillOnce([this, i, &sgs](uint64_t, uint64_t, uint8_t, bool) {
           sgs[i] = createMockSubgroupConsumer();
           EXPECT_CALL(*sgs[i], objectPayload(_, false))
-              .WillRepeatedly(Return(
-                  folly::makeExpected<MoQPublishError>(
-                      ObjectPublishStatus::IN_PROGRESS)));
+              .WillRepeatedly(
+                  Return(folly::makeExpected<MoQPublishError>(ObjectPublishStatus::IN_PROGRESS)));
           // Will be reset by cleanup code at end of test
-          EXPECT_CALL(*sgs[i], reset(ResetStreamErrorCode::SESSION_CLOSED))
-              .Times(1);
-          return folly::
-              makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                  sgs[i]);
+          EXPECT_CALL(*sgs[i], reset(ResetStreamErrorCode::SESSION_CLOSED)).Times(1);
+          return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sgs[i]);
         });
   }
 
   // Publish track and add subscribers
   auto publishConsumer = doPublish(publisherSession, kTestTrackName);
   for (size_t i = 0; i < 3; ++i) {
-    subscribeToTrack(
-        subscribers[i], kTestTrackName, consumers[i], RequestID(i + 1));
+    subscribeToTrack(subscribers[i], kTestTrackName, consumers[i], RequestID(i + 1));
   }
 
   // Begin subgroup and object
@@ -1439,18 +1328,15 @@ TEST_F(ORelayTest, SubscribeUpdateStartLocationCanDecrease) {
   EXPECT_EQ(subscriber->range.start, (AbsoluteLocation{10, 0}));
 
   // Send SubscribeUpdate with decreased start location
-  SubscribeUpdate subscribeUpdate{
-      RequestID(2),           // requestID for the update
-      sub.requestID,          // subscriptionRequestID
-      AbsoluteLocation{5, 0}, // Start decreased from {10, 0} to {5, 0}
-      0,                      // endGroup (open-ended)
-      kDefaultPriority,
-      true}; // forward
+  SubscribeUpdate subscribeUpdate{RequestID(2),           // requestID for the update
+                                  sub.requestID,          // subscriptionRequestID
+                                  AbsoluteLocation{5, 0}, // Start decreased from {10, 0} to {5, 0}
+                                  0,                      // endGroup (open-ended)
+                                  kDefaultPriority,
+                                  true}; // forward
 
-  auto updateRes =
-      folly::coro::blockingWait(subscriber->requestUpdate(subscribeUpdate));
-  EXPECT_TRUE(updateRes.hasValue())
-      << "RequestUpdate with decreased start should succeed";
+  auto updateRes = folly::coro::blockingWait(subscriber->requestUpdate(subscribeUpdate));
+  EXPECT_TRUE(updateRes.hasValue()) << "RequestUpdate with decreased start should succeed";
 
   // Verify start location was updated
   EXPECT_EQ(subscriber->range.start, (AbsoluteLocation{5, 0}))
@@ -1480,13 +1366,10 @@ TEST_F(ORelayTest, SubgroupTombstonedAfterCancelledError) {
         // First object succeeds, second fails with CANCELLED
         EXPECT_CALL(*sg, object(0, _, _, false)).WillOnce(Return(folly::unit));
         EXPECT_CALL(*sg, object(1, _, _, false))
-            .WillOnce(Return(
-                folly::makeUnexpected(MoQPublishError(
-                    MoQPublishError::CANCELLED, "STOP_SENDING"))));
+            .WillOnce(Return(folly::makeUnexpected(
+                MoQPublishError(MoQPublishError::CANCELLED, "STOP_SENDING"))));
         // Per API contract, error implies implicit reset - no reset() call
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
       });
 
   // Second subgroup should still be created (subscription is alive)
@@ -1495,9 +1378,7 @@ TEST_F(ORelayTest, SubgroupTombstonedAfterCancelledError) {
       .WillOnce([this, &sg2](uint64_t, uint64_t, uint8_t, bool) {
         sg2 = createMockSubgroupConsumer();
         EXPECT_CALL(*sg2, endOfSubgroup()).WillOnce(Return(folly::unit));
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg2);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg2);
       });
 
   subscribeToTrack(subscriber, kTestTrackName, consumer, RequestID(1));
@@ -1546,16 +1427,13 @@ TEST_F(ORelayTest, TombstonedSubgroupIgnoresSubsequentObjects) {
         sg = createMockSubgroupConsumer();
         // First object fails with CANCELLED
         EXPECT_CALL(*sg, object(0, _, _, false))
-            .WillOnce(Return(
-                folly::makeUnexpected(MoQPublishError(
-                    MoQPublishError::CANCELLED, "delivery timeout"))));
+            .WillOnce(Return(folly::makeUnexpected(
+                MoQPublishError(MoQPublishError::CANCELLED, "delivery timeout"))));
         // Per API contract, error implies implicit reset - no reset() call
         // After tombstoning, should NOT receive any more objects
         EXPECT_CALL(*sg, object(1, _, _, _)).Times(0);
         EXPECT_CALL(*sg, object(2, _, _, _)).Times(0);
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
       });
 
   subscribeToTrack(subscriber, kTestTrackName, consumer, RequestID(1));
@@ -1600,13 +1478,10 @@ TEST_F(ORelayTest, LateJoinerGetsSubgroupAfterTombstone) {
       .WillOnce([this, &sg1](uint64_t, uint64_t, uint8_t, bool) {
         sg1 = createMockSubgroupConsumer();
         EXPECT_CALL(*sg1, object(0, _, _, false))
-            .WillOnce(Return(
-                folly::makeUnexpected(MoQPublishError(
-                    MoQPublishError::CANCELLED, "STOP_SENDING"))));
+            .WillOnce(Return(folly::makeUnexpected(
+                MoQPublishError(MoQPublishError::CANCELLED, "STOP_SENDING"))));
         // Per API contract, error implies implicit reset - no reset() call
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg1);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg1);
       });
 
   // Second subscriber (late joiner) should still get the subgroup
@@ -1618,9 +1493,7 @@ TEST_F(ORelayTest, LateJoinerGetsSubgroupAfterTombstone) {
         sg2 = createMockSubgroupConsumer();
         EXPECT_CALL(*sg2, object(1, _, _, false)).WillOnce(Return(folly::unit));
         EXPECT_CALL(*sg2, endOfSubgroup()).WillOnce(Return(folly::unit));
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg2);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg2);
       });
 
   // Subscribe first subscriber
@@ -1664,14 +1537,11 @@ TEST_F(ORelayTest, HardErrorsRemoveSubscriber) {
       .WillOnce([this, &sg](uint64_t, uint64_t, uint8_t, bool) {
         sg = createMockSubgroupConsumer();
         EXPECT_CALL(*sg, object(0, _, _, false))
-            .WillOnce(Return(
-                folly::makeUnexpected(MoQPublishError(
-                    MoQPublishError::WRITE_ERROR, "transport broken"))));
+            .WillOnce(Return(folly::makeUnexpected(
+                MoQPublishError(MoQPublishError::WRITE_ERROR, "transport broken"))));
         // Should be reset when subscriber is removed
         EXPECT_CALL(*sg, reset(_)).Times(1);
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
       });
 
   // publishDone should be called because subscription is being removed
@@ -1726,24 +1596,17 @@ TEST_F(ORelayTest, EndOfSubgroupHardErrorDoesNotCrash) {
         sg = createMockSubgroupConsumer();
         // Override endOfSubgroup to return a hard error (WRITE_ERROR)
         EXPECT_CALL(*sg, endOfSubgroup())
-            .WillOnce(Return(
-                folly::makeUnexpected(MoQPublishError(
-                    MoQPublishError::WRITE_ERROR, "transport broken"))));
-        return folly::
-            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
-                sg);
+            .WillOnce(Return(folly::makeUnexpected(
+                MoQPublishError(MoQPublishError::WRITE_ERROR, "transport broken"))));
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
       });
 
   // publishDone is called when subscription is removed due to hard error
   EXPECT_CALL(*consumer, publishDone(_))
       .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
 
-  subscribeToTrack(
-      subscriberSession,
-      kTestTrackName,
-      consumer,
-      RequestID(1),
-      /*addToState=*/false);
+  subscribeToTrack(subscriberSession, kTestTrackName, consumer, RequestID(1),
+                   /*addToState=*/false);
 
   // Begin subgroup - sets up the subscriber's subgroup consumer
   auto subgroupRes = publishConsumer->beginSubgroup(0, 0, 0);


### PR DESCRIPTION
EDIT: See #31 first

Result of running `scripts/format.sh`

I don't really like the result, but I also don't really care. We just should enforce some kind of formatting. 
We need CI enforcement of formatting soon, as this should have never get to main without proper formatting. 
I am not sure about the #13 state. Giovanni working hard on CI so I would rather not break his things. 

I think it's fine to merge this in its current form so that main has consistent `scripts/format.sh` and the actual files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/28)
<!-- Reviewable:end -->
