### PR TITLE
Add basic HTTP admin server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,11 @@ if(ORLY_BUILD_TESTS)
     LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
   )
   gtest_discover_tests(o_rly_config_resolver_test)
+
+  add_test(
+    NAME admin_info_endpoint
+    COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_info.sh $<TARGET_FILE:o_rly>
+  )
 endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/Lint.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ target_link_libraries(o_rly_core PUBLIC
 )
 
 target_compile_options(o_rly_core PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_definitions(o_rly_core PRIVATE ORLY_VERSION="${PROJECT_VERSION}")
 
 # --- Config types (resolved Config structs, header-only, no rfl dependency) ---
 # Library consumers that only need the Config API link this.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ FetchContent_MakeAvailable(reflectcpp)
 add_library(o_rly_core STATIC
   src/ORelay.cpp
   src/ORelayServer.cpp
+  src/admin/AdminServer.cpp
+  src/admin/BuiltinRoutes.cpp
 )
 
 target_include_directories(o_rly_core
@@ -84,6 +86,10 @@ target_link_libraries(o_rly_core PUBLIC
   moxygen::moxygen_relay_moq_cache
   moxygen::moxygen_moq_relay_session
   moxygen::moxygen_moq_server
+  proxygen::proxygenhttpserver
+  # Workaround: wangle::wangle_acceptor_acceptor_core uses AsyncFdSocket from
+  # FizzAcceptorHandshakeHelper but omits this dep from its cmake config.
+  Folly::folly_io_async_fdsock_async_fd_socket
 )
 
 target_compile_options(o_rly_core PRIVATE -Wall -Wextra -Wpedantic)

--- a/include/o_rly/admin/AdminServer.h
+++ b/include/o_rly/admin/AdminServer.h
@@ -47,7 +47,7 @@ public:
   AdminServer();
   ~AdminServer();
 
-  // Register a route. Must be called before start().
+  // Register a route. Must be called before start(); CHECKs if called after.
   void addRoute(std::string method, std::string path, RouteHandler handler);
 
   // Start the HTTP admin server on the given port. Blocks until the server is

--- a/include/o_rly/admin/AdminServer.h
+++ b/include/o_rly/admin/AdminServer.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <folly/io/IOBuf.h>
+
+// Forward declarations
+namespace proxygen {
+class ScopedHTTPServer;
+class HTTPMessage;
+class ResponseHandler;
+} // namespace proxygen
+
+namespace openmoq::o_rly::admin {
+
+// Route handler: receives the complete request (headers + body) and owns the
+// response. May respond asynchronously — launch a coroutine and send via
+// downstream later.
+using RouteHandler = std::function<void(
+    std::unique_ptr<proxygen::HTTPMessage> req,
+    std::unique_ptr<folly::IOBuf> body,
+    proxygen::ResponseHandler* downstream
+)>;
+
+struct Route {
+  std::string method;
+  std::string path;
+  RouteHandler handler;
+};
+
+// Wraps proxygen::HTTPServer with a simple method+path route table.
+//
+// Call addRoute() before start(); call stop() on shutdown.
+//
+// Async handlers (e.g. Prometheus scrape) launch a coroutine from within
+// the RouteHandler and send the response asynchronously via downstream.
+//
+// Note: Uses proxygen/httpserver/HTTPServer.h (classic RequestHandler API).
+// Future: migrate to proxygen/lib/http/coro/server/HTTPServer.h.
+// Future: TLS/mTLS via wangle::SSLContextConfig (PR #29 config).
+// Future routes: GET /sessions for live session inspection.
+class AdminServer {
+public:
+  AdminServer();
+  ~AdminServer();
+
+  // Register a route. Must be called before start().
+  void addRoute(std::string method, std::string path, RouteHandler handler);
+
+  // Start the HTTP admin server on the given port. Blocks until the server is
+  // ready to accept connections (or fails). Returns true on success.
+  bool start(uint16_t port);
+
+  // Stop the admin server.
+  void stop();
+
+private:
+  std::vector<Route> routes_;
+  std::unique_ptr<proxygen::ScopedHTTPServer> httpServer_;
+};
+
+} // namespace openmoq::o_rly::admin

--- a/include/o_rly/admin/BuiltinRoutes.h
+++ b/include/o_rly/admin/BuiltinRoutes.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace openmoq::o_rly::admin {
+
+class AdminServer;
+
+// Registers built-in admin routes: GET /info, and future /health, /version.
+void registerBuiltinRoutes(AdminServer& server);
+
+} // namespace openmoq::o_rly::admin

--- a/src/admin/AdminServer.cpp
+++ b/src/admin/AdminServer.cpp
@@ -1,0 +1,112 @@
+#include <o_rly/admin/AdminServer.h>
+
+#include <folly/io/IOBufQueue.h>
+#include <folly/logging/xlog.h>
+#include <proxygen/httpserver/RequestHandler.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <proxygen/httpserver/ScopedHTTPServer.h>
+
+namespace openmoq::o_rly::admin {
+
+// ---------------------------------------------------------------------------
+// AdminRequestHandler — generic request aggregator
+//
+// The only proxygen::RequestHandler subclass needed. Accumulates request
+// headers and body, then dispatches to the RouteHandler on EOM.
+// ---------------------------------------------------------------------------
+class AdminRequestHandler : public proxygen::RequestHandler {
+public:
+  explicit AdminRequestHandler(RouteHandler handler) : handler_(std::move(handler)) {}
+
+  void onRequest(std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override {
+    req_ = std::move(headers);
+  }
+
+  void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override {
+    body_.append(std::move(body));
+  }
+
+  void onEOM() noexcept override { handler_(std::move(req_), body_.move(), downstream_); }
+
+  void onUpgrade(proxygen::UpgradeProtocol /*proto*/) noexcept override {}
+
+  void requestComplete() noexcept override { delete this; }
+
+  void onError(proxygen::ProxygenError /*err*/) noexcept override { delete this; }
+
+private:
+  RouteHandler handler_;
+  std::unique_ptr<proxygen::HTTPMessage> req_;
+  folly::IOBufQueue body_{folly::IOBufQueue::cacheChainLength()};
+};
+
+// ---------------------------------------------------------------------------
+// AdminHandlerFactory — holds the route table and creates AdminRequestHandlers
+// ---------------------------------------------------------------------------
+class AdminHandlerFactory : public proxygen::RequestHandlerFactory {
+public:
+  explicit AdminHandlerFactory(std::vector<Route> routes) : routes_(std::move(routes)) {}
+
+  void onServerStart(folly::EventBase* /*evb*/) noexcept override {}
+  void onServerStop() noexcept override {}
+
+  proxygen::RequestHandler*
+  onRequest(proxygen::RequestHandler* /*upstream*/, proxygen::HTTPMessage* msg) noexcept override {
+    const auto& method = msg->getMethodString();
+    const auto& path = msg->getPath();
+
+    for (const auto& route : routes_) {
+      if (route.method == method && route.path == path) {
+        return new AdminRequestHandler(route.handler);
+      }
+    }
+
+    // Unknown route → 404
+    return new AdminRequestHandler([](auto /*req*/, auto /*body*/, auto* downstream) {
+      proxygen::ResponseBuilder(downstream)
+          .status(404, "Not Found")
+          .body(folly::IOBuf::copyBuffer("Not Found\n"))
+          .sendWithEOM();
+    });
+  }
+
+private:
+  std::vector<Route> routes_;
+};
+
+// ---------------------------------------------------------------------------
+// AdminServer
+// ---------------------------------------------------------------------------
+
+AdminServer::AdminServer() = default;
+AdminServer::~AdminServer() = default;
+
+void AdminServer::addRoute(std::string method, std::string path, RouteHandler handler) {
+  routes_.push_back({std::move(method), std::move(path), std::move(handler)});
+}
+
+bool AdminServer::start(uint16_t port) {
+  proxygen::HTTPServerOptions options;
+  options.threads = 1;
+  options.handlerFactories.push_back(std::make_unique<AdminHandlerFactory>(routes_));
+
+  proxygen::HTTPServer::IPConfig cfg{
+      folly::SocketAddress("::", port),
+      proxygen::HTTPServer::Protocol::HTTP
+  };
+
+  try {
+    httpServer_ = proxygen::ScopedHTTPServer::start(std::move(cfg), std::move(options));
+    return true;
+  } catch (const std::exception& ex) {
+    XLOG(ERR) << "AdminServer failed to start on port " << port << ": " << ex.what();
+    return false;
+  }
+}
+
+void AdminServer::stop() {
+  httpServer_.reset();
+}
+
+} // namespace openmoq::o_rly::admin

--- a/src/admin/AdminServer.cpp
+++ b/src/admin/AdminServer.cpp
@@ -6,6 +6,7 @@
 #include <proxygen/httpserver/RequestHandlerFactory.h>
 #include <proxygen/httpserver/ResponseBuilder.h>
 #include <proxygen/httpserver/ScopedHTTPServer.h>
+#include <proxygen/lib/http/HTTPMessage.h>
 
 namespace openmoq::o_rly::admin {
 
@@ -65,7 +66,7 @@ public:
     // Unknown route → 404
     return new AdminRequestHandler([](auto /*req*/, auto /*body*/, auto* downstream) {
       proxygen::ResponseBuilder(downstream)
-          .status(404, "Not Found")
+          .status(404, proxygen::HTTPMessage::getDefaultReason(404))
           .body(folly::IOBuf::copyBuffer("Not Found\n"))
           .sendWithEOM();
     });
@@ -83,12 +84,15 @@ AdminServer::AdminServer() = default;
 AdminServer::~AdminServer() = default;
 
 void AdminServer::addRoute(std::string method, std::string path, RouteHandler handler) {
+  XCHECK(!httpServer_) << "addRoute() called after start()";
   routes_.push_back({std::move(method), std::move(path), std::move(handler)});
 }
 
+static constexpr int kAdminServerThreads = 1;
+
 bool AdminServer::start(uint16_t port) {
   proxygen::HTTPServerOptions options;
-  options.threads = 1;
+  options.threads = kAdminServerThreads;
   options.handlerFactories.push_back(std::make_unique<AdminHandlerFactory>(routes_));
 
   proxygen::HTTPServer::IPConfig cfg{

--- a/src/admin/BuiltinRoutes.cpp
+++ b/src/admin/BuiltinRoutes.cpp
@@ -1,0 +1,20 @@
+#include <o_rly/admin/BuiltinRoutes.h>
+
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+
+#include <o_rly/admin/AdminServer.h>
+
+namespace openmoq::o_rly::admin {
+
+void registerBuiltinRoutes(AdminServer& server) {
+  server.addRoute("GET", "/info", [](auto /*req*/, auto /*body*/, auto* downstream) {
+    proxygen::ResponseBuilder(downstream)
+        .status(200, "OK")
+        .header("Content-Type", "application/json")
+        .body(folly::IOBuf::copyBuffer("{\"service\":\"o-rly\",\"version\":\"0.1.0\"}\n"))
+        .sendWithEOM();
+  });
+}
+
+} // namespace openmoq::o_rly::admin

--- a/src/admin/BuiltinRoutes.cpp
+++ b/src/admin/BuiltinRoutes.cpp
@@ -2,6 +2,7 @@
 
 #include <folly/io/IOBuf.h>
 #include <proxygen/httpserver/ResponseBuilder.h>
+#include <proxygen/lib/http/HTTPMessage.h>
 
 #include <o_rly/admin/AdminServer.h>
 
@@ -10,9 +11,11 @@ namespace openmoq::o_rly::admin {
 void registerBuiltinRoutes(AdminServer& server) {
   server.addRoute("GET", "/info", [](auto /*req*/, auto /*body*/, auto* downstream) {
     proxygen::ResponseBuilder(downstream)
-        .status(200, "OK")
+        .status(200, proxygen::HTTPMessage::getDefaultReason(200))
         .header("Content-Type", "application/json")
-        .body(folly::IOBuf::copyBuffer("{\"service\":\"o-rly\",\"version\":\"0.1.0\"}\n"))
+        .body(
+            folly::IOBuf::copyBuffer("{\"service\":\"o-rly\",\"version\":\"" ORLY_VERSION "\"}\n")
+        )
         .sendWithEOM();
   });
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,10 @@
 #include <o_rly/admin/BuiltinRoutes.h>
 #include <o_rly/config/loader/config_init.h>
 
+#include <csignal>
+
 #include <folly/init/Init.h>
+#include <folly/io/async/AsyncSignalHandler.h>
 #include <folly/logging/xlog.h>
 
 #include <iostream>
@@ -18,6 +21,19 @@ namespace {
 namespace cfg = openmoq::o_rly::config;
 
 constexpr std::string_view kServeCommand = "serve";
+
+class ShutdownSignalHandler : public folly::AsyncSignalHandler {
+public:
+  explicit ShutdownSignalHandler(folly::EventBase* evb) : AsyncSignalHandler(evb) {
+    registerSignalHandler(SIGTERM);
+    registerSignalHandler(SIGINT);
+  }
+
+  void signalReceived(int signum) noexcept override {
+    XLOG(INFO) << "Received signal " << signum << ", shutting down";
+    getEventBase()->terminateLoopSoon();
+  }
+};
 
 std::shared_ptr<openmoq::o_rly::ORelayServer> createServer(const cfg::Config& resolved) {
   const auto& listener = resolved.listener;
@@ -88,12 +104,11 @@ int main(int argc, char* argv[]) {
   // (currently handled implicitly by folly::Init)
 
   // === 3. Set up signal handling ===
-  // TODO: SIGINT, SIGTERM handlers for graceful shutdown
-  // Use a shutdown promise/future triggered by signals
+  folly::EventBase evb;
+  ShutdownSignalHandler signalHandler(&evb);
 
   // === 4. Initialize resources ===
   // TODO: thread pools, event loops, IO contexts
-  folly::EventBase evb;
 
   // === 5. Initialize dependencies ===
   // TODO: TBD

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 
 DEFINE_string(config, "", "Path to config file (required)");
 DEFINE_bool(strict_config, false, "Reject unknown config fields");
-DEFINE_int32(admin_port, 9669, "HTTP admin port (0 to disable)");
+DEFINE_int32(admin_port, 9669, "HTTP admin port");
 
 namespace {
 
@@ -105,14 +105,11 @@ int main(int argc, char* argv[]) {
 
   // === 7. Start health checks / admin endpoints ===
   openmoq::o_rly::admin::AdminServer adminServer;
-  if (FLAGS_admin_port != 0) {
-    openmoq::o_rly::admin::registerBuiltinRoutes(adminServer);
-    if (!adminServer.start(static_cast<uint16_t>(FLAGS_admin_port))) {
-      XLOG(ERR) << "Failed to start admin server on port " << FLAGS_admin_port;
-    } else {
-      XLOG(INFO) << "Admin server listening on port " << FLAGS_admin_port;
-    }
+  openmoq::o_rly::admin::registerBuiltinRoutes(adminServer);
+  if (!adminServer.start(static_cast<uint16_t>(FLAGS_admin_port))) {
+    XLOG(FATAL) << "Failed to start admin server on port " << FLAGS_admin_port;
   }
+  XLOG(INFO) << "Admin server listening on port " << FLAGS_admin_port;
 
   // === 8. Start serving ===
   // Bind listeners, accept connections, enter event loop

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,6 @@
 #include <o_rly/ORelayServer.h>
+#include <o_rly/admin/AdminServer.h>
+#include <o_rly/admin/BuiltinRoutes.h>
 #include <o_rly/config/loader/config_init.h>
 
 #include <folly/init/Init.h>
@@ -9,6 +11,7 @@
 
 DEFINE_string(config, "", "Path to config file (required)");
 DEFINE_bool(strict_config, false, "Reject unknown config fields");
+DEFINE_int32(admin_port, 9669, "HTTP admin port (0 to disable)");
 
 namespace {
 
@@ -101,8 +104,15 @@ int main(int argc, char* argv[]) {
   auto server = createServer(config);
 
   // === 7. Start health checks / admin endpoints ===
-  // TODO: readiness/liveness probes
-  // Health state machine: starting -> healthy -> draining -> stopped
+  openmoq::o_rly::admin::AdminServer adminServer;
+  if (FLAGS_admin_port != 0) {
+    openmoq::o_rly::admin::registerBuiltinRoutes(adminServer);
+    if (!adminServer.start(static_cast<uint16_t>(FLAGS_admin_port))) {
+      XLOG(ERR) << "Failed to start admin server on port " << FLAGS_admin_port;
+    } else {
+      XLOG(INFO) << "Admin server listening on port " << FLAGS_admin_port;
+    }
+  }
 
   // === 8. Start serving ===
   // Bind listeners, accept connections, enter event loop
@@ -127,7 +137,8 @@ int main(int argc, char* argv[]) {
   // TODO: ensure observability data is sent
 
   // === 13. Clean up resources ===
-  // TODO: TBD
+  // Stop admin last — allows a final metrics scrape during drain.
+  adminServer.stop();
 
   // === 14. Exit with appropriate code ===
   return 0;

--- a/tests/test.config.yaml
+++ b/tests/test.config.yaml
@@ -1,0 +1,14 @@
+# Minimal config for integration tests (insecure, no TLS).
+listeners:
+  - name: main
+    udp:
+      socket:
+        address: "::"
+        port: 9668
+    tls:
+      insecure: true
+    endpoint: "/moq-relay"
+cache:
+  enabled: true
+  max_tracks: 100
+  max_groups_per_track: 3

--- a/tests/test_admin_info.sh
+++ b/tests/test_admin_info.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINARY="${1:-$(dirname "$0")/../build/o_rly}"
+TESTDIR="$(cd "$(dirname "$0")" && pwd)"
+ADMIN_PORT=9669
+ADMIN_URL="http://localhost:${ADMIN_PORT}/info"
+
+if [[ ! -x "$BINARY" ]]; then
+  echo "ERROR: binary not found or not executable: $BINARY" >&2
+  exit 1
+fi
+
+# Start o_rly with test config in the background.
+"$BINARY" --config="$TESTDIR/test.config.yaml" --admin_port="$ADMIN_PORT" &
+O_RLY_PID=$!
+trap 'kill "$O_RLY_PID" 2>/dev/null; wait "$O_RLY_PID" 2>/dev/null || true' EXIT
+
+# Wait for the admin server to become ready (up to 5 s).
+for i in $(seq 1 50); do
+  if curl -sf "$ADMIN_URL" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+  if [[ $i -eq 50 ]]; then
+    echo "ERROR: admin server did not become ready in time" >&2
+    exit 1
+  fi
+done
+
+# Fetch the /info response.
+RESPONSE=$(curl -sf "$ADMIN_URL")
+echo "Response: $RESPONSE"
+
+# Validate expected fields.
+if ! echo "$RESPONSE" | grep -q '"service":"o-rly"'; then
+  echo "FAIL: missing \"service\":\"o-rly\" in response" >&2
+  exit 1
+fi
+
+if ! echo "$RESPONSE" | grep -q '"version":'; then
+  echo "FAIL: missing \"version\" field in response" >&2
+  exit 1
+fi
+
+echo "PASS"


### PR DESCRIPTION
Introduces AdminServer wrapping proxygen::ScopedHTTPServer with a simple method+path route table and a generic request aggregator. Routes are registered via addRoute() before start(); async handlers can launch coroutines and respond via downstream.

We will migrate to proxygen::coro::HTTPServer when proxygen::coro finishes WebTransport support.  For now, we'll use proxygen::HTTPServer.

Adds registerBuiltinRoutes() with GET /info returning a JSON version string. Wires up --admin_port flag (default 9669, 0 to disable) in main.

Workaround: wangle::wangle_acceptor_acceptor_core omits Folly::folly_io_async_fdsock_async_fd_socket from its cmake deps (FizzAcceptorHandshakeHelper uses AsyncFdSocket); added explicitly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/34)
<!-- Reviewable:end -->
