### PR TITLE
Improve build change detection

### DIFF
--- a/scripts/build-meta-deps.sh
+++ b/scripts/build-meta-deps.sh
@@ -41,6 +41,7 @@ build_dep() {
 
   cmake --build "$build_dir"
   cmake --install "$build_dir"
+  git -C "$src" rev-parse HEAD > "${inst_dir}/.build-rev"
   echo "${name} done."
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,9 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCRATCH="${ORLY_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
 
 HASHES_DIR="${PROJECT_ROOT}/deps/moxygen/build/deps/github_hashes"
+MANIFESTS_DIR="${PROJECT_ROOT}/deps/moxygen/build/fbcode_builder/manifests"
 META_HASH_FILE="${SCRATCH}/meta-deps.hash"
+MANIFESTS_HASH_FILE="${SCRATCH}/manifests.hash"
 MOXYGEN_REV_FILE="${SCRATCH}/moxygen.rev"
 PREFIX_PATH_FILE="${SCRATCH}/cmake_prefix_path.txt"
 
@@ -23,6 +25,25 @@ needs_setup() {
   [[ ! -f "$PREFIX_PATH_FILE" ]]
 }
 
+manifests_hash() {
+  local deps
+  deps=$(python3 "${MANIFESTS_DIR}/../getdeps.py" list-deps moxygen 2>/dev/null)
+  local files=()
+  for dep in $deps; do
+    files+=("${MANIFESTS_DIR}/${dep}")
+  done
+  cat "${files[@]}" 2>/dev/null | sha256sum | awk '{print $1}'
+}
+
+manifests_changed() {
+  local current
+  current=$(manifests_hash)
+  if [[ ! -f "$MANIFESTS_HASH_FILE" ]] || [[ "$current" != "$(cat "$MANIFESTS_HASH_FILE")" ]]; then
+    return 0
+  fi
+  return 1
+}
+
 meta_deps_hash() {
   cat "$HASHES_DIR"/*/*-rev.txt 2>/dev/null | sha256sum | awk '{print $1}'
 }
@@ -34,6 +55,19 @@ meta_deps_changed() {
     return 0
   fi
   return 1
+}
+
+meta_deps_installed() {
+  local inst_dir="${SCRATCH}/installed"
+  for key in "${!REPO_DIRS[@]}"; do
+    local name
+    name=$(basename "$key")
+    local pinned
+    pinned=$(awk '{print $3}' "${HASHES_DIR}/${key}-rev.txt" 2>/dev/null) || return 1
+    local stamp="${inst_dir}/${name}/.build-rev"
+    [[ -f "$stamp" ]] && [[ "$(cat "$stamp")" == "$pinned" ]] || return 1
+  done
+  return 0
 }
 
 moxygen_rev() {
@@ -92,7 +126,15 @@ warn_stale_patches() {
 save_stamps() {
   mkdir -p "$SCRATCH"
   meta_deps_hash > "$META_HASH_FILE"
+  manifests_hash > "$MANIFESTS_HASH_FILE"
   moxygen_rev > "$MOXYGEN_REV_FILE"
+  local inst_dir="${SCRATCH}/installed"
+  for key in "${!REPO_DIRS[@]}"; do
+    local name
+    name=$(basename "$key")
+    local repo_dir="${SCRATCH}/repos/${REPO_DIRS[$key]}"
+    [[ -d "$repo_dir" ]] && git -C "$repo_dir" rev-parse HEAD > "${inst_dir}/${name}/.build-rev"
+  done
 }
 
 # --- Main ---
@@ -100,6 +142,7 @@ save_stamps() {
 if needs_setup; then
   echo "No prior build found. Running initial setup..."
   "${SCRIPT_DIR}/setup-deps.sh"
+  update_meta_repos
   "${SCRIPT_DIR}/configure.sh"
   save_stamps
   cmake --build "${PROJECT_ROOT}/build"
@@ -108,10 +151,13 @@ fi
 
 NEED_CONFIGURE=false
 
-if meta_deps_changed; then
-  echo "Meta dep pinned revisions changed."
+if manifests_changed; then
+  echo "Manifest files changed. Re-running full dependency setup..."
+  "${SCRIPT_DIR}/setup-deps.sh"
+  NEED_CONFIGURE=true
+elif meta_deps_changed || ! meta_deps_installed; then
+  echo "Meta dep pinned revisions changed or installs incomplete."
   has_stale_patches && warn_stale_patches
-  update_meta_repos
   "${SCRIPT_DIR}/build-meta-deps.sh"
   NEED_CONFIGURE=true
 elif moxygen_changed; then
@@ -120,6 +166,8 @@ elif moxygen_changed; then
   "${SCRIPT_DIR}/build-moxygen.sh"
   NEED_CONFIGURE=true
 fi
+
+update_meta_repos
 
 if [[ "$NEED_CONFIGURE" == true ]]; then
   "${SCRIPT_DIR}/configure.sh"


### PR DESCRIPTION
Track moxygen's full dependency manifest tree so changes to any
upstream manifest trigger a full setup-deps.sh run. Use getdeps.py
to derive the manifest list dynamically rather than maintaining it
by hand.

Add .build-rev stamps after each meta dep build and check them in
meta_deps_installed() so that incomplete or interrupted installs
trigger a rebuild on the next run. Write stamps in save_stamps() so
initial setup via setup-deps.sh also produces them.

Also updates the submodule hash that fixes pico's getdeps file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/55)
<!-- Reviewable:end -->
