### PR TITLE
Sync ORelay from moxygen relay (21c3597..b426e6c6); add sync-relay.sh

### DIFF
--- a/include/o_rly/ORelay.h
+++ b/include/o_rly/ORelay.h
@@ -61,6 +61,9 @@ public:
     XLOG(INFO) << "Processing goaway uri=" << goaway.newSessionUri;
   }
 
+  folly::coro::Task<moxygen::Publisher::TrackStatusResult> trackStatus(moxygen::TrackStatus req
+  ) override;
+
   std::shared_ptr<moxygen::MoQSession> findPublishNamespaceSession(const moxygen::TrackNamespace& ns
   );
 
@@ -76,8 +79,8 @@ public:
 
   // Test accessor: check if a publish exists and return node/publish state
   struct PublishState {
-    bool nodeExists{false};
-    std::shared_ptr<moxygen::MoQSession> session{nullptr};
+    bool nodeExists{false};                                // true if tree node exists
+    std::shared_ptr<moxygen::MoQSession> session{nullptr}; // publish session if exists
   };
   PublishState findPublishState(const moxygen::FullTrackName& ftn);
 
@@ -123,9 +126,20 @@ private:
 
     // Maps a track name to a the session performing the PUBLISH
     folly::F14FastMap<std::string, std::shared_ptr<moxygen::MoQSession>> publishes;
-    // Sessions with a SUBSCRIBE_NAMESPACE here, with their forward preference
-    // Key: session, Value: forward (true = forward data, false = don't forward)
-    folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, bool> sessions;
+
+    // Info stored per SUBSCRIBE_NAMESPACE subscriber
+    struct NamespaceSubscriberInfo {
+      bool forward{true};
+      moxygen::SubscribeNamespaceOptions options{moxygen::SubscribeNamespaceOptions::BOTH};
+      // Handle for sending NAMESPACE / NAMESPACE_DONE on the bidi stream
+      // (draft 16+). Null for draft <= 15.
+      std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> namespacePublishHandle;
+      // The namespace prefix this subscriber used for SUBSCRIBE_NAMESPACE
+      moxygen::TrackNamespace trackNamespacePrefix;
+    };
+
+    // Sessions with a SUBSCRIBE_NAMESPACE here, with their preferences
+    folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, NamespaceSubscriberInfo> sessions;
     // All active PUBLISH_NAMESPACEs for this node (includes prefix sessions)
     folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, std::shared_ptr<PublishNamespaceHandle>>
         namespacesPublished;
@@ -152,7 +166,9 @@ private:
       const moxygen::TrackNamespace& ns,
       bool createMissingNodes = false,
       MatchType matchType = MatchType::Exact,
