### PR TITLE
Fix Docker entrypoint for services config format

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,14 +39,19 @@ listeners:
       insecure: ${ORLY_INSECURE:-false}
     endpoint: "/moq-relay"
 
-cache:
-  enabled: true
-  max_tracks: ${ORLY_MAX_TRACKS:-1000}
-  max_groups_per_track: ${ORLY_MAX_GROUPS:-100}
+services:
+  default:
+    match:
+      - authority: {any: true}
+        path: {prefix: "/"}
+    cache:
+      enabled: true
+      max_tracks: ${ORLY_MAX_TRACKS:-1000}
+      max_groups_per_track: ${ORLY_MAX_GROUPS:-100}
 
 admin:
   port: ${ORLY_ADMIN_PORT:-8000}
-  address: "::"
+  address: "${ORLY_BIND_ADDR:-0.0.0.0}"
   plaintext: true
 EOF
 


### PR DESCRIPTION
PR #58 changed config from top-level `cache:` to `services:` map with per-service cache. Entrypoint now generates the new format with a `default` service matching all requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/o-rly/79)
<!-- Reviewable:end -->
