### PR TITLE
Upstream provider for relay-to-relay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,15 @@ if(MOQX_BUILD_TESTS)
   gtest_discover_tests(moqx_service_matcher_test)
 
   add_test(
+    NAME relay_chain
+    COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_relay_chain.sh $<TARGET_FILE:moqx>
+  )
+  set_tests_properties(relay_chain PROPERTIES
+    TIMEOUT 120
+    ENVIRONMENT "MOQBIN=${PROJECT_SOURCE_DIR}/.scratch/moxygen-install/bin"
+  )
+
+  add_test(
     NAME admin_info_endpoint
     COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_info.sh $<TARGET_FILE:moqx>
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(moqx_core STATIC
   src/stats/StatsRegistry.cpp
   src/stats/MoQStatsCollector.cpp
   src/stats/QuicStatsCollector.cpp
+  src/UpstreamProvider.cpp
 )
 
 target_include_directories(moqx_core
@@ -98,6 +99,7 @@ target_link_libraries(moqx_core PUBLIC
   # Workaround: wangle::wangle_acceptor_acceptor_core uses AsyncFdSocket from
   # FizzAcceptorHandshakeHelper but omits this dep from its cmake config.
   Folly::folly_io_async_fdsock_async_fd_socket
+  moxygen::moxygen_moqclient
 )
 
 target_compile_options(moqx_core PRIVATE -Wall -Wextra -Wpedantic)
@@ -267,6 +269,20 @@ if(MOQX_BUILD_TESTS)
     NAME admin_metrics_endpoint
     COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_metrics.sh $<TARGET_FILE:moqx>
   )
+
+  add_executable(moqx_upstream_provider_test
+    tests/UpstreamProviderTest.cpp
+  )
+  target_link_libraries(moqx_upstream_provider_test PRIVATE
+    moqx_core
+    moqx_test_utils
+    moqx_test_main
+    moxygen::moqtest_utils
+    moxygen::moxygen_events_moq_folly_executor_impl
+    moxygen::moxygen_moqclient
+    GTest::gmock
+  )
+  gtest_discover_tests(moqx_upstream_provider_test)
 endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/Lint.cmake)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,6 +35,11 @@ services:
       max_tracks: 500             # Override: 100 → 500
       max_groups_per_track: 10    # Override: 3 → 10
       # enabled: inherited (true) from service_defaults
+    # upstream:                   # Optional: enable relay chaining for this service
+    #   url: "moqt://origin.example.com:4433/moq-relay"
+    #   tls:
+    #     insecure: false         # true = skip cert verification (dev only)
+    #     # ca_cert: /path/to/ca.pem  # Custom CA cert (mutually exclusive with insecure: true)
 
   testing:
     match:
@@ -53,3 +58,5 @@ admin:
   # tls:
   #   cert_file: /path/to/cert.pem
   #   key_file: /path/to/key.pem
+
+# relay_id: "my-relay-1"     # Relay identity (optional; random hex string generated if absent)

--- a/include/moqx/MoqxRelay.h
+++ b/include/moqx/MoqxRelay.h
@@ -9,11 +9,13 @@
 #pragma once
 
 #include <folly/coro/SharedPromise.h>
+#include <moqx/UpstreamProvider.h>
 #include <moxygen/MoQSession.h>
 #include <moxygen/relay/MoQCache.h>
 #include <moxygen/relay/MoQForwarder.h>
 
 #include <folly/container/F14Set.h>
+#include <string>
 
 namespace openmoq::moqx {
 
@@ -24,8 +26,10 @@ class MoqxRelay : public moxygen::Publisher,
 public:
   explicit MoqxRelay(
       size_t maxCachedTracks = moxygen::kDefaultMaxCachedTracks,
-      size_t maxCachedGroupsPerTrack = moxygen::kDefaultMaxCachedGroupsPerTrack
-  ) {
+      size_t maxCachedGroupsPerTrack = moxygen::kDefaultMaxCachedGroupsPerTrack,
+      std::string relayID = {}
+  )
+      : relayID_(std::move(relayID)) {
     if (maxCachedTracks > 0) {
       cache_ = std::make_unique<moxygen::MoQCache>(maxCachedTracks, maxCachedGroupsPerTrack);
     }
@@ -33,6 +37,13 @@ public:
 
   void setAllowedNamespacePrefix(moxygen::TrackNamespace allowed) {
     allowedNamespacePrefix_ = std::move(allowed);
+  }
+
+  // Store the upstream provider. The provider must have been constructed with
+  // publishHandler=this and subscribeHandler=this so that the upstream relay's
+  // reciprocal subNs and namespace announcements route through MoqxRelay.
+  void setUpstreamProvider(std::shared_ptr<UpstreamProvider> upstream) {
+    upstream_ = std::move(upstream);
   }
 
   folly::coro::Task<SubscribeResult> subscribe(
@@ -44,12 +55,12 @@ public:
   fetch(moxygen::Fetch fetch, std::shared_ptr<moxygen::FetchConsumer> consumer) override;
 
   folly::coro::Task<SubscribeNamespaceResult> subscribeNamespace(
-      moxygen::SubscribeNamespace subAnn,
+      moxygen::SubscribeNamespace subNs,
       std::shared_ptr<NamespacePublishHandle> namespacePublishHandle
   ) override;
 
   folly::coro::Task<moxygen::Subscriber::PublishNamespaceResult>
-  publishNamespace(moxygen::PublishNamespace ann, std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback>)
+  publishNamespace(moxygen::PublishNamespace pubNs, std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback>)
       override;
 
   PublishResult publish(
@@ -76,6 +87,20 @@ public:
     }
     return {};
   }
+
+  // Sync cores of publishNamespace/publishNamespaceDone. Called by the
+  // Subscriber coroutine interface and directly by MoqxRelayNamespaceHandle
+  // (which provides the session explicitly — no getRequestSession() needed).
+  std::shared_ptr<moxygen::Subscriber::PublishNamespaceHandle> doPublishNamespace(
+      moxygen::PublishNamespace pubNs,
+      std::shared_ptr<moxygen::MoQSession> session,
+      std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback> callback
+  );
+
+  void doPublishNamespaceDone(
+      const moxygen::TrackNamespace& trackNamespace,
+      std::shared_ptr<moxygen::MoQSession> session
+  );
 
   // Test accessor: check if a publish exists and return node/publish state
   struct PublishState {
@@ -191,7 +216,7 @@ private:
 
   folly::coro::Task<void> publishNamespaceToSession(
       std::shared_ptr<moxygen::MoQSession> session,
-      moxygen::PublishNamespace ann,
+      moxygen::PublishNamespace pubNs,
       std::shared_ptr<NamespaceNode> nodePtr
   );
 
@@ -207,6 +232,16 @@ private:
   void publishNamespaceDone(const moxygen::TrackNamespace& trackNamespace, NamespaceNode* node);
 
   moxygen::TrackNamespace allowedNamespacePrefix_;
+  std::string relayID_;
+  std::shared_ptr<UpstreamProvider> upstream_;
+
+  // Reciprocal peer subNs handles: one per peer relay session that has
+  // connected to us. Kept alive so the subscription is not immediately
+  // cancelled. Keyed by raw session pointer (valid for session lifetime).
+  folly::F14FastMap<
+      moxygen::MoQSession*,
+      std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle>>
+      peerSubNsHandles_;
   folly::F14FastMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
       subscriptions_;
 
@@ -216,5 +251,13 @@ private:
   );
   std::unique_ptr<moxygen::MoQCache> cache_;
 };
+
+// Creates a NamespacePublishHandle that bridges NAMESPACE/NAMESPACE_DONE
+// messages from a peer relay into relay->doPublishNamespace() synchronously.
+// Used for both the initiating (UpstreamProvider) and reciprocal (MoqxRelay) paths.
+std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> makeNamespaceBridgeHandle(
+    std::weak_ptr<MoqxRelay> relay,
+    std::shared_ptr<moxygen::MoQSession> session
+);
 
 } // namespace openmoq::moqx

--- a/include/moqx/MoqxRelay.h
+++ b/include/moqx/MoqxRelay.h
@@ -46,6 +46,27 @@ public:
     upstream_ = std::move(upstream);
   }
 
+  // Stops and releases the upstream provider, breaking the shared_ptr cycle
+  // between MoqxRelay and UpstreamProvider. Safe to call with no upstream.
+  void stop() {
+    if (upstream_) {
+      upstream_->stop();
+      // Do not reset upstream_ here: the provider's session/client live on the
+      // worker EVB thread and must be freed there (via the reconnect coroutine's
+      // shared_from_this dropping after it co_returns). Releasing upstream_ when
+      // relay is destroyed naturally (services_ cleared) is safe because by then
+      // stop() has already cleared the back-refs so relay's refcount == 1.
+    }
+  }
+
+  // Called by UpstreamProvider's onConnect hook after a new upstream session is
+  // established. Issues the peer subNs handshake and saves the handle.
+  folly::coro::Task<void> onUpstreamConnect(std::shared_ptr<moxygen::MoQSession> session);
+
+  // Called by UpstreamProvider's onDisconnect hook when the upstream session
+  // closes. Releases the peer subNs handle.
+  void onUpstreamDisconnect();
+
   folly::coro::Task<SubscribeResult> subscribe(
       moxygen::SubscribeRequest subReq,
       std::shared_ptr<moxygen::TrackConsumer> consumer
@@ -234,6 +255,10 @@ private:
   moxygen::TrackNamespace allowedNamespacePrefix_;
   std::string relayID_;
   std::shared_ptr<UpstreamProvider> upstream_;
+
+  // Holds the peer subNs handle for the upstream (initiating) direction.
+  // Kept alive so the subscription is not cancelled when onUpstreamConnect returns.
+  std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle> upstreamSubNsHandle_;
 
   // Reciprocal peer subNs handles: one per peer relay session that has
   // connected to us. Kept alive so the subscription is not immediately

--- a/include/moqx/MoqxRelayServer.h
+++ b/include/moqx/MoqxRelayServer.h
@@ -4,6 +4,7 @@
 
 #include <moqx/MoqxRelay.h>
 #include <moqx/ServiceMatcher.h>
+#include <moqx/UpstreamProvider.h>
 #include <moqx/config/config.h>
 #include <moqx/stats/MoQStatsCollector.h>
 #include <moqx/stats/StatsRegistry.h>
@@ -19,17 +20,28 @@ public:
       const std::string& key,
       const std::string& endpoint,
       const std::string& versions,
-      folly::F14FastMap<std::string, config::ServiceConfig> services
+      folly::F14FastMap<std::string, config::ServiceConfig> services,
+      const std::string& relayID = {}
   );
 
   // Used when the insecure flag is true
   MoqxRelayServer(
       const std::string& endpoint,
       const std::string& versions,
-      folly::F14FastMap<std::string, config::ServiceConfig> services
+      folly::F14FastMap<std::string, config::ServiceConfig> services,
+      const std::string& relayID = {}
   );
 
+  ~MoqxRelayServer() override;
+
   void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
+
+  // Binds listeners then initialises per-service upstream providers (requires
+  // draft 16+ for relay chaining).
+  void start(const folly::SocketAddress& addr) {
+    MoQServer::start(addr);
+    initUpstreams();
+  }
 
   void onNewSession(std::shared_ptr<moxygen::MoQSession> clientSession) override;
 
@@ -48,10 +60,19 @@ protected:
   ) override;
 
 private:
-  void initRelays(const folly::F14FastMap<std::string, config::ServiceConfig>& services);
+  void initServices(
+      const folly::F14FastMap<std::string, config::ServiceConfig>& services,
+      const std::string& relayID
+  );
+  void initUpstreams();
 
-  folly::F14FastMap<std::string, std::shared_ptr<MoqxRelay>> relays_;
+  struct ServiceEntry {
+    config::ServiceConfig config;
+    std::shared_ptr<MoqxRelay> relay;
+  };
+  folly::F14FastMap<std::string, ServiceEntry> services_;
   ServiceMatcher serviceMatcher_;
+  std::string relayID_;
   std::shared_ptr<stats::StatsRegistry> statsRegistry_;
   std::shared_ptr<stats::MoQStatsCollector> statsCollector_;
 };

