### PR TITLE
Admin port: localhost-only, parameterized per instance

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -43,6 +43,7 @@ jobs:
             moqx-000)
               echo "domain=moqx-000.ci.openmoq.org" >> "$GITHUB_OUTPUT"
               echo "port=4433" >> "$GITHUB_OUTPUT"
+              echo "admin_port=8000" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Unknown instance: $INSTANCE"
@@ -57,6 +58,7 @@ jobs:
           DOMAIN=${{ steps.config.outputs.domain }}
           CERTBOT_EMAIL=gmarzot@openmoq.org
           ORLY_PORT=${{ steps.config.outputs.port }}
+          ORLY_ADMIN_PORT=${{ steps.config.outputs.admin_port }}
           EOF
           # Strip leading whitespace from heredoc (YAML indentation artifact)
           sed -i 's/^[[:space:]]*//' .env
@@ -101,7 +103,7 @@ jobs:
 
           echo "==> Waiting for admin endpoint..."
           for i in $(seq 1 30); do
-            if curl -sf http://[::1]:9669/info >/dev/null 2>&1; then
+            if curl -sf http://127.0.0.1:${{ steps.config.outputs.admin_port }}/info >/dev/null 2>&1; then
               break
             fi
             sleep 1
@@ -112,7 +114,7 @@ jobs:
             fi
           done
 
-          RESP=$(curl -sf http://[::1]:9669/info)
+          RESP=$(curl -sf http://127.0.0.1:${{ steps.config.outputs.admin_port }}/info)
           echo "==> Relay running: $RESP"
 
       - name: Notify Slack

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,12 +25,14 @@ services:
     restart: unless-stopped
     ports:
       - "${ORLY_PORT:-4433}:${ORLY_PORT:-4433}/udp"
+      - "127.0.0.1:${ORLY_ADMIN_PORT:-8000}:${ORLY_ADMIN_PORT:-8000}/tcp"
     volumes:
       - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/certs:ro
     environment:
       ORLY_CERT: /certs/live/${DOMAIN}/fullchain.pem
       ORLY_KEY:  /certs/live/${DOMAIN}/privkey.pem
       ORLY_PORT: ${ORLY_PORT:-4433}
+      ORLY_ADMIN_PORT: ${ORLY_ADMIN_PORT:-8000}
 
   # Cloudflare DNS-01 challenge.
   # Requires: docker/cloudflare.ini (see cloudflare.ini.example)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,7 @@
 #   ORLY_CERT      — path to TLS certificate PEM (required unless ORLY_INSECURE=true)
 #   ORLY_KEY       — path to TLS private key PEM  (required unless ORLY_INSECURE=true)
 #   ORLY_PORT      — UDP listen port (default: 4433)
+#   ORLY_ADMIN_PORT — admin HTTP port (default: 8000)
 #   ORLY_INSECURE  — use built-in dev cert (default: false)
 set -e
 
@@ -29,8 +30,8 @@ cache:
   max_groups_per_track: 3
 
 admin:
-  port: 9669
-  address: "::"
+  port: ${ORLY_ADMIN_PORT:-8000}
+  address: "127.0.0.1"
   plaintext: true
 EOF
 


### PR DESCRIPTION
## Summary

- Admin endpoint bound to `127.0.0.1` (not publicly reachable, SSH tunnel only)
- Admin port parameterized via `ORLY_ADMIN_PORT` env var (default: 8000)
- Port scheme: moqx-000 → relay 4433, admin 8000; moqx-001 → relay 4434, admin 8001; etc.
- Deploy workflow health check updated to use per-instance admin port
- Default relay port changed to 4433 (standard MoQ/WebTransport)

## Port allocation

| Instance | Relay (UDP, public) | Admin (TCP, localhost) |
|----------|-------------------|----------------------|
| moqx-000 | 4433 | 8000 |
| moqx-001 | 4434 | 8001 |
| moqx-002 | 4435 | 8002 |

## Test plan

- [ ] Deploy moqx-000 via workflow_dispatch
- [ ] Verify relay listens on 4433/udp
- [ ] Verify admin reachable via `ssh -L 8000:localhost:8000` then `curl http://localhost:8000/info`
- [ ] Verify admin NOT reachable from outside

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/64)
<!-- Reviewable:end -->
