### PR TITLE
Set relay container name to moqx

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,7 @@ name: o-rly
 
 services:
   o-rly:
+    container_name: moqx
     image: ghcr.io/openmoq/o-rly:latest
     restart: unless-stopped
     ports:
@@ -80,7 +81,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
-      DOZZLE_FILTER: "name=o-rly"
+      DOZZLE_FILTER: "name=moqx"
     profiles: [debug]
 
   # Route53 DNS-01 challenge.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,7 @@
 #   ORLY_MAX_GROUPS — max groups per track in cache (default: 100)
 #   ORLY_LOG_LEVEL  — min log level: 0=INFO 1=WARNING 2=ERROR 3=FATAL (default: 0)
 #   ORLY_VERBOSE    — verbose/debug level: 0=off, 1-4=increasing detail (default: 0)
+#   ORLY_BIND_ADDR  — listen address: "0.0.0.0" (IPv4, default) or "::" (IPv6/dual-stack)
 set -e
 
 # Map ORLY_* logging env vars to GLOG_* (used by folly/glog)
@@ -30,7 +31,7 @@ listeners:
   - name: relay
     udp:
       socket:
-        address: "::"
+        address: "${ORLY_BIND_ADDR:-0.0.0.0}"
         port: ${ORLY_PORT:-4433}
     tls:
       cert_file: "${ORLY_CERT:-}"


### PR DESCRIPTION
Container name `moqx` instead of `o-rly-o-rly-1`. Update dozzle filter to match.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/70)
<!-- Reviewable:end -->