--- a/include/moqx/UpstreamProvider.h
+++ b/include/moqx/UpstreamProvider.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fizz/protocol/CertificateVerifier.h>
+#include <folly/CancellationToken.h>
+#include <folly/coro/SharedPromise.h>
+#include <folly/coro/Sleep.h>
+#include <folly/coro/Task.h>
+#include <functional>
+#include <moxygen/MoQClient.h>
+#include <moxygen/MoQSession.h>
+#include <moxygen/MoQTypes.h>
+#include <moxygen/Publisher.h>
+#include <moxygen/Subscriber.h>
+#include <moxygen/events/MoQExecutor.h>
+#include <optional>
+#include <proxygen/lib/utils/URL.h>
+#include <string>
+
+namespace openmoq::moqx {
+
+// --- Relay peering auth helpers ---
+// Used by UpstreamProvider (initiating peer subNs) and MoqxRelay (reciprocation).
+
+// Returns true if subNs carries a relay peer auth token.
+bool isPeerSubNs(const moxygen::SubscribeNamespace& subNs);
+
+// Builds a wildcard SubscribeNamespace(prefix={}, BOTH).
+// With relayID: includes the relay auth token (initiating peer).
+// Without relayID: no token (reciprocal response — prevents loops).
+moxygen::SubscribeNamespace makePeerSubNs(std::optional<std::string> relayID = std::nullopt);
+
+/**
+ * UpstreamProvider connects to a remote MoQ endpoint as a client and presents
+ * itself locally as both a Publisher and Subscriber. After connecting it issues
+ * a wildcard subscribeNamespace(*, BOTH) with a relay auth token to initiate
+ * the relay peering handshake. On disconnect it proactively reconnects
+ * immediately, then backs off exponentially (1s → 60s cap) on repeated
+ * failures.
+ */
+class UpstreamProvider : public moxygen::Publisher,
+                         public moxygen::Subscriber,
+                         public moxygen::MoQSession::MoQSessionCloseCallback,
+                         public std::enable_shared_from_this<UpstreamProvider> {
+public:
+  using OnConnectHook =
+      std::function<folly::coro::Task<void>(std::shared_ptr<moxygen::MoQSession>)>;
+  using OnDisconnectHook = std::function<void()>;
+
+  UpstreamProvider(
+      std::shared_ptr<moxygen::MoQExecutor> exec,
+      proxygen::URL url,
+      std::shared_ptr<moxygen::Publisher> publishHandler,
+      std::shared_ptr<moxygen::Subscriber> subscribeHandler,
+      std::shared_ptr<fizz::CertificateVerifier> verifier = nullptr,
+      OnConnectHook onConnect = nullptr,
+      OnDisconnectHook onDisconnect = nullptr,
+      std::chrono::milliseconds connectTimeout = std::chrono::milliseconds(5000),
+      std::chrono::milliseconds idleTimeout = std::chrono::milliseconds(5000)
+  );
+
+  ~UpstreamProvider() override;
+
+  // Initiates the first connection to the upstream server.
+  folly::coro::Task<void> start();
+
+  // Gracefully shuts down, closes the session, cancels reconnection.
+  void stop();
+
+  // Suspends until the upstream session is Connected (i.e., QUIC session
+  // established + peering handshake completed), or the timeout elapses.
+  // Returns immediately if already connected, stopped, or no connection is
+  // in progress.  Swallows connection errors — caller must re-check state.
+  folly::coro::Task<void> waitForConnected(std::chrono::milliseconds timeout);
+
+  // --- Publisher interface (forwarded to upstream session) ---
+
+  folly::coro::Task<SubscribeResult> subscribe(
+      moxygen::SubscribeRequest sub,
+      std::shared_ptr<moxygen::TrackConsumer> callback
+  ) override;
+
+  folly::coro::Task<FetchResult>
+  fetch(moxygen::Fetch fetch, std::shared_ptr<moxygen::FetchConsumer> fetchCallback) override;
+
+  folly::coro::Task<TrackStatusResult> trackStatus(moxygen::TrackStatus req) override;
+
+  folly::coro::Task<SubscribeNamespaceResult> subscribeNamespace(
+      moxygen::SubscribeNamespace subNs,
+      std::shared_ptr<NamespacePublishHandle> handle
+  ) override;
+
+  // --- Subscriber interface (forwarded to upstream session) ---
+
+  folly::coro::Task<PublishNamespaceResult> publishNamespace(
+      moxygen::PublishNamespace ann,
+      std::shared_ptr<PublishNamespaceCallback> cb = nullptr
+  ) override;
+
+  PublishResult publish(
+      moxygen::PublishRequest pub,
+      std::shared_ptr<moxygen::SubscriptionHandle> handle = nullptr
+  ) override;
+
+  // --- Goaway (shared by Publisher and Subscriber) ---
+  void goaway(moxygen::Goaway goaway) override;
+
+  // --- MoQSessionCloseCallback ---
+  void onMoQSessionClosed() override;
+
+  // Access the current session (may be null)
+  std::shared_ptr<moxygen::MoQSession> currentSession() const { return session_; }
+
+private:
+  enum class State { Disconnected, Connecting, Connected };
+
+  // Returns the current session if already connected, null otherwise.
+  // Used for the synchronous fast path in forwarding methods.
+  std::shared_ptr<moxygen::MoQSession> getSession() const {
+    if (!stopped_ && state_ == State::Connected && session_) {
+      return session_;
+    }
+    return nullptr;
+  }
+
+  // Resets session_ and client_ on the exec thread (while EVBs are alive),
+  // allowing ~MoQClientBase() to call moqSession_->close() on a live EVB.
+  folly::coro::Task<void> close();
+
+  // Ensures a session exists, connecting if needed. Called by slow-path
+  // coroutines when getSession() returns null.
+  folly::coro::Task<std::shared_ptr<moxygen::MoQSession>> getOrConnectSession();
+
+  // Slow-path coroutine forwarders: called when not yet connected.
+  folly::coro::Task<SubscribeResult>
+  coSubscribe(moxygen::SubscribeRequest sub, std::shared_ptr<moxygen::TrackConsumer> callback);
+  folly::coro::Task<FetchResult>
+  coFetch(moxygen::Fetch fetch, std::shared_ptr<moxygen::FetchConsumer> fetchCallback);
+  folly::coro::Task<TrackStatusResult> coTrackStatus(moxygen::TrackStatus req);
+  folly::coro::Task<SubscribeNamespaceResult> coSubscribeNamespace(
+      moxygen::SubscribeNamespace subNs,
+      std::shared_ptr<NamespacePublishHandle> handle
+  );
+  folly::coro::Task<PublishNamespaceResult>
+  coPublishNamespace(moxygen::PublishNamespace pubNs, std::shared_ptr<PublishNamespaceCallback> cb);
+  folly::coro::Task<folly::Expected<moxygen::PublishOk, moxygen::PublishError>> coPublish(
+      moxygen::PublishRequest pub,
+      std::shared_ptr<moxygen::SubscriptionHandle> handle,
+      std::shared_ptr<moxygen::TrackConsumer> pending,
+      moxygen::RequestID reqID
+  );
+
+  // Performs the actual connection to upstream.
+  folly::coro::Task<void> doConnect();
+
+  // Resets the session state to Disconnected.
+  void resetSession();
+
+  // Tries to connect, retrying with exponential backoff until success or stop().
+  // Exits once connected; onMoQSessionClosed()/goaway() spawn it again on drop.
+  folly::coro::Task<void> reconnectLoop();
+
+  State state_{State::Disconnected};
+  std::unique_ptr<moxygen::MoQClient> client_;
+  std::shared_ptr<moxygen::MoQSession> session_;
+  std::shared_ptr<moxygen::Publisher> publishHandler_;
+  std::shared_ptr<moxygen::Subscriber> subscribeHandler_;
+  proxygen::URL url_;
+  std::shared_ptr<moxygen::MoQExecutor> exec_;
+  std::shared_ptr<fizz::CertificateVerifier> verifier_;
+  OnConnectHook onConnect_;
+  OnDisconnectHook onDisconnect_;
+  std::chrono::milliseconds connectTimeout_;
+  std::chrono::milliseconds idleTimeout_;
+  bool stopped_{false};
+
+  // Connection gating: when Connecting, operations co_await this
+  std::optional<folly::coro::SharedPromise<folly::Unit>> connectPromise_;
+
+  // Cancelled by stop() to break the reconnect loop out of backoff sleeps.
+  folly::CancellationSource stopSource_;
+
+  // Current backoff before next connect attempt. Reset to 0 on success,
+  // doubled on failure (capped at kMaxReconnectBackoff).
+  std::chrono::milliseconds reconnectBackoff_{0};
+};
+
+} // namespace openmoq::moqx

--- a/include/moqx/config/config.h
+++ b/include/moqx/config/config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -35,6 +36,18 @@ struct ListenerConfig {
   std::string moqtVersions; // comma-separated string
 };
 
