### PR TITLE
Fix relay deploy: config-based entrypoint + certbot creds

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -58,12 +58,14 @@ jobs:
           CERTBOT_EMAIL=gmarzot@openmoq.org
           ORLY_PORT=${{ steps.config.outputs.port }}
           EOF
+          # Strip leading whitespace from heredoc (YAML indentation artifact)
+          sed -i 's/^[[:space:]]*//' .env
 
       - name: Ensure TLS cert
         env:
           DOMAIN: ${{ steps.config.outputs.domain }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.OMOQ_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.OMOQ_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OMOQ_CERTBOT_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OMOQ_CERTBOT_SECRET_ACCESS_KEY }}
         run: |
           CERT="/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
           if [ ! -f "$CERT" ]; then

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     environment:
       ORLY_CERT: /certs/live/${DOMAIN}/fullchain.pem
       ORLY_KEY:  /certs/live/${DOMAIN}/privkey.pem
+      ORLY_PORT: ${ORLY_PORT:-9668}
 
   # Cloudflare DNS-01 challenge.
   # Requires: docker/cloudflare.ini (see cloudflare.ini.example)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,13 +24,13 @@ services:
     image: ghcr.io/openmoq/o-rly:latest
     restart: unless-stopped
     ports:
-      - "${ORLY_PORT:-9668}:${ORLY_PORT:-9668}/udp"
+      - "${ORLY_PORT:-4433}:${ORLY_PORT:-4433}/udp"
     volumes:
       - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/certs:ro
     environment:
       ORLY_CERT: /certs/live/${DOMAIN}/fullchain.pem
       ORLY_KEY:  /certs/live/${DOMAIN}/privkey.pem
-      ORLY_PORT: ${ORLY_PORT:-9668}
+      ORLY_PORT: ${ORLY_PORT:-4433}
 
   # Cloudflare DNS-01 challenge.
   # Requires: docker/cloudflare.ini (see cloudflare.ini.example)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: ghcr.io/openmoq/o-rly:latest
     restart: unless-stopped
     ports:
-      - "${ORLY_PORT:-9668}:9668/udp"
+      - "${ORLY_PORT:-9668}:${ORLY_PORT:-9668}/udp"
     volumes:
       - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/certs:ro
     environment:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,7 +4,7 @@
 # Env vars:
 #   ORLY_CERT      — path to TLS certificate PEM (required unless ORLY_INSECURE=true)
 #   ORLY_KEY       — path to TLS private key PEM  (required unless ORLY_INSECURE=true)
-#   ORLY_PORT      — UDP listen port (default: 9668)
+#   ORLY_PORT      — UDP listen port (default: 4433)
 #   ORLY_INSECURE  — use built-in dev cert (default: false)
 set -e
 
@@ -16,7 +16,7 @@ listeners:
     udp:
       socket:
         address: "::"
-        port: ${ORLY_PORT:-9668}
+        port: ${ORLY_PORT:-4433}
     tls:
       cert_file: "${ORLY_CERT:-}"
       key_file: "${ORLY_KEY:-}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,37 @@
 #!/bin/sh
-# Translate ORLY_CERT / ORLY_KEY env vars to --cert / --key flags,
-# then exec o-rly with any additional arguments passed to the container.
+# Generate relay config from env vars and exec o_rly.
+#
+# Env vars:
+#   ORLY_CERT      — path to TLS certificate PEM (required unless ORLY_INSECURE=true)
+#   ORLY_KEY       — path to TLS private key PEM  (required unless ORLY_INSECURE=true)
+#   ORLY_PORT      — UDP listen port (default: 9668)
+#   ORLY_INSECURE  — use built-in dev cert (default: false)
 set -e
-exec /usr/local/bin/o-rly \
-    ${ORLY_CERT:+--cert="$ORLY_CERT"} \
-    ${ORLY_KEY:+--key="$ORLY_KEY"} \
-    "$@"
+
+CONFIG=/tmp/relay.yaml
+
+cat > "$CONFIG" <<EOF
+listeners:
+  - name: relay
+    udp:
+      socket:
+        address: "::"
+        port: ${ORLY_PORT:-9668}
+    tls:
+      cert_file: "${ORLY_CERT:-}"
+      key_file: "${ORLY_KEY:-}"
+      insecure: ${ORLY_INSECURE:-false}
+    endpoint: "/moq-relay"
+
+cache:
+  enabled: true
+  max_tracks: 100
+  max_groups_per_track: 3
+
+admin:
+  port: 9669
+  address: "::"
+  plaintext: true
+EOF
+
+exec /usr/local/bin/o-rly --config "$CONFIG" "$@"


### PR DESCRIPTION
## Summary
- Rewrite `docker/entrypoint.sh` to generate relay config YAML from env vars and pass `--config` to `o_rly` (the binary doesn't accept `--cert`/`--key` CLI flags)
- Switch deploy workflow certbot step to `OMOQ_CERTBOT_*` secrets (separate from SES email credentials)
- Fix `.env` heredoc leading-whitespace bug in deploy workflow
- Pass `ORLY_PORT` through docker-compose environment

## Test plan
- [x] Verify PR CI passes
- [ ] After merge + publish, trigger deploy workflow on moqx-000
- [ ] Confirm relay starts and admin endpoint responds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/62)
<!-- Reviewable:end -->
