### PR TITLE
Fix deploy: start all services including dozzle

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -111,7 +111,7 @@ jobs:
           docker compose down --remove-orphans 2>/dev/null || true
 
           echo "==> Starting relay (${INSTANCE} on port ${{ steps.config.outputs.port }})..."
-          docker compose up -d o-rly
+          docker compose up -d
 
 
           echo "==> Waiting for admin endpoint..."

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -74,6 +74,7 @@ services:
 
   # Log viewer — browse relay logs at http://localhost:${ORLY_LOG_PORT:-9999}
   dozzle:
+    container_name: moqx-logs
     image: amir20/dozzle:latest
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Deploy workflow was only starting `o-rly` service explicitly. Now that dozzle has no profile gate, `docker compose up -d` starts both.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/74)
<!-- Reviewable:end -->
