### PR TITLE
CI refinements: Docker fix, Linode runner, bump workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ build/
 build-san/
 install/
 _build/
+.git/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .scratch/
 build/
 build-san/
+install/
+_build/

--- a/.github/workflows/auto-merge-bump.yml
+++ b/.github/workflows/auto-merge-bump.yml
@@ -1,0 +1,105 @@
+name: bump auto-merge
+
+# Fires when ci pr completes on a bump-moxygen/* branch.
+# If build passed, merges the corresponding PR into main.
+# If build failed, sends Slack + email notifications.
+#
+# NOTE: workflow_run always runs from the default branch.
+
+on:
+  workflow_run:
+    workflows: ["ci pr"]
+    types: [completed]
+    branches:
+      - bump-moxygen/**
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-22.04
+    if: startsWith(github.event.workflow_run.head_branch, 'bump-moxygen/')
+    steps:
+      - name: Find bump PR
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_NUM=$(gh api "repos/${REPO}/pulls?state=open&base=main" \
+            --jq "[.[] | select(.head.ref == \"${HEAD_BRANCH}\")] | .[0].number // empty")
+          echo "pr_num=${PR_NUM}" >> "$GITHUB_OUTPUT"
+
+      # ── verification failed: notify ───────────────────────────────────
+
+      - name: Notify Slack (verification failure)
+        if: github.event.workflow_run.conclusion != 'success'
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
+        run: |
+          PR_NUM="${{ steps.find-pr.outputs.pr_num }}"
+          PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          TEXT=":x: *${{ github.repository }}* \`${BRANCH}\` — verification failed: PR: <${PR_URL}|#${PR_NUM}>"
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "{\"text\": \"${TEXT}\"}"
+
+      - name: Notify email (verification failure)
+        if: github.event.workflow_run.conclusion != 'success'
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.OMOQ_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OMOQ_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          PR_NUM="${{ steps.find-pr.outputs.pr_num }}"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
+          CI_RUN_URL="${{ github.event.workflow_run.html_url }}"
+          SUBJECT="[o-rly] bump verification failed — ${BRANCH}"
+          BODY="Moxygen bump verification failed.\n\nBranch: ${BRANCH}\nPR: ${PR_URL}\nRun: ${CI_RUN_URL}"
+          aws ses send-email \
+            --from "noreply@ci.openmoq.org" \
+            --destination '{"ToAddresses":["github-notifications@openmoq.org"]}' \
+            --message "{
+              \"Subject\": {\"Data\": \"${SUBJECT}\"},
+              \"Body\": {\"Text\": {\"Data\": \"${BODY}\"}}
+            }"
+
+      # ── build passed: merge ──────────────────────────────────────────────
+
+      - name: Generate app token
+        if: github.event.workflow_run.conclusion == 'success'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - name: Merge bump PR
+        if: github.event.workflow_run.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Build passed on ${HEAD_BRANCH} (${HEAD_SHA})"
+
+          PR_NUM=$(gh api \
+            "repos/${REPO}/pulls?state=open&base=main" \
+            --jq "[.[] | select(.head.ref == \"${HEAD_BRANCH}\" and .head.sha == \"${HEAD_SHA}\")] | .[0].number // empty")
+
+          if [ -z "$PR_NUM" ]; then
+            echo "No open bump PR found for ${HEAD_BRANCH} at ${HEAD_SHA}. Nothing to do."
+            exit 0
+          fi
+
+          echo "Merging bump PR #${PR_NUM}..."
+          gh pr merge "${PR_NUM}" --merge --repo "${REPO}"
+          echo "Merged PR #${PR_NUM}."

--- a/.github/workflows/bump-moxygen.yml
+++ b/.github/workflows/bump-moxygen.yml
@@ -1,0 +1,109 @@
+name: bump moxygen
+
+# Advance the deps/moxygen submodule to a new commit.
+# Creates a PR branch bump-moxygen/<short-sha> with the updated submodule.
+#
+# Usage:
+#   gh workflow run bump-moxygen.yml                     # latest moxygen main
+#   gh workflow run bump-moxygen.yml -f target_sha=abc123  # specific commit
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: "Moxygen commit SHA (default: latest main HEAD)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve target SHA
+        id: resolve
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          INPUT_SHA: ${{ inputs.target_sha }}
+        run: |
+          OLD_SHA=$(git -C deps/moxygen rev-parse HEAD)
+          echo "old_sha=$OLD_SHA" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$INPUT_SHA" ]]; then
+            TARGET="$INPUT_SHA"
+          else
+            TARGET=$(gh api repos/openmoq/moxygen/commits/main --jq '.sha')
+          fi
+          echo "target_sha=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "short=${TARGET:0:7}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$OLD_SHA" == "$TARGET" ]]; then
+            echo "Submodule already at $TARGET — nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate moxygen artifacts exist
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+        run: |
+          RUN_ID=$(gh api "repos/openmoq/moxygen/actions/workflows/omoq-ci-main.yml/runs?head_sha=${TARGET_SHA}&status=success&per_page=1" \
+              --jq '.workflow_runs[0].id // empty')
+          if [[ -z "$RUN_ID" ]]; then
+            echo "Error: no successful moxygen publish run for ${TARGET_SHA:0:7}" >&2
+            echo "Artifacts must exist before bumping the submodule." >&2
+            exit 1
+          fi
+          echo "Validated: moxygen run $RUN_ID has artifacts for ${TARGET_SHA:0:7}"
+
+      - name: Update submodule
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+        run: |
+          git -C deps/moxygen fetch origin
+          git -C deps/moxygen checkout "$TARGET_SHA"
+
+      - name: Create PR
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OLD_SHA: ${{ steps.resolve.outputs.old_sha }}
+          TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
+          SHORT: ${{ steps.resolve.outputs.short }}
+        run: |
+          BRANCH="bump-moxygen/${SHORT}"
+          git checkout -b "$BRANCH"
+          git add deps/moxygen
+          git commit -m "Bump moxygen submodule to ${SHORT}"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "Bump moxygen to ${SHORT}" \
+            --body "$(cat <<EOF
+          Update \`deps/moxygen\` submodule.
+
+          | | SHA |
+          |---|---|
+          | **Old** | \`${OLD_SHA:0:12}\` |
+          | **New** | \`${TARGET_SHA:0:12}\` |
+
+          [Diff](https://github.com/openmoq/moxygen/compare/${OLD_SHA:0:12}...${TARGET_SHA:0:12})
+          EOF
+          )"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,13 +1,13 @@
 name: ci main
 
-# Full pipeline on push to main: format, build/test, publish artifacts + Docker,
-# release snapshot, notify. PRs use ci-pr.yml (format + build/test only).
+# Full pipeline on push to main: check-format, build/test, publish artifacts +
+# Docker, release snapshot, notify. PRs use ci-pr.yml (check-format + build/test only).
 #
 # Job graph:
 #
-#   format ─────────────────────────────────────────────┐
-#   build (linux, asan debug) ── publish ── release ────┼── notify
-#                                                       │   (always)
+#   check-format ──────────────────────────────────────────┐
+#   build (linux, asan debug) ── publish ── release ───────┼── notify
+#                                                          │   (always)
 
 on:
   push:
@@ -27,7 +27,7 @@ jobs:
   # Verify: format + build/test matrix
   # ════════════════════════════════════════════════════════════════════════════
 
-  format:
+  check-format:
     runs-on: ubuntu-latest
     container: debian:trixie
     steps:
@@ -106,7 +106,7 @@ jobs:
         include:
           - name: ubuntu-22.04-amd64
     name: publish (${{ matrix.name }})
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linode]
     steps:
       - name: Generate app token
         id: app-token
@@ -127,12 +127,6 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bash scripts/setup-deps-tarball.sh
 
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: publish-${{ matrix.name }}
-          max-size: 500M
-
       - name: Configure
         run: |
           cmake -S . -B _build --preset default \
@@ -147,12 +141,25 @@ jobs:
       - name: Install
         run: cmake --install _build --prefix "$GITHUB_WORKSPACE/install"
 
+      - name: Download bookworm moxygen tarball for Docker
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SHA=$(git -C deps/moxygen rev-parse HEAD)
+          RUN_ID=$(gh api "repos/openmoq/moxygen/actions/workflows/omoq-ci-main.yml/runs?head_sha=${SHA}&status=success&per_page=1" \
+              --jq '.workflow_runs[0].id // empty')
+          if [[ -z "$RUN_ID" ]]; then
+            echo "Error: no successful moxygen run for ${SHA:0:7}" >&2
+            exit 1
+          fi
+          mkdir -p .docker-deps
+          gh run download "$RUN_ID" --repo openmoq/moxygen \
+              --name "moxygen-bookworm-amd64.tar.gz" --dir .docker-deps
+
       - name: Log in to GHCR
-        if: runner.os == 'Linux'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
-        if: runner.os == 'Linux'
         run: |
           SHORT="${GITHUB_SHA:0:7}"
           IMAGE="ghcr.io/${{ github.repository }}"
@@ -222,7 +229,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   notify:
-    needs: [format, build, publish, release]
+    needs: [check-format, build, publish, release]
     if: always()
     runs-on: ubuntu-22.04
     steps:
@@ -244,7 +251,7 @@ jobs:
             esac
           }
 
-          FMT=$(fmt_status "${{ needs.format.result }}")
+          FMT=$(fmt_status "${{ needs.check-format.result }}")
           VER=$(fmt_status "${{ needs.build.result }}")
           PUB=$(fmt_status "${{ needs.publish.result }}")
           REL=$(fmt_status "${{ needs.release.result }}")
@@ -272,7 +279,7 @@ jobs:
           SHORT="${GITHUB_SHA:0:7}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          FMT="${{ needs.format.result }}"
+          FMT="${{ needs.check-format.result }}"
           VER="${{ needs.build.result }}"
           PUB="${{ needs.publish.result }}"
           REL="${{ needs.release.result }}"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -16,7 +16,7 @@ permissions:
   checks: write
 
 jobs:
-  format:
+  check-format:
     runs-on: ubuntu-latest
     container: debian:trixie
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,9 @@ RUN mkdir -p /opt/moxygen && tar xzf /tmp/moxygen.tar.gz -C /opt/moxygen
 # Copy o-rly source (use .dockerignore to exclude build dirs)
 COPY . /build
 
-RUN cmake -S /build -B /build/_build --preset default \
+RUN cmake -S /build -B /build/_build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \
         -DCMAKE_PREFIX_PATH=/opt/moxygen \
         -DBUILD_TESTING=OFF \
     && cmake --build /build/_build -j"$(nproc)" \
@@ -58,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgflags2.2 \
         libgoogle-glog0v6 \
         libsodium23 \
-        libboost-context1.81.0 \
+        libboost-context1.74.0 \
         libssl3 \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,70 @@
+# Multi-stage build: compile in bookworm, run in bookworm-slim.
+#
+# The CI workflow pre-downloads the moxygen bookworm tarball into
+# .docker-deps/ before running docker build, so we COPY it in rather
+# than needing gh CLI inside the container.
+#
+#   docker build -f docker/Dockerfile .
+
+# ── Stage 1: Build ────────────────────────────────────────────────────────────
+
+FROM debian:bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        ninja-build \
+        git \
+        ca-certificates \
+        libssl-dev \
+        libunwind-dev \
+        libgoogle-glog-dev \
+        libgflags-dev \
+        libdouble-conversion-dev \
+        libevent-dev \
+        libsodium-dev \
+        libzstd-dev \
+        libboost-all-dev \
+        libfmt-dev \
+        zlib1g-dev \
+        libc-ares-dev \
+        gperf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Unpack moxygen tarball (pre-downloaded by CI)
+COPY .docker-deps/moxygen-bookworm-amd64.tar.gz /tmp/moxygen.tar.gz
+RUN mkdir -p /opt/moxygen && tar xzf /tmp/moxygen.tar.gz -C /opt/moxygen
+
+# Copy o-rly source (use .dockerignore to exclude build dirs)
+COPY . /build
+
+RUN cmake -S /build -B /build/_build --preset default \
+        -DCMAKE_PREFIX_PATH=/opt/moxygen \
+        -DBUILD_TESTING=OFF \
+    && cmake --build /build/_build -j"$(nproc)" \
+    && cmake --install /build/_build --prefix /staging
+
+# ── Stage 2: Runtime ──────────────────────────────────────────────────────────
+
 FROM debian:bookworm-slim
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libfmt9 \
         libunwind8 \
+        libdouble-conversion3 \
+        libevent-2.1-7 \
+        libgflags2.2 \
+        libgoogle-glog0v6 \
+        libsodium23 \
+        libboost-context1.81.0 \
+        libssl3 \
+        zlib1g \
     && rm -rf /var/lib/apt/lists/*
-COPY install/bin/o_rly /usr/local/bin/o-rly
+
+COPY --from=builder /staging/bin/o_rly /usr/local/bin/o-rly
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- **Multi-stage Dockerfile**: build in `debian:bookworm` using bookworm moxygen tarball, fixing shared lib mismatch crash (binary was built on ubuntu-22.04 but runtime was bookworm-slim)
- **Linode self-hosted runner** for publish job (faster builds, persistent deps)
- **Rename** `format` → `check-format` in ci-pr.yml and ci-main.yml
- **bump-moxygen.yml**: `workflow_dispatch` to advance `deps/moxygen` submodule, validates artifacts exist before creating PR
- **auto-merge-bump.yml**: auto-merges bump PRs when CI passes, notifies on failure

## Changes
- `docker/Dockerfile` — multi-stage: build stage (bookworm + system deps + moxygen tarball), runtime stage (bookworm-slim + runtime libs)
- `.dockerignore` — exclude `install/` and `_build/`
- `.github/workflows/ci-main.yml` — Linode runner for publish, bookworm tarball download for Docker, check-format rename
- `.github/workflows/ci-pr.yml` — check-format rename
- `.github/workflows/bump-moxygen.yml` (new)
- `.github/workflows/auto-merge-bump.yml` (new)

## Test plan
- [x] ci-pr passes (check-format + build/test)
- [ ] After merge: publish job builds on Linode, Docker image starts without missing .so errors
- [ ] `docker run --rm ghcr.io/openmoq/o-rly:latest --help` works
- [ ] Trigger bump-moxygen workflow → creates PR → CI passes → auto-merges

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/54)
<!-- Reviewable:end -->
