### PR TITLE
Fix from-source builds with shared-only gflags (e.g. CentOS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,9 @@ if(ORLY_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
   add_link_options(-fsanitize=address,undefined)
 endif()
 
-# Prefer static libraries for all transitive deps
-set(GFLAGS_SHARED OFF CACHE BOOL "" FORCE)
+# Prefer static libraries for all transitive deps (from-release mode).
+# For from-source builds, build.sh overrides this to ON (system gflags is shared-only).
+set(GFLAGS_SHARED OFF CACHE BOOL "")
 
 list(APPEND CMAKE_MODULE_PATH
   "${PROJECT_SOURCE_DIR}/deps/moxygen/build/fbcode_builder/CMake"
@@ -173,17 +174,22 @@ if(ORLY_BUILD_TESTS)
     o_rly_config_loader
     GTest::gtest_main
     GTest::gmock
-    # LINK_LIBRARY:WHOLE_ARCHIVE requires CMake >= 3.24 (cmake_minimum_required is 3.25).
-    "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
-  )
-  # gflags_nothreads_static also appears as a plain transitive dep from folly;
-  # override the feature so CMake doesn't warn about mixed link strategies.
-  set_property(TARGET o_rly_config_test PROPERTY
-    LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
   )
   target_compile_definitions(o_rly_config_test PRIVATE
     CONFIG_EXAMPLE_PATH="${PROJECT_SOURCE_DIR}/config.example.yaml"
   )
+  # When using static gflags (from-release), gflags_nothreads_static also
+  # appears as a plain transitive dep from folly — link it as WHOLE_ARCHIVE
+  # and override the feature to avoid mixed link strategy warnings.
+  # LINK_LIBRARY:WHOLE_ARCHIVE requires CMake >= 3.24 (cmake_minimum_required is 3.25).
+  if(NOT GFLAGS_SHARED)
+    target_link_libraries(o_rly_config_test PRIVATE
+      "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
+    )
+    set_property(TARGET o_rly_config_test PROPERTY
+      LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
+    )
+  endif()
   gtest_discover_tests(o_rly_config_test)
 
   add_executable(o_rly_config_resolver_test
@@ -193,11 +199,15 @@ if(ORLY_BUILD_TESTS)
     o_rly_config_loader
     GTest::gtest_main
     GTest::gmock
-    "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
   )
-  set_property(TARGET o_rly_config_resolver_test PROPERTY
-    LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
-  )
+  if(NOT GFLAGS_SHARED)
+    target_link_libraries(o_rly_config_resolver_test PRIVATE
+      "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
+    )
+    set_property(TARGET o_rly_config_resolver_test PROPERTY
+      LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
+    )
+  endif()
   gtest_discover_tests(o_rly_config_resolver_test)
 
   add_test(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -318,9 +318,20 @@ cmd_build() {
   # Map profile to cmake preset
   local preset="$profile"
 
+  # from-source builds use system libs (e.g. gflags shared-only on CentOS);
+  # override the preset's .a-only suffix to allow shared system libraries.
+  local extra_cmake_args=()
+  local deps_mode=""
+  [[ -f "$DEPS_MODE_FILE" ]] && deps_mode=$(cat "$DEPS_MODE_FILE")
+  if [[ "$deps_mode" == "from-source" ]]; then
+    extra_cmake_args+=("-DCMAKE_FIND_LIBRARY_SUFFIXES=.so;.a")
+    extra_cmake_args+=("-DGFLAGS_SHARED=ON")
+  fi
+
   echo "==> Configuring (profile: $profile, build: $build_dir)..."
   cmake -S "$PROJECT_ROOT" -B "$build_dir" \
     --preset "$preset" \
+    "${extra_cmake_args[@]+"${extra_cmake_args[@]}"}" \
     -DCMAKE_PREFIX_PATH="$prefix_path"
 
   echo "==> Building ($nproc jobs)..."

--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -43,6 +43,7 @@ cmake -S "$STANDALONE_SRC" -B "$BUILD_DIR" \
     -G Ninja \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+    -DINSTALL_DEPS=ON \
     -DBUILD_TESTS=OFF \
     -DBUILD_SHARED_LIBS=OFF
 
@@ -57,7 +58,8 @@ cmake --install "$BUILD_DIR"
 
 mkdir -p "$SCRATCH"
 echo "$INSTALL_DIR" > "${SCRATCH}/cmake_prefix_path.txt"
-echo "standalone" > "${SCRATCH}/deps-mode"
+
+echo "from-source" > "${SCRATCH}/deps-mode"
 
 NLIBS=$(find "$INSTALL_DIR/lib" -name '*.a' 2>/dev/null | wc -l)
 echo "==> Done: $NLIBS static libs in $INSTALL_DIR"


### PR DESCRIPTION
- Remove FORCE from GFLAGS_SHARED so build.sh can override it per build mode
- Gate WHOLE_ARCHIVE gflags linking on NOT GFLAGS_SHARED in test targets
- build.sh: detect from-source deps mode and pass -DGFLAGS_SHARED=ON + -DCMAKE_FIND_LIBRARY_SUFFIXES=.so;.a to allow shared system libraries
- setup-deps-standalone.sh: add -DINSTALL_DEPS=ON to cmake configure step
- Bump moxygen submodule

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/72)
<!-- Reviewable:end -->
