### PR TITLE
macOS CI, notifications, rolling snapshot release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,5 @@ jobs:
           name: "test (${{ matrix.name }})"
           path: ${{ matrix.build_dir }}/test-results.xml
           reporter: java-junit
+          fail-on-empty: 'false'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: build
+name: verify
 
 on:
   pull_request:
@@ -19,11 +19,17 @@ jobs:
           - name: linux
             preset: default
             build_dir: build
+            runner: ubuntu-22.04
+          - name: macos
+            preset: default
+            build_dir: build
+            runner: macos-15
           - name: asan debug
             preset: san
             build_dir: build-san
+            runner: ubuntu-22.04
     name: ${{ matrix.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,7 +47,7 @@ jobs:
         run: bash scripts/configure.sh ${{ matrix.build_dir }} ${{ matrix.preset }}
 
       - name: Build
-        run: cmake --build ${{ matrix.build_dir }} -j$(nproc)
+        run: cmake --build ${{ matrix.build_dir }} -j$(getconf _NPROCESSORS_ONLN)
 
       - name: Test
         env:

--- a/.github/workflows/notify-main-failure.yml
+++ b/.github/workflows/notify-main-failure.yml
@@ -25,7 +25,7 @@ jobs:
           SHORT="${{ github.event.workflow_run.head_sha }}"
           SHORT="${SHORT:0:7}"
           RUN_URL="${{ github.event.workflow_run.html_url }}"
-          TEXT=":x: *${{ github.repository }}* \`main\` \`${SHORT}\` — build failed: Run <${RUN_URL}|#${{ github.event.workflow_run.run_number }}>"
+          TEXT=":x: *${{ github.repository }}* \`main\` \`${SHORT}\` — verify failed: <${RUN_URL}|#${{ github.event.workflow_run.run_number }}>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"
@@ -40,8 +40,8 @@ jobs:
           SHORT="${{ github.event.workflow_run.head_sha }}"
           SHORT="${SHORT:0:7}"
           RUN_URL="${{ github.event.workflow_run.html_url }}"
-          SUBJECT="[o-rly] build failed on main ${SHORT}"
-          BODY="Build failed on main.\n\nCommit: ${{ github.event.workflow_run.head_sha }}\nRun: ${RUN_URL}"
+          SUBJECT="[o-rly] verify failed on main ${SHORT}"
+          BODY="Verify failed on main.\n\nCommit: ${{ github.event.workflow_run.head_sha }}\nRun: ${RUN_URL}"
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \
             --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \

--- a/.github/workflows/notify-main-failure.yml
+++ b/.github/workflows/notify-main-failure.yml
@@ -1,11 +1,11 @@
 name: notify main failure
 
-# Fires only when the build workflow completes on main (push events).
+# Fires only when the verify workflow completes on main (push events).
 # PR branch builds never match the branches: [main] filter.
 
 on:
   workflow_run:
-    workflows: ["build"]
+    workflows: ["verify"]
     types: [completed]
     branches: [main]
 
@@ -23,9 +23,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
         run: |
           SHORT="${{ github.event.workflow_run.head_sha }}"
-          SHORT="${SHORT:0:12}"
+          SHORT="${SHORT:0:7}"
           RUN_URL="${{ github.event.workflow_run.html_url }}"
-          TEXT=":x: *${{ github.repository }}* \`main\` CI failed — <${RUN_URL}|run>"
+          TEXT=":x: *${{ github.repository }}* \`main\` \`${SHORT}\` CI failed — run: <${RUN_URL}|view>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"
@@ -38,12 +38,14 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
         run: |
           SHORT="${{ github.event.workflow_run.head_sha }}"
-          SHORT="${SHORT:0:12}"
+          SHORT="${SHORT:0:7}"
           RUN_URL="${{ github.event.workflow_run.html_url }}"
+          SUBJECT="[o-rly] CI failed on main ${SHORT}"
+          BODY="CI failed on main.\n\nCommit: ${{ github.event.workflow_run.head_sha }}\nRun: ${RUN_URL}"
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \
             --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \
             --message "{
-              \"Subject\": {\"Data\": \"[o-rly] CI failed on main ${SHORT}\"},
-              \"Body\": {\"Text\": {\"Data\": \"${{ github.repository }} · main · ${SHORT}\n${RUN_URL}\"}}
+              \"Subject\": {\"Data\": \"${SUBJECT}\"},
+              \"Body\": {\"Text\": {\"Data\": \"${BODY}\"}}
             }"

--- a/.github/workflows/notify-main-failure.yml
+++ b/.github/workflows/notify-main-failure.yml
@@ -25,7 +25,7 @@ jobs:
           SHORT="${{ github.event.workflow_run.head_sha }}"
           SHORT="${SHORT:0:7}"
           RUN_URL="${{ github.event.workflow_run.html_url }}"
-          TEXT=":x: *${{ github.repository }}* \`main\` \`${SHORT}\` CI failed — run: <${RUN_URL}|view>"
+          TEXT=":x: *${{ github.repository }}* \`main\` \`${SHORT}\` build failed — run: <${RUN_URL}|view>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"
@@ -40,8 +40,8 @@ jobs:
           SHORT="${{ github.event.workflow_run.head_sha }}"
           SHORT="${SHORT:0:7}"
           RUN_URL="${{ github.event.workflow_run.html_url }}"
-          SUBJECT="[o-rly] CI failed on main ${SHORT}"
-          BODY="CI failed on main.\n\nCommit: ${{ github.event.workflow_run.head_sha }}\nRun: ${RUN_URL}"
+          SUBJECT="[o-rly] build failed on main ${SHORT}"
+          BODY="Build failed on main.\n\nCommit: ${{ github.event.workflow_run.head_sha }}\nRun: ${RUN_URL}"
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \
             --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \

--- a/.github/workflows/notify-main-failure.yml
+++ b/.github/workflows/notify-main-failure.yml
@@ -25,7 +25,7 @@ jobs:
           SHORT="${{ github.event.workflow_run.head_sha }}"
           SHORT="${SHORT:0:7}"
           RUN_URL="${{ github.event.workflow_run.html_url }}"
-          TEXT=":x: *${{ github.repository }}* \`main\` \`${SHORT}\` build failed — run: <${RUN_URL}|view>"
+          TEXT=":x: *${{ github.repository }}* \`main\` \`${SHORT}\` — build failed: Run <${RUN_URL}|#${{ github.event.workflow_run.run_number }}>"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
-name: publish release
+name: publish artifacts
 
 # Builds o-rly on each target platform and publishes per-architecture
-# artifact tarballs as a GitHub Release keyed by commit SHA.
+# artifact tarballs as a rolling GitHub pre-release (snapshot-latest).
 
 on:
   push:
@@ -20,6 +20,8 @@ jobs:
         include:
           - name: ubuntu-22.04-amd64
             runner: ubuntu-22.04
+          - name: macos-15-arm64
+            runner: macos-15
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
@@ -52,23 +54,25 @@ jobs:
             -DBUILD_TESTING=OFF
 
       - name: Build
-        run: cmake --build _build -j$(nproc)
+        run: cmake --build _build -j$(getconf _NPROCESSORS_ONLN)
 
       - name: Install
         run: cmake --install _build --prefix "$GITHUB_WORKSPACE/install"
 
       - name: Log in to GHCR
+        if: runner.os == 'Linux'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
+        if: runner.os == 'Linux'
         run: |
-          SHORT="${GITHUB_SHA:0:12}"
+          SHORT="${GITHUB_SHA:0:7}"
           IMAGE="ghcr.io/${{ github.repository }}"
           docker build -f docker/Dockerfile \
-            -t "${IMAGE}:build-${SHORT}" \
+            -t "${IMAGE}:${SHORT}" \
             -t "${IMAGE}:latest" \
             .
-          docker push "${IMAGE}:build-${SHORT}"
+          docker push "${IMAGE}:${SHORT}"
           docker push "${IMAGE}:latest"
 
       - name: Package
@@ -99,24 +103,31 @@ jobs:
         with:
           path: artifacts/
 
-      - name: Create release
+      - name: Publish snapshot
         if: needs.build.result == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          SHORT="${GITHUB_SHA:0:12}"
-          TAG="build-${SHORT}"
-          gh release create "$TAG" artifacts/**/* \
-            --repo "${{ github.repository }}" \
-            --title "build ${SHORT}" \
-            --notes "Automated release from \`${{ github.ref_name }}\` at \`${SHORT}\`. Docker: \`ghcr.io/${{ github.repository }}:build-${SHORT}\`."
+          SHORT="${GITHUB_SHA:0:7}"
+          TAG="snapshot-latest"
 
-          # Prune old releases, keep 20
-          gh api "repos/${{ github.repository }}/releases" \
-            --jq 'sort_by(.created_at) | reverse | .[20:] | .[].tag_name' \
-          | while read -r tag; do
-              gh release delete "$tag" --repo "${{ github.repository }}" --yes --cleanup-tag 2>/dev/null || true
-            done
+          gh release delete "$TAG" --yes 2>/dev/null || true
+          git tag -d "$TAG" 2>/dev/null || true
+          git push origin ":refs/tags/$TAG" 2>/dev/null || true
+
+          gh release create "$TAG" artifacts/**/* \
+            --title "Latest build ($SHORT)" \
+            --prerelease \
+            --notes "$(cat <<EOF
+          Rolling snapshot of the latest build from \`main\`.
+
+          **Commit:** \`${GITHUB_SHA}\`
+          **Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          **Docker:** \`ghcr.io/${{ github.repository }}:${SHORT}\`
+
+          This pre-release is automatically replaced on every push to \`main\`.
+          EOF
+          )"
 
       - name: Notify Slack
         if: always()
@@ -124,13 +135,13 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
         run: |
-          SHORT="${GITHUB_SHA:0:12}"
+          SHORT="${GITHUB_SHA:0:7}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ "${{ needs.build.result }}" = "success" ]; then
-            REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/build-${SHORT}"
-            TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — <${REL_URL}|release> · <${RUN_URL}|run>"
+            REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
+            TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — run: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
           else
-            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — build failed · <${RUN_URL}|run>"
+            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — run: <${RUN_URL}|#${{ github.run_number }}>"
           fi
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
@@ -144,21 +155,20 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OMOQ_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          SHORT="${GITHUB_SHA:0:12}"
+          SHORT="${GITHUB_SHA:0:7}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          REPO_NAME="${{ github.event.repository.name }}"
-          RESULT="${{ needs.build.result }}"
-          JOB_STATUS="${{ job.status }}"
-          if [ "$RESULT" = "success" ] && [ "$JOB_STATUS" = "success" ]; then
-            SUBJECT="[${REPO_NAME}] published ${{ github.ref_name }} ${SHORT}"
+          if [ "${{ needs.build.result }}" = "success" ]; then
+            REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
+            SUBJECT="[o-rly] published ${{ github.ref_name }} ${SHORT}"
+            BODY="Repository: ${{ github.repository }}\nBranch: ${{ github.ref_name }}\nCommit: ${GITHUB_SHA}\nDocker: ghcr.io/${{ github.repository }}:${SHORT}\nArtifacts: ${REL_URL}\nRun: ${RUN_URL}"
           else
-            SUBJECT="[${REPO_NAME}] build FAILED ${{ github.ref_name }} ${SHORT}"
+            SUBJECT="[o-rly] build FAILED ${{ github.ref_name }} ${SHORT}"
+            BODY="Repository: ${{ github.repository }}\nBranch: ${{ github.ref_name }}\nCommit: ${GITHUB_SHA}\nRun: ${RUN_URL}"
           fi
-          BODY="${{ github.repository }} · ${{ github.ref_name }} · ${SHORT}\n${RUN_URL}"
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \
             --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \
             --message "{
-              \"Subject\": {\"Data\": \"$SUBJECT\"},
-              \"Body\": {\"Text\": {\"Data\": \"$BODY\"}}
+              \"Subject\": {\"Data\": \"${SUBJECT}\"},
+              \"Body\": {\"Text\": {\"Data\": \"${BODY}\"}}
             }"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,7 +141,7 @@ jobs:
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
             TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
           else
-            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release: <${RUN_URL}|#${{ github.run_number }}>"
+            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release failed: <${RUN_URL}|#${{ github.run_number }}>"
           fi
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -34,9 +41,9 @@ jobs:
       - name: Install system dependencies
         run: bash deps/moxygen/standalone/install-system-deps.sh
 
-      - name: Download moxygen release tarball
+      - name: Download moxygen artifacts
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bash scripts/setup-deps-tarball.sh
 
       - name: Set up ccache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,9 +139,9 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ "${{ needs.build.result }}" = "success" ]; then
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
-            TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — run: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
+            TEXT=":white_check_mark: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release: <${RUN_URL}|#${{ github.run_number }}> artifacts: <${REL_URL}|view>"
           else
-            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — run: <${RUN_URL}|#${{ github.run_number }}>"
+            TEXT=":x: *${{ github.repository }}* \`${{ github.ref_name }}\` \`${SHORT}\` — publish release: <${RUN_URL}|#${{ github.run_number }}>"
           fi
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,12 +23,9 @@ jobs:
       matrix:
         include:
           - name: ubuntu-22.04-amd64
-            runner: ubuntu-22.04
-          - name: macos-15-arm64
-            runner: macos-15
 
     name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Generate app token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: publish
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write  # for Docker image publishing to GHCR

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,6 +31,13 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -38,9 +45,9 @@ jobs:
       - name: Install system dependencies
         run: bash deps/moxygen/standalone/install-system-deps.sh
 
-      - name: Download moxygen release tarball
+      - name: Download moxygen artifacts
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bash scripts/setup-deps-tarball.sh
 
       - name: Configure

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -80,5 +80,5 @@ jobs:
           name: "test (${{ matrix.name }})"
           path: ${{ matrix.build_dir }}/test-results.xml
           reporter: java-junit
-          fail-on-empty: 'false'
+          fail-on-empty: ${{ job.status == 'success' && 'true' || 'false' }}
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,10 +32,6 @@ jobs:
             preset: default
             build_dir: build
             runner: ubuntu-22.04
-          - name: macos
-            preset: default
-            build_dir: build
-            runner: macos-15
           - name: asan debug
             preset: san
             build_dir: build-san

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,8 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_FIND_LIBRARY_SUFFIXES": ".a",
-        "CMAKE_MODULE_PATH": "${sourceDir}/cmake"
+        "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
       }
     },
     {
@@ -26,7 +27,8 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "ORLY_ENABLE_SANITIZERS": "ON",
         "CMAKE_FIND_LIBRARY_SUFFIXES": ".a",
-        "CMAKE_MODULE_PATH": "${sourceDir}/cmake"
+        "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
       }
     }
   ],

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,16 @@
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends libssl3 && rm -rf /var/lib/apt/lists/*
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libboost-context1.74.0 \
+        libdouble-conversion3 \
+        libevent-2.1-7 \
+        libfmt8 \
+        libgflags2.2 \
+        libgoogle-glog0v5 \
+        libsodium23 \
+        libssl3 \
+        libunwind8 \
+        libzstd1 \
+    && rm -rf /var/lib/apt/lists/*
 COPY install/bin/o_rly /usr/local/bin/o-rly
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,7 @@
-FROM ubuntu:22.04
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libboost-context1.74.0 \
-        libdouble-conversion3 \
-        libevent-2.1-7 \
-        libfmt8 \
-        libgflags2.2 \
-        libgoogle-glog0v5 \
-        libsodium23 \
-        libssl3 \
+        libfmt9 \
         libunwind8 \
-        libzstd1 \
     && rm -rf /var/lib/apt/lists/*
 COPY install/bin/o_rly /usr/local/bin/o-rly
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # setup-deps-tarball.sh — Populate .scratch with prebuilt moxygen release artifacts.
 #
-# Downloads the snapshot-latest release tarball from openmoq/moxygen.
+# Uses the submodule commit SHA to find the exact publish workflow run
+# on openmoq/moxygen, then downloads the matching platform artifact.
 # Writes .scratch/cmake_prefix_path.txt for configure.sh.
 #
 # Usage:
 #   ./scripts/setup-deps-tarball.sh
 #
-# Requires: gh CLI authenticated, deps/moxygen submodule initialized.
+# Requires: gh CLI authenticated (with actions:read on openmoq/moxygen),
+#           deps/moxygen submodule initialized.
 
 set -euo pipefail
 
@@ -61,29 +63,40 @@ detect_platform() {
 PLATFORM=$(detect_platform)
 echo "==> Platform: $PLATFORM"
 
-# ── Download from snapshot-latest ─────────────────────────────────────────────
+# ── Find publish run matching submodule SHA ───────────────────────────────────
 
 SHA=$(git -C "$MOXYGEN_DIR" rev-parse HEAD)
-TAG="snapshot-latest"
 echo "==> Moxygen submodule SHA: ${SHA:0:7}"
-echo "==> Downloading from release: $TAG"
-
-if ! gh api "repos/openmoq/moxygen/releases/tags/$TAG" --jq '.tag_name' >/dev/null 2>&1; then
-    echo "Error: release $TAG not found in openmoq/moxygen." >&2
-    echo "  The publish workflow may not have run yet." >&2
-    exit 1
-fi
 
 TARBALL="moxygen-${PLATFORM}.tar.gz"
 DOWNLOAD_DIR="${SCRATCH}/downloads"
 mkdir -p "$DOWNLOAD_DIR"
 
-echo "==> Downloading $TARBALL..."
-rm -f "${DOWNLOAD_DIR}/${TARBALL}"
-gh release download "$TAG" \
-    --repo openmoq/moxygen \
-    --pattern "$TARBALL" \
-    --dir "$DOWNLOAD_DIR"
+echo "==> Searching for publish run at ${SHA:0:7}..."
+RUN_ID=$(gh api "repos/openmoq/moxygen/actions/workflows/omoq-publish-artifacts.yml/runs?head_sha=${SHA}&status=success&per_page=1" \
+    --jq '.workflow_runs[0].id // empty')
+
+if [[ -n "$RUN_ID" ]]; then
+    echo "==> Found publish run $RUN_ID, downloading $TARBALL..."
+    rm -f "${DOWNLOAD_DIR}/${TARBALL}"
+    gh run download "$RUN_ID" \
+        --repo openmoq/moxygen \
+        --name "$TARBALL" \
+        --dir "$DOWNLOAD_DIR"
+else
+    echo "==> No publish run for ${SHA:0:7}, trying snapshot-latest release..."
+    if ! gh api "repos/openmoq/moxygen/releases/tags/snapshot-latest" --jq '.tag_name' >/dev/null 2>&1; then
+        echo "Error: no artifacts found for SHA ${SHA:0:7} and no snapshot-latest release." >&2
+        echo "  The publish workflow may not have run yet for this commit." >&2
+        exit 1
+    fi
+    rm -f "${DOWNLOAD_DIR}/${TARBALL}"
+    gh release download "snapshot-latest" \
+        --repo openmoq/moxygen \
+        --pattern "$TARBALL" \
+        --dir "$DOWNLOAD_DIR"
+    echo "  Warning: using snapshot-latest (may not match submodule SHA)"
+fi
 
 # ── Extract ───────────────────────────────────────────────────────────────────
 

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # setup-deps-tarball.sh — Populate .scratch with prebuilt moxygen release artifacts.
 #
-# Downloads the release tarball from openmoq/moxygen matching the current
-# submodule commit. Writes .scratch/cmake_prefix_path.txt for configure.sh.
+# Downloads the snapshot-latest release tarball from openmoq/moxygen.
+# Writes .scratch/cmake_prefix_path.txt for configure.sh.
 #
 # Usage:
 #   ./scripts/setup-deps-tarball.sh
@@ -61,19 +61,18 @@ detect_platform() {
 PLATFORM=$(detect_platform)
 echo "==> Platform: $PLATFORM"
 
-# ── Find release matching submodule SHA ───────────────────────────────────────
+# ── Download from snapshot-latest ─────────────────────────────────────────────
 
 SHA=$(git -C "$MOXYGEN_DIR" rev-parse HEAD)
-TAG="build-${SHA:0:12}"
-echo "==> Moxygen SHA: ${SHA:0:12}  →  release tag: $TAG"
+TAG="snapshot-latest"
+echo "==> Moxygen submodule SHA: ${SHA:0:7}"
+echo "==> Downloading from release: $TAG"
 
 if ! gh api "repos/openmoq/moxygen/releases/tags/$TAG" --jq '.tag_name' >/dev/null 2>&1; then
     echo "Error: release $TAG not found in openmoq/moxygen." >&2
-    echo "  The publish workflow may not have run yet for this commit." >&2
+    echo "  The publish workflow may not have run yet." >&2
     exit 1
 fi
-
-# ── Download ──────────────────────────────────────────────────────────────────
 
 TARBALL="moxygen-${PLATFORM}.tar.gz"
 DOWNLOAD_DIR="${SCRATCH}/downloads"

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -84,18 +84,10 @@ if [[ -n "$RUN_ID" ]]; then
         --name "$TARBALL" \
         --dir "$DOWNLOAD_DIR"
 else
-    echo "==> No publish run for ${SHA:0:7}, trying snapshot-latest release..."
-    if ! gh api "repos/openmoq/moxygen/releases/tags/snapshot-latest" --jq '.tag_name' >/dev/null 2>&1; then
-        echo "Error: no artifacts found for SHA ${SHA:0:7} and no snapshot-latest release." >&2
-        echo "  The publish workflow may not have run yet for this commit." >&2
-        exit 1
-    fi
-    rm -f "${DOWNLOAD_DIR}/${TARBALL}"
-    gh release download "snapshot-latest" \
-        --repo openmoq/moxygen \
-        --pattern "$TARBALL" \
-        --dir "$DOWNLOAD_DIR"
-    echo "  Warning: using snapshot-latest (may not match submodule SHA)"
+    echo "Error: no successful publish run found for moxygen SHA ${SHA:0:7}." >&2
+    echo "  The publish workflow may not have run yet for this commit." >&2
+    echo "  Check: https://github.com/openmoq/moxygen/actions/workflows/omoq-publish-artifacts.yml" >&2
+    exit 1
 fi
 
 # ── Extract ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Add macOS to CI and publish** — `macos-15` runner in both matrices
- **Rename workflows** — `build` → `verify`, `publish release` → `publish artifacts`
- **Fix notify-main-failure trigger** — `"build"` → `"verify"` (same class of bug as moxygen #56)
- **Standardize notifications** — bold `*org/repo*`, backtick branch/hash, verbose email
- **Update `setup-deps-tarball.sh`** — download from `snapshot-latest` instead of `build-<sha>` tag
- **Advance moxygen submodule** to `b4e4abd9` (includes #56 changes)

## Changes

| File | What |
|------|------|
| `ci.yml` | `name: verify`, add macOS matrix, `nproc` → `getconf _NPROCESSORS_ONLN` |
| `publish.yml` | `name: publish artifacts`, macOS matrix, Docker conditioned on Linux, snapshot-latest, standardized notifications |
| `notify-main-failure.yml` | Trigger `"verify"`, 7-char hashes, bold/code Slack format |
| `setup-deps-tarball.sh` | Download from `snapshot-latest` instead of `build-<sha>` |
| `deps/moxygen` | Submodule → `b4e4abd9` |

## Depends on

- [x] openmoq/moxygen#56 (merged)
- [ ] openmoq/moxygen#57 (Slack formatting — cosmetic, not blocking)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/40)
<!-- Reviewable:end -->
