### PR TITLE
Add relay deploy workflow (moqx-000)

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -2,8 +2,7 @@ name: deploy relay
 
 # Deploy o-rly relay Docker container to a self-hosted runner.
 # Uses the repo's docker/docker-compose.yml with secrets-driven .env.
-#
-# Certs must already be provisioned on the target machine.
+# Automatically provisions or renews TLS certs via Route53 DNS challenge.
 
 on:
   workflow_dispatch:
@@ -59,6 +58,25 @@ jobs:
           CERTBOT_EMAIL=gmarzot@openmoq.org
           ORLY_PORT=${{ steps.config.outputs.port }}
           EOF
+
+      - name: Ensure TLS cert
+        env:
+          DOMAIN: ${{ steps.config.outputs.domain }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OMOQ_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OMOQ_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          CERT="/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
+          if [ ! -f "$CERT" ]; then
+            echo "::warning::No cert for ${DOMAIN} — provisioning via Route53"
+            sudo certbot certonly --dns-route53 \
+              -d "$DOMAIN" --non-interactive --agree-tos \
+              --email gmarzot@openmoq.org
+          elif ! sudo openssl x509 -in "$CERT" -noout -checkend 2592000 2>/dev/null; then
+            echo "::warning::Cert for ${DOMAIN} expires within 30 days — renewing"
+            sudo certbot renew --cert-name "$DOMAIN"
+          else
+            echo "Cert for ${DOMAIN} is valid"
+          fi
 
       - name: Pull image
         run: docker pull "ghcr.io/${{ github.repository }}:${IMAGE_TAG}"

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,0 +1,109 @@
+name: deploy relay
+
+# Deploy o-rly relay Docker container to a self-hosted runner.
+# Uses the repo's docker/docker-compose.yml with secrets-driven .env.
+#
+# Certs must already be provisioned on the target machine.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker image tag (default: latest)"
+        required: false
+        default: "latest"
+        type: string
+      instance:
+        description: "Instance name (determines domain + port)"
+        required: false
+        default: "moqx-000"
+        type: choice
+        options:
+          - moqx-000
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, linode]
+    env:
+      INSTANCE: ${{ inputs.instance }}
+      IMAGE_TAG: ${{ inputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Set instance config
+        id: config
+        run: |
+          case "$INSTANCE" in
+            moqx-000)
+              echo "domain=moqx-000.ci.openmoq.org" >> "$GITHUB_OUTPUT"
+              echo "port=4433" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unknown instance: $INSTANCE"
+              exit 1
+              ;;
+          esac
+
+      - name: Write .env
+        working-directory: docker
+        run: |
+          cat > .env <<EOF
+          DOMAIN=${{ steps.config.outputs.domain }}
+          CERTBOT_EMAIL=gmarzot@openmoq.org
+          ORLY_PORT=${{ steps.config.outputs.port }}
+          EOF
+
+      - name: Pull image
+        run: docker pull "ghcr.io/${{ github.repository }}:${IMAGE_TAG}"
+
+      - name: Deploy
+        working-directory: docker
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}:${IMAGE_TAG}"
+
+          # Tag as the expected image name if not "latest"
+          if [ "$IMAGE_TAG" != "latest" ]; then
+            docker tag "$IMAGE" "ghcr.io/${{ github.repository }}:latest"
+          fi
+
+          echo "==> Stopping existing container (if any)..."
+          docker compose down --remove-orphans 2>/dev/null || true
+
+          echo "==> Starting relay (${INSTANCE} on port ${{ steps.config.outputs.port }})..."
+          docker compose up -d o-rly
+
+          echo "==> Waiting for admin endpoint..."
+          for i in $(seq 1 30); do
+            if curl -sf http://[::1]:9669/info >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+            if [ "$i" -eq 30 ]; then
+              echo "::error::Admin endpoint did not respond within 30s"
+              docker compose logs o-rly
+              exit 1
+            fi
+          done
+
+          RESP=$(curl -sf http://[::1]:9669/info)
+          echo "==> Relay running: $RESP"
+
+      - name: Notify Slack
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.OMOQ_SLACK_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA:0:7}"
+          DOMAIN="${{ steps.config.outputs.domain }}"
+          PORT="${{ steps.config.outputs.port }}"
+          TEXT=":rocket: *${{ github.repository }}* deployed \`${IMAGE_TAG}\` to \`${DOMAIN}:${PORT}\`"
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "{\"text\": \"${TEXT}\"}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - "${ORLY_PORT:-9668}:9668/udp"
     volumes:
-      - certs:/certs:ro
+      - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/certs:ro
     environment:
       ORLY_CERT: /certs/live/${DOMAIN}/fullchain.pem
       ORLY_KEY:  /certs/live/${DOMAIN}/privkey.pem
@@ -37,7 +37,7 @@ services:
   certbot-cloudflare:
     image: certbot/dns-cloudflare
     volumes:
-      - certs:/etc/letsencrypt
+      - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/etc/letsencrypt
       - ./cloudflare.ini:/run/secrets/cloudflare.ini:ro
     command: >
       certonly
@@ -56,7 +56,7 @@ services:
   certbot-route53:
     image: certbot/dns-route53
     volumes:
-      - certs:/etc/letsencrypt
+      - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/etc/letsencrypt
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
@@ -69,6 +69,3 @@ services:
       --dns-route53
       -d ${DOMAIN}
     profiles: [certbot-route53]
-
-volumes:
-  certs:


### PR DESCRIPTION
## Summary

Manual `workflow_dispatch` to deploy the o-rly Docker container to the
self-hosted Linode runner.

- **Instance**: `moqx-000.ci.openmoq.org:4433` (expandable via choice input)
- Pulls image from GHCR (tag selectable, default `latest`)
- Restarts via `docker compose` using repo's `docker/docker-compose.yml`
- Verifies admin `/info` endpoint responds after deploy
- Notifies Slack on success

Instance config (domain, port) is driven by a `case` block — adding
more instances is just adding to the choice list and the case.

## Prerequisites

- Self-hosted runner registered on o-rly with `[self-hosted, linode]` labels
- Certs provisioned on the target machine for `moqx-000.ci.openmoq.org`
- DNS A record for `moqx-000.ci.openmoq.org`

## Test plan

- [ ] actionlint: clean (custom label warning only)
- [ ] Merge, then trigger manually and verify relay starts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/60)
<!-- Reviewable:end -->