+struct UpstreamTlsConfig {
+  bool insecure{false};
+  std::optional<std::string> caCertFile; // mutually exclusive with insecure=true
+};
+
+struct UpstreamConfig {
+  std::string url;
+  UpstreamTlsConfig tls;
+  std::chrono::milliseconds connectTimeout{5000};
+  std::chrono::milliseconds idleTimeout{5000};
+};
+
 struct ServiceConfig {
   struct MatchEntry {
     struct ExactAuthority {
@@ -59,6 +72,7 @@ struct ServiceConfig {
 
   std::vector<MatchEntry> match;
   CacheConfig cache;
+  std::optional<UpstreamConfig> upstream; // set if this service chains to an upstream relay
 };
 
 struct AdminConfig {
@@ -70,6 +84,7 @@ struct Config {
   ListenerConfig listener;
   folly::F14FastMap<std::string, ServiceConfig> services;
   std::optional<AdminConfig> admin;
+  std::string relayID; // always set: from config or randomly generated
 };
 
 } // namespace openmoq::moqx::config

--- a/include/moqx/config/loader/parsed_config.h
+++ b/include/moqx/config/loader/parsed_config.h
@@ -63,6 +63,23 @@ struct ParsedAdminConfig {
   rfl::Description<"TLS configuration", std::optional<ParsedAdminTlsConfig>> tls;
 };
 
+struct ParsedUpstreamTlsConfig {
+  rfl::Description<"Skip TLS certificate verification (dev only)", bool> insecure;
+  rfl::Description<"Path to CA certificate file for peer verification", std::optional<std::string>>
+      ca_cert;
+};
+
+struct ParsedUpstreamConfig {
+  rfl::Description<"Upstream MoQ server URL (moqt://host:port/path)", std::string> url;
+  rfl::Description<"TLS configuration for upstream connection", ParsedUpstreamTlsConfig> tls;
+  rfl::Description<"QUIC connect timeout in milliseconds (default: 5000)", std::optional<uint32_t>>
+      connect_timeout_ms;
+  rfl::Description<
+      "MoQ session idle timeout in milliseconds (default: 5000)",
+      std::optional<uint32_t>>
+      idle_timeout_ms;
+};
+
 struct ParsedServiceConfig {
   struct MatchRule {
     struct ExactAuthority {
@@ -104,6 +121,10 @@ struct ParsedServiceConfig {
       "Per-service cache settings (overrides service_defaults)",
       std::optional<ParsedCacheConfig>>
       cache;
+  rfl::Description<
+      "Upstream MoQ server for this service (optional; enables relay chaining)",
+      std::optional<ParsedUpstreamConfig>>
+      upstream;
 };
 
 struct ParsedServiceDefaultsConfig {
@@ -121,6 +142,10 @@ struct ParsedConfig {
       service_defaults;
   rfl::Description<"Service definitions", std::map<std::string, ParsedServiceConfig>> services;
   rfl::Description<"Admin HTTP server settings", std::optional<ParsedAdminConfig>> admin;
+  rfl::Description<
+      "Relay identity string (optional; random string generated if absent)",
+      std::optional<std::string>>
+      relay_id;
 };
 
 } // namespace openmoq::moqx::config

--- a/scripts/test-relay-shutdown.sh
+++ b/scripts/test-relay-shutdown.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Test that relay pair shuts down cleanly (no ASAN leaks or crashes).
+# Usage: ./scripts/test-relay-shutdown.sh [up_config] [down_config]
+#   up_config   config with no upstream (default: /tmp/up.yaml, port 12345)
+#   down_config config with upstream pointing to up (default: /tmp/down.yaml, port 12346)
+
+set -euo pipefail
+
+BIN="${BIN:-./build-san/moqx}"
+UP_CFG="${1:-/tmp/up.yaml}"
+DOWN_CFG="${2:-/tmp/down.yaml}"
+SHUTDOWN_TIMEOUT="${SHUTDOWN_TIMEOUT:-10}"  # seconds to wait for clean exit before declaring a hang
+
+if [[ ! -x "$BIN" ]]; then
+  echo "ERROR: binary not found: $BIN (set BIN= to override)" >&2
+  exit 1
+fi
+
+UP_LOG=$(mktemp /tmp/moqx-up-XXXXXX.log)
+DOWN_LOG=$(mktemp /tmp/moqx-down-XXXXXX.log)
+PASS=true
+
+cleanup() {
+  kill "$UP_PID" "$DOWN_PID" 2>/dev/null || true
+  wait "$UP_PID" "$DOWN_PID" 2>/dev/null || true
+  rm -f "$UP_LOG" "$DOWN_LOG"
+}
+trap cleanup EXIT
+
+# wait_or_kill <pid> <label> <exit_var>
+# Waits up to $SHUTDOWN_TIMEOUT seconds for <pid> to exit, then SIGKILL and fail.
+wait_or_kill() {
+  local pid="$1" label="$2" exitvar="$3"
+  local deadline=$(( $(date +%s) + SHUTDOWN_TIMEOUT ))
+  while kill -0 "$pid" 2>/dev/null; do
+    if (( $(date +%s) >= deadline )); then
+      echo "HANG: $label did not exit within ${SHUTDOWN_TIMEOUT}s — sending SIGKILL" >&2
+      kill -KILL "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      eval "$exitvar=1"
+      PASS=false
+      return
+    fi
+    sleep 0.5
+  done
+  local wrc=0
+  wait "$pid" 2>/dev/null && wrc=0 || wrc=$?
+  eval "$exitvar=$wrc"
+}
+
+echo "==> Starting upstream relay (no upstream provider)..."
+"$BIN" --config "$UP_CFG" --logging=DBG4 >"$UP_LOG" 2>&1 &
+UP_PID=$!
+
+echo "==> Starting downstream relay (has upstream provider)..."
+"$BIN" --config "$DOWN_CFG" --logging=DBG4 >"$DOWN_LOG" 2>&1 &
+DOWN_PID=$!
+
+echo "==> Waiting for downstream to connect to upstream..."
+for i in $(seq 1 20); do
+  if grep -q "reconnectLoop connected" "$DOWN_LOG" 2>/dev/null; then
+    echo "    Connected after ${i}s."
+    break
+  fi
+  sleep 1
+  if ! kill -0 "$DOWN_PID" 2>/dev/null; then
+    echo "ERROR: downstream relay died unexpectedly" >&2
+    cat "$DOWN_LOG" >&2
+    exit 1
+  fi
+done
+
+if ! grep -q "reconnectLoop connected" "$DOWN_LOG" 2>/dev/null; then
+  echo "ERROR: downstream never connected" >&2
+  cat "$DOWN_LOG" >&2
+  exit 1
+fi
+
+# --- Scenario 1: kill downstream (has active upstream session) first ---
+echo ""
+echo "==> [Scenario 1] Killing downstream relay (active upstream session)..."
+kill -INT "$DOWN_PID"
+DOWN_EXIT=0
+wait_or_kill "$DOWN_PID" "downstream" DOWN_EXIT
+echo "    Downstream exited with code $DOWN_EXIT."
+
+if grep -q "LeakSanitizer\|ERROR: AddressSanitizer\|Aborted\|Check failed" "$DOWN_LOG"; then
+  echo "FAIL: downstream had ASAN errors or crash:"
+  grep -E "LeakSanitizer|ERROR: AddressSanitizer|Aborted|Check failed|SUMMARY:" "$DOWN_LOG" | head -20
+  PASS=false
+else
+  echo "    PASS: no ASAN errors in downstream."
+fi
+
+echo "==> Waiting 3s then killing upstream relay..."
+sleep 3
+kill -INT "$UP_PID"
+UP_EXIT=0
+wait_or_kill "$UP_PID" "upstream" UP_EXIT
+echo "    Upstream exited with code $UP_EXIT."
+
+if grep -q "LeakSanitizer\|ERROR: AddressSanitizer\|Aborted\|Check failed" "$UP_LOG"; then
+  echo "FAIL: upstream had ASAN errors or crash:"
+  grep -E "LeakSanitizer|ERROR: AddressSanitizer|Aborted|Check failed|SUMMARY:" "$UP_LOG" | head -20
+  PASS=false
+else
+  echo "    PASS: no ASAN errors in upstream."
+fi
+
+# --- Scenario 2: kill upstream first, wait for downstream to enter reconnect, then kill downstream ---
+echo ""
+echo "==> [Scenario 2] Restarting both relays..."
+"$BIN" --config "$UP_CFG" --logging=DBG1 >>"$UP_LOG" 2>&1 &
+UP_PID=$!
+"$BIN" --config "$DOWN_CFG" --logging=DBG1 >>"$DOWN_LOG" 2>&1 &
+DOWN_PID=$!
+
+echo "==> Waiting for downstream to connect again..."
+for i in $(seq 1 20); do
+  if grep -c "reconnectLoop connected" "$DOWN_LOG" 2>/dev/null | grep -q "^[2-9]"; then
+    echo "    Reconnected after ${i}s."
+    break
+  fi
+  sleep 1
+done
+
+echo "==> Killing upstream first..."
+kill -INT "$UP_PID"
+UP_EXIT=0; wait_or_kill "$UP_PID" "upstream(s2)" UP_EXIT
+
+echo "==> Waiting 4s for downstream to enter reconnect loop..."
+sleep 4
+
+echo "==> Killing downstream (in reconnect/backoff)..."
+kill -INT "$DOWN_PID"
+DOWN_EXIT=0
+wait_or_kill "$DOWN_PID" "downstream(s2)" DOWN_EXIT
+echo "    Downstream exited with code $DOWN_EXIT."
+
+if grep -q "LeakSanitizer\|ERROR: AddressSanitizer\|Aborted\|Check failed" "$DOWN_LOG"; then
+  echo "FAIL: downstream had ASAN errors or crash (scenario 2):"
+  grep -E "LeakSanitizer|ERROR: AddressSanitizer|Aborted|Check failed|SUMMARY:" "$DOWN_LOG" | tail -30
+  PASS=false
+else
+  echo "    PASS: no ASAN errors in downstream (scenario 2)."
+fi
+
+echo ""
+if $PASS; then
+  echo "ALL PASS"
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -18,6 +18,42 @@ using namespace moxygen;
 
 namespace openmoq::moqx {
 
+// Bridges NAMESPACE/NAMESPACE_DONE messages from a peer relay directly into
+// MoqxRelay::doPublishNamespace/doPublishNamespaceDone — no coroutine overhead,
+// no handle map needed.
+class MoqxRelayNamespaceHandle : public Publisher::NamespacePublishHandle {
+public:
+  MoqxRelayNamespaceHandle(std::weak_ptr<MoqxRelay> relay, std::shared_ptr<MoQSession> session)
+      : relay_(std::move(relay)), session_(std::move(session)) {}
+
+  void namespaceMsg(const TrackNamespace& suffix) override {
+    auto relay = relay_.lock();
+    if (!relay || !session_) {
+      return;
+    }
+    PublishNamespace pubNs;
+    pubNs.trackNamespace = suffix;
+    relay->doPublishNamespace(std::move(pubNs), session_, nullptr);
+  }
+
+  void namespaceDoneMsg(const TrackNamespace& suffix) override {
+    auto relay = relay_.lock();
+    if (!relay || !session_) {
+      return;
+    }
+    relay->doPublishNamespaceDone(suffix, session_);
+  }
+
+private:
+  std::weak_ptr<MoqxRelay> relay_;
+  std::shared_ptr<MoQSession> session_;
+};
+
+std::shared_ptr<Publisher::NamespacePublishHandle>
+makeNamespaceBridgeHandle(std::weak_ptr<MoqxRelay> relay, std::shared_ptr<MoQSession> session) {
+  return std::make_shared<MoqxRelayNamespaceHandle>(std::move(relay), std::move(session));
+}
+
 // Sends SUBSCRIBE_UPDATE to update forwarding state. Called from:
 // - subscribeNamespace: forwarder was empty, new subscriber added
 // (forward=true)
@@ -75,23 +111,20 @@ std::shared_ptr<MoqxRelay::NamespaceNode> MoqxRelay::findNamespaceNode(
   return nodePtr;
 }
 
-folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespace(
-    PublishNamespace ann,
+std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespace(
+    PublishNamespace pubNs,
+    std::shared_ptr<MoQSession> session,
     std::shared_ptr<Subscriber::PublishNamespaceCallback> callback
 ) {
-  XLOG(DBG1) << __func__ << " ns=" << ann.trackNamespace;
+  XLOG(DBG1) << __func__ << " ns=" << pubNs.trackNamespace;
   // check auth
-  if (!ann.trackNamespace.startsWith(allowedNamespacePrefix_)) {
-    co_return folly::makeUnexpected(PublishNamespaceError{
-        ann.requestID,
-        PublishNamespaceErrorCode::UNINTERESTED,
-        "bad namespace"
-    });
+  if (!pubNs.trackNamespace.startsWith(allowedNamespacePrefix_)) {
+    return nullptr;
   }
   std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>
       sessions;
   auto nodePtr = findNamespaceNode(
-      ann.trackNamespace,
+      pubNs.trackNamespace,
       /*createMissingNodes=*/true,
       MatchType::Exact,
       &sessions
@@ -100,7 +133,7 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespac
   // Log if there is already a session that has publishNamespace-d this track
   if (nodePtr->sourceSession) {
     XLOG(WARNING) << "PublishNamespace: Existing session (" << nodePtr->sourceSession.get()
-                  << ") has already published trackNamespace=" << ann.trackNamespace;
+                  << ") has already published trackNamespace=" << pubNs.trackNamespace;
     // Since we don't fully support multiple publishers -- cancel the old
     // publishNamespace and remove ongoing subscriptions to this publisher
     // in that namespace.  Note: it could have publishNamespace-d a more
@@ -115,7 +148,7 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespac
     }
     for (auto it = subscriptions_.begin(); it != subscriptions_.end();) {
       // Check if the subscription's FullTrackName is in this namespace
-      if (it->first.trackNamespace.startsWith(ann.trackNamespace) &&
+      if (it->first.trackNamespace.startsWith(pubNs.trackNamespace) &&
           it->second.upstream == nodePtr->sourceSession) {
         XLOG(DBG4) << "Erasing subscription to " << it->first;
         it = subscriptions_.erase(it);
@@ -123,12 +156,8 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespac
         ++it;
       }
     }
-
     nodePtr->sourceSession.reset();
   }
-
-  // TODO: store auth for forwarding on future SubscribeNamespace?
-  auto session = MoQSession::getRequestSession();
 
   // Include sessions that subscribed exactly this namespace as well.
   // findNamespaceNode(..., &sessions) collects subscribers attached to prefixes
@@ -140,8 +169,8 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespac
   bool wasEmpty = !nodePtr->hasLocalSessions();
   nodePtr->sourceSession = session;
   nodePtr->publishNamespaceCallback = std::move(callback);
-  nodePtr->trackNamespace_ = ann.trackNamespace;
-  nodePtr->setPublishNamespaceOk({ann.requestID});
+  nodePtr->trackNamespace_ = pubNs.trackNamespace;
+  nodePtr->setPublishNamespaceOk({.requestID = pubNs.requestID, .requestSpecificParams = {}});
 
   // If this is the first content added to this node, notify parent
   if (wasEmpty && nodePtr->parent_) {
@@ -153,26 +182,42 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespac
       if (info.namespacePublishHandle) {
         // Draft 16+: send NAMESPACE message on the bidi stream
         TrackNamespace suffix(std::vector<std::string>(
-            ann.trackNamespace.trackNamespace.begin() + info.trackNamespacePrefix.size(),
-            ann.trackNamespace.trackNamespace.end()
+            pubNs.trackNamespace.trackNamespace.begin() + info.trackNamespacePrefix.size(),
+            pubNs.trackNamespace.trackNamespace.end()
         ));
         info.namespacePublishHandle->namespaceMsg(suffix);
       } else {
         // Draft <= 15: send PUBLISH_NAMESPACE on a new stream
         auto exec = outSession->getExecutor();
-        co_withExecutor(exec, publishNamespaceToSession(outSession, ann, nodePtr)).start();
+        co_withExecutor(exec, publishNamespaceToSession(outSession, pubNs, nodePtr)).start();
       }
     }
   }
-  co_return nodePtr;
+  return nodePtr;
+}
+
+folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespace(
+    PublishNamespace pubNs,
+    std::shared_ptr<Subscriber::PublishNamespaceCallback> callback
+) {
+  // TODO: store auth for forwarding on future SubscribeNamespace?
+  auto session = MoQSession::getRequestSession();
+  auto requestID = pubNs.requestID;
+  auto result = doPublishNamespace(std::move(pubNs), session, std::move(callback));
+  if (!result) {
+    co_return folly::makeUnexpected(
+        PublishNamespaceError{requestID, PublishNamespaceErrorCode::UNINTERESTED, "bad namespace"}
+    );
+  }
+  co_return result;
 }
 
 folly::coro::Task<void> MoqxRelay::publishNamespaceToSession(
     std::shared_ptr<MoQSession> session,
-    PublishNamespace ann,
+    PublishNamespace pubNs,
     std::shared_ptr<NamespaceNode> nodePtr
 ) {
-  auto publishNamespaceHandle = co_await session->publishNamespace(ann);
+  auto publishNamespaceHandle = co_await session->publishNamespace(pubNs);
   if (publishNamespaceHandle.hasError()) {
     XLOG(ERR) << "PublishNamespace failed err=" << publishNamespaceHandle.error().reasonPhrase;
   } else {
@@ -247,7 +292,10 @@ void MoqxRelay::NamespaceNode::tryPruneChild(const std::string& childKey) {
   parentOfNodeToRemove->children.erase(keyToRemove);
 }
 
-void MoqxRelay::publishNamespaceDone(const TrackNamespace& trackNamespace, NamespaceNode*) {
+void MoqxRelay::doPublishNamespaceDone(
+    const TrackNamespace& trackNamespace,
+    std::shared_ptr<MoQSession> session
+) {
   XLOG(DBG1) << __func__ << " ns=" << trackNamespace;
   // Node would be useful if there were back links
   auto nodePtr = findNamespaceNode(trackNamespace);
@@ -259,8 +307,6 @@ void MoqxRelay::publishNamespaceDone(const TrackNamespace& trackNamespace, Names
 
   // Track if node had local content before modification
   bool hadLocalContent = nodePtr->hasLocalSessions();
-
-  auto session = MoQSession::getRequestSession();
 
   // Only allow publishNamespaceDone if there is an owner and the caller is that
   // owner
@@ -318,6 +364,10 @@ void MoqxRelay::publishNamespaceDone(const TrackNamespace& trackNamespace, Names
       !trackNamespace.trackNamespace.empty()) {
     nodePtr->parent_->tryPruneChild(trackNamespace.trackNamespace.back());
   }
+}
+
+void MoqxRelay::publishNamespaceDone(const TrackNamespace& trackNamespace, NamespaceNode*) {
+  doPublishNamespaceDone(trackNamespace, MoQSession::getRequestSession());
 }
 
 void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
@@ -576,6 +626,25 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   XLOG(DBG1) << __func__ << " nsp=" << subNs.trackNamespacePrefix;
 
   auto session = MoQSession::getRequestSession();
+
+  // Relay peering: if the incoming subNs carries a relay auth token, the peer
+  // is a relay. Reciprocate with our own peer subNs so the peer gets our
+  // namespace announcements as publishers connect.
+  if (!relayID_.empty() && isPeerSubNs(subNs)) {
+    XLOG(INFO) << __func__ << ": peer relay detected, reciprocating peer subNs";
+    auto handle = makeNamespaceBridgeHandle(weak_from_this(), session);
+    auto recipResult = co_await session->subscribeNamespace(
+        makePeerSubNs(),
+        handle
+    ); // no token: reciprocal, prevents loop
+    if (recipResult.hasError()) {
+      XLOG(ERR) << "Reciprocal peer subNs failed: " << recipResult.error().reasonPhrase;
+    } else {
+      peerSubNsHandles_.emplace(session.get(), std::move(recipResult.value()));
+    }
+    // Fall through: register the peer as a normal subNs subscriber so it
+    // receives namespace announcements as publishers connect.
+  }
   auto maybeNegotiatedVersion = session->getNegotiatedVersion();
   CHECK(maybeNegotiatedVersion.has_value());
 
@@ -671,7 +740,7 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   co_return std::make_shared<NamespaceSubscription>(
       shared_from_this(),
       std::move(session),
-      SubscribeNamespaceOk{subNs.requestID},
+      SubscribeNamespaceOk{.requestID = subNs.requestID, .requestSpecificParams = {}},
       subNs.trackNamespacePrefix
   );
 }
@@ -681,6 +750,8 @@ void MoqxRelay::unsubscribeNamespace(
     std::shared_ptr<MoQSession> session
 ) {
   XLOG(DBG1) << __func__ << " nsp=" << trackNamespacePrefix;
+  // Clean up the reciprocal peer subNs handle for this session if present.
+  peerSubNsHandles_.erase(session.get());
   auto nodePtr = findNamespaceNode(trackNamespacePrefix);
   if (!nodePtr) {
     // TODO: maybe error?

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -12,7 +12,8 @@
 
 namespace {
 constexpr uint8_t kDefaultUpstreamPriority = 128;
-}
+constexpr std::chrono::seconds kUpstreamConnectWaitTimeout(5);
+} // namespace
 
 using namespace moxygen;
 
@@ -52,6 +53,20 @@ private:
 std::shared_ptr<Publisher::NamespacePublishHandle>
 makeNamespaceBridgeHandle(std::weak_ptr<MoqxRelay> relay, std::shared_ptr<MoQSession> session) {
   return std::make_shared<MoqxRelayNamespaceHandle>(std::move(relay), std::move(session));
+}
+
+folly::coro::Task<void> MoqxRelay::onUpstreamConnect(std::shared_ptr<MoQSession> session) {
+  auto nsHandle = makeNamespaceBridgeHandle(weak_from_this(), session);
+  auto result = co_await session->subscribeNamespace(makePeerSubNs(relayID_), nsHandle);
+  if (result.hasValue()) {
+    upstreamSubNsHandle_ = std::move(result.value());
+  } else {
+    XLOG(ERR) << "MoqxRelay: upstream peer subNs failed: " << result.error().reasonPhrase;
+  }
+}
+
+void MoqxRelay::onUpstreamDisconnect() {
+  upstreamSubNsHandle_.reset();
 }
 
 // Sends SUBSCRIBE_UPDATE to update forwarding state. Called from:
@@ -826,6 +841,10 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
       ));
     }
     auto upstreamSession = findPublishNamespaceSession(subReq.fullTrackName.trackNamespace);
+    if (!upstreamSession && upstream_) {
+      co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
+      upstreamSession = findPublishNamespaceSession(subReq.fullTrackName.trackNamespace);
+    }
     if (!upstreamSession) {
       // no such namespace has been published
       co_return folly::makeUnexpected(SubscribeError(
@@ -985,6 +1004,10 @@ MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   }
 
   auto upstreamSession = findPublishNamespaceSession(fetch.fullTrackName.trackNamespace);
+  if (!upstreamSession && upstream_) {
+    co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
+    upstreamSession = findPublishNamespaceSession(fetch.fullTrackName.trackNamespace);
+  }
   if (!upstreamSession) {
     // Attempt to find matching upstream subscription (from publish)
     auto subscriptionIt = subscriptions_.find(fetch.fullTrackName);
@@ -1058,7 +1081,10 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatus(TrackStat
   } else {
     // No subscription - forward to upstream
     auto upstreamSession = findPublishNamespaceSession(trackStatus.fullTrackName.trackNamespace);
-
+    if (!upstreamSession && upstream_) {
+      co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
+      upstreamSession = findPublishNamespaceSession(trackStatus.fullTrackName.trackNamespace);
+    }
     if (!upstreamSession) {
       XLOG(DBG1) << "No upstream session for track: " << trackStatus.fullTrackName;
       co_return folly::makeUnexpected(TrackStatusError{

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -2,6 +2,8 @@
 #include <moqx/stats/MoQStatsCollector.h>
 #include <moqx/stats/QuicStatsCollector.h>
 #include <moxygen/MoQRelaySession.h>
+#include <moxygen/events/MoQFollyExecutorImpl.h>
+#include <moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h>
 
 #include <folly/logging/xlog.h>
 
@@ -20,13 +22,21 @@ std::vector<std::string> buildAlpns(const std::string& versions) {
 
 } // namespace
 
-void MoqxRelayServer::initRelays(
-    const folly::F14FastMap<std::string, config::ServiceConfig>& services
+void MoqxRelayServer::initServices(
+    const folly::F14FastMap<std::string, config::ServiceConfig>& services,
+    const std::string& relayID
 ) {
   for (const auto& [name, svc] : services) {
-    relays_.emplace(
+    services_.emplace(
         name,
-        std::make_shared<MoqxRelay>(svc.cache.maxCachedTracks, svc.cache.maxCachedGroupsPerTrack)
+        ServiceEntry{
+            svc,
+            std::make_shared<MoqxRelay>(
+                svc.cache.maxCachedTracks,
+                svc.cache.maxCachedGroupsPerTrack,
+                relayID
+            )
+        }
     );
   }
 }
@@ -36,7 +46,8 @@ MoqxRelayServer::MoqxRelayServer(
     const std::string& key,
     const std::string& endpoint,
     const std::string& versions,
-    folly::F14FastMap<std::string, config::ServiceConfig> services
+    folly::F14FastMap<std::string, config::ServiceConfig> services,
+    const std::string& relayID
 )
     : MoQServer(
           quic::samples::createFizzServerContext(
@@ -47,14 +58,15 @@ MoqxRelayServer::MoqxRelayServer(
           ),
           endpoint
       ),
-      serviceMatcher_(services) {
-  initRelays(services);
+      serviceMatcher_(services), relayID_(relayID) {
+  initServices(services, relayID);
 }
 
 MoqxRelayServer::MoqxRelayServer(
     const std::string& endpoint,
     const std::string& versions,
-    folly::F14FastMap<std::string, config::ServiceConfig> services
+    folly::F14FastMap<std::string, config::ServiceConfig> services,
+    const std::string& relayID
 )
     : MoQServer(
           quic::samples::createFizzServerContextWithInsecureDefault(
@@ -65,8 +77,19 @@ MoqxRelayServer::MoqxRelayServer(
           ),
           endpoint
       ),
-      serviceMatcher_(services) {
-  initRelays(services);
+      serviceMatcher_(services), relayID_(relayID) {
+  initServices(services, relayID);
+}
+
+MoqxRelayServer::~MoqxRelayServer() {
+  // 1. Signal upstreams to stop — cancels reconnect backoff sleep so the
+  //    reconnect coroutine on the worker EVB can exit cleanly.
+  for (auto& [name, entry] : services_) {
+    entry.relay->stop();
+  }
+  // 2. Close incoming connections, drain worker EVBs (terminateClientSession
+  //    and ~MoQSession complete here), then destroy EVBs.
+  MoQServer::stop();
 }
 
 void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
@@ -78,6 +101,65 @@ void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> reg
 
     // Wire up QUIC transport stats factory
     setQuicStatsFactory(std::make_unique<stats::QuicStatsCollector::Factory>(statsRegistry_));
+  }
+}
+
+namespace {
+
+// Relay chaining requires draft 16+ for wildcard subscribeNamespace and
+// NAMESPACE messages on the bidi stream. Connections negotiating an earlier
+// draft will not receive namespace announcements from the upstream relay.
+std::shared_ptr<fizz::CertificateVerifier> makeUpstreamVerifier(const config::UpstreamTlsConfig& tls
+) {
+  if (tls.insecure) {
+    return std::make_shared<moxygen::test::InsecureVerifierDangerousDoNotUseInProduction>();
+  }
+  if (tls.caCertFile) {
+    // TODO: load custom CA cert via fizz OpenSSLCertUtils / X509 store
+    XLOG(WARN) << "upstream.tls.ca_cert is not yet implemented; "
+                  "using system CAs";
+  }
+  return nullptr; // nullptr = fizz uses system CAs
+}
+
+} // namespace
+
+void MoqxRelayServer::initUpstreams() {
+  auto evbs = getWorkerEvbs();
+  CHECK(!evbs.empty()) << "initUpstreams must be called after start()";
+
+  // Use the first worker EVB for all upstream connections.
+  // Per-EVB providers (one per worker thread) are a follow-up.
+  auto exec = std::make_shared<MoQFollyExecutorImpl>(evbs[0]);
+
+  for (auto& [name, entry] : services_) {
+    if (!entry.config.upstream) {
+      continue;
+    }
+    const auto& cfg = *entry.config.upstream;
+    auto verifier = makeUpstreamVerifier(cfg.tls);
+    auto relay = entry.relay;
+    auto onConnect = [relay](std::shared_ptr<MoQSession> session) -> folly::coro::Task<void> {
+      co_await relay->onUpstreamConnect(session);
+    };
+    auto onDisconnect = [relay]() { relay->onUpstreamDisconnect(); };
+    auto provider = std::make_shared<UpstreamProvider>(
+        exec,
+        proxygen::URL(cfg.url),
+        /*publishHandler=*/entry.relay,
+        /*subscribeHandler=*/entry.relay,
+        verifier,
+        std::move(onConnect),
+        std::move(onDisconnect),
+        cfg.connectTimeout,
+        cfg.idleTimeout
+    );
+    entry.relay->setUpstreamProvider(provider);
+
+    // Eagerly connect so the peering handshake fires before any subscribers
+    // arrive. The connection is lazy in UpstreamProvider but we kick it off
+    // now so the upstream namespace tree is ready.
+    co_withExecutor(evbs[0], provider->start()).start();
   }
 }
 
@@ -125,10 +207,10 @@ folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayServer::validateAut
   }
 
   // Route: set per-service relay as handler
-  auto it = relays_.find(*matchedName);
-  CHECK(it != relays_.end()) << "Service '" << *matchedName << "' matched but no relay found";
-  session->setPublishHandler(it->second);
-  session->setSubscribeHandler(it->second);
+  auto it = services_.find(*matchedName);
+  CHECK(it != services_.end()) << "Service '" << *matchedName << "' matched but no entry found";
+  session->setPublishHandler(it->second.relay);
+  session->setSubscribeHandler(it->second.relay);
   return folly::unit;
 }
 

--- a/src/UpstreamProvider.cpp
+++ b/src/UpstreamProvider.cpp
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/coro/Timeout.h>
+#include <moqx/UpstreamProvider.h>
+#include <moxygen/MoQFilters.h>
+#include <moxygen/MoQRelaySession.h>
+#include <moxygen/MoQVersions.h>
+
+using namespace moxygen;
+
+namespace openmoq::moqx {
+
+// Randomly chosen token type identifying a relay-to-relay peering subNs.
+// Must fit in a QUIC variable-length integer (top 2 bits must be 00, i.e. < 2^62).
+static constexpr uint64_t kRelayAuthTokenType = 0x1B2C'3D4E'5F6A'7B8CULL;
+
+bool isPeerSubNs(const SubscribeNamespace& subNs) {
+  const uint64_t authKey = static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN);
+  for (const auto& param : subNs.params) {
+    if (param.key == authKey && param.asAuthToken.tokenType == kRelayAuthTokenType) {
+      return true;
+    }
+  }
+  return false;
+}
+
+SubscribeNamespace makePeerSubNs(std::optional<std::string> relayID) {
+  SubscribeNamespace subNs;
+  subNs.trackNamespacePrefix = {};
+  subNs.options = SubscribeNamespaceOptions::BOTH;
+  if (relayID) {
+    subNs.params.insertParam(Parameter(
+        static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),
+        AuthToken{
+            .tokenType = kRelayAuthTokenType,
+            .tokenValue = *relayID,
+            .alias = AuthToken::DontRegister,
+        }
+    ));
+  }
+  return subNs;
+}
+
+namespace {
+
+// TrackConsumer proxy whose downstream is set after connecting to upstream.
+// Per MoQ protocol, publishers must not send data before PublishOk, so
+// setDownstream() is always called before any forwarding methods are used.
+class PendingTrackConsumer : public TrackConsumerFilter {
+public:
+  PendingTrackConsumer() : TrackConsumerFilter(nullptr) {}
+
+  void setDownstream(std::shared_ptr<TrackConsumer> downstream) {
+    downstream_ = std::move(downstream);
+  }
+};
+
+} // namespace
+
+UpstreamProvider::UpstreamProvider(
+    std::shared_ptr<MoQExecutor> exec,
+    proxygen::URL url,
+    std::shared_ptr<Publisher> publishHandler,
+    std::shared_ptr<Subscriber> subscribeHandler,
+    std::shared_ptr<fizz::CertificateVerifier> verifier,
+    OnConnectHook onConnect,
+    OnDisconnectHook onDisconnect,
+    std::chrono::milliseconds connectTimeout,
+    std::chrono::milliseconds idleTimeout
+)
+    : publishHandler_(std::move(publishHandler)), subscribeHandler_(std::move(subscribeHandler)),
+      url_(std::move(url)), exec_(std::move(exec)), verifier_(std::move(verifier)),
+      onConnect_(std::move(onConnect)), onDisconnect_(std::move(onDisconnect)),
+      connectTimeout_(connectTimeout), idleTimeout_(idleTimeout) {
+  XLOG(DBG1) << "UpstreamProvider created, url=" << url_.getUrl();
+}
+
+UpstreamProvider::~UpstreamProvider() {
+  // close() holds shared_from_this() and runs during MoQServer::stop() EVB
+  // drain — both before member dtors fire. These must be null by now.
+  XCHECK(!session_) << "UpstreamProvider dtor with live session; was stop() called?";
+  XCHECK(!client_) << "UpstreamProvider dtor with live client; was stop() called?";
+  XLOG(DBG1) << "UpstreamProvider destroyed";
+}
+
+folly::coro::Task<void> UpstreamProvider::start() {
+  XLOG(DBG1) << "UpstreamProvider::start";
+  return reconnectLoop();
+}
+
+static constexpr auto kInitialReconnectBackoff = std::chrono::seconds(1);
+static constexpr auto kMaxReconnectBackoff = std::chrono::seconds(60);
+
+folly::coro::Task<void> UpstreamProvider::reconnectLoop() {
+  auto self = shared_from_this();
+  while (!stopped_) {
+    if (reconnectBackoff_.count() > 0) {
+      XLOG(INFO) << "UpstreamProvider: reconnecting in " << reconnectBackoff_.count() << "ms";
+      try {
+        co_await folly::coro::co_withCancellation(
+            stopSource_.getToken(),
+            folly::coro::sleep(reconnectBackoff_)
+        );
+      } catch (const folly::OperationCancelled&) {
+        co_return;
+      }
+    }
+    if (stopped_) {
+      co_return;
+    }
+
+    try {
+      co_await folly::coro::co_withCancellation(stopSource_.getToken(), getOrConnectSession());
+      XLOG(DBG1) << "UpstreamProvider::reconnectLoop connected, session=" << session_.get();
+      reconnectBackoff_ = std::chrono::milliseconds(0);
+      co_return; // Connected — exit. onMoQSessionClosed()/goaway() will respawn.
+    } catch (const folly::OperationCancelled&) {
+      co_return;
+    } catch (const std::exception& ex) {
+      if (stopped_) {
+        co_return;
+      }
+      reconnectBackoff_ =
+          reconnectBackoff_.count() == 0
+              ? kInitialReconnectBackoff
+              : std::min(reconnectBackoff_ * 2, std::chrono::milliseconds(kMaxReconnectBackoff));
+      XLOG(ERR) << "UpstreamProvider: connect failed: " << ex.what() << ", retrying in "
+                << reconnectBackoff_.count() << "ms";
+    }
+  }
+}
+
+folly::coro::Task<void> UpstreamProvider::close() {
+  auto self = shared_from_this();
+  XLOG(DBG1) << "UpstreamProvider::close";
+  session_.reset();
+  client_.reset(); // ~MoQClientBase() calls moqSession_->close() implicitly
+  state_ = State::Disconnected;
+  co_return;
+}
+
+void UpstreamProvider::stop() {
+  XLOG(DBG1) << "UpstreamProvider::stop";
+  stopped_ = true;
+
+  // Cancel any in-progress backoff sleep or connect in reconnectLoop().
+  stopSource_.requestCancellation();
+
+  // Break the shared_ptr cycle: relay owns us via upstream_, and we hold
+  // back-refs to relay through these members.
+  publishHandler_.reset();
+  subscribeHandler_.reset();
+  onConnect_ = nullptr;
+  onDisconnect_ = nullptr;
+
+  // Close the upstream session on the exec EVB thread while EVBs are still
+  // alive.
+  co_withExecutor(exec_.get(), close()).start();
+}
+
+// --- Publisher interface ---
+
+folly::coro::Task<Publisher::SubscribeResult>
+UpstreamProvider::subscribe(SubscribeRequest sub, std::shared_ptr<TrackConsumer> callback) {
+  XLOG(DBG1) << "UpstreamProvider::subscribe ftn=" << sub.fullTrackName;
+  if (auto sess = getSession()) {
+    return sess->subscribe(std::move(sub), std::move(callback));
+  }
+  return coSubscribe(std::move(sub), std::move(callback));
+}
+
+folly::coro::Task<Publisher::SubscribeResult>
+UpstreamProvider::coSubscribe(SubscribeRequest sub, std::shared_ptr<TrackConsumer> callback) {
+  auto sess = co_await getOrConnectSession();
+  co_return co_await sess->subscribe(std::move(sub), std::move(callback));
+}
+
+folly::coro::Task<Publisher::FetchResult>
+UpstreamProvider::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> fetchCallback) {
+  XLOG(DBG1) << "UpstreamProvider::fetch ftn=" << fetch.fullTrackName;
+  if (auto sess = getSession()) {
+    return sess->fetch(std::move(fetch), std::move(fetchCallback));
+  }
+  return coFetch(std::move(fetch), std::move(fetchCallback));
+}
+
+folly::coro::Task<Publisher::FetchResult>
+UpstreamProvider::coFetch(Fetch fetch, std::shared_ptr<FetchConsumer> fetchCallback) {
+  auto sess = co_await getOrConnectSession();
+  co_return co_await sess->fetch(std::move(fetch), std::move(fetchCallback));
+}
+
+folly::coro::Task<Publisher::TrackStatusResult> UpstreamProvider::trackStatus(TrackStatus req) {
+  XLOG(DBG1) << "UpstreamProvider::trackStatus ftn=" << req.fullTrackName;
+  if (auto sess = getSession()) {
+    return sess->trackStatus(req);
+  }
+  return coTrackStatus(req);
+}
+
+folly::coro::Task<Publisher::TrackStatusResult> UpstreamProvider::coTrackStatus(TrackStatus req) {
+  auto sess = co_await getOrConnectSession();
+  co_return co_await sess->trackStatus(req);
+}
+
+folly::coro::Task<Publisher::SubscribeNamespaceResult> UpstreamProvider::subscribeNamespace(
+    SubscribeNamespace subNs,
+    std::shared_ptr<NamespacePublishHandle> handle
+) {
+  XLOG(DBG1) << "UpstreamProvider::subscribeNamespace nsp=" << subNs.trackNamespacePrefix;
+  if (auto sess = getSession()) {
+    return sess->subscribeNamespace(std::move(subNs), std::move(handle));
+  }
+  return coSubscribeNamespace(std::move(subNs), std::move(handle));
+}
+
+folly::coro::Task<Publisher::SubscribeNamespaceResult> UpstreamProvider::coSubscribeNamespace(
+    SubscribeNamespace subNs,
+    std::shared_ptr<NamespacePublishHandle> handle
+) {
+  auto sess = co_await getOrConnectSession();
+  co_return co_await sess->subscribeNamespace(std::move(subNs), std::move(handle));
+}
+
+// --- Subscriber interface ---
+
+folly::coro::Task<Subscriber::PublishNamespaceResult> UpstreamProvider::publishNamespace(
+    PublishNamespace pubNs,
+    std::shared_ptr<PublishNamespaceCallback> cb
+) {
+  XLOG(DBG1) << "UpstreamProvider::publishNamespace ns=" << pubNs.trackNamespace;
+  if (auto sess = getSession()) {
+    return sess->publishNamespace(std::move(pubNs), std::move(cb));
+  }
+  return coPublishNamespace(std::move(pubNs), std::move(cb));
+}
+
+folly::coro::Task<Subscriber::PublishNamespaceResult> UpstreamProvider::coPublishNamespace(
+    PublishNamespace pubNs,
+    std::shared_ptr<PublishNamespaceCallback> cb
+) {
+  auto sess = co_await getOrConnectSession();
+  co_return co_await sess->publishNamespace(std::move(pubNs), std::move(cb));
+}
+
+Subscriber::PublishResult
+UpstreamProvider::publish(PublishRequest pub, std::shared_ptr<moxygen::SubscriptionHandle> handle) {
+  XLOG(DBG1) << "UpstreamProvider::publish ftn=" << pub.fullTrackName;
+  if (stopped_) {
+    return folly::makeUnexpected(
+        PublishError{pub.requestID, PublishErrorCode::INTERNAL_ERROR, "UpstreamProvider stopped"}
+    );
+  }
+  if (state_ == State::Connected && session_) {
+    return session_->publish(std::move(pub), std::move(handle));
+  }
+  // Not connected — use a PendingTrackConsumer so the reply task can wire up
+  // the real upstream consumer after connecting. Per MoQ protocol the
+  // publisher must not send data before PublishOk, so setDownstream() is
+  // guaranteed to be called before any forwarding methods.
+  auto pending = std::make_shared<PendingTrackConsumer>();
+  auto reqID = pub.requestID;
+  auto reply = coPublish(std::move(pub), std::move(handle), pending, reqID);
+  return Subscriber::PublishConsumerAndReplyTask{std::move(pending), std::move(reply)};
+}
+
+folly::coro::Task<folly::Expected<PublishOk, PublishError>> UpstreamProvider::coPublish(
+    PublishRequest pub,
+    std::shared_ptr<moxygen::SubscriptionHandle> handle,
+    std::shared_ptr<TrackConsumer> pendingBase,
+    RequestID reqID
+) {
+  try {
+    auto session = co_await getOrConnectSession();
+    auto result = session->publish(std::move(pub), std::move(handle));
+    if (result.hasError()) {
+      co_return folly::makeUnexpected(result.error());
+    }
+    std::static_pointer_cast<PendingTrackConsumer>(pendingBase)
+        ->setDownstream(std::move(result.value().consumer));
+    co_return co_await std::move(result.value().reply);
+  } catch (const std::exception& ex) {
+    co_return folly::makeUnexpected(PublishError{reqID, PublishErrorCode::INTERNAL_ERROR, ex.what()}
+    );
+  }
+}
+
+// --- Goaway ---
+
+void UpstreamProvider::goaway(Goaway goaway) {
+  XLOG(INFO) << "UpstreamProvider::goaway uri=" << goaway.newSessionUri;
+
+  if (!goaway.newSessionUri.empty()) {
+    XLOG(INFO) << "UpstreamProvider: updating URL from goaway: " << goaway.newSessionUri;
+    url_ = proxygen::URL(goaway.newSessionUri);
+  }
+
+  resetSession();
+  if (!stopped_) {
+    reconnectBackoff_ = std::chrono::milliseconds(0);
+    co_withExecutor(exec_.get(), reconnectLoop()).start();
+  }
+}
+
+// --- MoQSessionCloseCallback ---
+
+void UpstreamProvider::onMoQSessionClosed() {
+  XLOG(INFO) << "UpstreamProvider::onMoQSessionClosed";
+  resetSession();
+  if (!stopped_) {
+    reconnectBackoff_ = std::chrono::milliseconds(0);
+    co_withExecutor(exec_.get(), reconnectLoop()).start();
+  }
+}
+
+// --- Private methods ---
+
+folly::coro::Task<std::shared_ptr<MoQSession>> UpstreamProvider::getOrConnectSession() {
+  if (stopped_) {
+    XLOG(DBG1) << "UpstreamProvider::getOrConnectSession - stopped";
+    co_yield folly::coro::co_error(std::runtime_error("UpstreamProvider stopped"));
+  }
+
+  if (state_ == State::Connected && session_) {
+    co_return session_;
+  }
+
+  if (state_ == State::Connecting) {
+    XLOG(DBG1) << "UpstreamProvider::getOrConnectSession - waiting for "
+                  "in-progress connection";
+    CHECK(connectPromise_);
+    co_await connectPromise_->getFuture();
+    if (!session_) {
+      co_yield folly::coro::co_error(std::runtime_error("Connection failed"));
+    }
+    co_return session_;
+  }
+
+  // State::Disconnected - initiate connection
+  XLOG(DBG1) << "UpstreamProvider::getOrConnectSession - initiating connection";
+  state_ = State::Connecting;
+  connectPromise_.emplace();
+
+  try {
+    co_await doConnect();
+    state_ = State::Connected;
+    XLOG(DBG1) << "UpstreamProvider: connected to upstream, session=" << session_.get();
+    connectPromise_->setValue(folly::unit);
+    co_return session_;
+  } catch (const std::exception& ex) {
+    XLOG(ERR) << "UpstreamProvider: connection failed: " << ex.what();
+    state_ = State::Disconnected;
+    client_.reset();
+    connectPromise_->setException(folly::exception_wrapper(std::current_exception()));
+    connectPromise_.reset();
+    throw;
+  }
+}
+
+folly::coro::Task<void> UpstreamProvider::doConnect() {
+  XLOG(DBG1) << "UpstreamProvider::doConnect url=" << url_.getUrl();
+
+  client_ = std::make_unique<MoQClient>(
+      exec_,
+      url_,
+      MoQRelaySession::createRelaySessionFactory(),
+      verifier_
+  );
+
+  quic::TransportSettings ts;
+  ts.orderedReadCallbacks = true;
+
+  // Relay chaining requires draft 16+. Only offer standard draft-16 ALPN
+  // ("moqt-16") so we fail fast if the upstream doesn't support it.
+  co_await client_->setupMoQSession(
+      connectTimeout_,
+      idleTimeout_,
+      publishHandler_,
+      subscribeHandler_,
+      ts,
+      getMoqtProtocols("16", /*useStandard=*/true)
+  );
+
+  session_ = client_->moqSession_;
+  CHECK(session_) << "setupMoQSession succeeded but session is null";
+
+  // Register for close notifications
+  session_->setSessionCloseCallback(this);
+
+  if (onConnect_) {
+    co_await onConnect_(session_);
+  }
+
+  XLOG(DBG1) << "UpstreamProvider::doConnect completed, session=" << session_.get();
+}
+
+folly::coro::Task<void> UpstreamProvider::waitForConnected(std::chrono::milliseconds timeout) {
+  if (stopped_ || (state_ == State::Connected && session_)) {
+    co_return;
+  }
+  if (!connectPromise_) {
+    co_return;
+  }
+  co_await folly::coro::co_awaitTry(folly::coro::timeout(connectPromise_->getFuture(), timeout));
+}
+
+void UpstreamProvider::resetSession() {
+  XLOG(DBG1) << "UpstreamProvider::resetSession";
+  if (session_) {
+    session_->setSessionCloseCallback(nullptr);
+    if (onDisconnect_) {
+      onDisconnect_();
+    }
+  }
+  session_.reset();
+  // Do NOT reset client_ here: ~MoQClientBase() calls moqSession_->close()
+  // which would re-enter resetSession() while already inside a close() call
+  // stack. client_ is replaced by doConnect() on the next connect, and torn
+  // down cleanly by close() or the dtor safety net after EVBs die.
+  state_ = State::Disconnected;
+}
+
+} // namespace openmoq::moqx

--- a/src/config/config_resolver.cpp
+++ b/src/config/config_resolver.cpp
@@ -1,5 +1,8 @@
 #include "moqx/config/loader/config_resolver.h"
 
+#include <iomanip>
+#include <random>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -230,6 +233,33 @@ bool validatePath(
   return valid;
 }
 
+// --- Upstream validation and resolution ---
+
+void validateUpstream(const ParsedUpstreamConfig& upstream, std::vector<std::string>& errors) {
+  if (upstream.url.value().empty()) {
+    errors.push_back("upstream.url must be non-empty");
+  }
+  const auto& tls = upstream.tls.value();
+  if (tls.insecure.value() && tls.ca_cert.value().has_value()) {
+    errors.push_back("upstream.tls: insecure=true and ca_cert are mutually exclusive");
+  }
+}
+
+UpstreamConfig resolveUpstream(const ParsedUpstreamConfig& upstream) {
+  const auto& tls = upstream.tls.value();
+  return UpstreamConfig{
+      .url = upstream.url.value(),
+      .tls =
+          UpstreamTlsConfig{
+              .insecure = tls.insecure.value(),
+              .caCertFile = tls.ca_cert.value(),
+          },
+      .connectTimeout =
+          std::chrono::milliseconds(upstream.connect_timeout_ms.value().value_or(5000)),
+      .idleTimeout = std::chrono::milliseconds(upstream.idle_timeout_ms.value().value_or(5000)),
+  };
+}
+
 // --- Service validation ---
 
 void validateService(
@@ -298,6 +328,19 @@ void validateService(
   }
 
   mergedCaches.emplace(name, std::move(merged));
+
+  // Validate per-service upstream if present.
+  if (svc.upstream.value().has_value()) {
+    validateUpstream(*svc.upstream.value(), errors);
+  }
+}
+
+std::string generateRelayID() {
+  std::random_device rd;
+  const uint64_t val = (static_cast<uint64_t>(rd()) << 32) | static_cast<uint64_t>(rd());
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0') << std::setw(16) << val;
+  return oss.str();
 }
 
 // --- Resolution helpers ---
@@ -357,9 +400,14 @@ ServiceConfig resolveService(const ParsedServiceConfig& svc, const ParsedCacheCo
   for (const auto& entry : svc.match.value()) {
     entries.push_back(resolveMatchEntry(entry));
   }
+  std::optional<UpstreamConfig> upstream;
+  if (svc.upstream.value().has_value()) {
+    upstream = resolveUpstream(*svc.upstream.value());
+  }
   return ServiceConfig{
       .match = std::move(entries),
       .cache = resolveCacheConfig(cache),
+      .upstream = std::move(upstream),
   };
 }
 
@@ -388,6 +436,7 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
   validateAdmin(config, errors);
 
   // === Validate services ===
+  // Per-service upstream config is validated inside validateService().
 
   const auto& services = config.services.value();
   if (services.empty()) {
@@ -428,12 +477,16 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
     };
   }
 
+  // Resolve relayID: use configured value or generate a random hex string
+  std::string relayID = config.relay_id.value().value_or(generateRelayID());
+
   return ResolvedConfig{
       .config =
           Config{
               .listener = resolveListener(listener),
               .services = std::move(resolvedServices),
               .admin = std::move(adminConfig),
+              .relayID = std::move(relayID),
           },
       .warnings = std::move(warnings),
   };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,8 @@ std::shared_ptr<openmoq::moqx::MoqxRelayServer> createServer(const cfg::Config& 
           return std::make_shared<openmoq::moqx::MoqxRelayServer>(
               listener.endpoint,
               listener.moqtVersions,
-              std::move(services)
+              std::move(services),
+              config.relayID
           );
         } else {
           return std::make_shared<openmoq::moqx::MoqxRelayServer>(
@@ -55,7 +56,8 @@ std::shared_ptr<openmoq::moqx::MoqxRelayServer> createServer(const cfg::Config& 
               tls.keyFile,
               listener.endpoint,
               listener.moqtVersions,
-              std::move(services)
+              std::move(services),
+              config.relayID
           );
         }
       },
@@ -134,7 +136,6 @@ int main(int argc, char* argv[]) {
   }
 
   // === 8. Start serving ===
-  // Bind listeners, accept connections, enter event loop
   server->start(config.listener.address);
   evb.loopForever();
 

--- a/tests/MoQIntegrationTestFixture.h
+++ b/tests/MoQIntegrationTestFixture.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/io/async/EventBase.h>
+#include <folly/logging/xlog.h>
+#include <folly/portability/GTest.h>
+#include <folly/synchronization/Baton.h>
+#include <moxygen/MoQClient.h>
+#include <moxygen/MoQRelaySession.h>
+#include <moxygen/MoQServer.h>
+#include <moxygen/MoQVersions.h>
+#include <moxygen/Publisher.h>
+#include <moxygen/Subscriber.h>
+#include <moxygen/events/MoQFollyExecutorImpl.h>
+#include <moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h>
+#include <proxygen/httpserver/samples/hq/FizzContext.h>
+#include <proxygen/lib/utils/URL.h>
+
+#include <thread>
+
+namespace openmoq::moqx::test {
+
+/**
+ * MoQIntegrationTestFixture - Reusable GTest fixture that runs a real MoQ
+ * server in-process and provides helpers to create real MoQ clients.
+ *
+ * Subclasses override createServerPublishHandler() and optionally
+ * createServerSubscribeHandler() to provide the server-side handlers.
+ */
+class MoQIntegrationTestFixture : public ::testing::Test {
+protected:
+  // Subclasses must override to provide server's Publisher handler
+  virtual std::shared_ptr<moxygen::Publisher> createServerPublishHandler() = 0;
+
+  // Subclasses optionally override to provide server's Subscriber handler
+  virtual std::shared_ptr<moxygen::Subscriber> createServerSubscribeHandler() { return nullptr; }
+
+  void SetUp() override {
+    // Start the server thread. The server must be constructed and started
+    // on the same thread (QuicServer requirement).
+    folly::Baton<> serverReady;
+    serverThread_ = std::thread([this, &serverReady]() {
+      XLOG(DBG1) << "Server thread starting";
+
+      // Create insecure fizz context
+      // Include both experimental (Meta-specific) and standard ALPNs so
+      // clients offering either variant can connect.
+      auto alpns = moxygen::getDefaultMoqtProtocols(true);
+      auto standard = moxygen::getMoqtProtocols("", /*useStandard=*/true);
+      alpns.insert(alpns.end(), standard.begin(), standard.end());
+      alpns.push_back("h3");
+      auto fizzContext = quic::samples::createFizzServerContextWithInsecureDefault(
+          alpns,
+          fizz::server::ClientAuthMode::None,
+          "" /* cert */,
+          "" /* key */
+      );
+
+      // Create and start the server on this thread
+      server_ = std::make_unique<TestServer>(*this, std::move(fizzContext));
+      server_->start(folly::SocketAddress("::1", 0));
+
+      // Get the assigned port
+      auto addr = server_->getAddress();
+      port_ = addr.getPort();
+      XLOG(DBG1) << "Test server started on port " << port_;
+
+      serverReady.post();
+
+      // Run event loop (server creates its own worker EVBs)
+      serverEvb_.loopForever();
+      XLOG(DBG1) << "Server thread exiting";
+    });
+
+    serverReady.wait();
+    XLOG(DBG1) << "Server ready on port " << port_;
+
+    // Create client executor - the EVB will be driven by blockingWait
+    // in the test thread (not a separate thread)
+    clientExec_ = std::make_shared<moxygen::MoQFollyExecutorImpl>(&clientEvb_);
+  }
+
+  void TearDown() override {
+    // Stop the server
+    if (server_) {
+      server_->stop();
+    }
+
+    // Drain the client EventBase so any pending close/cleanup work can run
+    // before tearing down the server.
+    clientEvb_.loop();
+
+    // Stop event bases
+    serverEvb_.terminateLoopSoon();
+
+    if (serverThread_.joinable()) {
+      serverThread_.join();
+    }
+
+    server_.reset();
+  }
+
+  // Create a URL pointing at the test server
+  proxygen::URL serverUrl() const {
+    return proxygen::URL(folly::to<std::string>("moqt://localhost:", port_, "/test"));
+  }
+
+  // Create a new MoQ client configured for the test server
+  std::unique_ptr<moxygen::MoQClient> createClient() {
+    return std::make_unique<moxygen::MoQClient>(
+        clientExec_,
+        serverUrl(),
+        moxygen::MoQRelaySession::createRelaySessionFactory(),
+        std::make_shared<moxygen::test::InsecureVerifierDangerousDoNotUseInProduction>()
+    );
+  }
+
+  // Get the client executor
+  std::shared_ptr<moxygen::MoQExecutor> clientExec() const { return clientExec_; }
+
+  // Get the server's assigned port
+  uint16_t serverPort() const { return port_; }
+
+  // Access the client event base for scheduling
+  folly::EventBase& clientEvb() { return clientEvb_; }
+
+  // Access the server event base for scheduling
+  folly::EventBase& serverEvb() { return serverEvb_; }
+
+private:
+  // Simple MoQServer subclass that delegates to fixture's handler factories
+  class TestServer : public moxygen::MoQServer {
+  public:
+    TestServer(
+        MoQIntegrationTestFixture& fixture,
+        std::shared_ptr<const fizz::server::FizzServerContext> fizzContext
+    )
+        : MoQServer(std::move(fizzContext), "/test"), fixture_(fixture) {}
+
+    void onNewSession(std::shared_ptr<moxygen::MoQSession> session) override {
+      XLOG(DBG1) << "TestServer: new session " << session.get();
+      auto pub = fixture_.createServerPublishHandler();
+      auto sub = fixture_.createServerSubscribeHandler();
+      if (pub) {
+        session->setPublishHandler(pub);
+      }
+      if (sub) {
+        session->setSubscribeHandler(sub);
+      }
+    }
+
+  protected:
+    std::shared_ptr<moxygen::MoQSession> createSession(
+        folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+        std::shared_ptr<moxygen::MoQExecutor> executor
+    ) override {
+      return std::make_shared<moxygen::MoQRelaySession>(
+          folly::MaybeManagedPtr<proxygen::WebTransport>(std::move(wt)),
+          *this,
+          std::move(executor)
+      );
+    }
+
+  private:
+    MoQIntegrationTestFixture& fixture_;
+  };
+
+  std::unique_ptr<TestServer> server_;
+  folly::EventBase serverEvb_;
+  folly::EventBase clientEvb_;
+  std::thread serverThread_;
+  uint16_t port_{0};
+  std::shared_ptr<moxygen::MoQFollyExecutorImpl> clientExec_;
+};
+
+} // namespace openmoq::moqx::test

--- a/tests/MoqxRelayTest.cpp
+++ b/tests/MoqxRelayTest.cpp
@@ -2158,4 +2158,34 @@ TEST_F(MoQRelayTest, TrackStatusViaPrefixMatching) {
   removeSession(requester);
 }
 
+// Test: makeNamespaceBridgeHandle routes namespaceMsg to doPublishNamespace
+TEST_F(MoQRelayTest, NamespaceBridgeHandleForwardsNamespaceMsg) {
+  auto peerSession = createMockSession();
+
+  // Bridge handle routes NAMESPACE messages from peerSession into the relay.
+  // For peering the subscription prefix is empty, so the suffix == full namespace.
+  auto handle = makeNamespaceBridgeHandle(relay_, peerSession);
+  handle->namespaceMsg(kTestNamespace);
+
+  auto sessions = relay_->findPublishNamespaceSessions(kTestNamespace);
+  ASSERT_EQ(sessions.size(), 1u);
+  EXPECT_EQ(sessions[0], peerSession);
+
+  removeSession(peerSession);
+}
+
+// Test: makeNamespaceBridgeHandle routes namespaceDoneMsg to doPublishNamespaceDone
+TEST_F(MoQRelayTest, NamespaceBridgeHandleForwardsDoneMsg) {
+  auto peerSession = createMockSession();
+  auto handle = makeNamespaceBridgeHandle(relay_, peerSession);
+
+  handle->namespaceMsg(kTestNamespace);
+  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+
+  handle->namespaceDoneMsg(kTestNamespace);
+  EXPECT_TRUE(relay_->findPublishNamespaceSessions(kTestNamespace).empty());
+
+  removeSession(peerSession);
+}
+
 } // namespace moxygen::test

--- a/tests/UpstreamProviderTest.cpp
+++ b/tests/UpstreamProviderTest.cpp
@@ -1,0 +1,609 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MoQIntegrationTestFixture.h"
+#include <moqx/UpstreamProvider.h>
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Collect.h>
+#include <folly/coro/Sleep.h>
+#include <folly/coro/Task.h>
+#include <folly/logging/xlog.h>
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/MoQSession.h>
+#include <moxygen/ObjectReceiver.h>
+#include <moxygen/test/Mocks.h>
+
+using namespace moxygen;
+using namespace testing;
+
+namespace openmoq::moqx::test {
+
+namespace {
+
+const TrackNamespace kTestNamespace{{"test", "ns"}};
+const FullTrackName kTestTrack{kTestNamespace, "track1"};
+
+Publisher::SubscribeResult makeSubscribeOk(const SubscribeRequest& sub) {
+  SubscribeOk ok;
+  ok.requestID = sub.requestID;
+  ok.trackAlias = TrackAlias(sub.requestID.value);
+  ok.expires = std::chrono::milliseconds(0);
+  ok.groupOrder = GroupOrder::OldestFirst;
+  return std::make_shared<MockSubscriptionHandle>(std::move(ok));
+}
+
+Publisher::FetchResult makeFetchOk(const Fetch& fetch) {
+  FetchOk ok;
+  ok.requestID = fetch.requestID;
+  ok.groupOrder = GroupOrder::OldestFirst;
+  ok.endOfTrack = 1;
+  return std::make_shared<MockFetchHandle>(std::move(ok));
+}
+
+Publisher::SubscribeNamespaceResult makeSubscribeNamespaceOk(const SubscribeNamespace& subNs) {
+  return std::make_shared<MockSubscribeNamespaceHandle>(SubscribeNamespaceOk{subNs.requestID});
+}
+
+Publisher::TrackStatusResult makeTrackStatusOk(const TrackStatus& req) {
+  TrackStatusOk ok;
+  ok.requestID = req.requestID;
+  ok.trackAlias = TrackAlias(req.requestID.value);
+  ok.statusCode = TrackStatusCode::IN_PROGRESS;
+  return ok;
+}
+
+folly::coro::Task<folly::Expected<PublishOk, PublishError>> makePublishOkTask(RequestID reqID) {
+  PublishOk ok;
+  ok.requestID = reqID;
+  co_return ok;
+}
+
+Subscriber::PublishResult makePublishOk(const PublishRequest& pub) {
+  auto consumer = std::make_shared<NiceMock<MockTrackConsumer>>();
+  ON_CALL(*consumer, setTrackAlias(_))
+      .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  ON_CALL(*consumer, publishDone(_))
+      .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  return Subscriber::PublishConsumerAndReplyTask{
+      std::move(consumer),
+      makePublishOkTask(pub.requestID),
+  };
+}
+
+struct NoopObjectCallback : public ObjectReceiverCallback {
+  FlowControlState onObject(std::optional<TrackAlias>, const ObjectHeader&, Payload) override {
+    return FlowControlState::UNBLOCKED;
+  }
+  void onObjectStatus(std::optional<TrackAlias>, const ObjectHeader&) override {}
+  void onEndOfStream() override {}
+  void onError(ResetStreamErrorCode) override {}
+  void onPublishDone(PublishDone) override {}
+};
+
+} // namespace
+
+// --- Pure function tests: isPeerSubNs / makePeerSubNs ---
+// These don't need a fixture or event loop.
+
+TEST(PeerSubNsHelpers, PeerSubNsRoundTrip) {
+  // A subNs built with a relayID is detected as a peer subNs; without it is not.
+  auto withID = makePeerSubNs("my-relay-id");
+  EXPECT_TRUE(isPeerSubNs(withID));
+  EXPECT_EQ(withID.trackNamespacePrefix, TrackNamespace{});
+  EXPECT_EQ(withID.options, SubscribeNamespaceOptions::BOTH);
+
+  auto withoutID = makePeerSubNs();
+  EXPECT_FALSE(isPeerSubNs(withoutID));
+}
+
+TEST(PeerSubNsHelpers, NormalSubNsIsNotPeer) {
+  SubscribeNamespace subNs;
+  subNs.trackNamespacePrefix = TrackNamespace{{"test"}};
+  subNs.options = SubscribeNamespaceOptions::BOTH;
+  EXPECT_FALSE(isPeerSubNs(subNs));
+}
+
+// --- Integration fixture tests ---
+// All coroutine tests must use blockingWait(..., &clientEvb()) because the
+// provider and its session are bound to that event loop. CO_TEST_F cannot be
+// used here.
+
+class UpstreamProviderTest : public MoQIntegrationTestFixture {
+protected:
+  std::shared_ptr<Publisher> createServerPublishHandler() override { return serverPublisher_; }
+
+  std::shared_ptr<Subscriber> createServerSubscribeHandler() override { return serverSubscriber_; }
+
+  void SetUp() override {
+    serverPublisher_ = std::make_shared<NiceMock<MockPublisher>>();
+    serverSubscriber_ = std::make_shared<NiceMock<MockSubscriber>>();
+    MoQIntegrationTestFixture::SetUp();
+    provider_ = std::make_shared<UpstreamProvider>(
+        clientExec(),
+        serverUrl(),
+        /*publishHandler=*/nullptr,
+        /*subscribeHandler=*/nullptr,
+        std::make_shared<moxygen::test::InsecureVerifierDangerousDoNotUseInProduction>()
+    );
+  }
+
+  void TearDown() override {
+    provider_->stop();
+    MoQIntegrationTestFixture::TearDown();
+  }
+
+  std::shared_ptr<ObjectReceiver> makeReceiver() {
+    return std::make_shared<ObjectReceiver>(
+        ObjectReceiver::SUBSCRIBE,
+        std::make_shared<NoopObjectCallback>()
+    );
+  }
+
+  SubscribeRequest makeSubscribeRequest() {
+    return SubscribeRequest::make(
+        kTestTrack,
+        kDefaultPriority,
+        GroupOrder::OldestFirst,
+        /*forward=*/true,
+        LocationType::LargestObject
+    );
+  }
+
+  Fetch makeFetchRequest() {
+    return Fetch(RequestID(2), kTestTrack, AbsoluteLocation{0, 0}, AbsoluteLocation{100, 100});
+  }
+
+  void expectSubscribe() {
+    EXPECT_CALL(*serverPublisher_, subscribe(_, _))
+        .WillOnce(
+            [](SubscribeRequest sub,
+               std::shared_ptr<TrackConsumer>) -> folly::coro::Task<Publisher::SubscribeResult> {
+              co_return makeSubscribeOk(sub);
+            }
+        );
+  }
+
+  void allowSubscribe() {
+    EXPECT_CALL(*serverPublisher_, subscribe(_, _))
+        .WillRepeatedly(
+            [](SubscribeRequest sub,
+               std::shared_ptr<TrackConsumer>) -> folly::coro::Task<Publisher::SubscribeResult> {
+              co_return makeSubscribeOk(sub);
+            }
+        );
+  }
+
+  void expectPublishNamespace() {
+    EXPECT_CALL(*serverSubscriber_, publishNamespace(_, _))
+        .WillOnce(
+            [](PublishNamespace pubNs, std::shared_ptr<Subscriber::PublishNamespaceCallback>)
+                -> folly::coro::Task<Subscriber::PublishNamespaceResult> {
+              co_return std::make_shared<MockPublishNamespaceHandle>(
+                  PublishNamespaceOk{pubNs.requestID}
+              );
+            }
+        );
+  }
+
+  std::shared_ptr<UpstreamProvider> provider_;
+  std::shared_ptr<NiceMock<MockPublisher>> serverPublisher_;
+  std::shared_ptr<NiceMock<MockSubscriber>> serverSubscriber_;
+};
+
+TEST_F(UpstreamProviderTest, ConnectAndSetup) {
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+        EXPECT_NE(provider_->currentSession(), nullptr);
+      }(),
+      &clientEvb()
+  );
+}
+
+// Exercises slow path (coSubscribe): not yet connected when subscribe is called.
+TEST_F(UpstreamProviderTest, SubscribeForwardsToUpstream) {
+  expectSubscribe();
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        auto result = co_await provider_->subscribe(makeSubscribeRequest(), makeReceiver());
+        EXPECT_TRUE(result.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+// Exercises fast path (getSession()): already connected when subscribe is called.
+TEST_F(UpstreamProviderTest, SubscribeFastPathAfterConnect) {
+  allowSubscribe();
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+        auto result = co_await provider_->subscribe(makeSubscribeRequest(), makeReceiver());
+        EXPECT_TRUE(result.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+// Two subscribes fired before connected: both wait on the same connectPromise_
+// and succeed after a single connection is established.
+TEST_F(UpstreamProviderTest, ConcurrentSubscribesWhileConnecting) {
+  EXPECT_CALL(*serverPublisher_, subscribe(_, _))
+      .Times(2)
+      .WillRepeatedly(
+          [](SubscribeRequest sub,
+             std::shared_ptr<TrackConsumer>) -> folly::coro::Task<Publisher::SubscribeResult> {
+            co_return makeSubscribeOk(sub);
+          }
+      );
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        auto [r1, r2] = co_await folly::coro::collectAll(
+            provider_->subscribe(makeSubscribeRequest(), makeReceiver()),
+            provider_->subscribe(makeSubscribeRequest(), makeReceiver())
+        );
+        EXPECT_TRUE(r1.hasValue());
+        EXPECT_TRUE(r2.hasValue());
+        EXPECT_NE(provider_->currentSession(), nullptr);
+      }(),
+      &clientEvb()
+  );
+}
+
+TEST_F(UpstreamProviderTest, FetchForwardsToUpstream) {
+  EXPECT_CALL(*serverPublisher_, fetch(_, _))
+      .WillOnce(
+          [](Fetch fetch,
+             std::shared_ptr<FetchConsumer>) -> folly::coro::Task<Publisher::FetchResult> {
+            co_return makeFetchOk(fetch);
+          }
+      );
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        auto result = co_await provider_->fetch(makeFetchRequest(), nullptr);
+        EXPECT_TRUE(result.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+TEST_F(UpstreamProviderTest, SubscribeNamespaceForwardsToUpstream) {
+  EXPECT_CALL(*serverPublisher_, subscribeNamespace(_, _))
+      .WillOnce(
+          [](SubscribeNamespace subNs, std::shared_ptr<Publisher::NamespacePublishHandle>)
+              -> folly::coro::Task<Publisher::SubscribeNamespaceResult> {
+            co_return makeSubscribeNamespaceOk(subNs);
+          }
+      );
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        SubscribeNamespace subNs;
+        subNs.requestID = RequestID(3);
+        subNs.trackNamespacePrefix = kTestNamespace;
+        subNs.options = SubscribeNamespaceOptions::BOTH;
+        auto result = co_await provider_->subscribeNamespace(std::move(subNs), nullptr);
+        EXPECT_TRUE(result.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+TEST_F(UpstreamProviderTest, PublishNamespaceForwardsToUpstream) {
+  expectPublishNamespace();
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        PublishNamespace pubNs;
+        pubNs.requestID = RequestID(1);
+        pubNs.trackNamespace = kTestNamespace;
+        auto result = co_await provider_->publishNamespace(std::move(pubNs), nullptr);
+        EXPECT_TRUE(result.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+// When relayID is set, UpstreamProvider issues a wildcard subscribeNamespace
+// with a peer auth token to the upstream on connect.
+TEST_F(UpstreamProviderTest, PeerSubNsHandshakeOnConnect) {
+  EXPECT_CALL(*serverPublisher_, subscribeNamespace(_, _))
+      .WillOnce(
+          [](SubscribeNamespace subNs, std::shared_ptr<Publisher::NamespacePublishHandle>)
+              -> folly::coro::Task<Publisher::SubscribeNamespaceResult> {
+            EXPECT_TRUE(isPeerSubNs(subNs));
+            EXPECT_EQ(subNs.trackNamespacePrefix, TrackNamespace{});
+            co_return makeSubscribeNamespaceOk(subNs);
+          }
+      );
+
+  // Rebuild provider_ with the onConnect hook so TearDown handles cleanup.
+  // The default provider was never started (session_==null), so no stop() needed.
+  provider_ = std::make_shared<UpstreamProvider>(
+      clientExec(),
+      serverUrl(),
+      /*publishHandler=*/nullptr,
+      /*subscribeHandler=*/nullptr,
+      std::make_shared<moxygen::test::InsecureVerifierDangerousDoNotUseInProduction>(),
+      /*onConnect=*/
+      [](std::shared_ptr<MoQSession> session) -> folly::coro::Task<void> {
+        auto result = co_await session->subscribeNamespace(makePeerSubNs("test-relay-id"), nullptr);
+        EXPECT_TRUE(result.hasValue());
+      }
+  );
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+        EXPECT_NE(provider_->currentSession(), nullptr);
+      }(),
+      &clientEvb()
+  );
+}
+
+TEST_F(UpstreamProviderTest, StopFailsPendingOperations) {
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+        provider_->stop();
+
+        bool threw = false;
+        try {
+          co_await provider_->subscribe(makeSubscribeRequest(), makeReceiver());
+        } catch (const std::runtime_error& e) {
+          threw = true;
+          XLOG(DBG1) << "Expected error: " << e.what();
+        }
+        EXPECT_TRUE(threw);
+      }(),
+      &clientEvb()
+  );
+}
+
+TEST_F(UpstreamProviderTest, SessionCloseTriggersProactiveReconnect) {
+  allowSubscribe();
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->subscribe(makeSubscribeRequest(), makeReceiver());
+        auto firstSession = provider_->currentSession();
+        EXPECT_NE(firstSession, nullptr);
+
+        // Close the session; provider proactively starts a reconnect loop.
+        firstSession->close(SessionCloseErrorCode::NO_ERROR);
+
+        // After re-subscribing the provider should have a new session.
+        auto result = co_await provider_->subscribe(makeSubscribeRequest(), makeReceiver());
+        EXPECT_TRUE(result.hasValue());
+        EXPECT_NE(provider_->currentSession(), nullptr);
+        EXPECT_NE(provider_->currentSession(), firstSession);
+      }(),
+      &clientEvb()
+  );
+}
+
+TEST_F(UpstreamProviderTest, GoawayResetsSession) {
+  allowSubscribe();
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->subscribe(makeSubscribeRequest(), makeReceiver());
+        auto firstSession = provider_->currentSession();
+        EXPECT_NE(firstSession, nullptr);
+
+        provider_->goaway(Goaway{""});
+        EXPECT_EQ(provider_->currentSession(), nullptr);
+
+        auto result = co_await provider_->subscribe(makeSubscribeRequest(), makeReceiver());
+        EXPECT_TRUE(result.hasValue());
+        EXPECT_NE(provider_->currentSession(), nullptr);
+      }(),
+      &clientEvb()
+  );
+}
+
+TEST_F(UpstreamProviderTest, PublishFailsWhenStopped) {
+  provider_->stop();
+
+  PublishRequest pub;
+  pub.requestID = RequestID(1);
+  pub.fullTrackName = kTestTrack;
+  pub.groupOrder = GroupOrder::OldestFirst;
+
+  auto result = provider_->publish(std::move(pub), nullptr);
+  EXPECT_TRUE(result.hasError());
+  EXPECT_EQ(result.error().errorCode, PublishErrorCode::INTERNAL_ERROR);
+}
+
+// --- trackStatus ---
+
+TEST_F(UpstreamProviderTest, TrackStatusForwardsToUpstream) {
+  EXPECT_CALL(*serverPublisher_, trackStatus(_))
+      .WillOnce([](TrackStatus req) -> folly::coro::Task<Publisher::TrackStatusResult> {
+        co_return makeTrackStatusOk(req);
+      });
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        auto result = co_await provider_->trackStatus(makeSubscribeRequest());
+        EXPECT_TRUE(result.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+TEST_F(UpstreamProviderTest, TrackStatusFastPathAfterConnect) {
+  EXPECT_CALL(*serverPublisher_, trackStatus(_))
+      .WillOnce([](TrackStatus req) -> folly::coro::Task<Publisher::TrackStatusResult> {
+        co_return makeTrackStatusOk(req);
+      });
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+        auto result = co_await provider_->trackStatus(makeSubscribeRequest());
+        EXPECT_TRUE(result.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+// --- publish() ---
+
+// publish() when already connected: synchronous fast-path via session_->publish().
+TEST_F(UpstreamProviderTest, PublishFastPathAfterConnect) {
+  EXPECT_CALL(*serverSubscriber_, publish(_, _))
+      .WillOnce(
+          [](PublishRequest pub, std::shared_ptr<SubscriptionHandle>) -> Subscriber::PublishResult {
+            return makePublishOk(pub);
+          }
+      );
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+
+        PublishRequest pub;
+        pub.requestID = RequestID(1);
+        pub.fullTrackName = kTestTrack;
+        pub.groupOrder = GroupOrder::OldestFirst;
+
+        auto result = provider_->publish(
+            pub,
+            std::make_shared<NiceMock<MockSubscriptionHandle>>(SubscribeOk{})
+        );
+        EXPECT_TRUE(result.hasValue());
+        if (!result.hasValue()) {
+          co_return;
+        }
+        auto ok = co_await std::move(result.value().reply);
+        EXPECT_TRUE(ok.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+// publish() before connected: PendingTrackConsumer proxy that connects and wires
+// setDownstream() before any forwarding can happen.
+TEST_F(UpstreamProviderTest, PublishPreConnectPath) {
+  EXPECT_CALL(*serverSubscriber_, publish(_, _))
+      .WillOnce(
+          [](PublishRequest pub, std::shared_ptr<SubscriptionHandle>) -> Subscriber::PublishResult {
+            return makePublishOk(pub);
+          }
+      );
+
+  PublishRequest pub;
+  pub.requestID = RequestID(1);
+  pub.fullTrackName = kTestTrack;
+  pub.groupOrder = GroupOrder::OldestFirst;
+
+  // Not yet connected — returns PendingTrackConsumer + reply task immediately.
+  auto result =
+      provider_->publish(pub, std::make_shared<NiceMock<MockSubscriptionHandle>>(SubscribeOk{}));
+  ASSERT_TRUE(result.hasValue());
+
+  // Driving the reply task triggers connect and returns PublishOk.
+  folly::coro::blockingWait(
+      [reply = std::move(result.value().reply)]() mutable -> folly::coro::Task<void> {
+        auto ok = co_await std::move(reply);
+        EXPECT_TRUE(ok.hasValue());
+      }(),
+      &clientEvb()
+  );
+}
+
+// --- waitForConnected ---
+
+TEST_F(UpstreamProviderTest, WaitForConnectedAlreadyConnected) {
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+        // Already connected — must return immediately rather than blocking until timeout.
+        co_await provider_->waitForConnected(std::chrono::milliseconds(100));
+        EXPECT_NE(provider_->currentSession(), nullptr);
+      }(),
+      &clientEvb()
+  );
+}
+
+// --- Shutdown / close paths ---
+
+// stop() with no session established — dtor XCHECK (!session_ && !client_) must hold.
+TEST_F(UpstreamProviderTest, StopBeforeStart) {
+  provider_->stop();
+  // TearDown calls stop() again; both must be safe.
+}
+
+// stop() is idempotent: calling it twice must not crash or double-free.
+TEST_F(UpstreamProviderTest, StopIsIdempotent) {
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> { co_await provider_->start(); }(),
+      &clientEvb()
+  );
+  provider_->stop();
+  provider_->stop();
+}
+
+// onDisconnect hook fires when the upstream session is closed.
+TEST_F(UpstreamProviderTest, OnDisconnectHookFires) {
+  // Replace the default (never-started) provider with one that has the hook.
+  bool fired = false;
+  provider_ = std::make_shared<UpstreamProvider>(
+      clientExec(),
+      serverUrl(),
+      /*publishHandler=*/nullptr,
+      /*subscribeHandler=*/nullptr,
+      std::make_shared<moxygen::test::InsecureVerifierDangerousDoNotUseInProduction>(),
+      /*onConnect=*/nullptr,
+      /*onDisconnect=*/[&fired]() { fired = true; }
+  );
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+        EXPECT_NE(provider_->currentSession(), nullptr);
+        if (!provider_->currentSession()) {
+          co_return;
+        }
+        provider_->currentSession()->close(SessionCloseErrorCode::NO_ERROR);
+        co_await folly::coro::sleep(std::chrono::milliseconds(50));
+        EXPECT_TRUE(fired);
+      }(),
+      &clientEvb()
+  );
+}
+
+// stop() before a session close must not spawn a reconnect loop.
+TEST_F(UpstreamProviderTest, StopSuppressesReconnectAfterSessionClose) {
+  allowSubscribe();
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        co_await provider_->start();
+        auto session = provider_->currentSession();
+        EXPECT_NE(session, nullptr);
+        if (!session) {
+          co_return;
+        }
+
+        provider_->stop();
+        session->close(SessionCloseErrorCode::NO_ERROR);
+
+        co_await folly::coro::sleep(std::chrono::milliseconds(50));
+        EXPECT_EQ(provider_->currentSession(), nullptr);
+      }(),
+      &clientEvb()
+  );
+}
+
+} // namespace openmoq::moqx::test

--- a/tests/config/config_resolver_test.cpp
+++ b/tests/config/config_resolver_test.cpp
@@ -788,5 +788,97 @@ TEST(ResolveConfig, AdminTlsCustomAlpn) {
   EXPECT_THAT(result.value().config.admin->tls->alpn, ::testing::ElementsAre("h2"));
 }
 
+// --- Upstream config tests ---
+
+ParsedUpstreamConfig makeUpstreamConfig(
+    std::string url = "moqt://origin.example.com:4433/relay",
+    bool insecure = false,
+    std::optional<std::string> caCert = std::nullopt
+) {
+  ParsedUpstreamConfig upstream;
+  upstream.url = std::move(url);
+  ParsedUpstreamTlsConfig tls;
+  tls.insecure = insecure;
+  tls.ca_cert = std::move(caCert);
+  upstream.tls = std::move(tls);
+  return upstream;
+}
+
+// Upstream is per-service: set it on the "default" service in the test config.
+static void setServiceUpstream(ParsedConfig& cfg, ParsedUpstreamConfig upstream) {
+  cfg.services.value().at("default").upstream =
+      std::optional<ParsedUpstreamConfig>{std::move(upstream)};
+}
+
+TEST(ResolveConfig, UpstreamAbsent) {
+  auto cfg = makeMinimalInsecureConfig();
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_FALSE(result.value().config.services.at("default").upstream.has_value());
+}
+
+TEST(ResolveConfig, UpstreamInsecureFalseNoCA) {
+  auto cfg = makeMinimalInsecureConfig();
+  setServiceUpstream(cfg, makeUpstreamConfig());
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_TRUE(result.value().config.services.at("default").upstream.has_value());
+  const auto& up = *result.value().config.services.at("default").upstream;
+  EXPECT_EQ(up.url, "moqt://origin.example.com:4433/relay");
+  EXPECT_FALSE(up.tls.insecure);
+  EXPECT_FALSE(up.tls.caCertFile.has_value());
+}
+
+TEST(ResolveConfig, UpstreamInsecureTrue) {
+  auto cfg = makeMinimalInsecureConfig();
+  setServiceUpstream(cfg, makeUpstreamConfig("moqt://dev:4433/", true));
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_TRUE(result.value().config.services.at("default").upstream.has_value());
+  EXPECT_TRUE(result.value().config.services.at("default").upstream->tls.insecure);
+}
+
+TEST(ResolveConfig, UpstreamInsecureTrueWithCACertRejected) {
+  auto cfg = makeMinimalInsecureConfig();
+  setServiceUpstream(cfg, makeUpstreamConfig("moqt://dev:4433/", true, "/path/to/ca.pem"));
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("mutually exclusive"));
+}
+
+TEST(ResolveConfig, UpstreamEmptyUrlRejected) {
+  auto cfg = makeMinimalInsecureConfig();
+  setServiceUpstream(cfg, makeUpstreamConfig(""));
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("upstream.url must be non-empty"));
+}
+
+// --- relayID tests ---
+
+TEST(ResolveConfig, RelayIDAbsentGeneratesNonEmpty) {
+  auto cfg = makeMinimalInsecureConfig();
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_FALSE(result.value().config.relayID.empty());
+}
+
+TEST(ResolveConfig, RelayIDGeneratedUniquePerCall) {
+  auto cfg = makeMinimalInsecureConfig();
+  auto r1 = resolveConfig(cfg);
+  auto r2 = resolveConfig(cfg);
+  ASSERT_TRUE(r1.hasValue());
+  ASSERT_TRUE(r2.hasValue());
+  EXPECT_NE(r1.value().config.relayID, r2.value().config.relayID);
+}
+
+TEST(ResolveConfig, RelayIDExplicitPreserved) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.relay_id = std::optional<std::string>{"my-relay-1"};
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(result.value().config.relayID, "my-relay-1");
+}
+
 } // namespace
 } // namespace openmoq::moqx::config

--- a/tests/test_relay_chain.sh
+++ b/tests/test_relay_chain.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# test_relay_chain.sh — end-to-end relay chaining test.
+#
+# Starts two moqx instances (upstream + downstream), a moqdateserver
+# publishing to the upstream relay, and a moqtextclient subscribing from
+# the downstream relay. Passes if at least one date object flows through
+# the chain within the timeout.
+#
+# Requires draft 16+ for relay peering (wildcard subscribeNamespace).
+# moqdateserver and moqtextclient must be at:
+#   .scratch/moxygen-install/bin/  (relative to repo root)
+#
+# Usage: bash scripts/test_relay_chain.sh [path/to/moqx] [--save-logs [dir]]
+#   --save-logs [dir]  Save relay DBG4 logs; dir defaults to /tmp/relay_chain_logs
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+BINARY="${1:-$REPO/build/moqx}"
+MOQBIN="${MOQBIN:-$REPO/.scratch/moxygen-install/bin}"
+
+# Parse --save-logs option (may appear anywhere in args)
+SAVE_LOGS=false
+LOG_DIR="/tmp/relay_chain_logs"
+for i in "$@"; do
+  if [[ "$i" == "--save-logs" ]]; then
+    SAVE_LOGS=true
+  elif [[ "$SAVE_LOGS" == "true" && "$i" != --* && "$i" != "$BINARY" ]]; then
+    LOG_DIR="$i"
+  fi
+done
+DATESERVER="$MOQBIN/moqdateserver"
+TEXTCLIENT="$MOQBIN/moqtextclient"
+
+UPSTREAM_PORT=19668
+DOWNSTREAM_PORT=19670
+UPSTREAM_RELAY_ID="upstream-test"
+DOWNSTREAM_RELAY_ID="downstream-test"
+NAMESPACE="moq-date"
+NAMESPACE2="moq-date-2"
+NAMESPACE3="moq-publish"  # for --publish push-mode test
+TIMEOUT=5   # seconds to wait for data
+
+# ── Prereq checks ──────────────────────────────────────────────────────────────
+for f in "$BINARY" "$DATESERVER" "$TEXTCLIENT"; do
+  if [[ ! -x "$f" ]]; then
+    echo "ERROR: not found or not executable: $f" >&2
+    exit 1
+  fi
+done
+
+for port in "$UPSTREAM_PORT" "$DOWNSTREAM_PORT"; do
+  if ss -ulnp 2>/dev/null | grep -q ":$port "; then
+    echo "ERROR: port $port already in use (stale relay process?)" >&2
+    ss -ulnp 2>/dev/null | grep ":$port " >&2
+    exit 1
+  fi
+done
+
+# ── Temp files ─────────────────────────────────────────────────────────────────
+TMPDIR_SCRIPT="$(mktemp -d)"
+UPSTREAM_CFG="$TMPDIR_SCRIPT/upstream.yaml"
+DOWNSTREAM_CFG="$TMPDIR_SCRIPT/downstream.yaml"
+CLIENT_OUT="$TMPDIR_SCRIPT/client.out"
+CLIENT_OUT2="$TMPDIR_SCRIPT/client2.out"
+CLIENT_OUT3="$TMPDIR_SCRIPT/client3.out"
+DATESERVER_LOG="$TMPDIR_SCRIPT/dateserver.log"
+DATESERVER_LOG2="$TMPDIR_SCRIPT/dateserver2.log"
+
+# ── Cleanup ────────────────────────────────────────────────────────────────────
+PIDS=()
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  for pid in "${PIDS[@]:-}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+  rm -rf "$TMPDIR_SCRIPT"
+}
+trap cleanup EXIT
+
+# ── Configs ────────────────────────────────────────────────────────────────────
+cat >"$UPSTREAM_CFG" <<EOF
+relay_id: "$UPSTREAM_RELAY_ID"
+listeners:
+  - name: upstream
+    udp:
+      socket:
+        address: "::"
+        port: $UPSTREAM_PORT
+    tls:
+      insecure: true
+    endpoint: "/moq-relay"
+services:
+  default:
+    match:
+      - authority: {any: true}
+        path: {prefix: "/"}
+    cache:
+      enabled: false
+      max_tracks: 100
+      max_groups_per_track: 3
+EOF
+
+cat >"$DOWNSTREAM_CFG" <<EOF
+relay_id: "$DOWNSTREAM_RELAY_ID"
+listeners:
+  - name: downstream
+    udp:
+      socket:
+        address: "::"
+        port: $DOWNSTREAM_PORT
+    tls:
+      insecure: true
+    endpoint: "/moq-relay"
+services:
+  default:
+    match:
+      - authority: {any: true}
+        path: {prefix: "/"}
+    cache:
+      enabled: false
+      max_tracks: 100
+      max_groups_per_track: 3
+    upstream:
+      url: "moqt://localhost:$UPSTREAM_PORT/moq-relay"
+      tls:
+        insecure: true
+      idle_timeout_ms: 60000
+EOF
+
+# ── Start relays ───────────────────────────────────────────────────────────────
+if [[ "$SAVE_LOGS" == "true" ]]; then
+  mkdir -p "$LOG_DIR"
+  UPSTREAM_LOG="$LOG_DIR/upstream.log"
+  DOWNSTREAM_LOG="$LOG_DIR/downstream.log"
+  DATESERVER_LOG="$LOG_DIR/dateserver.log"
+  DATESERVER_LOG2="$LOG_DIR/dateserver2.log"
+  echo "Saving relay logs to $LOG_DIR"
+  RELAY_LOG_ARGS="--logging=DBG4"
+  DATESERVER_LOG_ARGS="--logging=DBG4"
+else
+  UPSTREAM_LOG="/dev/null"
+  DOWNSTREAM_LOG="/dev/null"
+  RELAY_LOG_ARGS=""
+  DATESERVER_LOG_ARGS=""
+fi
+
+echo "Starting upstream relay on port $UPSTREAM_PORT..."
+"$BINARY" --config="$UPSTREAM_CFG" $RELAY_LOG_ARGS >"$UPSTREAM_LOG" 2>&1 &
+PIDS+=($!)
+
+echo "Starting downstream relay on port $DOWNSTREAM_PORT..."
+"$BINARY" --config="$DOWNSTREAM_CFG" $RELAY_LOG_ARGS >"$DOWNSTREAM_LOG" 2>&1 &
+PIDS+=($!)
+
+# Give relays time to start and complete the peering handshake.
+sleep 1
+
+check_received() {
+  local label="$1" out="$2"
+  if grep -q "SubscribeError" "$out" 2>/dev/null; then
+    echo "FAIL [$label]: SubscribeError" >&2
+    cat "$out" >&2
+    echo "--- dateserver log ---" >&2
+    cat "$DATESERVER_LOG" 2>/dev/null >&2 || true
+    return 1
+  elif grep -q "Largest=" "$out" 2>/dev/null; then
+    echo "PASS [$label]: $(grep 'Largest=' "$out" | head -1)"
+    return 0
+  else
+    echo "FAIL [$label]: no data received" >&2
+    cat "$out" >&2
+    echo "--- dateserver log ---" >&2
+    cat "$DATESERVER_LOG" 2>/dev/null >&2 || true
+    return 1
+  fi
+}
+
+# ── Direction 1: publisher → upstream, subscriber via downstream ───────────────
+echo "Direction 1: moqdateserver → upstream, subscribe via downstream"
+
+"$DATESERVER" \
+  --relay_url="https://localhost:$UPSTREAM_PORT/moq-relay" \
+  --ns="$NAMESPACE" --insecure $DATESERVER_LOG_ARGS \
+  >"$DATESERVER_LOG" 2>&1 &
+PIDS+=($!)
+
+sleep 1
+
+timeout "$TIMEOUT" "$TEXTCLIENT" \
+  --connect_url="https://localhost:$DOWNSTREAM_PORT/moq-relay" \
+  --track_namespace="$NAMESPACE" --track_name="date" --insecure \
+  >"$CLIENT_OUT" 2>&1 || true
+
+check_received "upstream→downstream" "$CLIENT_OUT" || exit 1
+
+# ── Direction 2: publisher → downstream, subscriber via upstream ───────────────
+echo "Direction 2: moqdateserver → downstream, subscribe via upstream"
+
+"$DATESERVER" \
+  --relay_url="https://localhost:$DOWNSTREAM_PORT/moq-relay" \
+  --ns="$NAMESPACE2" --insecure $DATESERVER_LOG_ARGS \
+  >"$DATESERVER_LOG2" 2>&1 &
+PIDS+=($!)
+
+sleep 1
+
+timeout "$TIMEOUT" "$TEXTCLIENT" \
+  --connect_url="https://localhost:$UPSTREAM_PORT/moq-relay" \
+  --track_namespace="$NAMESPACE2" --track_name="date" --insecure \
+  >"$CLIENT_OUT2" 2>&1 || true
+
+check_received "downstream→upstream" "$CLIENT_OUT2" || exit 1
+
+# ── Direction 3: joining fetch via relay chain ─────────────────────────────────
+# moq-date dateserver from direction 1 is still running on upstream.
+# --jrfetch --join_start=1: fetches 1 group back while also subscribing forward.
+# Exercises both fetch and subscribe forwarding through the relay chain.
+echo "Direction 3: joining fetch via downstream relay"
+
+timeout "$TIMEOUT" "$TEXTCLIENT" \
+  --connect_url="https://localhost:$DOWNSTREAM_PORT/moq-relay" \
+  --track_namespace="$NAMESPACE" --track_name="date" --insecure \
+  --jrfetch --join_start=1 \
+  >"$CLIENT_OUT" 2>&1 || true
+
+if grep -qE "SubscribeError|Fetch.*failed" "$CLIENT_OUT" 2>/dev/null; then
+  echo "FAIL [joining fetch via downstream]: error" >&2
+  cat "$CLIENT_OUT" >&2
+  exit 1
+elif grep -q "Largest=" "$CLIENT_OUT" 2>/dev/null; then
+  echo "PASS [joining fetch via downstream]: $(grep 'Largest=' "$CLIENT_OUT" | head -1)"
+else
+  echo "FAIL [joining fetch via downstream]: no data" >&2
+  cat "$CLIENT_OUT" >&2
+  exit 1
+fi
+
+# ── Direction 4: --publish push mode through relay chain ───────────────────────
+# textclient registers subscribeNamespace on downstream; dateserver --publish
+# pushes via PUBLISH to upstream; relay chain routes it to textclient.
+echo "Direction 4: --publish push mode (upstream→downstream)"
+
+# Start textclient --publish first so it registers subscribeNamespace.
+timeout "$TIMEOUT" "$TEXTCLIENT" \
+  --connect_url="https://localhost:$DOWNSTREAM_PORT/moq-relay" \
+  --track_namespace="$NAMESPACE3" --track_name="date" --insecure \
+  --publish \
+  >"$CLIENT_OUT3" 2>&1 &
+TCPID=$!
+
+sleep 1
+
+# dateserver --publish: connects to upstream and pushes via PUBLISH.
+"$DATESERVER" \
+  --relay_url="https://localhost:$UPSTREAM_PORT/moq-relay" \
+  --ns="$NAMESPACE3" --insecure --publish \
+  &>/dev/null &
+PIDS+=($!)
+
+wait $TCPID || true
+
+# Success: textclient received date objects printed to stdout by onObject().
+if grep -qE "^[0-9]|PublishDone" "$CLIENT_OUT3" 2>/dev/null; then
+  echo "PASS [--publish mode]: data received via PUBLISH push"
+else
+  echo "FAIL [--publish mode]: no data" >&2
+  cat "$CLIENT_OUT3" >&2
+  exit 1
+fi
+
+echo "All relay chain tests passed."


### PR DESCRIPTION
Still a WIP, but tested with 2 relays for publishNamespace+subscribe flows.

1. Each Relay can declare a string relay ID, if unset, randomly generated
2. Each service can optionally list an upstream URL
3. moqx will proactively establish a draft-16 session the the upstream
4. It will auto-reconnect with exponential backoff if it breaks/fails to connect
5. It sends a SUBSCRIBE_NAMESPACE(*, BOTH) to upstream including it's relay ID in an Auth Token
6. When receiving a SUBSCRIBE_NAMESPACE with the Auth Token, send a reciprocal SUBSCRIBE_NAMESPACE(*, BOTH) [no token]
7. Any PUBLISH entering the network will automatically flow through all chained relays to end subscribers
8. Any PUBLISH_NAMESPACE entering the network will flow through chained relays as NAMESPACE
9. Any SUBSCRIBE, FETCH or TRACK_STATUS will automatically follow the chain to the publisher
10. SUBSCRIBE_NAMESPACE does not need to be propagated, since there's already a maximal one to every peer

Limitations:

1. If you configure a loop, e.g. `A <-> B` or `A -> B -> C -> A`, you're gonna have a bad time.  Stick to tree-structures.
2. Multipublisher is not yet supported, and last publisher wins.  Races are possible and not pretty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/80)
<!-- Reviewable:end -->
