### PR TITLE
Deploy: verbose logging input, dozzle always on, build.sh fixes

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -19,6 +19,16 @@ on:
         type: choice
         options:
           - moqx-000
+      verbose:
+        description: "GLOG verbose level (0=off, 1-3=increasing detail)"
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
+          - "2"
+          - "3"
 
 permissions:
   contents: read
@@ -60,7 +70,7 @@ jobs:
           ORLY_PORT=${{ steps.config.outputs.port }}
           ORLY_ADMIN_PORT=${{ steps.config.outputs.admin_port }}
           ORLY_LOG_LEVEL=0
-          ORLY_VERBOSE=0
+          ORLY_VERBOSE=${{ inputs.verbose }}
           EOF
           # Strip leading whitespace from heredoc (YAML indentation artifact)
           sed -i 's/^[[:space:]]*//' .env
@@ -102,6 +112,7 @@ jobs:
 
           echo "==> Starting relay (${INSTANCE} on port ${{ steps.config.outputs.port }})..."
           docker compose up -d o-rly
+
 
           echo "==> Waiting for admin endpoint..."
           for i in $(seq 1 30); do

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ target_link_libraries(o_rly PRIVATE o_rly_core o_rly_config_loader)
 
 if(ORLY_BUILD_TESTS)
   enable_testing()
-  find_package(GTest REQUIRED)
+  find_package(GTest REQUIRED CONFIG)
 
   add_executable(o_rly_relay_test
     tests/ORelayTest.cpp

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -73,16 +73,15 @@ services:
     profiles: [certbot-cloudflare]
 
   # Log viewer — browse relay logs at http://localhost:${ORLY_LOG_PORT:-9999}
-  # Start with: docker compose --profile debug up -d dozzle
   dozzle:
     image: amir20/dozzle:latest
+    restart: unless-stopped
     ports:
-      - "${ORLY_LOG_PORT:-9999}:8080"
+      - "127.0.0.1:${ORLY_LOG_PORT:-9999}:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       DOZZLE_FILTER: "name=moqx"
-    profiles: [debug]
 
   # Route53 DNS-01 challenge.
   # Requires: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY in docker/.env


### PR DESCRIPTION
- Add `verbose` input (0-3) to deploy workflow for GLOG_v control
- Dozzle log viewer starts by default (no longer debug profile), bound to 127.0.0.1:9999
- Access remote logs via SSH tunnel: `ssh -L 19999:127.0.0.1:9999 <host>` then browse `http://localhost:19999`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/73)
<!-- Reviewable:end -->
