### PR TITLE
CI: Add format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,18 @@ permissions:
   checks: write
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    container: debian:trixie
+    steps:
+      - name: Install tools
+        run: apt-get update && apt-get install -y --no-install-recommends ca-certificates git clang-format
+
+      - uses: actions/checkout@v4
+
+      - name: Check formatting
+        run: bash scripts/format.sh --check
+
   build:
     strategy:
       fail-fast: false

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,12 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FILES=$(rg --files -g '*.{h,hpp,cc,cpp,cxx}' include src tests tools)
+REQUIRED_CF_VERSION=19
+
+CF_BIN=${CF_BIN:-$(command -v clang-format-${REQUIRED_CF_VERSION} || command -v clang-format)}
+CF_VERSION=$(${CF_BIN} --version | sed -n 's/.*version \([0-9]*\)\..*/\1/p' | head -1)
+if [[ -z "${CF_VERSION}" ]]; then
+  echo "error: could not determine clang-format version" >&2
+  exit 1
+fi
+if [[ "${CF_VERSION}" -ne "${REQUIRED_CF_VERSION}" ]]; then
+  echo "error: clang-format ${REQUIRED_CF_VERSION} required, found ${CF_VERSION}" >&2
+  echo "Install clang-format ${REQUIRED_CF_VERSION}:" >&2
+  echo "  Debian/Ubuntu:  apt install clang-format-${REQUIRED_CF_VERSION}  (or https://apt.llvm.org)" >&2
+  echo "  macOS:          brew install llvm@${REQUIRED_CF_VERSION}" >&2
+  echo "  CentOS/RHEL:    yum install clang-tools-extra-${REQUIRED_CF_VERSION}.0  (EPEL/AppStream)" >&2
+  exit 1
+fi
+
+FILES=$(find include src tests tools -name '*.h' -o -name '*.hpp' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx')
 
 if [[ -z "${FILES}" ]]; then
   echo "No source files found."
   exit 0
 fi
 
-echo "Formatting files..."
-clang-format -i ${FILES}
+if [[ "${1:-}" == "--check" ]]; then
+  echo "Checking formatting..."
+  ${CF_BIN} --dry-run -Werror ${FILES}
+else
+  echo "Formatting files..."
+  ${CF_BIN} -i ${FILES}
+fi

--- a/src/admin/BuiltinRoutes.cpp
+++ b/src/admin/BuiltinRoutes.cpp
@@ -13,8 +13,7 @@ void registerBuiltinRoutes(AdminServer& server) {
     proxygen::ResponseBuilder(downstream)
         .status(200, proxygen::HTTPMessage::getDefaultReason(200))
         .header("Content-Type", "application/json")
-        .body(
-            folly::IOBuf::copyBuffer("{\"service\":\"o-rly\",\"version\":\"" ORLY_VERSION "\"}\n")
+        .body(folly::IOBuf::copyBuffer("{\"service\":\"o-rly\",\"version\":\"" ORLY_VERSION "\"}\n")
         )
         .sendWithEOM();
   });


### PR DESCRIPTION
Add --check flag to scripts/format.sh rather than calling clang-format
directly in ci.yml, so the set of matched files stays consistent between
local formatting and CI verification.

Replace rg with find in the script to avoid requiring ripgrep in CI.

Rename workflow from "build" to "ci" to match the filename and reflect
that it now covers more than building.

The format job uses ubuntu-24.04 (unlike the build jobs) to get a
reasonably modern clang-format, even though we target older compilers
for building.
  
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/42)
<!-- Reviewable:end -->
