### PR TITLE
Fix moxygen sync: approve step continue-on-error

### DIFF
--- a/.github/workflows/moxygen-sync.yml
+++ b/.github/workflows/moxygen-sync.yml
@@ -177,6 +177,7 @@ jobs:
       # ── Approve PR (different identity for required review) ──
       - name: Approve PR
         if: steps.blocking.outputs.blocked == 'false' && steps.target.outputs.needs_update == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.OMOQ_SYNC_TOKEN }}
         run: |


### PR DESCRIPTION
Approve step fails on private repo (no OMOQ_SYNC_TOKEN). Not needed until branch protection is enabled. Mark continue-on-error to stop false failures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/77)
<!-- Reviewable:end -->