-      std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>>* sessions = nullptr
+      std::vector<
+          std::pair<std::shared_ptr<moxygen::MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>*
+          sessions = nullptr
   );
 
   struct RelaySubscription {
@@ -182,7 +198,6 @@ private:
   folly::coro::Task<void> publishToSession(
       std::shared_ptr<moxygen::MoQSession> session,
       std::shared_ptr<moxygen::MoQForwarder> forwarder,
-      moxygen::PublishRequest pub,
       bool forward
   );
 

--- a/scripts/sync-relay.sh
+++ b/scripts/sync-relay.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# sync-relay.sh - Sync ORelay from deps/moxygen/moxygen/relay/
+#
+# Usage: scripts/sync-relay.sh [--no-build] [--no-test]
+#
+# Transforms:
+#   MoQRelay.h            -> include/o_rly/ORelay.h
+#   MoQRelay.cpp          -> src/ORelay.cpp
+#   test/MoQRelayTest.cpp -> tests/ORelayTest.cpp
+#
+# Name/namespace mappings applied:
+#   class MoQRelay           -> class ORelay
+#   namespace moxygen        -> namespace openmoq::o_rly
+#   unqualified moxygen types in header get moxygen:: prefix
+#   using namespace moxygen; added before namespace in .cpp
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MOXYGEN_RELAY="${REPO_ROOT}/deps/moxygen/moxygen/relay"
+
+NO_BUILD=false
+NO_TEST=false
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) NO_BUILD=true ;;
+    --no-test)  NO_TEST=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+MOXYGEN_REV="$(git -C "${REPO_ROOT}/deps/moxygen" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "==> Syncing relay files from moxygen @ ${MOXYGEN_REV}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: replace Meta-only Apache 2.0 copyright with combined OpenMOQ header
+# ─────────────────────────────────────────────────────────────────────────────
+replace_copyright() {
+  local file="$1"
+  python3 - "$file" <<'PYEOF'
+import re, sys
+path = sys.argv[1]
+with open(path) as f:
+    content = f.read()
+new_header = """\
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Originally from github.com/facebookexperimental/moxygen.
+ * See deps/moxygen/LICENSE for the original license terms.
+ *
+ * Copyright (c) OpenMOQ contributors.
+ */"""
+content = re.sub(
+    r'/\*.*?This source code is licensed under.*?\*/',
+    new_header, content, count=1, flags=re.DOTALL)
+with open(path, 'w') as f:
+    f.write(content)
+PYEOF
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: add moxygen:: qualifier to unqualified moxygen types
+#
+# Called only on the header, where we're now in namespace openmoq::o_rly and
+# moxygen types are no longer implicitly visible.  Uses negative lookbehind so
+# already-qualified occurrences (e.g. moxygen::Publisher) are left alone.
+# ─────────────────────────────────────────────────────────────────────────────
+qualify_moxygen_types() {
+  local file="$1"
+  perl -pi -e '
+    next if /^#include/;
+    s/(?<!moxygen::)\bPublisher\b/moxygen::Publisher/g;
+    s/(?<!moxygen::)\bSubscriber\b/moxygen::Subscriber/g;
+    s/(?<!moxygen::)\bMoQForwarder\b/moxygen::MoQForwarder/g;
+    s/(?<!moxygen::)\bMoQSession\b/moxygen::MoQSession/g;
+    s/(?<!moxygen::)\bMoQCache\b/moxygen::MoQCache/g;
+    s/(?<!moxygen::)\bTrackNamespace\b/moxygen::TrackNamespace/g;
+    s/(?<!moxygen::)\bTrackConsumer\b/moxygen::TrackConsumer/g;
+    s/(?<!moxygen::)\bFetchConsumer\b/moxygen::FetchConsumer/g;
+    s/(?<!moxygen::)\bFullTrackName\b/moxygen::FullTrackName/g;
+    s/(?<!moxygen::)\bSubscribeRequest\b/moxygen::SubscribeRequest/g;
+    s/(?<!moxygen::)\bSubscribeNamespaceOptions\b/moxygen::SubscribeNamespaceOptions/g;
+    s/(?<!moxygen::)\bSubscribeNamespace\b/moxygen::SubscribeNamespace/g;
+    s/(?<!moxygen::)\bPublishNamespace\b/moxygen::PublishNamespace/g;
+    s/(?<!moxygen::)\bPublishRequest\b/moxygen::PublishRequest/g;
+    s/(?<!moxygen::)\bGoaway\b/moxygen::Goaway/g;
+    s/(?<!moxygen::)\bTrackStatus\b/moxygen::TrackStatus/g;
+    s/(?<!moxygen::)\bRequestUpdate\b/moxygen::RequestUpdate/g;
+    s/(?<!moxygen::)\bRequestErrorCode\b/moxygen::RequestErrorCode/g;
+    s/(?<!moxygen::)\bRequestError\b/moxygen::RequestError/g;
+    s/(?<!moxygen::)\bRequestID\b/moxygen::RequestID/g;
+    s/(?<!moxygen::)\bFetch\b/moxygen::Fetch/g;
+    s/(?<!moxygen::)\bkDefaultMaxCachedTracks\b/moxygen::kDefaultMaxCachedTracks/g;
+    s/(?<!moxygen::)\bkDefaultMaxCachedGroupsPerTrack\b/moxygen::kDefaultMaxCachedGroupsPerTrack/g;
+  ' "$file"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. MoQRelay.h → include/o_rly/ORelay.h
+# ─────────────────────────────────────────────────────────────────────────────
+process_header() {
+  local src="${MOXYGEN_RELAY}/MoQRelay.h"
+  local dst="${REPO_ROOT}/include/o_rly/ORelay.h"
+  local tmp="${TMP_DIR}/ORelay.h"
+
+  echo "  MoQRelay.h -> include/o_rly/ORelay.h"
+  cp "$src" "$tmp"
+
+  replace_copyright "$tmp"
+
+  # Include style: "moxygen/relay/MoQRelay.h" -> <o_rly/ORelay.h>; other "..." -> <...>
+  sed -i 's|#include "moxygen/relay/MoQRelay\.h"|#include <o_rly/ORelay.h>|g' "$tmp"
+  sed -i 's|#include "\(moxygen/[^"]*\)"|#include <\1>|g' "$tmp"
+
+  # Class rename
+  sed -i 's/\bMoQRelay\b/ORelay/g' "$tmp"
+
+  # Namespace
+  sed -i 's/^namespace moxygen {$/namespace openmoq::o_rly {/' "$tmp"
+  sed -i 's|^} // namespace moxygen$|} // namespace openmoq::o_rly|' "$tmp"
+
+  # Qualify unqualified moxygen types (order matters: more specific before less specific)
+  qualify_moxygen_types "$tmp"
+
+  cp "$tmp" "$dst"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. MoQRelay.cpp → src/ORelay.cpp
+# ─────────────────────────────────────────────────────────────────────────────
+process_source() {
+  local src="${MOXYGEN_RELAY}/MoQRelay.cpp"
+  local dst="${REPO_ROOT}/src/ORelay.cpp"
+  local tmp="${TMP_DIR}/ORelay.cpp"
+
+  echo "  MoQRelay.cpp -> src/ORelay.cpp"
+  cp "$src" "$tmp"
+
+  replace_copyright "$tmp"
+
+  # Include style: relay header -> ORelay.h; other "..." -> <...>
+  sed -i 's|#include "moxygen/relay/MoQRelay\.h"|#include <o_rly/ORelay.h>|g' "$tmp"
+  sed -i 's|#include "\(moxygen/[^"]*\)"|#include <\1>|g' "$tmp"
+
+  # Class/method references
+  sed -i 's/\bMoQRelay\b/ORelay/g' "$tmp"
+
+  # Namespace: insert "using namespace moxygen;" before the namespace block
+  # so types in the implementation don't need moxygen:: qualification
+  sed -i 's/^namespace moxygen {$/using namespace moxygen;\n\nnamespace openmoq::o_rly {/' "$tmp"
+  sed -i 's|^} // namespace moxygen$|} // namespace openmoq::o_rly|' "$tmp"
+
+  cp "$tmp" "$dst"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. test/MoQRelayTest.cpp → tests/ORelayTest.cpp
+# ─────────────────────────────────────────────────────────────────────────────
+process_test() {
+  local src="${MOXYGEN_RELAY}/test/MoQRelayTest.cpp"
+  local dst="${REPO_ROOT}/tests/ORelayTest.cpp"
+  local tmp="${TMP_DIR}/ORelayTest.cpp"
+
+  echo "  test/MoQRelayTest.cpp -> tests/ORelayTest.cpp"
+  cp "$src" "$tmp"
+
+  replace_copyright "$tmp"
+
+  # Replace MoQRelay include with ORelay
+  sed -i 's|#include <moxygen/relay/MoQRelay\.h>|#include <o_rly/ORelay.h>|g' "$tmp"
+
+  # Relay class under test
+  sed -i 's/\bMoQRelay\b/ORelay/g' "$tmp"
+
+  # Add openmoq::o_rly namespace (and moxygen for types used at file scope).
+  # The test lives in namespace moxygen::test, but globals defined before that
+  # namespace block need explicit usings.
+  sed -i 's/^using namespace testing;$/using namespace testing;\nusing namespace moxygen;\nusing namespace openmoq::o_rly;/' "$tmp"
+
+  cp "$tmp" "$dst"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Run transformations
+# ─────────────────────────────────────────────────────────────────────────────
+echo "--> Transforming files"
+process_header
+process_source
+process_test
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Format
+# ─────────────────────────────────────────────────────────────────────────────
+echo "--> Formatting"
+"${SCRIPT_DIR}/format.sh"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Build
+# ─────────────────────────────────────────────────────────────────────────────
+if ! ${NO_BUILD}; then
+  echo "--> Building"
+  "${SCRIPT_DIR}/build.sh"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test
+# ─────────────────────────────────────────────────────────────────────────────
+if ! ${NO_TEST}; then
+  echo "--> Testing"
+  "${SCRIPT_DIR}/test.sh"
+fi
+
+echo "==> Done"

--- a/src/ORelay.cpp
+++ b/src/ORelay.cpp
@@ -7,14 +7,13 @@
  */
 
 #include <moxygen/MoQFilters.h>
-#include <moxygen/MoQTrackProperties.h>
 #include <o_rly/ORelay.h>
-
-using namespace moxygen;
 
 namespace {
 constexpr uint8_t kDefaultUpstreamPriority = 128;
 }
+
+using namespace moxygen;
 
 namespace openmoq::o_rly {
 
@@ -43,14 +42,15 @@ std::shared_ptr<ORelay::NamespaceNode> ORelay::findNamespaceNode(
     const TrackNamespace& ns,
     bool createMissingNodes,
     MatchType matchType,
-    std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>* sessions
+    std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>*
+        sessions
 ) {
   std::shared_ptr<NamespaceNode> nodePtr(std::shared_ptr<void>(), &publishNamespaceRoot_);
   for (auto i = 0ul; i < ns.size(); i++) {
     if (sessions) {
-      // Extract session pointers with their forward preferences from the map
-      for (const auto& [session, forward] : nodePtr->sessions) {
-        sessions->emplace_back(session, forward);
+      // Extract session pointers with their subscriber info from the map
+      for (const auto& [session, info] : nodePtr->sessions) {
+        sessions->emplace_back(session, info);
       }
     }
     auto& name = ns[i];
@@ -87,7 +87,8 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> ORelay::publishNamespace(
         "bad namespace"
     });
   }
-  std::vector<std::pair<std::shared_ptr<MoQSession>, bool>> sessions;
+  std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>
+      sessions;
   auto nodePtr = findNamespaceNode(
       ann.trackNamespace,
       /*createMissingNodes=*/true,
@@ -127,8 +128,16 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> ORelay::publishNamespace(
 
   // TODO: store auth for forwarding on future SubscribeNamespace?
   auto session = MoQSession::getRequestSession();
+
+  // Include sessions that subscribed exactly this namespace as well.
+  // findNamespaceNode(..., &sessions) collects subscribers attached to prefixes
+  // along the path, but does not include this node's own sessions.
+  for (const auto& [outSession, info] : nodePtr->sessions) {
+    sessions.emplace_back(outSession, info);
+  }
+
   bool wasEmpty = !nodePtr->hasLocalSessions();
-  nodePtr->sourceSession = std::move(session);
+  nodePtr->sourceSession = session;
   nodePtr->publishNamespaceCallback = std::move(callback);
   nodePtr->trackNamespace_ = ann.trackNamespace;
   nodePtr->setPublishNamespaceOk({ann.requestID});
@@ -137,10 +146,21 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> ORelay::publishNamespace(
   if (wasEmpty && nodePtr->parent_) {
     nodePtr->parent_->incrementActiveChildren();
   }
-  for (auto& [outSession, forward] : sessions) {
-    if (outSession != session) {
-      auto exec = outSession->getExecutor();
-      co_withExecutor(exec, publishNamespaceToSession(outSession, ann, nodePtr)).start();
+  for (auto& [outSession, info] : sessions) {
+    if (outSession != session && (info.options == SubscribeNamespaceOptions::NAMESPACE ||
+                                  info.options == SubscribeNamespaceOptions::BOTH)) {
+      if (info.namespacePublishHandle) {
+        // Draft 16+: send NAMESPACE message on the bidi stream
+        TrackNamespace suffix(std::vector<std::string>(
+            ann.trackNamespace.trackNamespace.begin() + info.trackNamespacePrefix.size(),
+            ann.trackNamespace.trackNamespace.end()
+        ));
+        info.namespacePublishHandle->namespaceMsg(suffix);
+      } else {
+        // Draft <= 15: send PUBLISH_NAMESPACE on a new stream
+        auto exec = outSession->getExecutor();
+        co_withExecutor(exec, publishNamespaceToSession(outSession, ann, nodePtr)).start();
+      }
     }
   }
   co_return nodePtr;
@@ -251,11 +271,44 @@ void ORelay::publishNamespaceDone(const TrackNamespace& trackNamespace, Namespac
 
   nodePtr->sourceSession = nullptr;
   nodePtr->publishNamespaceCallback.reset();
-  for (auto& pubNamespace : nodePtr->namespacesPublished) {
-    auto exec = pubNamespace.first->getExecutor();
-    exec->add([publishNamespaceHandle = pubNamespace.second] {
-      publishNamespaceHandle->publishNamespaceDone();
-    });
+
+  // Notify downstream namespace subscribers
+  std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>
+      sessions;
+  findNamespaceNode(
+      trackNamespace,
+      /*createMissingNodes=*/false,
+      MatchType::Exact,
+      &sessions
+  );
+  // Also include sessions at the target node itself
+  for (const auto& [sessionPtr, info] : nodePtr->sessions) {
+    sessions.emplace_back(sessionPtr, info);
+  }
+  for (auto& [outSession, info] : sessions) {
+    if (outSession != session && (info.options == SubscribeNamespaceOptions::NAMESPACE ||
+                                  info.options == SubscribeNamespaceOptions::BOTH)) {
+      auto maybeVersion = outSession->getNegotiatedVersion();
+      if (maybeVersion.has_value() && getDraftMajorVersion(*maybeVersion) >= 16) {
+        // Draft 16+: send NAMESPACE_DONE on the bidi stream
+        if (info.namespacePublishHandle) {
+          TrackNamespace suffix(std::vector<std::string>(
+              trackNamespace.trackNamespace.begin() + info.trackNamespacePrefix.size(),
+              trackNamespace.trackNamespace.end()
+          ));
+          info.namespacePublishHandle->namespaceDoneMsg(suffix);
+        }
+      } else {
+        // Draft <= 15: send PUBLISH_NAMESPACE_DONE on the existing stream
+        auto it = nodePtr->namespacesPublished.find(outSession);
+        if (it != nodePtr->namespacesPublished.end()) {
+          auto exec = outSession->getExecutor();
+          exec->add([publishNamespaceHandle = it->second] {
+            publishNamespaceHandle->publishNamespaceDone();
+          });
+        }
+      }
+    }
   }
   nodePtr->namespacesPublished.clear();
 
@@ -319,16 +372,17 @@ ORelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHandl
 
   // Find All Nodes that Subscribed to this namespace (including
   // prefix ns)
-  std::vector<std::pair<std::shared_ptr<MoQSession>, bool>> sessions = {};
+  std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>
+      sessions = {};
   auto nodePtr = findNamespaceNode(
       pub.fullTrackName.trackNamespace,
       /*createMissingNodes=*/true,
       MatchType::Exact,
       &sessions
   );
-  // Extract session pointers with their forward preferences from the map
-  for (const auto& [sessionPtr, forward] : nodePtr->sessions) {
-    sessions.emplace_back(sessionPtr, forward);
+  // Extract session pointers with their subscriber info from the map
+  for (const auto& [sessionPtr, info] : nodePtr->sessions) {
+    sessions.emplace_back(sessionPtr, info);
   }
 
   auto session = MoQSession::getRequestSession();
@@ -359,17 +413,10 @@ ORelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHandl
   }
 
   // Create Forwarder for this publish
-  auto forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, std::nullopt);
+  auto forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
 
   // Set Forwarder Params
-  forwarder->setGroupOrder(pub.groupOrder);
-
-  // Extract delivery timeout from publish request extensions and store in
-  // forwarder
-  auto deliveryTimeout = getPublisherDeliveryTimeout(pub);
-  if (deliveryTimeout && deliveryTimeout->count() > 0) {
-    forwarder->setDeliveryTimeout(deliveryTimeout->count());
-  }
+  forwarder->setExtensions(pub.extensions);
 
   auto subRes = subscriptions_.emplace(
       std::piecewise_construct,
@@ -383,11 +430,12 @@ ORelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHandl
   rsub.isPublish = true;
 
   uint64_t nSubscribers = 0;
-  for (auto& [outSession, forward] : sessions) {
-    if (outSession != session) {
+  for (auto& [outSession, info] : sessions) {
+    if (outSession != session && (info.options == SubscribeNamespaceOptions::PUBLISH ||
+                                  info.options == SubscribeNamespaceOptions::BOTH)) {
       nSubscribers++;
       auto exec = outSession->getExecutor();
-      co_withExecutor(exec, publishToSession(outSession, forwarder, pub, forward)).start();
+      co_withExecutor(exec, publishToSession(outSession, forwarder, info.forward)).start();
     }
   }
   forwarder->setCallback(shared_from_this());
@@ -414,24 +462,17 @@ ORelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHandl
 folly::coro::Task<void> ORelay::publishToSession(
     std::shared_ptr<MoQSession> session,
     std::shared_ptr<MoQForwarder> forwarder,
-    PublishRequest pub,
     bool forward
 ) {
-  pub.forward = forward;
-  auto subscriber = forwarder->addSubscriber(session, pub);
+  auto subscriber = forwarder->addSubscriber(session, forward);
   if (!subscriber) {
-    XLOG(ERR) << "Subscribe failed: addSubscriber returned null for " << forwarder->fullTrackName()
-              << " reqID=" << pub.requestID;
+    XLOG(ERR) << "Subscribe failed: addSubscriber returned null for " << forwarder->fullTrackName();
     co_return;
   }
-  XLOG(DBG4) << "added subscriber for ftn=" << pub.fullTrackName;
+  XLOG(DBG4) << "added subscriber for ftn=" << forwarder->fullTrackName();
   auto guard = folly::makeGuard([subscriber] { subscriber->unsubscribe(); });
-  if (pub.largest) {
-    subscriber->updateLargest(*pub.largest);
-  }
-  subscriber->setPublisherGroupOrder(pub.groupOrder);
 
-  auto pubInitial = session->publish(pub, subscriber);
+  auto pubInitial = session->publish(subscriber->getPublishRequest(), subscriber);
   if (pubInitial.hasError()) {
     XLOG(ERR) << "Publish failed err=" << pubInitial.error().reasonPhrase;
     co_return;
@@ -530,20 +571,36 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> ORelay::subscribeNamespac
     std::shared_ptr<NamespacePublishHandle> namespacePublishHandle
 ) {
   XLOG(DBG1) << __func__ << " nsp=" << subNs.trackNamespacePrefix;
+
+  auto session = MoQSession::getRequestSession();
+  auto maybeNegotiatedVersion = session->getNegotiatedVersion();
+  CHECK(maybeNegotiatedVersion.has_value());
+
   // check auth
-  if (subNs.trackNamespacePrefix.empty()) {
+  // Allow empty namespace prefix only for draft-16 and above.
+  if (subNs.trackNamespacePrefix.empty() && getDraftMajorVersion(*maybeNegotiatedVersion) < 16) {
     co_return folly::makeUnexpected(SubscribeNamespaceError{
         subNs.requestID,
         SubscribeNamespaceErrorCode::NAMESPACE_PREFIX_UNKNOWN,
         "empty"
     });
   }
-  auto session = MoQSession::getRequestSession();
   auto nodePtr = findNamespaceNode(subNs.trackNamespacePrefix, /*createMissingNodes=*/true);
+
+  SubscribeNamespaceOptions effectiveOptions;
+  effectiveOptions = subNs.options;
 
   // Check if this is the first session subscriber for this node
   bool wasEmpty = !nodePtr->hasLocalSessions();
-  nodePtr->sessions.emplace(session, subNs.forward);
+  nodePtr->sessions.emplace(
+      session,
+      NamespaceNode::NamespaceSubscriberInfo{
+          subNs.forward,
+          effectiveOptions,
+          namespacePublishHandle,
+          subNs.trackNamespacePrefix
+      }
+  );
 
   // If this is the first content added to this node, notify parent
   if (wasEmpty && nodePtr->hasLocalSessions() && nodePtr->parent_) {
@@ -559,24 +616,31 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> ORelay::subscribeNamespac
     auto [prefix, nodePtr] = std::move(*nodes.begin());
     nodes.pop_front();
     if (nodePtr->sourceSession && nodePtr->sourceSession != session) {
-      // TODO: Auth/params
-      co_withExecutor(exec, publishNamespaceToSession(session, {subNs.requestID, prefix}, nodePtr))
-          .start();
+      if (getDraftMajorVersion(*maybeNegotiatedVersion) >= 16) {
+        if (subNs.options == SubscribeNamespaceOptions::NAMESPACE ||
+            subNs.options == SubscribeNamespaceOptions::BOTH) {
+          // Compute the suffix: prefix minus subNs.trackNamespacePrefix
+          TrackNamespace suffix(std::vector<std::string>(
+              prefix.trackNamespace.begin() + subNs.trackNamespacePrefix.size(),
+              prefix.trackNamespace.end()
+          ));
+          namespacePublishHandle->namespaceMsg(suffix);
+        }
+      } else {
+        // TODO: Auth/params
+        co_withExecutor(
+            exec,
+            publishNamespaceToSession(session, {subNs.requestID, prefix}, nodePtr)
+        )
+            .start();
+      }
     }
-    PublishRequest pub{
-        0,
-        FullTrackName{prefix, ""},
-        TrackAlias(0), // filled in by library
-        GroupOrder::Default,
-        std::nullopt,
-        /*forward=*/false
-    };
     for (auto& publishEntry : nodePtr->publishes) {
       auto& publishSession = publishEntry.second;
-      pub.fullTrackName.trackName = publishEntry.first;
-      auto subscriptionIt = subscriptions_.find(pub.fullTrackName);
+      FullTrackName ftn{prefix, publishEntry.first};
+      auto subscriptionIt = subscriptions_.find(ftn);
       if (subscriptionIt == subscriptions_.end()) {
-        XLOG(ERR) << "Invalid state, no subscription for publish ftn=" << pub.fullTrackName;
+        XLOG(ERR) << "Invalid state, no subscription for publish ftn=" << ftn;
         continue;
       }
       auto& forwarder = subscriptionIt->second.forwarder;
@@ -585,10 +649,14 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> ORelay::subscribeNamespac
         co_withExecutor(exec, doSubscribeUpdate(subscriptionIt->second.handle, subNs.forward))
             .start();
       }
-      pub.groupOrder = forwarder->groupOrder();
-      pub.largest = forwarder->largest();
-      if (publishSession != session) {
-        co_withExecutor(exec, publishToSession(session, forwarder, pub, subNs.forward)).start();
+      auto maybeNegotiatedVersion = session->getNegotiatedVersion();
+      CHECK(maybeNegotiatedVersion.has_value());
+      if (getDraftMajorVersion(*maybeNegotiatedVersion) <= 15 ||
+          (subNs.options == SubscribeNamespaceOptions::BOTH ||
+           subNs.options == SubscribeNamespaceOptions::PUBLISH)) {
+        if (publishSession != session) {
+          co_withExecutor(exec, publishToSession(session, forwarder, subNs.forward)).start();
+        }
       }
     }
     for (auto& nextNodeIt : nodePtr->children) {
@@ -749,23 +817,14 @@ ORelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consum
       forwarder->updateLargest(largest->group, largest->object);
       subscriber->updateLargest(*largest);
     }
-    auto pubGroupOrder = subRes.value()->subscribeOk().groupOrder;
-    forwarder->setGroupOrder(pubGroupOrder);
-
-    // Store upstream delivery timeout in forwarder
-    auto deliveryTimeout = getPublisherDeliveryTimeout(subRes.value()->subscribeOk());
-
-    // Add delivery timeout to downstream subscriber explicitly as this is the
-    // first subscriber. Forwarder can add it to subsequent subscribers
-    if (deliveryTimeout && deliveryTimeout->count() > 0) {
-      forwarder->setDeliveryTimeout(deliveryTimeout->count());
-      subscriber->setParam(
-          {folly::to_underlying(TrackRequestParamKey::DELIVERY_TIMEOUT),
-           static_cast<uint64_t>(deliveryTimeout->count())}
-      );
+    // Save upstream extensions to forwarder (and existing subscribers) and
+    // cache
+    auto& upstreamExtensions = subRes.value()->subscribeOk().extensions;
+    forwarder->setExtensions(upstreamExtensions);
+    if (cache_) {
+      cache_->setTrackExtensions(subReq.fullTrackName, upstreamExtensions);
     }
 
-    subscriber->setPublisherGroupOrder(pubGroupOrder);
     auto it = subscriptions_.find(subReq.fullTrackName);
     // There are cases that remove the subscription like failing to
     // publish a datagram that was received before the subscribeOK
@@ -881,6 +940,70 @@ ORelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
     co_return co_await upstreamSession->fetch(fetch, std::move(consumer));
   }
   co_return co_await cache_->fetch(fetch, std::move(consumer), std::move(upstreamSession));
+}
+
+folly::coro::Task<Publisher::TrackStatusResult> ORelay::trackStatus(TrackStatus trackStatus) {
+  XLOG(DBG1) << __func__ << " ftn=" << trackStatus.fullTrackName;
+
+  if (trackStatus.fullTrackName.trackNamespace.empty()) {
+    co_return folly::makeUnexpected(TrackStatusError(
+        {trackStatus.requestID, TrackStatusErrorCode::TRACK_NOT_EXIST, "namespace required"}
+    ));
+  }
+
+  auto subscriptionIt = subscriptions_.find(trackStatus.fullTrackName);
+  if (subscriptionIt != subscriptions_.end() &&
+      subscriptionIt->second.forwarder->numForwardingSubscribers() > 0) {
+    // We have active subscription - answer directly from local forwarder state
+    auto& subscription = subscriptionIt->second;
+    auto& forwarder = subscription.forwarder;
+
+    TrackStatusCode statusCode = TrackStatusCode::TRACK_NOT_STARTED;
+    // forwarder->largest() being set means: we have actually
+    // received at least one object for this track.
+    // subscription.handle being non-null means: the relay still has a
+    // live upstream Publisher::SubscriptionHandle for this track
+    if (forwarder->largest()) {
+      if (subscription.handle) {
+        statusCode = TrackStatusCode::IN_PROGRESS;
+      } else {
+        statusCode = TrackStatusCode::UNKNOWN;
+      }
+    }
+
+    TrackStatusOk trackStatusOk;
+    trackStatusOk.requestID = trackStatus.requestID;
+    trackStatusOk.groupOrder = forwarder->groupOrder();
+    trackStatusOk.largest = forwarder->largest();
+    trackStatusOk.fullTrackName = trackStatus.fullTrackName;
+    trackStatusOk.statusCode = statusCode;
+
+    XLOG(DBG1) << "Returning local track status for " << trackStatus.fullTrackName
+               << " statusCode=" << (uint32_t)statusCode;
+    co_return trackStatusOk;
+  } else {
+    // No subscription - forward to upstream
+    auto upstreamSession = findPublishNamespaceSession(trackStatus.fullTrackName.trackNamespace);
+
+    if (!upstreamSession) {
+      XLOG(DBG1) << "No upstream session for track: " << trackStatus.fullTrackName;
+      co_return folly::makeUnexpected(TrackStatusError{
+          trackStatus.requestID,
+          TrackStatusErrorCode::TRACK_NOT_EXIST,
+          "no such namespace or track"
+      });
+    }
+
+    // Forward the trackStatus request to the upstream publisher session
+    auto result = co_await upstreamSession->trackStatus(trackStatus);
+
+    if (result.hasError()) {
+      XLOG(DBG1) << "Upstream trackStatus failed: " << result.error().reasonPhrase;
+    } else {
+      XLOG(DBG1) << "Upstream trackStatus succeeded";
+    }
+    co_return result;
+  }
 }
 
 void ORelay::onEmpty(MoQForwarder* forwarder) {

--- a/tests/ORelayTest.cpp
+++ b/tests/ORelayTest.cpp
@@ -52,7 +52,7 @@ private:
 // This provides a skeleton for testing ORelay functionality.
 // Full integration tests with real sessions will be added when implementing
 // multi-publisher support.
-class ORelayTest : public ::testing::Test {
+class MoQRelayTest : public ::testing::Test {
 protected:
   void SetUp() override {
     exec_ = std::make_shared<TestMoQExecutor>();
@@ -315,12 +315,12 @@ protected:
 };
 
 // Test: Basic relay construction
-TEST_F(ORelayTest, Construction) {
+TEST_F(MoQRelayTest, Construction) {
   EXPECT_NE(relay_, nullptr);
 }
 
 // Test: Verify allowed namespace prefix is set correctly
-TEST_F(ORelayTest, AllowedNamespacePrefix) {
+TEST_F(MoQRelayTest, AllowedNamespacePrefix) {
   // This just verifies the relay can be constructed with a namespace prefix
   // More detailed testing requires full session setup
   auto relay2 = std::make_shared<ORelay>(/*enableCache=*/true);
@@ -329,14 +329,14 @@ TEST_F(ORelayTest, AllowedNamespacePrefix) {
 }
 
 // Test: MockMoQSession can be created
-TEST_F(ORelayTest, MockSessionCreation) {
+TEST_F(MoQRelayTest, MockSessionCreation) {
   auto mockSession = createMockSession();
   EXPECT_NE(mockSession, nullptr);
   EXPECT_NE(mockSession->getExecutor(), nullptr);
 }
 
 // Test: Publish a track through the relay
-TEST_F(ORelayTest, PublishSuccess) {
+TEST_F(MoQRelayTest, PublishSuccess) {
   auto publisherSession = createMockSession();
 
   // Publish the namespace
@@ -352,7 +352,7 @@ TEST_F(ORelayTest, PublishSuccess) {
 // Test: Tree pruning when leaf node is removed
 // Scenario: test/A/B/C and test/A/D exist. Remove C should prune B but keep A
 // and D
-TEST_F(ORelayTest, PruneLeafKeepSiblings) {
+TEST_F(MoQRelayTest, PruneLeafKeepSiblings) {
   auto publisherABC = createMockSession();
   auto publisherAD = createMockSession();
 
@@ -379,7 +379,7 @@ TEST_F(ORelayTest, PruneLeafKeepSiblings) {
 
 // Test: Tree pruning removes highest empty ancestor
 // Scenario: test/A/B/C only. Remove C should prune A (highest empty after test)
-TEST_F(ORelayTest, PruneHighestEmptyAncestor) {
+TEST_F(MoQRelayTest, PruneHighestEmptyAncestor) {
   auto publisher = createMockSession();
 
   // PublishNamespace test/A/B/C (don't add to state because we
@@ -400,7 +400,7 @@ TEST_F(ORelayTest, PruneHighestEmptyAncestor) {
 }
 
 // Test: Pruning happens automatically on removeSession
-TEST_F(ORelayTest, PruneOnRemoveSession) {
+TEST_F(MoQRelayTest, PruneOnRemoveSession) {
   auto publisher = createMockSession();
 
   // PublishNamespace deep tree test/A/B/C/D
@@ -418,7 +418,7 @@ TEST_F(ORelayTest, PruneOnRemoveSession) {
 }
 
 // Test: No pruning when node still has content (multiple publishers)
-TEST_F(ORelayTest, NoPruneWhenNodeHasContent) {
+TEST_F(MoQRelayTest, NoPruneWhenNodeHasContent) {
   auto publisher1 = createMockSession();
   auto publisher2 = createMockSession();
 
@@ -441,7 +441,7 @@ TEST_F(ORelayTest, NoPruneWhenNodeHasContent) {
 // Test: EXPOSES BUG - onPublishDone should trigger pruning but doesn't
 // This test FAILS because onPublishDone removes the publish from the map
 // but doesn't call tryPruneChild to clean up empty nodes
-TEST_F(ORelayTest, PruneOnPublishDoneBug) {
+TEST_F(MoQRelayTest, PruneOnPublishDoneBug) {
   auto publisher = createMockSession();
 
   // Create deep tree test/A/B/C with only a publish (no publishNamespace)
@@ -491,7 +491,7 @@ TEST_F(ORelayTest, PruneOnPublishDoneBug) {
 }
 
 // Test: Mixed content types - node with publishNamespace + publish
-TEST_F(ORelayTest, MixedContentPublishNamespaceAndPublish) {
+TEST_F(MoQRelayTest, MixedContentPublishNamespaceAndPublish) {
   auto publisher = createMockSession();
 
   // PublishNamespace test/A/B
@@ -515,7 +515,7 @@ TEST_F(ORelayTest, MixedContentPublishNamespaceAndPublish) {
 
 // Test: Mixed content types - node with publishNamespace + sessions
 // (subscribers)
-TEST_F(ORelayTest, MixedContentPublishNamespaceAndSessions) {
+TEST_F(MoQRelayTest, MixedContentPublishNamespaceAndSessions) {
   auto publisher = createMockSession();
   auto subscriber = createMockSession();
 
@@ -544,7 +544,7 @@ TEST_F(ORelayTest, MixedContentPublishNamespaceAndSessions) {
 }
 
 // Test: UnsubscribeNamespace triggers pruning
-TEST_F(ORelayTest, PruneOnUnsubscribeNamespace) {
+TEST_F(MoQRelayTest, PruneOnUnsubscribeNamespace) {
   auto subscriber = createMockSession();
 
   // Subscribe to test/A/B/C namespace (creates tree without publishNamespace)
@@ -563,7 +563,7 @@ TEST_F(ORelayTest, PruneOnUnsubscribeNamespace) {
 // Test: Middle empty nodes in deep tree
 // Scenario: test/A (has publishNamespace), test/A/B (empty), test/A/B/C (has
 // publish) Remove C should prune B but keep A
-TEST_F(ORelayTest, PruneMiddleEmptyNode) {
+TEST_F(MoQRelayTest, PruneMiddleEmptyNode) {
   auto publisherA = createMockSession();
   auto publisherC = createMockSession();
 
@@ -593,7 +593,7 @@ TEST_F(ORelayTest, PruneMiddleEmptyNode) {
 }
 
 // Test: Double publishNamespaceDone doesn't crash or corrupt state
-TEST_F(ORelayTest, DoublePublishNamespaceDone) {
+TEST_F(MoQRelayTest, DoublePublishNamespaceDone) {
   auto publisher = createMockSession();
 
   // PublishNamespace test/A/B
@@ -619,7 +619,7 @@ TEST_F(ORelayTest, DoublePublishNamespaceDone) {
 // clearing state When a session calls publishNamespaceDone but is not the owner
 // of the namespace, the publishNamespaceDone should be ignored and the real
 // owner should remain.
-TEST_F(ORelayTest, StalePublishNamespaceDoneDoesNotAffectNewOwner) {
+TEST_F(MoQRelayTest, StalePublishNamespaceDoneDoesNotAffectNewOwner) {
   auto publisher1 = createMockSession();
   auto publisher2 = createMockSession();
 
@@ -659,7 +659,7 @@ TEST_F(ORelayTest, StalePublishNamespaceDoneDoesNotAffectNewOwner) {
 // Test: Pruning with multiple children at same level
 // Scenario: test/A has children B, C, D. Only B has content.
 // Remove B should prune B but keep A, C, D structure intact
-TEST_F(ORelayTest, PruneOneOfMultipleChildren) {
+TEST_F(MoQRelayTest, PruneOneOfMultipleChildren) {
   auto publisherB = createMockSession();
   auto subscriberC = createMockSession();
   auto subscriberD = createMockSession();
@@ -692,7 +692,7 @@ TEST_F(ORelayTest, PruneOneOfMultipleChildren) {
 }
 
 // Test: Empty namespace edge case
-TEST_F(ORelayTest, EmptyNamespacePublishNamespaceDone) {
+TEST_F(MoQRelayTest, EmptyNamespacePublishNamespaceDone) {
   auto publisher = createMockSession();
 
   // Try to publishNamespace empty namespace (edge case)
@@ -715,7 +715,7 @@ TEST_F(ORelayTest, EmptyNamespacePublishNamespaceDone) {
 }
 
 // Test: Verify activeChildCount consistency after complex operations
-TEST_F(ORelayTest, ActiveChildCountConsistency) {
+TEST_F(MoQRelayTest, ActiveChildCountConsistency) {
   auto pub1 = createMockSession();
   auto pub2 = createMockSession();
   auto sub1 = createMockSession();
@@ -750,7 +750,7 @@ TEST_F(ORelayTest, ActiveChildCountConsistency) {
 }
 
 // Test: Publish then publishNamespaceDone shouldn't prune while publish active
-TEST_F(ORelayTest, PublishKeepsNodeAliveAfterPublishNamespaceDone) {
+TEST_F(MoQRelayTest, PublishKeepsNodeAliveAfterPublishNamespaceDone) {
   auto publisher = createMockSession();
 
   // PublishNamespace test/A/B
@@ -776,7 +776,7 @@ TEST_F(ORelayTest, PublishKeepsNodeAliveAfterPublishNamespaceDone) {
 // Sequence: publish, sub1 joins, beginSubgroup (->1), beginObject (->1),
 // sub2 joins, beginObject (->1,2), sub3 joins, objectPayload (->1,2),
 // endOfSubgroup (->1,2)
-TEST_F(ORelayTest, ForwarderOnlyCreatesSubgroupsBeforeObjectData) {
+TEST_F(MoQRelayTest, ForwarderOnlyCreatesSubgroupsBeforeObjectData) {
   auto publisherSession = createMockSession();
   auto subscriber1 = createMockSession();
   auto subscriber2 = createMockSession();
@@ -854,7 +854,7 @@ TEST_F(ORelayTest, ForwarderOnlyCreatesSubgroupsBeforeObjectData) {
 // are drained (receive publishDone) but their open subgroups are NOT reset.
 // Draining subscribers should not receive new subgroups and are removed when
 // their last subgroup closes.
-TEST_F(ORelayTest, GracefulSessionDraining) {
+TEST_F(MoQRelayTest, GracefulSessionDraining) {
   auto publisherSession = createMockSession();
   std::array<std::shared_ptr<MoQSession>, 3> subscribers;
   for (auto& s : subscribers) {
@@ -930,7 +930,7 @@ TEST_F(ORelayTest, GracefulSessionDraining) {
 }
 
 // Test: removeSession (via unsubscribe) immediately resets all open subgroups
-TEST_F(ORelayTest, RemoveSessionResetsOpenSubgroups) {
+TEST_F(MoQRelayTest, RemoveSessionResetsOpenSubgroups) {
   auto publisherSession = createMockSession();
   auto subscriber = createMockSession();
 
@@ -980,7 +980,7 @@ TEST_F(ORelayTest, RemoveSessionResetsOpenSubgroups) {
 }
 
 // Test: Draining subscriber removed when subgroup closes with error
-TEST_F(ORelayTest, DrainingSubscriberRemovedOnSubgroupError) {
+TEST_F(MoQRelayTest, DrainingSubscriberRemovedOnSubgroupError) {
   auto publisherSession = createMockSession();
   auto subscriber = createMockSession();
 
@@ -1042,7 +1042,7 @@ TEST_F(ORelayTest, DrainingSubscriberRemovedOnSubgroupError) {
 // Test: Subscriber that ends subscription doesn't receive subsequent objects
 // Sequence: publish, sub1 subscribes, beginSubgroup, sub1 ends (publishDone),
 // sub2 subscribes, send object -> only goes to sub1
-TEST_F(ORelayTest, SubscriberUnsubscribeDoesNotReceiveNewObjects) {
+TEST_F(MoQRelayTest, SubscriberUnsubscribeDoesNotReceiveNewObjects) {
   auto publisherSession = createMockSession();
   auto subscriber1 = createMockSession();
   auto subscriber2 = createMockSession();
@@ -1104,7 +1104,7 @@ TEST_F(ORelayTest, SubscriberUnsubscribeDoesNotReceiveNewObjects) {
 // Sequence: subscribeNamespace (sub1), publish (sub1 gets it),
 // beginSubgroup, publishDone, subscribeNamespace (sub2), new publish
 // (only sub2 gets it)
-TEST_F(ORelayTest, SubscribeNamespaceDoesntAddDrainingPublish) {
+TEST_F(MoQRelayTest, SubscribeNamespaceDoesntAddDrainingPublish) {
   auto publisherSession = createMockSession();
   auto subscriber1 = createMockSession();
   auto subscriber2 = createMockSession();
@@ -1187,7 +1187,7 @@ TEST_F(ORelayTest, SubscribeNamespaceDoesntAddDrainingPublish) {
 // removed. This verifies that when a data operation (objectPayload with
 // fin=false) causes all subscribers to error out, the operation correctly
 // detects that data went nowhere and returns CANCELLED.
-TEST_F(ORelayTest, DataOperationCancelledWhenAllSubscribersFail) {
+TEST_F(MoQRelayTest, DataOperationCancelledWhenAllSubscribersFail) {
   auto publisherSession = createMockSession();
   std::array<std::shared_ptr<MoQSession>, 2> subscribers;
   std::array<std::shared_ptr<MockTrackConsumer>, 2> consumers;
@@ -1250,7 +1250,7 @@ TEST_F(ORelayTest, DataOperationCancelledWhenAllSubscribersFail) {
 // This verifies that when some subscribers fail but others succeed, the
 // operation continues successfully and only returns CANCELLED when ALL
 // subscribers are gone.
-TEST_F(ORelayTest, PartialSubscriberFailureDoesNotCancelData) {
+TEST_F(MoQRelayTest, PartialSubscriberFailureDoesNotCancelData) {
   auto publisherSession = createMockSession();
   std::array<std::shared_ptr<MoQSession>, 3> subscribers;
   std::array<std::shared_ptr<MockTrackConsumer>, 3> consumers;
@@ -1328,7 +1328,7 @@ TEST_F(ORelayTest, PartialSubscriberFailureDoesNotCancelData) {
 // Test: SubscribeUpdate can decrease start location
 // Per spec, start location can be decreased. The subscriber should use FETCH
 // to retrieve objects between the new start and the current largest location.
-TEST_F(ORelayTest, SubscribeUpdateStartLocationCanDecrease) {
+TEST_F(MoQRelayTest, SubscribeUpdateStartLocationCanDecrease) {
   auto publisherSession = createMockSession();
   auto subscriberSession = createMockSession();
 
@@ -1383,7 +1383,7 @@ TEST_F(ORelayTest, SubscribeUpdateStartLocationCanDecrease) {
 // Test: Subgroup is tombstoned after CANCELLED error (soft error)
 // Verifies that a CANCELLED error on a subgroup sets it to nullptr (tombstone)
 // but keeps the subscription alive
-TEST_F(ORelayTest, SubgroupTombstonedAfterCancelledError) {
+TEST_F(MoQRelayTest, SubgroupTombstonedAfterCancelledError) {
   auto publisherSession = createMockSession();
   auto subscriber = createMockSession();
 
@@ -1446,7 +1446,7 @@ TEST_F(ORelayTest, SubgroupTombstonedAfterCancelledError) {
 
 // Test: Objects published to tombstoned subgroup are skipped for that
 // subscriber
-TEST_F(ORelayTest, TombstonedSubgroupIgnoresSubsequentObjects) {
+TEST_F(MoQRelayTest, TombstonedSubgroupIgnoresSubsequentObjects) {
   auto publisherSession = createMockSession();
   auto subscriber = createMockSession();
 
@@ -1498,7 +1498,7 @@ TEST_F(ORelayTest, TombstonedSubgroupIgnoresSubsequentObjects) {
 }
 
 // Test: Late joiner gets subgroup even after another subscriber tombstoned it
-TEST_F(ORelayTest, LateJoinerGetsSubgroupAfterTombstone) {
+TEST_F(MoQRelayTest, LateJoinerGetsSubgroupAfterTombstone) {
   auto publisherSession = createMockSession();
   auto subscriber1 = createMockSession();
   auto subscriber2 = createMockSession();
@@ -1559,7 +1559,7 @@ TEST_F(ORelayTest, LateJoinerGetsSubgroupAfterTombstone) {
 }
 
 // Test: Hard errors (WRITE_ERROR) remove the entire subscription
-TEST_F(ORelayTest, HardErrorsRemoveSubscriber) {
+TEST_F(MoQRelayTest, HardErrorsRemoveSubscriber) {
   auto publisherSession = createMockSession();
   auto subscriber = createMockSession();
 
@@ -1618,7 +1618,7 @@ TEST_F(ORelayTest, HardErrorsRemoveSubscriber) {
 // removed the subscriber from the map (destroying the shared_ptr). The onError
 // lambda's captured copy was then the last reference. After it was destroyed,
 // closeSubgroupForSubscriber accessed the freed subscriber.
-TEST_F(ORelayTest, EndOfSubgroupHardErrorDoesNotCrash) {
+TEST_F(MoQRelayTest, EndOfSubgroupHardErrorDoesNotCrash) {
   auto publisherSession = createMockSession();
   auto subscriberSession = createMockSession();
 
@@ -1665,6 +1665,494 @@ TEST_F(ORelayTest, EndOfSubgroupHardErrorDoesNotCrash) {
 
   removeSession(publisherSession);
   removeSession(subscriberSession);
+}
+
+// Helper callback that drops the forwarder shared_ptr when onEmpty fires,
+// simulating what happens in production when the last reference holder
+// (e.g., SubscribeWriteback destructor chain) destroys the forwarder.
+class ForwarderDestroyingCallback : public MoQForwarder::Callback {
+public:
+  explicit ForwarderDestroyingCallback(std::shared_ptr<MoQForwarder>& forwarderRef)
+      : forwarderRef_(forwarderRef) {}
+
+  void onEmpty(MoQForwarder*) override {
+    // Drop the last shared_ptr, destroying the forwarder.
+    // This simulates the production scenario where onEmpty ->
+    // subscriptions_.erase -> MoQForwarder destructor.
+    forwarderRef_.reset();
+  }
+
+private:
+  std::shared_ptr<MoQForwarder>& forwarderRef_;
+};
+
+TEST_F(MoQRelayTest, SubscribeNamespaceEmptyPrefixRejectedPreV16) {
+  // Default session uses kVersionDraftCurrent (draft-14, which is < 16)
+  auto session = createMockSession();
+
+  TrackNamespace emptyNs{{}};
+  SubscribeNamespace subNs;
+  subNs.trackNamespacePrefix = emptyNs;
+
+  withSessionContext(session, [&]() {
+    auto task = relay_->subscribeNamespace(std::move(subNs), nullptr);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    ASSERT_FALSE(res.hasValue()
+    ) << "Empty namespace prefix should be rejected for pre-v16 sessions";
+    EXPECT_EQ(res.error().errorCode, SubscribeNamespaceErrorCode::NAMESPACE_PREFIX_UNKNOWN);
+    EXPECT_EQ(res.error().reasonPhrase, "empty");
+  });
+
+  removeSession(session);
+}
+
+TEST_F(MoQRelayTest, SubscribeNamespaceEmptyPrefixAllowedV16) {
+  auto session = createMockSession();
+  // Override the negotiated version to draft-16
+  ON_CALL(*session, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft16)));
+
+  TrackNamespace emptyNs{{}};
+  doSubscribeNamespace(session, emptyNs);
+
+  removeSession(session);
+}
+
+// Regression test: SubgroupForwarder::reset() use-after-free.
+// When the forwarder is draining (publishDone received) and a subscriber's
+// last subgroup is closed via reset(), closeSubgroupForSubscriber calls
+// removeSubscriber -> checkAndFireOnEmpty -> onEmpty callback. The onEmpty
+// callback destroys the MoQForwarder (by dropping the last shared_ptr).
+// But reset() is still inside forEachSubscriberSubgroup, which accesses
+// forwarder_.subscribers_ after the lambda returns, causing
+// heap-use-after-free.
+TEST_F(MoQRelayTest, ResetDuringDrainingDoesNotCrash) {
+  auto session = createMockSession();
+
+  auto forwarder = std::make_shared<MoQForwarder>(kTestTrackName, AbsoluteLocation{0, 0});
+  auto callback = std::make_shared<ForwarderDestroyingCallback>(forwarder);
+  forwarder->setCallback(callback);
+
+  // Create a subscriber
+  auto consumer = createMockConsumer();
+  std::shared_ptr<MockSubgroupConsumer> sg;
+
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([this, &sg](uint64_t, uint64_t, uint8_t, bool) {
+        sg = createMockSubgroupConsumer();
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+
+  EXPECT_CALL(*consumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+
+  SubscribeRequest sub;
+  sub.fullTrackName = kTestTrackName;
+  sub.requestID = RequestID(1);
+  sub.locType = LocationType::LargestGroup;
+  forwarder->addSubscriber(session, sub, consumer);
+
+  // Begin subgroup
+  auto subgroupRes = forwarder->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(subgroupRes.hasValue());
+  auto subgroup = *subgroupRes;
+
+  // Drain the subscriber
+  forwarder->publishDone(
+      PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher ended"}
+  );
+
+  // Now reset the subgroup. This triggers:
+  //  SubgroupForwarder::reset()
+  //    -> forEachSubscriberSubgroup()
+  //      -> reset subscriber's subgroupConsumer
+  //      -> closeSubgroupForSubscriber()
+  //        -> sub->shouldRemove() returns true (draining, last subgroup)
+  //        -> removeSubscriber()
+  //          -> checkAndFireOnEmpty()
+  //            -> onEmpty destroys the forwarder (drops shared_ptr)
+  //    -> forEachSubscriberSubgroup accesses forwarder_.subscribers_ -> CRASH
+  EXPECT_CALL(*sg, reset(_)).Times(1);
+  subgroup->reset(ResetStreamErrorCode::INTERNAL_ERROR);
+
+  // forwarder should have been destroyed by onEmpty
+  EXPECT_EQ(forwarder, nullptr);
+}
+
+// Same as above but with multiple subscribers draining.
+TEST_F(MoQRelayTest, ResetDuringDrainingMultipleSubscribersDoesNotCrash) {
+  auto session1 = createMockSession();
+  auto session2 = createMockSession();
+
+  auto forwarder = std::make_shared<MoQForwarder>(kTestTrackName, AbsoluteLocation{0, 0});
+  auto callback = std::make_shared<ForwarderDestroyingCallback>(forwarder);
+  forwarder->setCallback(callback);
+
+  // Create two subscribers
+  std::shared_ptr<MockSubgroupConsumer> sg1, sg2;
+  auto consumer1 = createMockConsumer();
+  auto consumer2 = createMockConsumer();
+
+  EXPECT_CALL(*consumer1, beginSubgroup(0, 0, _, _))
+      .WillOnce([this, &sg1](uint64_t, uint64_t, uint8_t, bool) {
+        sg1 = createMockSubgroupConsumer();
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg1);
+      });
+
+  EXPECT_CALL(*consumer2, beginSubgroup(0, 0, _, _))
+      .WillOnce([this, &sg2](uint64_t, uint64_t, uint8_t, bool) {
+        sg2 = createMockSubgroupConsumer();
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg2);
+      });
+
+  EXPECT_CALL(*consumer1, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  EXPECT_CALL(*consumer2, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+
+  SubscribeRequest sub1;
+  sub1.fullTrackName = kTestTrackName;
+  sub1.requestID = RequestID(1);
+  sub1.locType = LocationType::LargestGroup;
+  forwarder->addSubscriber(session1, sub1, consumer1);
+
+  SubscribeRequest sub2;
+  sub2.fullTrackName = kTestTrackName;
+  sub2.requestID = RequestID(2);
+  sub2.locType = LocationType::LargestGroup;
+  forwarder->addSubscriber(session2, sub2, consumer2);
+
+  // Begin subgroup - both subscribers get it
+  auto subgroupRes = forwarder->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(subgroupRes.hasValue());
+  auto subgroup = *subgroupRes;
+
+  // Drain both subscribers
+  forwarder->publishDone(
+      PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher ended"}
+  );
+
+  // Reset the subgroup. Both subscribers are draining with only this subgroup.
+  // As each is removed, the second removal triggers onEmpty which destroys
+  // the forwarder while we may still be iterating.
+  EXPECT_CALL(*sg1, reset(_)).Times(1);
+  EXPECT_CALL(*sg2, reset(_)).Times(1);
+  subgroup->reset(ResetStreamErrorCode::INTERNAL_ERROR);
+
+  EXPECT_EQ(forwarder, nullptr);
+}
+
+// Test: Extensions from publish are forwarded to subscribers via
+// subscribeNamespace
+TEST_F(MoQRelayTest, PublishExtensionsForwardedToSubscribers) {
+  auto publisherSession = createMockSession();
+  auto subscriber = createMockSession();
+
+  // Subscribe to namespace first
+  auto mockConsumer = createMockConsumer();
+  Extensions receivedExtensions;
+  EXPECT_CALL(*subscriber, publish(testing::_, testing::_))
+      .WillOnce([&mockConsumer, &receivedExtensions](PublishRequest pubReq, auto subHandle) {
+        receivedExtensions = pubReq.extensions;
+        return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
+            mockConsumer,
+            []() -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
+              co_return PublishOk{
+                  RequestID(1),
+                  true,
+                  0,
+                  GroupOrder::OldestFirst,
+                  LocationType::LargestObject,
+                  std::nullopt,
+                  std::nullopt
+              };
+            }()
+        });
+      });
+
+  doSubscribeNamespace(subscriber, kTestNamespace);
+
+  // Publish with extensions (both known and unknown)
+  PublishRequest pub;
+  pub.fullTrackName = kTestTrackName;
+  pub.extensions.insertMutableExtension(Extension{kDeliveryTimeoutExtensionType, 5000});
+  pub.extensions.insertMutableExtension(Extension{0xBEEF'0000, 42});
+
+  withSessionContext(publisherSession, [&]() {
+    auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+    EXPECT_TRUE(res.hasValue());
+    if (res.hasValue()) {
+      getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
+    }
+  });
+  exec_->drive();
+
+  // Verify extensions were forwarded
+  EXPECT_EQ(receivedExtensions.getIntExtension(kDeliveryTimeoutExtensionType), 5000);
+  EXPECT_EQ(receivedExtensions.getIntExtension(0xBEEF'0000), 42);
+
+  removeSession(publisherSession);
+  removeSession(subscriber);
+}
+
+// Test: Extensions from publish are forwarded to late-joining subscribers
+TEST_F(MoQRelayTest, PublishExtensionsForwardedToLateJoiners) {
+  auto publisherSession = createMockSession();
+  auto subscriber1 = createMockSession();
+  auto subscriber2 = createMockSession();
+
+  // Subscriber 1 subscribes first
+  auto mockConsumer1 = createMockConsumer();
+  EXPECT_CALL(*subscriber1, publish(testing::_, testing::_)).WillOnce([&mockConsumer1](auto, auto) {
+    return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
+        mockConsumer1,
+        []() -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
+          co_return PublishOk{
+              RequestID(1),
+              true,
+              0,
+              GroupOrder::OldestFirst,
+              LocationType::LargestObject,
+              std::nullopt,
+              std::nullopt
+          };
+        }()
+    });
+  });
+
+  doSubscribeNamespace(subscriber1, kTestNamespace);
+
+  // Publish with extensions
+  PublishRequest pub;
+  pub.fullTrackName = kTestTrackName;
+  pub.extensions.insertMutableExtension(Extension{kDeliveryTimeoutExtensionType, 3000});
+  pub.extensions.insertMutableExtension(Extension{0xCAFE'0000, 99});
+
+  withSessionContext(publisherSession, [&]() {
+    auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+    EXPECT_TRUE(res.hasValue());
+    if (res.hasValue()) {
+      getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
+    }
+  });
+  exec_->drive();
+
+  // Late-joining subscriber 2 should also get extensions
+  Extensions receivedExtensions;
+  auto mockConsumer2 = createMockConsumer();
+  EXPECT_CALL(*subscriber2, publish(testing::_, testing::_))
+      .WillOnce([&mockConsumer2, &receivedExtensions](PublishRequest pubReq, auto) {
+        receivedExtensions = pubReq.extensions;
+        return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
+            mockConsumer2,
+            []() -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
+              co_return PublishOk{
+                  RequestID(2),
+                  true,
+                  0,
+                  GroupOrder::OldestFirst,
+                  LocationType::LargestObject,
+                  std::nullopt,
+                  std::nullopt
+              };
+            }()
+        });
+      });
+
+  doSubscribeNamespace(subscriber2, kTestNamespace);
+  exec_->drive();
+
+  // Verify late-joiner received extensions
+  EXPECT_EQ(receivedExtensions.getIntExtension(kDeliveryTimeoutExtensionType), 3000);
+  EXPECT_EQ(receivedExtensions.getIntExtension(0xCAFE'0000), 99);
+
+  removeSession(publisherSession);
+  removeSession(subscriber1);
+  removeSession(subscriber2);
+}
+
+// Test: Extensions are included in SubscribeOk for subscribe path subscribers
+TEST_F(MoQRelayTest, ExtensionsIncludedInSubscribeOkForSubscribers) {
+  auto session1 = createMockSession();
+  auto session2 = createMockSession();
+
+  // Create forwarder with extensions
+  auto forwarder = std::make_shared<MoQForwarder>(kTestTrackName, AbsoluteLocation{0, 0});
+  Extensions ext;
+  ext.insertMutableExtension(Extension{kDeliveryTimeoutExtensionType, 7000});
+  ext.insertMutableExtension(Extension{0xDEAD'0000, 123});
+  forwarder->setExtensions(ext);
+
+  // Add subscriber via SubscribeRequest
+  auto consumer1 = createMockConsumer();
+  SubscribeRequest sub1;
+  sub1.fullTrackName = kTestTrackName;
+  sub1.requestID = RequestID(1);
+  sub1.locType = LocationType::LargestGroup;
+  auto subscriber1 = forwarder->addSubscriber(session1, sub1, consumer1);
+  ASSERT_NE(subscriber1, nullptr);
+
+  // Verify extensions are in the SubscribeOk
+  EXPECT_EQ(
+      subscriber1->subscribeOk().extensions.getIntExtension(kDeliveryTimeoutExtensionType),
+      7000
+  );
+  EXPECT_EQ(subscriber1->subscribeOk().extensions.getIntExtension(0xDEAD'0000), 123);
+
+  // Second subscriber should also get extensions
+  auto consumer2 = createMockConsumer();
+  SubscribeRequest sub2;
+  sub2.fullTrackName = kTestTrackName;
+  sub2.requestID = RequestID(2);
+  sub2.locType = LocationType::LargestGroup;
+  auto subscriber2 = forwarder->addSubscriber(session2, sub2, consumer2);
+  ASSERT_NE(subscriber2, nullptr);
+
+  EXPECT_EQ(
+      subscriber2->subscribeOk().extensions.getIntExtension(kDeliveryTimeoutExtensionType),
+      7000
+  );
+  EXPECT_EQ(subscriber2->subscribeOk().extensions.getIntExtension(0xDEAD'0000), 123);
+
+  // Add subscriber via publish path (bool forward)
+  auto session3 = createMockSession();
+  auto subscriber3 = forwarder->addSubscriber(session3, /*forward=*/false);
+  ASSERT_NE(subscriber3, nullptr);
+
+  EXPECT_EQ(
+      subscriber3->subscribeOk().extensions.getIntExtension(kDeliveryTimeoutExtensionType),
+      7000
+  );
+  EXPECT_EQ(subscriber3->subscribeOk().extensions.getIntExtension(0xDEAD'0000), 123);
+}
+
+TEST_F(MoQRelayTest, ExactNamespaceSubscriberReceivesPublishNamespace) {
+  auto subscriber = createMockSession();
+  auto publisher = createMockSession();
+
+  // Subscriber subscribes to exact namespace {"test", "namespace"}
+  doSubscribeNamespace(subscriber, kTestNamespace);
+
+  // Expect the subscriber to receive a publishNamespace forwarding when
+  // the publisher announces the same exact namespace
+  EXPECT_CALL(*subscriber, publishNamespace(_, _))
+      .WillOnce(
+          [](PublishNamespace ann, auto) -> folly::coro::Task<Subscriber::PublishNamespaceResult> {
+            EXPECT_EQ(ann.trackNamespace, kTestNamespace);
+            co_return folly::makeUnexpected(PublishNamespaceError{
+                ann.requestID,
+                PublishNamespaceErrorCode::UNINTERESTED,
+                "test"
+            });
+          }
+      );
+
+  // Publisher announces the same exact namespace
+  doPublishNamespace(publisher, kTestNamespace);
+
+  // Drive the executor so the async publishNamespace forwarding runs
+  exec_->drive();
+
+  removeSession(publisher);
+  removeSession(subscriber);
+}
+
+// Test: TrackStatus on non-existent track
+TEST_F(MoQRelayTest, TrackStatusNonExistentTrack) {
+  auto clientSession = createMockSession();
+
+  // Request trackStatus for a track that doesn't exist
+  TrackStatus trackStatus;
+  trackStatus.fullTrackName = kTestTrackName;
+  trackStatus.requestID = RequestID(1);
+
+  withSessionContext(clientSession, [&]() {
+    auto task = relay_->trackStatus(trackStatus);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+
+    // Should return error indicating track not found
+    EXPECT_FALSE(res.hasValue());
+    EXPECT_EQ(res.error().errorCode, TrackStatusErrorCode::TRACK_NOT_EXIST);
+    EXPECT_FALSE(res.error().reasonPhrase.empty());
+  });
+
+  removeSession(clientSession);
+}
+
+// Test: TrackStatus on existing track - returns forwarder state (no upstream
+// call)
+TEST_F(MoQRelayTest, TrackStatusSuccessfulForward) {
+  auto publisherSession = createMockSession();
+  auto clientSession = createMockSession();
+
+  doPublish(publisherSession, kTestTrackName);
+
+  auto consumer = createMockConsumer();
+  subscribeToTrack(clientSession, kTestTrackName, consumer, RequestID(1));
+
+  TrackStatus trackStatus;
+  trackStatus.fullTrackName = kTestTrackName;
+  trackStatus.requestID = RequestID(2);
+
+  withSessionContext(clientSession, [&]() {
+    auto task = relay_->trackStatus(trackStatus);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+
+    // Should return status from local forwarder
+    // Since no data was sent, statusCode should be TRACK_NOT_STARTED
+    EXPECT_TRUE(res.hasValue());
+    EXPECT_EQ(res.value().statusCode, TrackStatusCode::TRACK_NOT_STARTED);
+    EXPECT_EQ(res.value().fullTrackName, kTestTrackName);
+  });
+
+  removeSession(clientSession);
+  exec_->drive();
+  removeSession(publisherSession);
+}
+
+// Test: TrackStatus using namespace prefix matching (no exact subscription)
+// Verifies that when there's no exact subscription but a publisher has
+// published a matching namespace prefix, the relay correctly routes
+// TRACK_STATUS upstream using prefix matching
+TEST_F(MoQRelayTest, TrackStatusViaPrefixMatching) {
+  auto publisher = createMockSession();
+  auto requester = createMockSession();
+
+  // Publisher publishes namespace but NOT the specific track
+  doPublishNamespace(publisher, kTestNamespace);
+
+  // No exact subscription exists for kTestTrackName, so trackStatus should
+  // use prefix matching to find the publisher
+
+  // Mock the upstream trackStatus call
+  TrackStatusOk statusOk;
+  statusOk.requestID = RequestID(1);
+  statusOk.trackAlias = TrackAlias(0);
+  statusOk.largest = AbsoluteLocation{50, 25};
+
+  EXPECT_CALL(*publisher, trackStatus(_)).WillOnce([statusOk](auto /*ts*/) {
+    return folly::coro::makeTask<Publisher::TrackStatusResult>(statusOk);
+  });
+
+  // Execute trackStatus from requester's perspective
+  TrackStatus trackStatus;
+  trackStatus.requestID = RequestID(1);
+  trackStatus.fullTrackName = kTestTrackName;
+
+  withSessionContext(requester, [&]() {
+    auto task = relay_->trackStatus(trackStatus);
+    auto result = folly::coro::blockingWait(std::move(task), exec_.get());
+
+    // Should successfully forward via prefix matching and return the result
+    EXPECT_TRUE(result.hasValue()) << "TrackStatus via namespace prefix matching should succeed";
+    EXPECT_EQ(result.value().requestID, RequestID(1));
+    EXPECT_TRUE(result.value().largest.has_value());
+    EXPECT_EQ(result.value().largest->group, 50);
+    EXPECT_EQ(result.value().largest->object, 25);
+  });
+
+  removeSession(publisher);
+  removeSession(requester);
 }
 
 } // namespace moxygen::test


### PR DESCRIPTION
Brings ORelay up to date with 9 upstream moxygen commits:
- NamespaceSubscriberInfo struct (forward, options, namespacePublishHandle, trackNamespacePrefix) replacing bare bool in sessions map
- Draft 16+ bidi stream support in publishNamespace/publishNamespaceDone
- trackStatus method (forward to upstream or answer from local forwarder)
- publishToSession: remove PublishRequest param
- subscribeNamespace: allow empty prefix for draft 16+; store full NamespaceSubscriberInfo; draft 16+ namespace message path
- subscribe/publish: setExtensions replacing setGroupOrder/delivery timeout
- Remove MoQTrackProperties.h include
- 523 new test lines covering all new functionality

scripts/sync-relay.sh automates future syncs: copies MoQRelay.h/.cpp and MoQRelayTest.cpp from deps/moxygen, applies name/namespace transforms (MoQRelay→ORelay, namespace moxygen→openmoq::o_rly, moxygen:: qualifiers in header, using namespace moxygen in .cpp), formats, builds, and tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/51)
<!-- Reviewable:end -->
