### PR TITLE
Rename o-rly to moqx

### DIFF
--- a/.github/workflows/auto-merge-moxygen.yml
+++ b/.github/workflows/auto-merge-moxygen.yml
@@ -64,7 +64,7 @@ jobs:
           BRANCH="${{ github.event.workflow_run.head_branch }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
           CI_RUN_URL="${{ github.event.workflow_run.html_url }}"
-          SUBJECT="[o-rly] moxygen sync verification failed — ${BRANCH}"
+          SUBJECT="[moqx] moxygen sync verification failed — ${BRANCH}"
           BODY="Moxygen sync branch verification failed.\n\nBranch: ${BRANCH}\nPR: ${PR_URL}\nRun: ${CI_RUN_URL}\n\nManual investigation required."
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -28,12 +28,11 @@ jobs:
 
   check-format:
     runs-on: ubuntu-latest
-    container: debian:trixie
     steps:
-      - name: Install tools
-        run: apt-get update && apt-get install -y --no-install-recommends ca-certificates git clang-format
-
       - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: pip install clang-format==19.1.7
 
       - name: Check formatting
         run: bash scripts/format.sh --check

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -91,7 +91,7 @@ jobs:
           fail-on-empty: ${{ job.status == 'success' && 'true' || 'false' }}
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Publish: build o-rly, Docker image + smoke test, push
+  # Publish: build moqx, Docker image + smoke test, push
   # ════════════════════════════════════════════════════════════════════════════
 
   publish:
@@ -113,7 +113,7 @@ jobs:
       - name: Download bookworm moxygen tarball
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          ORLY_PLATFORM: bookworm-amd64
+          MOQX_PLATFORM: bookworm-amd64
         run: bash scripts/build.sh setup --from-release --no-fallback
 
       - name: Stage tarball for Docker build
@@ -137,26 +137,26 @@ jobs:
         run: |
           IMAGE="ghcr.io/${{ github.repository }}:latest"
           echo "==> ldd check"
-          docker run --rm --entrypoint ldd "${IMAGE}" /usr/local/bin/o-rly
-          if docker run --rm --entrypoint ldd "${IMAGE}" /usr/local/bin/o-rly 2>&1 | grep -q "not found"; then
+          docker run --rm --entrypoint ldd "${IMAGE}" /usr/local/bin/moqx
+          if docker run --rm --entrypoint ldd "${IMAGE}" /usr/local/bin/moqx 2>&1 | grep -q "not found"; then
             echo "ERROR: missing shared libraries"; exit 1
           fi
           echo "==> Start container with test config"
-          docker run -d --name orly-smoke --network host \
-            -v "$PWD/tests/test.config.yaml:/etc/o-rly/config.yaml:ro" \
-            "${IMAGE}" --config=/etc/o-rly/config.yaml
+          docker run -d --name moqx-smoke --network host \
+            -v "$PWD/tests/test.config.yaml:/etc/moqx/config.yaml:ro" \
+            "${IMAGE}" --config=/etc/moqx/config.yaml
           echo "==> Wait for admin /info"
           for i in $(seq 1 50); do
             if curl -sf http://[::1]:9669/info >/dev/null 2>&1; then break; fi
             sleep 0.1
             if [ "$i" -eq 50 ]; then
-              echo "ERROR: admin server did not start"; docker logs orly-smoke; exit 1
+              echo "ERROR: admin server did not start"; docker logs moqx-smoke; exit 1
             fi
           done
           RESP=$(curl -sf http://[::1]:9669/info)
           echo "Response: $RESP"
-          echo "$RESP" | grep -q '"service":"o-rly"' || { echo "FAIL: bad /info response"; exit 1; }
-          docker stop orly-smoke && docker rm orly-smoke
+          echo "$RESP" | grep -q '"service":"moqx"' || { echo "FAIL: bad /info response"; exit 1; }
+          docker stop moqx-smoke && docker rm moqx-smoke
           echo "==> Smoke test passed"
 
       - name: Push Docker image
@@ -169,10 +169,10 @@ jobs:
       - name: Package
         id: package
         run: |
-          ARTIFACT="o-rly-bookworm-amd64.tar.gz"
-          docker cp "$(docker create --name extract ghcr.io/${{ github.repository }}:latest):/usr/local/bin/o-rly" .
+          ARTIFACT="moqx-bookworm-amd64.tar.gz"
+          docker cp "$(docker create --name extract ghcr.io/${{ github.repository }}:latest):/usr/local/bin/moqx" .
           docker rm extract
-          mkdir -p install/bin && mv o-rly install/bin/
+          mkdir -p install/bin && mv moqx install/bin/
           tar czf "$ARTIFACT" -C install .
           echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
 
@@ -243,10 +243,10 @@ jobs:
           cat > .env <<EOF
           DOMAIN=moqx-000.ci.openmoq.org
           CERTBOT_EMAIL=gmarzot@openmoq.org
-          ORLY_PORT=4433
-          ORLY_ADMIN_PORT=8000
-          ORLY_LOG_LEVEL=0
-          ORLY_VERBOSE=0
+          MOQX_PORT=4433
+          MOQX_ADMIN_PORT=8000
+          MOQX_LOG_LEVEL=0
+          MOQX_VERBOSE=0
           EOF
           sed -i 's/^[[:space:]]*//' .env
 
@@ -360,10 +360,10 @@ jobs:
 
           if [ "${{ needs.release.result }}" = "success" ]; then
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/snapshot-latest"
-            SUBJECT="[o-rly] published ${{ github.ref_name }} ${SHORT}"
+            SUBJECT="[moqx] published ${{ github.ref_name }} ${SHORT}"
             BODY="Repository: ${{ github.repository }}\nBranch: ${{ github.ref_name }}\nCommit: ${GITHUB_SHA}\nStatus: ${STATUS}\nDocker: ghcr.io/${{ github.repository }}:${SHORT}\nArtifacts: ${REL_URL}\nRun: ${RUN_URL}"
           else
-            SUBJECT="[o-rly] pipeline failed ${{ github.ref_name }} ${SHORT}"
+            SUBJECT="[moqx] pipeline failed ${{ github.ref_name }} ${SHORT}"
             BODY="Repository: ${{ github.repository }}\nBranch: ${{ github.ref_name }}\nCommit: ${GITHUB_SHA}\nStatus: ${STATUS}\nRun: ${RUN_URL}"
           fi
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -38,6 +38,7 @@ jobs:
         run: bash scripts/format.sh --check
 
   build:
+    needs: [check-format]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -18,12 +18,11 @@ permissions:
 jobs:
   check-format:
     runs-on: ubuntu-latest
-    container: debian:trixie
     steps:
-      - name: Install tools
-        run: apt-get update && apt-get install -y --no-install-recommends ca-certificates git clang-format
-
       - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: pip install clang-format==19.1.7
 
       - name: Check formatting
         run: bash scripts/format.sh --check

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -28,6 +28,7 @@ jobs:
         run: bash scripts/format.sh --check
 
   build:
+    needs: [check-format]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: docker
         run: |
           echo "==> Restarting relay..."
-          docker compose restart o-rly
+          docker compose restart moqx
 
           echo "==> Waiting for admin endpoint..."
           for i in $(seq 1 30); do
@@ -62,7 +62,7 @@ jobs:
             sleep 1
             if [ "$i" -eq 30 ]; then
               echo "::error::Admin endpoint did not respond within 30s"
-              docker compose logs o-rly
+              docker compose logs moqx
               exit 1
             fi
           done
@@ -77,10 +77,10 @@ jobs:
           cat > .env <<EOF
           DOMAIN=${DOMAIN}
           CERTBOT_EMAIL=gmarzot@openmoq.org
-          ORLY_PORT=${RELAY_PORT}
-          ORLY_ADMIN_PORT=${ADMIN_PORT}
-          ORLY_LOG_LEVEL=0
-          ORLY_VERBOSE=${{ inputs.verbose }}
+          MOQX_PORT=${RELAY_PORT}
+          MOQX_ADMIN_PORT=${ADMIN_PORT}
+          MOQX_LOG_LEVEL=0
+          MOQX_VERBOSE=${{ inputs.verbose }}
           EOF
           sed -i 's/^[[:space:]]*//' .env
 
@@ -132,7 +132,7 @@ jobs:
             sleep 1
             if [ "$i" -eq 30 ]; then
               echo "::error::Admin endpoint did not respond within 30s"
-              docker compose logs o-rly
+              docker compose logs moqx
               exit 1
             fi
           done

--- a/.github/workflows/moxygen-sync.yml
+++ b/.github/workflows/moxygen-sync.yml
@@ -83,7 +83,7 @@ jobs:
           PR_REF="${{ steps.blocking.outputs.pr_ref }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          SUBJECT="[o-rly] moxygen sync paused — PR #${PR_NUM} pending"
+          SUBJECT="[moqx] moxygen sync paused — PR #${PR_NUM} pending"
           BODY="Moxygen submodule sync blocked by open PR.\n\nPR: ${PR_URL}\nBranch: ${PR_REF}\nRun: ${RUN_URL}\n\nResolve or merge the existing PR, then re-run manually."
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \
@@ -212,7 +212,7 @@ jobs:
         run: |
           TARGET="${{ steps.target.outputs.target_sha || 'unknown' }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          SUBJECT="[o-rly] moxygen sync FAILED"
+          SUBJECT="[moqx] moxygen sync FAILED"
           BODY="Moxygen submodule sync workflow failed.\n\nTarget SHA: ${TARGET}\nRun: ${RUN_URL}"
           aws ses send-email \
             --from "noreply@ci.openmoq.org" \

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,4 +1,4 @@
-# Building o-rly
+# Building moqx
 
 ## Supported Platforms
 
@@ -66,7 +66,7 @@ sudo deps/moxygen/standalone/install-system-deps.sh
 ## Quick Start
 
 ```bash
-git clone https://github.com/openmoq/o-rly.git && cd o-rly
+git clone https://github.com/openmoq/moqx.git && cd moqx
 git submodule update --init
 sudo deps/moxygen/standalone/install-system-deps.sh
 
@@ -77,7 +77,7 @@ sudo deps/moxygen/standalone/install-system-deps.sh
 
 ## Dependency Modes
 
-o-rly depends on moxygen (and its Meta deps: folly, fizz, wangle, mvfst, proxygen).
+moqx depends on moxygen (and its Meta deps: folly, fizz, wangle, mvfst, proxygen).
 The `deps/moxygen` submodule pins the exact version. Two ways to get these deps:
 
 | Mode | Command | Time | When to use |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(o_rly VERSION 0.1.0 LANGUAGES CXX)
+project(moqx VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -11,10 +11,10 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "" FORCE)
 endif()
 
-option(ORLY_BUILD_TESTS "Build tests" ON)
-option(ORLY_ENABLE_SANITIZERS "Enable ASAN/UBSAN (non-Release)" OFF)
+option(MOQX_BUILD_TESTS "Build tests" ON)
+option(MOQX_ENABLE_SANITIZERS "Enable ASAN/UBSAN (non-Release)" OFF)
 
-if(ORLY_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+if(MOQX_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
   add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
   add_link_options(-fsanitize=address,undefined)
 endif()
@@ -46,7 +46,7 @@ set(YAML_CPP_FORMAT_SOURCE OFF CACHE BOOL "" FORCE)
 
 # yaml-cpp 0.8.0 uses cmake_minimum_required(VERSION 3.0.2) which triggers a
 # deprecation warning on CMake ≥ 3.27. Suppress it for this dependency only.
-set(_orly_save_warn_deprecated "${CMAKE_WARN_DEPRECATED}")
+set(_moqx_save_warn_deprecated "${CMAKE_WARN_DEPRECATED}")
 set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(yaml-cpp
@@ -56,7 +56,7 @@ FetchContent_Declare(yaml-cpp
 )
 FetchContent_MakeAvailable(yaml-cpp)
 
-set(CMAKE_WARN_DEPRECATED "${_orly_save_warn_deprecated}" CACHE BOOL "" FORCE)
+set(CMAKE_WARN_DEPRECATED "${_moqx_save_warn_deprecated}" CACHE BOOL "" FORCE)
 
 # --- reflect-cpp (FetchContent, needs yaml-cpp available) ---
 
@@ -72,9 +72,9 @@ FetchContent_MakeAvailable(reflectcpp)
 
 # --- Core library ---
 
-add_library(o_rly_core STATIC
-  src/ORelay.cpp
-  src/ORelayServer.cpp
+add_library(moqx_core STATIC
+  src/MoqxRelay.cpp
+  src/MoqxRelayServer.cpp
   src/ServiceMatcher.cpp
   src/admin/AdminServer.cpp
   src/admin/BuiltinRoutes.cpp
@@ -83,12 +83,12 @@ add_library(o_rly_core STATIC
   src/stats/MoQStatsCollector.cpp
 )
 
-target_include_directories(o_rly_core
+target_include_directories(moqx_core
   PUBLIC
     ${PROJECT_SOURCE_DIR}/include
 )
 
-target_link_libraries(o_rly_core PUBLIC
+target_link_libraries(moqx_core PUBLIC
   moxygen::moxygen_relay_moq_forwarder
   moxygen::moxygen_relay_moq_cache
   moxygen::moxygen_moq_relay_session
@@ -99,20 +99,20 @@ target_link_libraries(o_rly_core PUBLIC
   Folly::folly_io_async_fdsock_async_fd_socket
 )
 
-target_compile_options(o_rly_core PRIVATE -Wall -Wextra -Wpedantic)
-target_compile_definitions(o_rly_core PRIVATE ORLY_VERSION="${PROJECT_VERSION}")
+target_compile_options(moqx_core PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_definitions(moqx_core PRIVATE MOQX_VERSION="${PROJECT_VERSION}")
 
 # --- Config types (resolved Config structs, header-only, no rfl dependency) ---
 # Library consumers that only need the Config API link this.
 
-add_library(o_rly_config INTERFACE)
+add_library(moqx_config INTERFACE)
 
-target_include_directories(o_rly_config
+target_include_directories(moqx_config
   INTERFACE
     ${PROJECT_SOURCE_DIR}/include
 )
 
-target_link_libraries(o_rly_config INTERFACE
+target_link_libraries(moqx_config INTERFACE
   Folly::folly_network_address
   Folly::folly_container_detail_f14_hash_detail
 )
@@ -120,67 +120,67 @@ target_link_libraries(o_rly_config INTERFACE
 # --- Config loader (YAML parsing + validation + resolution + init) ---
 # Application-level: ParsedConfig rfl structs, loadConfig(), resolveConfig(),
 # handleConfigSubcommand(). Links rfl/yaml-cpp; consumers that only need
-# resolved Config types can depend on o_rly_config alone.
+# resolved Config types can depend on moqx_config alone.
 
-add_library(o_rly_config_loader STATIC
+add_library(moqx_config_loader STATIC
   src/config/loader.cpp
   src/config/config_resolver.cpp
   src/config/config_init.cpp
 )
 
-target_include_directories(o_rly_config_loader
+target_include_directories(moqx_config_loader
   PUBLIC
     ${PROJECT_SOURCE_DIR}/include
 )
 
-target_link_libraries(o_rly_config_loader PUBLIC
-  o_rly_config
+target_link_libraries(moqx_config_loader PUBLIC
+  moqx_config
   reflectcpp
   yaml-cpp
   Folly::folly_file_util
 )
 
-target_compile_options(o_rly_config_loader PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_options(moqx_config_loader PRIVATE -Wall -Wextra -Wpedantic)
 
 # --- Main executable ---
 
-add_executable(o_rly
+add_executable(moqx
   src/main.cpp
 )
 
-target_link_libraries(o_rly PRIVATE o_rly_core o_rly_config_loader)
+target_link_libraries(moqx PRIVATE moqx_core moqx_config_loader)
 
 # --- Tests ---
 
-if(ORLY_BUILD_TESTS)
+if(MOQX_BUILD_TESTS)
   enable_testing()
   find_package(GTest REQUIRED CONFIG)
 
-  add_executable(o_rly_relay_test
-    tests/ORelayTest.cpp
+  add_executable(moqx_relay_test
+    tests/MoqxRelayTest.cpp
     ${PROJECT_SOURCE_DIR}/deps/moxygen/moxygen/test/TestUtils.cpp
   )
-  target_include_directories(o_rly_relay_test PRIVATE
+  target_include_directories(moqx_relay_test PRIVATE
     ${PROJECT_SOURCE_DIR}/deps/moxygen
   )
-  target_link_libraries(o_rly_relay_test PRIVATE
-    o_rly_core
+  target_link_libraries(moqx_relay_test PRIVATE
+    moqx_core
     moxygen::moxygen_events_moq_folly_executor_impl
     GTest::gtest_main
     GTest::gmock
   )
   include(GoogleTest)
-  gtest_discover_tests(o_rly_relay_test)
+  gtest_discover_tests(moqx_relay_test)
 
-  add_executable(o_rly_config_test
+  add_executable(moqx_config_test
     tests/config/loader_test.cpp
   )
-  target_link_libraries(o_rly_config_test PRIVATE
-    o_rly_config_loader
+  target_link_libraries(moqx_config_test PRIVATE
+    moqx_config_loader
     GTest::gtest_main
     GTest::gmock
   )
-  target_compile_definitions(o_rly_config_test PRIVATE
+  target_compile_definitions(moqx_config_test PRIVATE
     CONFIG_EXAMPLE_PATH="${PROJECT_SOURCE_DIR}/config.example.yaml"
   )
   # When using static gflags (from-release), gflags_nothreads_static also
@@ -188,70 +188,70 @@ if(ORLY_BUILD_TESTS)
   # and override the feature to avoid mixed link strategy warnings.
   # LINK_LIBRARY:WHOLE_ARCHIVE requires CMake >= 3.24 (cmake_minimum_required is 3.25).
   if(NOT GFLAGS_SHARED)
-    target_link_libraries(o_rly_config_test PRIVATE
+    target_link_libraries(moqx_config_test PRIVATE
       "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
     )
-    set_property(TARGET o_rly_config_test PROPERTY
+    set_property(TARGET moqx_config_test PROPERTY
       LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
     )
   endif()
-  gtest_discover_tests(o_rly_config_test)
+  gtest_discover_tests(moqx_config_test)
 
-  add_executable(o_rly_config_resolver_test
+  add_executable(moqx_config_resolver_test
     tests/config/config_resolver_test.cpp
   )
-  target_link_libraries(o_rly_config_resolver_test PRIVATE
-    o_rly_config_loader
+  target_link_libraries(moqx_config_resolver_test PRIVATE
+    moqx_config_loader
     GTest::gtest_main
     GTest::gmock
   )
   if(NOT GFLAGS_SHARED)
-    target_link_libraries(o_rly_config_resolver_test PRIVATE
+    target_link_libraries(moqx_config_resolver_test PRIVATE
       "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
     )
-    set_property(TARGET o_rly_config_resolver_test PROPERTY
+    set_property(TARGET moqx_config_resolver_test PROPERTY
       LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
     )
   endif()
-  gtest_discover_tests(o_rly_config_resolver_test)
+  gtest_discover_tests(moqx_config_resolver_test)
 
-  add_executable(o_rly_bounded_histogram_test
+  add_executable(moqx_bounded_histogram_test
     tests/stats/BoundedHistogramTest.cpp
   )
-  target_include_directories(o_rly_bounded_histogram_test PRIVATE
+  target_include_directories(moqx_bounded_histogram_test PRIVATE
     ${PROJECT_SOURCE_DIR}/include
   )
-  target_link_libraries(o_rly_bounded_histogram_test PRIVATE
+  target_link_libraries(moqx_bounded_histogram_test PRIVATE
     GTest::gtest_main
     GTest::gmock
   )
-  gtest_discover_tests(o_rly_bounded_histogram_test)
+  gtest_discover_tests(moqx_bounded_histogram_test)
 
-  add_executable(o_rly_service_matcher_test
+  add_executable(moqx_service_matcher_test
     tests/ServiceMatcherTest.cpp
   )
-  target_link_libraries(o_rly_service_matcher_test PRIVATE
-    o_rly_core
-    o_rly_config
+  target_link_libraries(moqx_service_matcher_test PRIVATE
+    moqx_core
+    moqx_config
     GTest::gtest_main
     GTest::gmock
   )
-  gtest_discover_tests(o_rly_service_matcher_test)
+  gtest_discover_tests(moqx_service_matcher_test)
 
   add_test(
     NAME admin_info_endpoint
-    COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_info.sh $<TARGET_FILE:o_rly>
+    COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_info.sh $<TARGET_FILE:moqx>
   )
   add_test(
     NAME admin_tls_endpoint
-    COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_tls.sh $<TARGET_FILE:o_rly>
+    COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_tls.sh $<TARGET_FILE:moqx>
   )
   add_test(
     NAME admin_metrics_endpoint
-    COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_metrics.sh $<TARGET_FILE:o_rly>
+    COMMAND bash ${PROJECT_SOURCE_DIR}/tests/test_admin_metrics.sh $<TARGET_FILE:moqx>
   )
 endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/Lint.cmake)
 
-install(TARGETS o_rly o_rly_core o_rly_config_loader)
+install(TARGETS moqx moqx_core moqx_config_loader)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,7 +25,7 @@
       "binaryDir": "${sourceDir}/build-san",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "ORLY_ENABLE_SANITIZERS": "ON",
+        "MOQX_ENABLE_SANITIZERS": "ON",
         "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
       }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# o-rly
+# moqx
 
 The OpenMOQ Relay — a MoQT relay server based on
 [moxygen](https://github.com/openmoq/moxygen)
@@ -10,8 +10,8 @@ For the underlying moxygen library architecture (session model, data plane,
 threading, transport abstraction), see
 [deps/moxygen/ARCHITECTURE.md](deps/moxygen/ARCHITECTURE.md).
 
-`ORelay` is a hard fork of moxygen's `MoQRelay`. We copy the relay core into
-o-rly so we can evolve it independently (threading model, custom cache miss
+`MoqxRelay` is a hard fork of moxygen's `MoQRelay`. We copy the relay core into
+moqx so we can evolve it independently (threading model, custom cache miss
 handling, chained caches, etc.) while still using moxygen's lower-level
 building blocks as libraries:
 
@@ -23,7 +23,7 @@ building blocks as libraries:
 - **MoQSession / MoQServer / MoQRelaySession** — session and server
   infrastructure, used as libraries.
 
-`ORelayServer` extends `MoQServer` to wire up `ORelay` as the publish/subscribe
+`MoqxRelayServer` extends `MoQServer` to wire up `MoqxRelay` as the publish/subscribe
 handler and create `MoQRelaySession` instances for incoming connections.
 
 ## Design Documents
@@ -37,7 +37,7 @@ handler and create `MoQRelaySession` instances for incoming connections.
 ## Quick Start
 
 ```bash
-git clone https://github.com/openmoq/o-rly.git && cd o-rly
+git clone https://github.com/openmoq/moqx.git && cd moqx
 git submodule update --init
 sudo deps/moxygen/standalone/install-system-deps.sh
 

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -5,7 +5,7 @@
 The relay is published as a Docker image on every push to main:
 
 ```bash
-docker pull ghcr.io/openmoq/o-rly:latest
+docker pull ghcr.io/openmoq/moqx:latest
 ```
 
 ## Quick Start (Docker Compose)
@@ -23,37 +23,37 @@ The default entrypoint generates a relay config from these env vars:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DOMAIN` | -- | TLS certificate domain |
-| `ORLY_PORT` | `4433` | QUIC/UDP listen port |
-| `ORLY_ADMIN_PORT` | `8000` | Admin HTTP port (localhost only) |
-| `ORLY_BIND_ADDR` | `0.0.0.0` | Listen address (`0.0.0.0` or `::`) |
-| `ORLY_MAX_TRACKS` | `1000` | Max cached tracks |
-| `ORLY_MAX_GROUPS` | `100` | Max groups per track in cache |
-| `ORLY_LOG_LEVEL` | `0` | Min log level: 0=INFO 1=WARNING 2=ERROR 3=FATAL |
-| `ORLY_VERBOSE` | `0` | GLOG verbose level: 0=off, 1-4=increasing detail |
-| `ORLY_INSECURE` | `false` | Use built-in dev cert (local testing only) |
-| `ORLY_ENTRY` | `./entrypoint.sh` | Custom entrypoint override path |
+| `MOQX_PORT` | `4433` | QUIC/UDP listen port |
+| `MOQX_ADMIN_PORT` | `8000` | Admin HTTP port (localhost only) |
+| `MOQX_BIND_ADDR` | `0.0.0.0` | Listen address (`0.0.0.0` or `::`) |
+| `MOQX_MAX_TRACKS` | `1000` | Max cached tracks |
+| `MOQX_MAX_GROUPS` | `100` | Max groups per track in cache |
+| `MOQX_LOG_LEVEL` | `0` | Min log level: 0=INFO 1=WARNING 2=ERROR 3=FATAL |
+| `MOQX_VERBOSE` | `0` | GLOG verbose level: 0=off, 1-4=increasing detail |
+| `MOQX_INSECURE` | `false` | Use built-in dev cert (local testing only) |
+| `MOQX_ENTRY` | `./entrypoint.sh` | Custom entrypoint override path |
 
 ## Using a Custom Config File
 
-The entrypoint auto-detects a config file at `/etc/o-rly/config.yaml`.
+The entrypoint auto-detects a config file at `/etc/moqx/config.yaml`.
 If present, it uses that directly instead of generating one from env vars.
-Log-level env vars (`ORLY_LOG_LEVEL`, `ORLY_VERBOSE`) still apply.
+Log-level env vars (`MOQX_LOG_LEVEL`, `MOQX_VERBOSE`) still apply.
 
 ```bash
 docker run --rm \
-  -v /path/to/your/config.yaml:/etc/o-rly/config.yaml:ro \
+  -v /path/to/your/config.yaml:/etc/moqx/config.yaml:ro \
   -v /etc/letsencrypt:/certs:ro \
   -p 4433:4433/udp \
-  ghcr.io/openmoq/o-rly:latest
+  ghcr.io/openmoq/moqx:latest
 ```
 
 Or with docker compose, add a volume in `docker-compose.override.yml`:
 
 ```yaml
 services:
-  o-rly:
+  moqx:
     volumes:
-      - /path/to/your/config.yaml:/etc/o-rly/config.yaml:ro
+      - /path/to/your/config.yaml:/etc/moqx/config.yaml:ro
 ```
 
 See [config.example.yaml](config.example.yaml) for the full config schema with
@@ -62,7 +62,7 @@ multi-service routing, cache tuning, and TLS options.
 Validate a config without starting the server:
 
 ```bash
-o_rly validate-config --config /path/to/config.yaml
+moqx validate-config --config /path/to/config.yaml
 ```
 
 ## TLS Certificate Provisioning
@@ -83,7 +83,7 @@ docker compose --profile certbot-cloudflare run --rm certbot-cloudflare
 
 ### Self-Signed or Custom Certs
 
-Set `ORLY_CERT` and `ORLY_KEY` in `.env` to point to your mounted cert files,
+Set `MOQX_CERT` and `MOQX_KEY` in `.env` to point to your mounted cert files,
 or use a custom config file (see above).
 
 ## Health Check
@@ -92,7 +92,7 @@ The relay exposes an admin HTTP endpoint:
 
 ```bash
 curl http://localhost:8000/info
-# {"service":"o-rly","version":"0.1.0"}
+# {"service":"moqx","version":"0.1.0"}
 ```
 
 Docker compose includes a health check that polls this endpoint. If the relay becomes

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,5 +1,5 @@
-# o-rly relay configuration
-# See: o_rly dump-config-schema | scripts/gen-config-reference.sh
+# moqx relay configuration
+# See: moqx dump-config-schema | scripts/gen-config-reference.sh
 
 listeners:
   - name: main

--- a/design/ci-architecture.md
+++ b/design/ci-architecture.md
@@ -15,15 +15,15 @@ artifact publishing, and relay deployment across the openmoq organization.
                           │  submodule SHA pins which tarball
                           ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  o-rly (application)                                        │
+│  moqx (application)                                        │
 │                                                             │
-│  ci main ──► Docker image (ghcr.io/openmoq/o-rly)          │
+│  ci main ──► Docker image (ghcr.io/openmoq/moqx)          │
 │              + binary tarball                                │
 │              + auto-deploy to moqx-000                       │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-o-rly's `deps/moxygen` submodule pins a moxygen commit. `setup-deps-release.sh`
+moqx's `deps/moxygen` submodule pins a moxygen commit. `setup-deps-release.sh`
 downloads the matching pre-built tarball from moxygen's release.
 
 ## End-to-End Flow
@@ -41,7 +41,7 @@ facebookexperimental/moxygen  (upstream commit lands)
    snapshot-latest updated with new tarballs
         │
         ▼  repository_dispatch (automatic)
-   moxygen sync creates sync-moxygen/<sha> PR on o-rly
+   moxygen sync creates sync-moxygen/<sha> PR on moqx
         │
         ▼  ci pr runs (~5 min)
    moxygen auto-merge merges PR
@@ -78,12 +78,12 @@ Required checks: `linux`, `macos`.
 **Trigger:** push to main | **Time:** ~40 min
 
 ```
-build (5 jobs) ──► publish (4 platforms) ──► release ──► notify + dispatch to o-rly
+build (5 jobs) ──► publish (4 platforms) ──► release ──► notify + dispatch to moqx
 ```
 
 Publish produces per-platform tarballs (ubuntu, bookworm, macos) + debug symbol archives.
 Release creates/updates `snapshot-latest` pre-release.
-Notify dispatches `moxygen-update` to o-rly via `repository_dispatch`.
+Notify dispatches `moxygen-update` to moqx via `repository_dispatch`.
 
 ### 3. `upstream sync` — Daily upstream mirror
 
@@ -109,7 +109,7 @@ Promotes `snapshot-latest` artifacts to a versioned `vX.Y.Z` release (no rebuild
 
 ---
 
-## o-rly Workflows
+## moqx Workflows
 
 ### 1. `ci pr` — Pull request verification
 
@@ -210,8 +210,8 @@ Based on recent runs (March 2026):
 |-------|-----------|----------------------|
 | moxygen PR | ~28 min | ~55 (+ macos 10x multiplier) |
 | moxygen main push | ~40 min | ~75 (3-platform publish) |
-| o-rly PR | ~5 min | ~10 |
-| o-rly main push | ~11 min | ~15 |
+| moqx PR | ~5 min | ~10 |
+| moqx main push | ~11 min | ~15 |
 
 All build jobs use ccache:
 

--- a/design/configuration.md
+++ b/design/configuration.md
@@ -123,7 +123,7 @@ Regex authority matching is planned but not yet implemented.
 >
 > Moxygen's `isAcceptedEndpoint()` check runs *before* the WebTransport upgrade completes. The listener's `endpoint` field is registered as the only accepted path. If a WT client connects with an HTTP path that doesn't match a registered endpoint, moxygen returns 404 before MOQT ever starts — `ServiceMatcher` never sees the connection.
 >
-> This means multi-service path matchers (e.g. `{exact: "/moq-relay"}` and `{prefix: "/live/"}`) only work for WT connections if every matched path is also registered as a listener endpoint via `MoQServerBase::addEndpoint()`. Currently o-rly passes only a single `endpoint` from the listener config.
+> This means multi-service path matchers (e.g. `{exact: "/moq-relay"}` and `{prefix: "/live/"}`) only work for WT connections if every matched path is also registered as a listener endpoint via `MoQServerBase::addEndpoint()`. Currently moqx passes only a single `endpoint` from the listener config.
 >
 > Additionally, moxygen's conflict detection (`MoQSession::onClientSetup()`): if WT already set authority/path from HTTP and CLIENT_SETUP also includes them, the session gets a PROTOCOL_VIOLATION.
 >
@@ -141,7 +141,7 @@ Includes are supported **only at the service level**: a `services_include` direc
 
 ```yaml
 services_include:
-  - /etc/o-rly/services.d/*.yaml # Each file defines one or more services
+  - /etc/moqx/services.d/*.yaml # Each file defines one or more services
 ```
 
 Each included file must contain complete service definitions. Partial overrides or nested includes are not supported.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -5,16 +5,16 @@ DOMAIN=relay.example.com
 CERTBOT_EMAIL=you@example.com
 
 # Relay UDP port
-ORLY_PORT=4433
+MOQX_PORT=4433
 
 # Admin HTTP port (localhost only)
-ORLY_ADMIN_PORT=8000
+MOQX_ADMIN_PORT=8000
 
 # Logging: 0=INFO 1=WARNING 2=ERROR 3=FATAL
-ORLY_LOG_LEVEL=0
+MOQX_LOG_LEVEL=0
 
 # Verbose/debug level: 0=off, 1-4=increasing detail
-# ORLY_VERBOSE=0
+# MOQX_VERBOSE=0
 
 # --- Route53 credentials (certbot-route53 profile only) ---
 # AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# ── Build stage: compile o-rly inside bookworm against moxygen tarball ───
+# ── Build stage: compile moqx inside bookworm against moxygen tarball ───
 FROM debian:bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -14,7 +14,7 @@ WORKDIR /src
 # Moxygen tarball (pre-extracted bookworm build)
 COPY .docker-deps/moxygen /opt/moxygen
 
-# O-rly source — only what cmake needs
+# MoQX source — only what cmake needs
 COPY CMakeLists.txt CMakePresets.json ./
 COPY cmake/ cmake/
 COPY src/ src/
@@ -23,7 +23,7 @@ COPY deps/moxygen/build/fbcode_builder/CMake deps/moxygen/build/fbcode_builder/C
 
 RUN cmake -S . -B _build --preset default \
         -DCMAKE_PREFIX_PATH=/opt/moxygen \
-        -DBUILD_TESTING=OFF -DORLY_BUILD_TESTS=OFF \
+        -DBUILD_TESTING=OFF -DMOQX_BUILD_TESTS=OFF \
     && cmake --build _build -j$(nproc) \
     && cmake --install _build --prefix /install
 
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /install/bin/o_rly /usr/local/bin/o-rly
+COPY --from=builder /install/bin/moqx /usr/local/bin/moqx
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-name: o-rly
+name: moqx
 
 # Usage:
 #
@@ -17,33 +17,33 @@ name: o-rly
 #     docker compose -f docker/docker-compose.yml up -d
 #
 #   Custom / self-signed cert (no certbot):
-#     Set ORLY_CERT and ORLY_KEY in docker/.env to point to your mounted cert files.
+#     Set MOQX_CERT and MOQX_KEY in docker/.env to point to your mounted cert files.
 
 services:
-  o-rly:
+  moqx:
     container_name: moqx
-    image: ghcr.io/openmoq/o-rly:latest
+    image: ghcr.io/openmoq/moqx:latest
     restart: unless-stopped
     ports:
-      - "${ORLY_PORT:-4433}:${ORLY_PORT:-4433}/udp"
-      - "${ORLY_ADMIN_PORT:-8000}:${ORLY_ADMIN_PORT:-8000}/tcp"
+      - "${MOQX_PORT:-4433}:${MOQX_PORT:-4433}/udp"
+      - "${MOQX_ADMIN_PORT:-8000}:${MOQX_ADMIN_PORT:-8000}/tcp"
     volumes:
-      - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/certs:ro
-      - orly-coredumps:/var/coredumps
-      - ${ORLY_ENTRY:-./entrypoint.sh}:/usr/local/bin/entrypoint.sh:ro
+      - ${MOQX_CERTS_DIR:-/etc/letsencrypt}:/certs:ro
+      - moqx-coredumps:/var/coredumps
+      - ${MOQX_ENTRY:-./entrypoint.sh}:/usr/local/bin/entrypoint.sh:ro
     environment:
-      ORLY_CERT: /certs/live/${DOMAIN}/fullchain.pem
-      ORLY_KEY:  /certs/live/${DOMAIN}/privkey.pem
-      ORLY_PORT: ${ORLY_PORT:-4433}
-      ORLY_ADMIN_PORT: ${ORLY_ADMIN_PORT:-8000}
-      ORLY_MAX_TRACKS: ${ORLY_MAX_TRACKS:-1000}
-      ORLY_MAX_GROUPS: ${ORLY_MAX_GROUPS:-100}
-      ORLY_LOG_LEVEL: ${ORLY_LOG_LEVEL:-0}
-      ORLY_VERBOSE: ${ORLY_VERBOSE:-0}
+      MOQX_CERT: /certs/live/${DOMAIN}/fullchain.pem
+      MOQX_KEY:  /certs/live/${DOMAIN}/privkey.pem
+      MOQX_PORT: ${MOQX_PORT:-4433}
+      MOQX_ADMIN_PORT: ${MOQX_ADMIN_PORT:-8000}
+      MOQX_MAX_TRACKS: ${MOQX_MAX_TRACKS:-1000}
+      MOQX_MAX_GROUPS: ${MOQX_MAX_GROUPS:-100}
+      MOQX_LOG_LEVEL: ${MOQX_LOG_LEVEL:-0}
+      MOQX_VERBOSE: ${MOQX_VERBOSE:-0}
     ulimits:
       core: -1
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:${ORLY_ADMIN_PORT:-8000}/info"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:${MOQX_ADMIN_PORT:-8000}/info"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -60,7 +60,7 @@ services:
   certbot-cloudflare:
     image: certbot/dns-cloudflare
     volumes:
-      - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/etc/letsencrypt
+      - ${MOQX_CERTS_DIR:-/etc/letsencrypt}:/etc/letsencrypt
       - ./cloudflare.ini:/run/secrets/cloudflare.ini:ro
     command: >
       certonly
@@ -72,13 +72,13 @@ services:
       -d ${DOMAIN}
     profiles: [certbot-cloudflare]
 
-  # Log viewer — browse relay logs at http://localhost:${ORLY_LOG_PORT:-9999}
+  # Log viewer — browse relay logs at http://localhost:${MOQX_LOG_PORT:-9999}
   dozzle:
     container_name: logmon
     image: amir20/dozzle:latest
     restart: unless-stopped
     ports:
-      - "127.0.0.1:${ORLY_LOG_PORT:-9999}:8080"
+      - "127.0.0.1:${MOQX_LOG_PORT:-9999}:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
@@ -91,7 +91,7 @@ services:
   certbot-route53:
     image: certbot/dns-route53
     volumes:
-      - ${ORLY_CERTS_DIR:-/etc/letsencrypt}:/etc/letsencrypt
+      - ${MOQX_CERTS_DIR:-/etc/letsencrypt}:/etc/letsencrypt
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
@@ -106,4 +106,4 @@ services:
     profiles: [certbot-route53]
 
 volumes:
-  orly-coredumps:
+  moqx-coredumps:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,28 +1,28 @@
 #!/bin/sh
-# Generate relay config from env vars and exec o_rly.
+# Generate relay config from env vars and exec moqx.
 #
-# To use a custom config, mount it at /etc/o-rly/config.yaml:
-#   docker run -v /path/to/config.yaml:/etc/o-rly/config.yaml:ro ...
+# To use a custom config, mount it at /etc/moqx/config.yaml:
+#   docker run -v /path/to/config.yaml:/etc/moqx/config.yaml:ro ...
 #
 # Env vars (used only when no custom config is mounted):
-#   ORLY_CERT       — path to TLS certificate PEM (required unless ORLY_INSECURE=true)
-#   ORLY_KEY        — path to TLS private key PEM  (required unless ORLY_INSECURE=true)
-#   ORLY_PORT       — UDP listen port (default: 4433)
-#   ORLY_ADMIN_PORT — admin HTTP port (default: 8000)
-#   ORLY_INSECURE   — use built-in dev cert (default: false)
-#   ORLY_MAX_TRACKS — max cached tracks (default: 1000)
-#   ORLY_MAX_GROUPS — max groups per track in cache (default: 100)
-#   ORLY_BIND_ADDR  — listen address: "0.0.0.0" (IPv4, default) or "::" (IPv6/dual-stack)
+#   MOQX_CERT       — path to TLS certificate PEM (required unless MOQX_INSECURE=true)
+#   MOQX_KEY        — path to TLS private key PEM  (required unless MOQX_INSECURE=true)
+#   MOQX_PORT       — UDP listen port (default: 4433)
+#   MOQX_ADMIN_PORT — admin HTTP port (default: 8000)
+#   MOQX_INSECURE   — use built-in dev cert (default: false)
+#   MOQX_MAX_TRACKS — max cached tracks (default: 1000)
+#   MOQX_MAX_GROUPS — max groups per track in cache (default: 100)
+#   MOQX_BIND_ADDR  — listen address: "0.0.0.0" (IPv4, default) or "::" (IPv6/dual-stack)
 #
 # Env vars (always apply):
-#   ORLY_LOG_LEVEL  — min log level: 0=INFO 1=WARNING 2=ERROR 3=FATAL (default: 0)
-#   ORLY_VERBOSE    — verbose/debug level: 0=off, 1-4=increasing detail (default: 0)
+#   MOQX_LOG_LEVEL  — min log level: 0=INFO 1=WARNING 2=ERROR 3=FATAL (default: 0)
+#   MOQX_VERBOSE    — verbose/debug level: 0=off, 1-4=increasing detail (default: 0)
 set -e
 
-# Map ORLY_* logging env vars to GLOG_* (used by folly/glog)
+# Map MOQX_* logging env vars to GLOG_* (used by folly/glog)
 export GLOG_logtostderr=1
-export GLOG_minloglevel="${ORLY_LOG_LEVEL:-0}"
-export GLOG_v="${ORLY_VERBOSE:-0}"
+export GLOG_minloglevel="${MOQX_LOG_LEVEL:-0}"
+export GLOG_v="${MOQX_VERBOSE:-0}"
 
 # Enable core dumps (requires ulimits.core=-1 in compose)
 if [ -d /var/coredumps ]; then
@@ -30,10 +30,10 @@ if [ -d /var/coredumps ]; then
 fi
 
 # Use custom config if mounted, otherwise generate from env vars
-CONFIG=/etc/o-rly/config.yaml
+CONFIG=/etc/moqx/config.yaml
 if [ -f "$CONFIG" ]; then
   echo "Using custom config: $CONFIG"
-  exec /usr/local/bin/o-rly --config "$CONFIG" "$@"
+  exec /usr/local/bin/moqx --config "$CONFIG" "$@"
 fi
 
 CONFIG=/tmp/relay.yaml
@@ -43,12 +43,12 @@ listeners:
   - name: relay
     udp:
       socket:
-        address: "${ORLY_BIND_ADDR:-0.0.0.0}"
-        port: ${ORLY_PORT:-4433}
+        address: "${MOQX_BIND_ADDR:-0.0.0.0}"
+        port: ${MOQX_PORT:-4433}
     tls:
-      cert_file: "${ORLY_CERT:-}"
-      key_file: "${ORLY_KEY:-}"
-      insecure: ${ORLY_INSECURE:-false}
+      cert_file: "${MOQX_CERT:-}"
+      key_file: "${MOQX_KEY:-}"
+      insecure: ${MOQX_INSECURE:-false}
     endpoint: "/moq-relay"
 
 services:
@@ -58,13 +58,13 @@ services:
         path: {prefix: "/"}
     cache:
       enabled: true
-      max_tracks: ${ORLY_MAX_TRACKS:-1000}
-      max_groups_per_track: ${ORLY_MAX_GROUPS:-100}
+      max_tracks: ${MOQX_MAX_TRACKS:-1000}
+      max_groups_per_track: ${MOQX_MAX_GROUPS:-100}
 
 admin:
-  port: ${ORLY_ADMIN_PORT:-8000}
-  address: "${ORLY_BIND_ADDR:-0.0.0.0}"
+  port: ${MOQX_ADMIN_PORT:-8000}
+  address: "${MOQX_BIND_ADDR:-0.0.0.0}"
   plaintext: true
 EOF
 
-exec /usr/local/bin/o-rly --config "$CONFIG" "$@"
+exec /usr/local/bin/moqx --config "$CONFIG" "$@"

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,12 +21,12 @@ The split between `ParsedConfig` and `Config` exists because the YAML-facing sha
 
 | File | Role |
 |---|---|
-| `include/o_rly/config/loader/parsed_config.h` | YAML-facing config structs with `rfl::Description` annotations |
-| `include/o_rly/config/config.h` | Final config types used by the application |
-| `include/o_rly/config/resolved_config.h` | `ResolvedConfig` — wraps `Config` + warnings |
-| `include/o_rly/config/loader/loader.h` | `loadConfig()`, `generateSchema()` |
-| `include/o_rly/config/loader/config_resolver.h` | `resolveConfig()` |
-| `include/o_rly/config/loader/config_init.h` | CLI subcommand handling (`validate-config`, `dump-config-schema`) |
+| `include/moqx/config/loader/parsed_config.h` | YAML-facing config structs with `rfl::Description` annotations |
+| `include/moqx/config/config.h` | Final config types used by the application |
+| `include/moqx/config/resolved_config.h` | `ResolvedConfig` — wraps `Config` + warnings |
+| `include/moqx/config/loader/loader.h` | `loadConfig()`, `generateSchema()` |
+| `include/moqx/config/loader/config_resolver.h` | `resolveConfig()` |
+| `include/moqx/config/loader/config_init.h` | CLI subcommand handling (`validate-config`, `dump-config-schema`) |
 | `src/config/loader.cpp` | Load & parse implementation |
 | `src/config/config_resolver.cpp` | Validation & resolution logic |
 | `src/config/config_init.cpp` | Subcommand orchestration |
@@ -103,8 +103,8 @@ If you need a new top-level section (not just a field), also:
 
 ## Subcommands
 
-- `o_rly dump-config-schema` — prints the JSON schema (auto-generated from `ParsedConfig` + `rfl::Description` annotations).
-- `o_rly validate-config --config <path>` — loads, parses, and validates without starting the server.
+- `moqx dump-config-schema` — prints the JSON schema (auto-generated from `ParsedConfig` + `rfl::Description` annotations).
+- `moqx validate-config --config <path>` — loads, parses, and validates without starting the server.
 - `--strict_config` flag — rejects unknown YAML fields and promotes warnings to errors.
 
 ## reflect-cpp notes

--- a/include/moqx/MoqxRelay.h
+++ b/include/moqx/MoqxRelay.h
@@ -18,9 +18,9 @@
 namespace openmoq::moqx {
 
 class MoqxRelay : public moxygen::Publisher,
-               public moxygen::Subscriber,
-               public std::enable_shared_from_this<MoqxRelay>,
-               public moxygen::MoQForwarder::Callback {
+                  public moxygen::Subscriber,
+                  public std::enable_shared_from_this<MoqxRelay>,
+                  public moxygen::MoQForwarder::Callback {
 public:
   explicit MoqxRelay(
       size_t maxCachedTracks = moxygen::kDefaultMaxCachedTracks,

--- a/include/moqx/MoqxRelay.h
+++ b/include/moqx/MoqxRelay.h
@@ -15,14 +15,14 @@
 
 #include <folly/container/F14Set.h>
 
-namespace openmoq::o_rly {
+namespace openmoq::moqx {
 
-class ORelay : public moxygen::Publisher,
+class MoqxRelay : public moxygen::Publisher,
                public moxygen::Subscriber,
-               public std::enable_shared_from_this<ORelay>,
+               public std::enable_shared_from_this<MoqxRelay>,
                public moxygen::MoQForwarder::Callback {
 public:
-  explicit ORelay(
+  explicit MoqxRelay(
       size_t maxCachedTracks = moxygen::kDefaultMaxCachedTracks,
       size_t maxCachedGroupsPerTrack = moxygen::kDefaultMaxCachedGroupsPerTrack
   ) {
@@ -96,7 +96,7 @@ private:
   void onPublishDone(const moxygen::FullTrackName& ftn);
 
   struct NamespaceNode : public moxygen::Subscriber::PublishNamespaceHandle {
-    explicit NamespaceNode(ORelay& relay, NamespaceNode* parent = nullptr)
+    explicit NamespaceNode(MoqxRelay& relay, NamespaceNode* parent = nullptr)
         : relay_(relay), parent_(parent) {}
 
     void publishNamespaceDone() override { relay_.publishNamespaceDone(trackNamespace_, this); }
@@ -147,13 +147,13 @@ private:
     std::shared_ptr<moxygen::MoQSession> sourceSession;
     std::shared_ptr<PublishNamespaceCallback> publishNamespaceCallback;
 
-    ORelay& relay_;
+    MoqxRelay& relay_;
 
     // Pruning support: parent pointer and active child count
     NamespaceNode* parent_{nullptr}; // back link (raw pointer, parent owns us)
     size_t activeChildCount_{0};     // count of children with content
 
-    friend class ORelay;
+    friend class MoqxRelay;
 
     void incrementActiveChildren();
     void decrementActiveChildren();
@@ -217,4 +217,4 @@ private:
   std::unique_ptr<moxygen::MoQCache> cache_;
 };
 
-} // namespace openmoq::o_rly
+} // namespace openmoq::moqx

--- a/include/moqx/MoqxRelayServer.h
+++ b/include/moqx/MoqxRelayServer.h
@@ -3,18 +3,18 @@
 #include <memory>
 
 #include <moxygen/MoQServer.h>
-#include <o_rly/ORelay.h>
-#include <o_rly/ServiceMatcher.h>
-#include <o_rly/config/config.h>
-#include <o_rly/stats/MoQStatsCollector.h>
-#include <o_rly/stats/StatsRegistry.h>
+#include <moqx/MoqxRelay.h>
+#include <moqx/ServiceMatcher.h>
+#include <moqx/config/config.h>
+#include <moqx/stats/MoQStatsCollector.h>
+#include <moqx/stats/StatsRegistry.h>
 
-namespace openmoq::o_rly {
+namespace openmoq::moqx {
 
-class ORelayServer : public moxygen::MoQServer {
+class MoqxRelayServer : public moxygen::MoQServer {
 public:
   // Used when the insecure flag is false
-  ORelayServer(
+  MoqxRelayServer(
       const std::string& cert,
       const std::string& key,
       const std::string& endpoint,
@@ -23,7 +23,7 @@ public:
   );
 
   // Used when the insecure flag is true
-  ORelayServer(
+  MoqxRelayServer(
       const std::string& endpoint,
       const std::string& versions,
       folly::F14FastMap<std::string, config::ServiceConfig> services
@@ -50,10 +50,10 @@ protected:
 private:
   void initRelays(const folly::F14FastMap<std::string, config::ServiceConfig>& services);
 
-  folly::F14FastMap<std::string, std::shared_ptr<ORelay>> relays_;
+  folly::F14FastMap<std::string, std::shared_ptr<MoqxRelay>> relays_;
   ServiceMatcher serviceMatcher_;
   std::shared_ptr<stats::StatsRegistry> statsRegistry_;
   std::shared_ptr<stats::MoQStatsCollector> statsCollector_;
 };
 
-} // namespace openmoq::o_rly
+} // namespace openmoq::moqx

--- a/include/moqx/MoqxRelayServer.h
+++ b/include/moqx/MoqxRelayServer.h
@@ -2,12 +2,12 @@
 
 #include <memory>
 
-#include <moxygen/MoQServer.h>
 #include <moqx/MoqxRelay.h>
 #include <moqx/ServiceMatcher.h>
 #include <moqx/config/config.h>
 #include <moqx/stats/MoQStatsCollector.h>
 #include <moqx/stats/StatsRegistry.h>
+#include <moxygen/MoQServer.h>
 
 namespace openmoq::moqx {
 

--- a/include/moqx/ServiceMatcher.h
+++ b/include/moqx/ServiceMatcher.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <o_rly/config/config.h>
+#include <moqx/config/config.h>
 
 #include <optional>
 #include <string>
@@ -9,7 +9,7 @@
 
 #include <folly/container/F14Map.h>
 
-namespace openmoq::o_rly {
+namespace openmoq::moqx {
 
 class ServiceMatcher {
 public:
@@ -43,4 +43,4 @@ private:
   PathRuleSet anyAuthorityRules_;
 };
 
-} // namespace openmoq::o_rly
+} // namespace openmoq::moqx

--- a/include/moqx/admin/AdminServer.h
+++ b/include/moqx/admin/AdminServer.h
@@ -8,7 +8,7 @@
 #include <folly/CancellationToken.h>
 #include <folly/io/IOBuf.h>
 
-#include <o_rly/config/config.h>
+#include <moqx/config/config.h>
 
 // Forward declarations
 namespace proxygen {
@@ -17,7 +17,7 @@ class HTTPMessage;
 class ResponseHandler;
 } // namespace proxygen
 
-namespace openmoq::o_rly::admin {
+namespace openmoq::moqx::admin {
 
 // Route handler: receives the complete request (headers + body) and owns the
 // response. May respond asynchronously — launch a coroutine and send via
@@ -67,4 +67,4 @@ private:
   std::unique_ptr<proxygen::ScopedHTTPServer> httpServer_;
 };
 
-} // namespace openmoq::o_rly::admin
+} // namespace openmoq::moqx::admin

--- a/include/moqx/admin/BuiltinRoutes.h
+++ b/include/moqx/admin/BuiltinRoutes.h
@@ -1,10 +1,10 @@
 #pragma once
 
-namespace openmoq::o_rly::admin {
+namespace openmoq::moqx::admin {
 
 class AdminServer;
 
 // Registers built-in admin routes: GET /info, and future /health, /version.
 void registerBuiltinRoutes(AdminServer& server);
 
-} // namespace openmoq::o_rly::admin
+} // namespace openmoq::moqx::admin

--- a/include/moqx/admin/MetricsHandler.h
+++ b/include/moqx/admin/MetricsHandler.h
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-namespace openmoq::o_rly {
+namespace openmoq::moqx {
 
 namespace admin {
 class AdminServer;
@@ -24,4 +24,4 @@ void registerMetricsRoute(AdminServer& adminServer, std::shared_ptr<stats::Stats
 
 } // namespace admin
 
-} // namespace openmoq::o_rly
+} // namespace openmoq::moqx

--- a/include/moqx/config/config.h
+++ b/include/moqx/config/config.h
@@ -10,7 +10,7 @@
 #include <folly/SocketAddress.h>
 #include <folly/container/F14Map.h>
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 struct TlsConfig {
   std::string certFile;
@@ -72,4 +72,4 @@ struct Config {
   std::optional<AdminConfig> admin;
 };
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/include/moqx/config/loader/config_init.h
+++ b/include/moqx/config/loader/config_init.h
@@ -5,9 +5,9 @@
 
 #include <folly/Expected.h>
 
-#include "o_rly/config/resolved_config.h"
+#include "moqx/config/resolved_config.h"
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 constexpr std::string_view kDumpConfigSchemaCommand = "dump-config-schema";
 constexpr std::string_view kValidateConfigCommand = "validate-config";
@@ -24,4 +24,4 @@ folly::Expected<ResolvedConfig, int> handleConfigSubcommand(
     const char* programName
 );
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/include/moqx/config/loader/config_resolver.h
+++ b/include/moqx/config/loader/config_resolver.h
@@ -4,14 +4,14 @@
 
 #include <folly/Expected.h>
 
-#include "o_rly/config/loader/parsed_config.h"
-#include "o_rly/config/resolved_config.h"
+#include "moqx/config/loader/parsed_config.h"
+#include "moqx/config/resolved_config.h"
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 /// Validate and resolve a ParsedConfig into concrete Config types.
 /// Returns warnings alongside the config on success.
 /// On validation failure, returns a combined error string.
 folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& config);
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/include/moqx/config/loader/loader.h
+++ b/include/moqx/config/loader/loader.h
@@ -2,9 +2,9 @@
 
 #include <string>
 
-#include "o_rly/config/loader/parsed_config.h"
+#include "moqx/config/loader/parsed_config.h"
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 /// Load config from a YAML file path.
 /// When strict=true, rejects unknown fields.
@@ -15,4 +15,4 @@ ParsedConfig loadConfig(const std::string& path, bool strict = false);
 /// Generate JSON schema string from config structs.
 std::string generateSchema();
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/include/moqx/config/loader/parsed_config.h
+++ b/include/moqx/config/loader/parsed_config.h
@@ -9,7 +9,7 @@
 #include <rfl.hpp>
 #include <rfl/yaml.hpp>
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 // Note: fields wrapped in rfl::Description<"...", T> expose a .value() accessor
 // that unwraps the Description wrapper — this is NOT std::optional::value().
@@ -123,4 +123,4 @@ struct ParsedConfig {
   rfl::Description<"Admin HTTP server settings", std::optional<ParsedAdminConfig>> admin;
 };
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/include/moqx/config/loader/string_literal.h
+++ b/include/moqx/config/loader/string_literal.h
@@ -9,7 +9,7 @@
 
 #include <rfl/internal/StringLiteral.hpp>
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 // Concatenate any number of StringLiterals into one.
 template <rfl::internal::StringLiteral... Parts> consteval auto str_concat() {
@@ -68,4 +68,4 @@ static_assert(bool_to_str<true>().string_view() == "true");
 static_assert(bool_to_str<false>().string_view() == "false");
 static_assert(str_concat<"hello", " ", "world">().string_view() == "hello world");
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/include/moqx/config/resolved_config.h
+++ b/include/moqx/config/resolved_config.h
@@ -3,13 +3,13 @@
 #include <string>
 #include <vector>
 
-#include "o_rly/config/config.h"
+#include "moqx/config/config.h"
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 struct ResolvedConfig {
   Config config;
   std::vector<std::string> warnings;
 };
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/include/moqx/stats/BoundedHistogram.h
+++ b/include/moqx/stats/BoundedHistogram.h
@@ -3,7 +3,7 @@
 #include <array>
 #include <cstdint>
 
-namespace openmoq::o_rly::stats {
+namespace openmoq::moqx::stats {
 
 // ---------------------------------------------------------------------------
 // BoundedHistogram
@@ -49,4 +49,4 @@ template <size_t N> struct BoundedHistogram {
   uint64_t count{0};
 };
 
-} // namespace openmoq::o_rly::stats
+} // namespace openmoq::moqx::stats

--- a/include/moqx/stats/MoQStatsCollector.h
+++ b/include/moqx/stats/MoQStatsCollector.h
@@ -7,10 +7,10 @@
 #include <folly/executors/SequencedExecutor.h>
 #include <moxygen/stats/MoQStats.h>
 
-#include <o_rly/stats/BoundedHistogram.h>
-#include <o_rly/stats/StatsRegistry.h>
+#include <moqx/stats/BoundedHistogram.h>
+#include <moqx/stats/StatsRegistry.h>
 
-namespace openmoq::o_rly::stats {
+namespace openmoq::moqx::stats {
 
 // MoQStatsCollector owns all metric storage and acts as the StatsCollectorBase
 // registered with the StatsRegistry.  It exposes two inner callback objects:
@@ -111,7 +111,7 @@ public:
   StatsSnapshot snapshot() const override;
   folly::Executor::KeepAlive<> owningExecutor() const override;
 
-  // Session lifecycle events (called directly by ORelayServer).
+  // Session lifecycle events (called directly by MoqxRelayServer).
   void onSessionStart();
   void onSessionEnd();
 
@@ -145,4 +145,4 @@ private:
 #undef DEFINE_ERROR_ARRAY
 };
 
-} // namespace openmoq::o_rly::stats
+} // namespace openmoq::moqx::stats

--- a/include/moqx/stats/StatsRegistry.h
+++ b/include/moqx/stats/StatsRegistry.h
@@ -13,7 +13,7 @@
 
 #include <moxygen/MoQTypes.h>
 
-namespace openmoq::o_rly::stats {
+namespace openmoq::moqx::stats {
 
 // Latency buckets in microseconds (SLO: < 1000 µs = 1 ms per spec 4.1).
 inline constexpr std::array<uint64_t, 11> kLatencyBucketsUs =
@@ -211,4 +211,4 @@ private:
   std::vector<std::shared_ptr<StatsCollectorBase>> collectors_;
 };
 
-} // namespace openmoq::o_rly::stats
+} // namespace openmoq::moqx::stats

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# build.sh — Developer build script for o-rly.
+# build.sh — Developer build script for moqx.
 #
 # Mirrors the same build flows used by CI. Supports two dependency modes:
 #   --from-release  — download released moxygen artifacts (~1 min)
@@ -28,7 +28,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-SCRATCH="${ORLY_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
+SCRATCH="${MOQX_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
 MOXYGEN_DIR="${PROJECT_ROOT}/deps/moxygen"
 
 PREFIX_PATH_FILE="${SCRATCH}/cmake_prefix_path.txt"
@@ -47,7 +47,7 @@ Usage:
 
 Commands:
   setup     Install moxygen dependencies (from release or source)
-  (default) Configure and build o-rly
+  (default) Configure and build moqx
   test      Run tests
 
 Setup options:
@@ -226,7 +226,7 @@ cmd_setup() {
   fi
 
   if [[ -n "$moxygen_dir" ]]; then
-    export ORLY_MOXYGEN_DIR="$moxygen_dir"
+    export MOQX_MOXYGEN_DIR="$moxygen_dir"
     echo "Using moxygen from: $moxygen_dir"
   else
     check_submodule

--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -19,13 +19,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-SCRATCH="${ORLY_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
-MOXYGEN_DIR="${ORLY_MOXYGEN_DIR:-${PROJECT_ROOT}/deps/moxygen}"
+SCRATCH="${MOQX_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
+MOXYGEN_DIR="${MOQX_MOXYGEN_DIR:-${PROJECT_ROOT}/deps/moxygen}"
 STANDALONE_SRC="${MOXYGEN_DIR}/standalone"
 BUILD_DIR="${SCRATCH}/standalone-build"
 INSTALL_DIR="${SCRATCH}/moxygen-install"
 
-if [[ -z "${ORLY_MOXYGEN_DIR:-}" ]] && [[ ! -e "$MOXYGEN_DIR/.git" ]]; then
+if [[ -z "${MOQX_MOXYGEN_DIR:-}" ]] && [[ ! -e "$MOXYGEN_DIR/.git" ]]; then
     echo "Error: deps/moxygen submodule not initialized." >&2
     echo "  Run: git submodule update --init" >&2
     exit 1

--- a/scripts/sync-relay.sh
+++ b/scripts/sync-relay.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 #
-# sync-relay.sh - Sync ORelay from deps/moxygen/moxygen/relay/
+# sync-relay.sh - Sync MoqxRelay from deps/moxygen/moxygen/relay/
 #
 # Usage: scripts/sync-relay.sh [--no-build] [--no-test]
 #
 # Transforms:
-#   MoQRelay.h            -> include/o_rly/ORelay.h
-#   MoQRelay.cpp          -> src/ORelay.cpp
-#   test/MoQRelayTest.cpp -> tests/ORelayTest.cpp
+#   MoQRelay.h            -> include/moqx/MoqxRelay.h
+#   MoQRelay.cpp          -> src/MoqxRelay.cpp
+#   test/MoQRelayTest.cpp -> tests/MoqxRelayTest.cpp
 #
 # Name/namespace mappings applied:
-#   class MoQRelay           -> class ORelay
-#   namespace moxygen        -> namespace openmoq::o_rly
+#   class MoQRelay           -> class MoqxRelay
+#   namespace moxygen        -> namespace openmoq::moqx
 #   unqualified moxygen types in header get moxygen:: prefix
 #   using namespace moxygen; added before namespace in .cpp
 
@@ -66,7 +66,7 @@ PYEOF
 # ─────────────────────────────────────────────────────────────────────────────
 # Helper: add moxygen:: qualifier to unqualified moxygen types
 #
-# Called only on the header, where we're now in namespace openmoq::o_rly and
+# Called only on the header, where we're now in namespace openmoq::moqx and
 # moxygen types are no longer implicitly visible.  Uses negative lookbehind so
 # already-qualified occurrences (e.g. moxygen::Publisher) are left alone.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -101,28 +101,28 @@ qualify_moxygen_types() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 1. MoQRelay.h → include/o_rly/ORelay.h
+# 1. MoQRelay.h → include/moqx/MoqxRelay.h
 # ─────────────────────────────────────────────────────────────────────────────
 process_header() {
   local src="${MOXYGEN_RELAY}/MoQRelay.h"
-  local dst="${REPO_ROOT}/include/o_rly/ORelay.h"
-  local tmp="${TMP_DIR}/ORelay.h"
+  local dst="${REPO_ROOT}/include/moqx/MoqxRelay.h"
+  local tmp="${TMP_DIR}/MoqxRelay.h"
 
-  echo "  MoQRelay.h -> include/o_rly/ORelay.h"
+  echo "  MoQRelay.h -> include/moqx/MoqxRelay.h"
   cp "$src" "$tmp"
 
   replace_copyright "$tmp"
 
-  # Include style: "moxygen/relay/MoQRelay.h" -> <o_rly/ORelay.h>; other "..." -> <...>
-  sed -i 's|#include "moxygen/relay/MoQRelay\.h"|#include <o_rly/ORelay.h>|g' "$tmp"
+  # Include style: "moxygen/relay/MoQRelay.h" -> <moqx/MoqxRelay.h>; other "..." -> <...>
+  sed -i 's|#include "moxygen/relay/MoQRelay\.h"|#include <moqx/MoqxRelay.h>|g' "$tmp"
   sed -i 's|#include "\(moxygen/[^"]*\)"|#include <\1>|g' "$tmp"
 
   # Class rename
-  sed -i 's/\bMoQRelay\b/ORelay/g' "$tmp"
+  sed -i 's/\bMoQRelay\b/MoqxRelay/g' "$tmp"
 
   # Namespace
-  sed -i 's/^namespace moxygen {$/namespace openmoq::o_rly {/' "$tmp"
-  sed -i 's|^} // namespace moxygen$|} // namespace openmoq::o_rly|' "$tmp"
+  sed -i 's/^namespace moxygen {$/namespace openmoq::moqx {/' "$tmp"
+  sed -i 's|^} // namespace moxygen$|} // namespace openmoq::moqx|' "$tmp"
 
   # Qualify unqualified moxygen types (order matters: more specific before less specific)
   qualify_moxygen_types "$tmp"
@@ -131,56 +131,56 @@ process_header() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 2. MoQRelay.cpp → src/ORelay.cpp
+# 2. MoQRelay.cpp → src/MoqxRelay.cpp
 # ─────────────────────────────────────────────────────────────────────────────
 process_source() {
   local src="${MOXYGEN_RELAY}/MoQRelay.cpp"
-  local dst="${REPO_ROOT}/src/ORelay.cpp"
-  local tmp="${TMP_DIR}/ORelay.cpp"
+  local dst="${REPO_ROOT}/src/MoqxRelay.cpp"
+  local tmp="${TMP_DIR}/MoqxRelay.cpp"
 
-  echo "  MoQRelay.cpp -> src/ORelay.cpp"
+  echo "  MoQRelay.cpp -> src/MoqxRelay.cpp"
   cp "$src" "$tmp"
 
   replace_copyright "$tmp"
 
-  # Include style: relay header -> ORelay.h; other "..." -> <...>
-  sed -i 's|#include "moxygen/relay/MoQRelay\.h"|#include <o_rly/ORelay.h>|g' "$tmp"
+  # Include style: relay header -> MoqxRelay.h; other "..." -> <...>
+  sed -i 's|#include "moxygen/relay/MoQRelay\.h"|#include <moqx/MoqxRelay.h>|g' "$tmp"
   sed -i 's|#include "\(moxygen/[^"]*\)"|#include <\1>|g' "$tmp"
 
   # Class/method references
-  sed -i 's/\bMoQRelay\b/ORelay/g' "$tmp"
+  sed -i 's/\bMoQRelay\b/MoqxRelay/g' "$tmp"
 
   # Namespace: insert "using namespace moxygen;" before the namespace block
   # so types in the implementation don't need moxygen:: qualification
-  sed -i 's/^namespace moxygen {$/using namespace moxygen;\n\nnamespace openmoq::o_rly {/' "$tmp"
-  sed -i 's|^} // namespace moxygen$|} // namespace openmoq::o_rly|' "$tmp"
+  sed -i 's/^namespace moxygen {$/using namespace moxygen;\n\nnamespace openmoq::moqx {/' "$tmp"
+  sed -i 's|^} // namespace moxygen$|} // namespace openmoq::moqx|' "$tmp"
 
   cp "$tmp" "$dst"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 3. test/MoQRelayTest.cpp → tests/ORelayTest.cpp
+# 3. test/MoQRelayTest.cpp → tests/MoqxRelayTest.cpp
 # ─────────────────────────────────────────────────────────────────────────────
 process_test() {
   local src="${MOXYGEN_RELAY}/test/MoQRelayTest.cpp"
-  local dst="${REPO_ROOT}/tests/ORelayTest.cpp"
-  local tmp="${TMP_DIR}/ORelayTest.cpp"
+  local dst="${REPO_ROOT}/tests/MoqxRelayTest.cpp"
+  local tmp="${TMP_DIR}/MoqxRelayTest.cpp"
 
-  echo "  test/MoQRelayTest.cpp -> tests/ORelayTest.cpp"
+  echo "  test/MoQRelayTest.cpp -> tests/MoqxRelayTest.cpp"
   cp "$src" "$tmp"
 
   replace_copyright "$tmp"
 
-  # Replace MoQRelay include with ORelay
-  sed -i 's|#include <moxygen/relay/MoQRelay\.h>|#include <o_rly/ORelay.h>|g' "$tmp"
+  # Replace MoQRelay include with MoqxRelay
+  sed -i 's|#include <moxygen/relay/MoQRelay\.h>|#include <moqx/MoqxRelay.h>|g' "$tmp"
 
   # Relay class under test
-  sed -i 's/\bMoQRelay\b/ORelay/g' "$tmp"
+  sed -i 's/\bMoQRelay\b/MoqxRelay/g' "$tmp"
 
-  # Add openmoq::o_rly namespace (and moxygen for types used at file scope).
+  # Add openmoq::moqx namespace (and moxygen for types used at file scope).
   # The test lives in namespace moxygen::test, but globals defined before that
   # namespace block need explicit usings.
-  sed -i 's/^using namespace testing;$/using namespace testing;\nusing namespace moxygen;\nusing namespace openmoq::o_rly;/' "$tmp"
+  sed -i 's/^using namespace testing;$/using namespace testing;\nusing namespace moxygen;\nusing namespace openmoq::moqx;/' "$tmp"
 
   cp "$tmp" "$dst"
 }

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -558,8 +558,10 @@ private:
   FullTrackName ftn_;
 };
 
-std::shared_ptr<TrackConsumer>
-MoqxRelay::getSubscribeWriteback(const FullTrackName& ftn, std::shared_ptr<TrackConsumer> consumer) {
+std::shared_ptr<TrackConsumer> MoqxRelay::getSubscribeWriteback(
+    const FullTrackName& ftn,
+    std::shared_ptr<TrackConsumer> consumer
+) {
   auto baseConsumer =
       cache_ ? cache_->getSubscribeWriteback(ftn, std::move(consumer)) : std::move(consumer);
   auto filterConsumer =

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <moxygen/MoQFilters.h>
-#include <o_rly/ORelay.h>
+#include <moqx/MoqxRelay.h>
 
 namespace {
 constexpr uint8_t kDefaultUpstreamPriority = 128;
@@ -15,7 +15,7 @@ constexpr uint8_t kDefaultUpstreamPriority = 128;
 
 using namespace moxygen;
 
-namespace openmoq::o_rly {
+namespace openmoq::moqx {
 
 // Sends SUBSCRIBE_UPDATE to update forwarding state. Called from:
 // - subscribeNamespace: forwarder was empty, new subscriber added
@@ -24,7 +24,7 @@ namespace openmoq::o_rly {
 // - onEmpty: last subscriber left a publish subscription (forward=false)
 // - forwardChanged: forwarding subscriber count changed
 folly::coro::Task<void>
-ORelay::doSubscribeUpdate(std::shared_ptr<Publisher::SubscriptionHandle> handle, bool forward) {
+MoqxRelay::doSubscribeUpdate(std::shared_ptr<Publisher::SubscriptionHandle> handle, bool forward) {
   auto updateRes = co_await handle->requestUpdate(
       {RequestID(0),
        handle->subscribeOk().requestID,
@@ -38,7 +38,7 @@ ORelay::doSubscribeUpdate(std::shared_ptr<Publisher::SubscriptionHandle> handle,
   }
 }
 
-std::shared_ptr<ORelay::NamespaceNode> ORelay::findNamespaceNode(
+std::shared_ptr<MoqxRelay::NamespaceNode> MoqxRelay::findNamespaceNode(
     const TrackNamespace& ns,
     bool createMissingNodes,
     MatchType matchType,
@@ -74,7 +74,7 @@ std::shared_ptr<ORelay::NamespaceNode> ORelay::findNamespaceNode(
   return nodePtr;
 }
 
-folly::coro::Task<Subscriber::PublishNamespaceResult> ORelay::publishNamespace(
+folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespace(
     PublishNamespace ann,
     std::shared_ptr<Subscriber::PublishNamespaceCallback> callback
 ) {
@@ -166,7 +166,7 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> ORelay::publishNamespace(
   co_return nodePtr;
 }
 
-folly::coro::Task<void> ORelay::publishNamespaceToSession(
+folly::coro::Task<void> MoqxRelay::publishNamespaceToSession(
     std::shared_ptr<MoQSession> session,
     PublishNamespace ann,
     std::shared_ptr<NamespaceNode> nodePtr
@@ -181,7 +181,7 @@ folly::coro::Task<void> ORelay::publishNamespaceToSession(
 }
 
 // NamespaceNode ref count management methods for pruning
-void ORelay::NamespaceNode::incrementActiveChildren() {
+void MoqxRelay::NamespaceNode::incrementActiveChildren() {
   activeChildCount_++;
   // Propagate up if this was the first active child
   if (activeChildCount_ == 1 && parent_ && !hasLocalSessions()) {
@@ -189,13 +189,13 @@ void ORelay::NamespaceNode::incrementActiveChildren() {
   }
 }
 
-void ORelay::NamespaceNode::decrementActiveChildren() {
+void MoqxRelay::NamespaceNode::decrementActiveChildren() {
   XCHECK_GT(activeChildCount_, 0);
   activeChildCount_--;
 }
 
 // Walk up the tree to find and prune the highest empty ancestor
-void ORelay::NamespaceNode::tryPruneChild(const std::string& childKey) {
+void MoqxRelay::NamespaceNode::tryPruneChild(const std::string& childKey) {
   auto it = children.find(childKey);
   if (it == children.end()) {
     return;
@@ -246,7 +246,7 @@ void ORelay::NamespaceNode::tryPruneChild(const std::string& childKey) {
   parentOfNodeToRemove->children.erase(keyToRemove);
 }
 
-void ORelay::publishNamespaceDone(const TrackNamespace& trackNamespace, NamespaceNode*) {
+void MoqxRelay::publishNamespaceDone(const TrackNamespace& trackNamespace, NamespaceNode*) {
   XLOG(DBG1) << __func__ << " ns=" << trackNamespace;
   // Node would be useful if there were back links
   auto nodePtr = findNamespaceNode(trackNamespace);
@@ -319,7 +319,7 @@ void ORelay::publishNamespaceDone(const TrackNamespace& trackNamespace, Namespac
   }
 }
 
-void ORelay::onPublishDone(const FullTrackName& ftn) {
+void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
   XLOG(DBG1) << __func__ << " ftn=" << ftn;
 
   auto it = subscriptions_.find(ftn);
@@ -355,7 +355,7 @@ void ORelay::onPublishDone(const FullTrackName& ftn) {
 }
 
 Subscriber::PublishResult
-ORelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHandle> handle) {
+MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHandle> handle) {
   XLOG(DBG1) << __func__ << " ftn=" << pub.fullTrackName;
   XCHECK(handle) << "Publish handle cannot be null";
   if (!pub.fullTrackName.trackNamespace.startsWith(allowedNamespacePrefix_)) {
@@ -459,7 +459,7 @@ ORelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHandl
   };
 }
 
-folly::coro::Task<void> ORelay::publishToSession(
+folly::coro::Task<void> MoqxRelay::publishToSession(
     std::shared_ptr<MoQSession> session,
     std::shared_ptr<MoQForwarder> forwarder,
     bool forward
@@ -498,10 +498,10 @@ folly::coro::Task<void> ORelay::publishToSession(
   subscriber->shouldForward = pubOk.forward;
 }
 
-class ORelay::NamespaceSubscription : public Publisher::SubscribeNamespaceHandle {
+class MoqxRelay::NamespaceSubscription : public Publisher::SubscribeNamespaceHandle {
 public:
   NamespaceSubscription(
-      std::shared_ptr<ORelay> relay,
+      std::shared_ptr<MoqxRelay> relay,
       std::shared_ptr<MoQSession> session,
       SubscribeNamespaceOk ok,
       TrackNamespace trackNamespacePrefix
@@ -525,16 +525,16 @@ public:
   }
 
 private:
-  std::shared_ptr<ORelay> relay_;
+  std::shared_ptr<MoqxRelay> relay_;
   std::shared_ptr<MoQSession> session_;
   TrackNamespace trackNamespacePrefix_;
 };
 
 // Filter TrackConsumer that intercepts publishDone to clean up relay state
-class ORelay::TerminationFilter : public TrackConsumerFilter {
+class MoqxRelay::TerminationFilter : public TrackConsumerFilter {
 public:
   TerminationFilter(
-      std::shared_ptr<ORelay> relay,
+      std::shared_ptr<MoqxRelay> relay,
       FullTrackName ftn,
       std::shared_ptr<TrackConsumer> downstream
   )
@@ -553,12 +553,12 @@ public:
   }
 
 private:
-  std::shared_ptr<ORelay> relay_;
+  std::shared_ptr<MoqxRelay> relay_;
   FullTrackName ftn_;
 };
 
 std::shared_ptr<TrackConsumer>
-ORelay::getSubscribeWriteback(const FullTrackName& ftn, std::shared_ptr<TrackConsumer> consumer) {
+MoqxRelay::getSubscribeWriteback(const FullTrackName& ftn, std::shared_ptr<TrackConsumer> consumer) {
   auto baseConsumer =
       cache_ ? cache_->getSubscribeWriteback(ftn, std::move(consumer)) : std::move(consumer);
   auto filterConsumer =
@@ -566,7 +566,7 @@ ORelay::getSubscribeWriteback(const FullTrackName& ftn, std::shared_ptr<TrackCon
   return std::static_pointer_cast<TrackConsumer>(filterConsumer);
 }
 
-folly::coro::Task<Publisher::SubscribeNamespaceResult> ORelay::subscribeNamespace(
+folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNamespace(
     SubscribeNamespace subNs,
     std::shared_ptr<NamespacePublishHandle> namespacePublishHandle
 ) {
@@ -673,7 +673,7 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> ORelay::subscribeNamespac
   );
 }
 
-void ORelay::unsubscribeNamespace(
+void MoqxRelay::unsubscribeNamespace(
     const TrackNamespace& trackNamespacePrefix,
     std::shared_ptr<MoQSession> session
 ) {
@@ -702,7 +702,7 @@ void ORelay::unsubscribeNamespace(
   XLOG(DBG1) << "Namespace prefix was not subscribed by this session";
 }
 
-std::shared_ptr<MoQSession> ORelay::findPublishNamespaceSession(const TrackNamespace& ns) {
+std::shared_ptr<MoQSession> MoqxRelay::findPublishNamespaceSession(const TrackNamespace& ns) {
   /*
    * This function is called from subscribe() and fetch().
    * We use MatchType::Prefix here because the relay routes SUBSCRIBE and FETCH
@@ -716,7 +716,7 @@ std::shared_ptr<MoQSession> ORelay::findPublishNamespaceSession(const TrackNames
   return nodePtr->sourceSession;
 }
 
-ORelay::PublishState ORelay::findPublishState(const FullTrackName& ftn) {
+MoqxRelay::PublishState MoqxRelay::findPublishState(const FullTrackName& ftn) {
   PublishState state;
   auto nodePtr =
       findNamespaceNode(ftn.trackNamespace, /*createMissingNodes=*/false, MatchType::Exact);
@@ -737,7 +737,7 @@ ORelay::PublishState ORelay::findPublishState(const FullTrackName& ftn) {
 }
 
 folly::coro::Task<Publisher::SubscribeResult>
-ORelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consumer) {
+MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
   auto subscriptionIt = subscriptions_.find(subReq.fullTrackName);
   if (subscriptionIt == subscriptions_.end()) {
@@ -877,7 +877,7 @@ ORelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consum
 }
 
 folly::coro::Task<Publisher::FetchResult>
-ORelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
+MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
 
   // check auth
@@ -942,7 +942,7 @@ ORelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   co_return co_await cache_->fetch(fetch, std::move(consumer), std::move(upstreamSession));
 }
 
-folly::coro::Task<Publisher::TrackStatusResult> ORelay::trackStatus(TrackStatus trackStatus) {
+folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatus(TrackStatus trackStatus) {
   XLOG(DBG1) << __func__ << " ftn=" << trackStatus.fullTrackName;
 
   if (trackStatus.fullTrackName.trackNamespace.empty()) {
@@ -1006,7 +1006,7 @@ folly::coro::Task<Publisher::TrackStatusResult> ORelay::trackStatus(TrackStatus 
   }
 }
 
-void ORelay::onEmpty(MoQForwarder* forwarder) {
+void MoqxRelay::onEmpty(MoQForwarder* forwarder) {
   auto subscriptionIt = subscriptions_.find(forwarder->fullTrackName());
   if (subscriptionIt == subscriptions_.end()) {
     return;
@@ -1034,7 +1034,7 @@ void ORelay::onEmpty(MoQForwarder* forwarder) {
   }
 }
 
-void ORelay::forwardChanged(MoQForwarder* forwarder) {
+void MoqxRelay::forwardChanged(MoQForwarder* forwarder) {
   auto subscriptionIt = subscriptions_.find(forwarder->fullTrackName());
   if (subscriptionIt == subscriptions_.end()) {
     return;
@@ -1058,4 +1058,4 @@ void ORelay::forwardChanged(MoQForwarder* forwarder) {
       .start();
 }
 
-} // namespace openmoq::o_rly
+} // namespace openmoq::moqx

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -6,8 +6,9 @@
  * Copyright (c) OpenMOQ contributors.
  */
 
-#include <moxygen/MoQFilters.h>
 #include <moqx/MoqxRelay.h>
+
+#include <moxygen/MoQFilters.h>
 
 namespace {
 constexpr uint8_t kDefaultUpstreamPriority = 128;

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -1,6 +1,6 @@
-#include <moxygen/MoQRelaySession.h>
 #include <moqx/MoqxRelayServer.h>
 #include <moqx/stats/MoQStatsCollector.h>
+#include <moxygen/MoQRelaySession.h>
 
 #include <folly/logging/xlog.h>
 
@@ -19,7 +19,8 @@ std::vector<std::string> buildAlpns(const std::string& versions) {
 
 } // namespace
 
-void MoqxRelayServer::initRelays(const folly::F14FastMap<std::string, config::ServiceConfig>& services
+void MoqxRelayServer::initRelays(
+    const folly::F14FastMap<std::string, config::ServiceConfig>& services
 ) {
   for (const auto& [name, svc] : services) {
     relays_.emplace(

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -1,12 +1,12 @@
 #include <moxygen/MoQRelaySession.h>
-#include <o_rly/ORelayServer.h>
-#include <o_rly/stats/MoQStatsCollector.h>
+#include <moqx/MoqxRelayServer.h>
+#include <moqx/stats/MoQStatsCollector.h>
 
 #include <folly/logging/xlog.h>
 
 using namespace moxygen;
 
-namespace openmoq::o_rly {
+namespace openmoq::moqx {
 
 namespace {
 
@@ -19,17 +19,17 @@ std::vector<std::string> buildAlpns(const std::string& versions) {
 
 } // namespace
 
-void ORelayServer::initRelays(const folly::F14FastMap<std::string, config::ServiceConfig>& services
+void MoqxRelayServer::initRelays(const folly::F14FastMap<std::string, config::ServiceConfig>& services
 ) {
   for (const auto& [name, svc] : services) {
     relays_.emplace(
         name,
-        std::make_shared<ORelay>(svc.cache.maxCachedTracks, svc.cache.maxCachedGroupsPerTrack)
+        std::make_shared<MoqxRelay>(svc.cache.maxCachedTracks, svc.cache.maxCachedGroupsPerTrack)
     );
   }
 }
 
-ORelayServer::ORelayServer(
+MoqxRelayServer::MoqxRelayServer(
     const std::string& cert,
     const std::string& key,
     const std::string& endpoint,
@@ -49,7 +49,7 @@ ORelayServer::ORelayServer(
   initRelays(services);
 }
 
-ORelayServer::ORelayServer(
+MoqxRelayServer::MoqxRelayServer(
     const std::string& endpoint,
     const std::string& versions,
     folly::F14FastMap<std::string, config::ServiceConfig> services
@@ -67,11 +67,11 @@ ORelayServer::ORelayServer(
   initRelays(services);
 }
 
-void ORelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
+void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
   statsRegistry_ = std::move(registry);
 }
 
-void ORelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
+void MoqxRelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
   // Relay handler routing deferred to validateAuthority() where authority is available
 
   if (statsRegistry_) {
@@ -91,14 +91,14 @@ void ORelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
   }
 }
 
-void ORelayServer::terminateClientSession(std::shared_ptr<MoQSession> session) {
+void MoqxRelayServer::terminateClientSession(std::shared_ptr<MoQSession> session) {
   if (statsCollector_) {
     statsCollector_->onSessionEnd();
   }
   MoQServer::terminateClientSession(std::move(session));
 }
 
-folly::Expected<folly::Unit, SessionCloseErrorCode> ORelayServer::validateAuthority(
+folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayServer::validateAuthority(
     const ClientSetup& clientSetup,
     uint64_t negotiatedVersion,
     std::shared_ptr<MoQSession> session
@@ -126,7 +126,7 @@ folly::Expected<folly::Unit, SessionCloseErrorCode> ORelayServer::validateAuthor
   return folly::unit;
 }
 
-std::shared_ptr<MoQSession> ORelayServer::createSession(
+std::shared_ptr<MoQSession> MoqxRelayServer::createSession(
     folly::MaybeManagedPtr<proxygen::WebTransport> wt,
     std::shared_ptr<MoQExecutor> executor
 ) {
@@ -137,4 +137,4 @@ std::shared_ptr<MoQSession> ORelayServer::createSession(
   );
 }
 
-} // namespace openmoq::o_rly
+} // namespace openmoq::moqx

--- a/src/ServiceMatcher.cpp
+++ b/src/ServiceMatcher.cpp
@@ -1,10 +1,10 @@
-#include <o_rly/ServiceMatcher.h>
+#include <moqx/ServiceMatcher.h>
 
 #include <algorithm>
 
 #include <folly/logging/xlog.h>
 
-namespace openmoq::o_rly {
+namespace openmoq::moqx {
 
 void ServiceMatcher::PathRuleSet::addRule(
     const config::ServiceConfig::MatchEntry::PathMatcher& path,
@@ -116,4 +116,4 @@ ServiceMatcher::match(std::string_view authority, std::string_view path) const {
   return anyAuthorityRules_.match(effectivePath);
 }
 
-} // namespace openmoq::o_rly
+} // namespace openmoq::moqx

--- a/src/admin/AdminServer.cpp
+++ b/src/admin/AdminServer.cpp
@@ -1,4 +1,4 @@
-#include <o_rly/admin/AdminServer.h>
+#include <moqx/admin/AdminServer.h>
 
 #include <list>
 
@@ -12,7 +12,7 @@
 #include <proxygen/lib/http/HTTPMessage.h>
 #include <wangle/ssl/SSLContextConfig.h>
 
-namespace openmoq::o_rly::admin {
+namespace openmoq::moqx::admin {
 
 // ---------------------------------------------------------------------------
 // AdminRequestHandler — generic request aggregator
@@ -136,4 +136,4 @@ void AdminServer::stop() {
   httpServer_.reset();
 }
 
-} // namespace openmoq::o_rly::admin
+} // namespace openmoq::moqx::admin

--- a/src/admin/BuiltinRoutes.cpp
+++ b/src/admin/BuiltinRoutes.cpp
@@ -1,12 +1,12 @@
-#include <o_rly/admin/BuiltinRoutes.h>
+#include <moqx/admin/BuiltinRoutes.h>
 
 #include <folly/io/IOBuf.h>
 #include <proxygen/httpserver/ResponseBuilder.h>
 #include <proxygen/lib/http/HTTPMessage.h>
 
-#include <o_rly/admin/AdminServer.h>
+#include <moqx/admin/AdminServer.h>
 
-namespace openmoq::o_rly::admin {
+namespace openmoq::moqx::admin {
 
 void registerBuiltinRoutes(AdminServer& server) {
   server.addRoute(
@@ -16,11 +16,11 @@ void registerBuiltinRoutes(AdminServer& server) {
         proxygen::ResponseBuilder(downstream)
             .status(200, proxygen::HTTPMessage::getDefaultReason(200))
             .header("Content-Type", "application/json")
-            .body(folly::IOBuf::copyBuffer("{\"service\":\"o-rly\",\"version\":\"" ORLY_VERSION
+            .body(folly::IOBuf::copyBuffer("{\"service\":\"moqx\",\"version\":\"" MOQX_VERSION
                                            "\"}\n"))
             .sendWithEOM();
       }
   );
 }
 
-} // namespace openmoq::o_rly::admin
+} // namespace openmoq::moqx::admin

--- a/src/admin/MetricsHandler.cpp
+++ b/src/admin/MetricsHandler.cpp
@@ -1,4 +1,4 @@
-#include <o_rly/admin/MetricsHandler.h>
+#include <moqx/admin/MetricsHandler.h>
 
 #include <folly/CancellationToken.h>
 #include <folly/coro/Task.h>
@@ -10,10 +10,10 @@
 #include <proxygen/httpserver/ResponseBuilder.h>
 #include <proxygen/lib/http/HTTPMessage.h>
 
-#include <o_rly/admin/AdminServer.h>
-#include <o_rly/stats/StatsRegistry.h>
+#include <moqx/admin/AdminServer.h>
+#include <moqx/stats/StatsRegistry.h>
 
-namespace openmoq::o_rly::admin {
+namespace openmoq::moqx::admin {
 
 void registerMetricsRoute(
     AdminServer& adminServer,
@@ -61,4 +61,4 @@ void registerMetricsRoute(
   );
 }
 
-} // namespace openmoq::o_rly::admin
+} // namespace openmoq::moqx::admin

--- a/src/config/config_init.cpp
+++ b/src/config/config_init.cpp
@@ -1,14 +1,14 @@
-#include "o_rly/config/loader/config_init.h"
+#include "moqx/config/loader/config_init.h"
 
-#include "o_rly/config/loader/config_resolver.h"
-#include "o_rly/config/loader/loader.h"
+#include "moqx/config/loader/config_resolver.h"
+#include "moqx/config/loader/loader.h"
 
 #include <gflags/gflags.h>
 
 #include <iostream>
 #include <string>
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 std::string configSubcommandUsage() {
   return "  validate-config      Load and validate config, then exit\n"
@@ -66,4 +66,4 @@ folly::Expected<ResolvedConfig, int> handleConfigSubcommand(
   return std::move(result.value());
 }
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/src/config/config_resolver.cpp
+++ b/src/config/config_resolver.cpp
@@ -1,11 +1,11 @@
-#include "o_rly/config/loader/config_resolver.h"
+#include "moqx/config/loader/config_resolver.h"
 
 #include <unordered_map>
 #include <unordered_set>
 
 #include <folly/String.h>
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 namespace {
 
@@ -439,4 +439,4 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
   };
 }
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/src/config/loader.cpp
+++ b/src/config/loader.cpp
@@ -1,4 +1,4 @@
-#include "o_rly/config/loader/loader.h"
+#include "moqx/config/loader/loader.h"
 
 #include <stdexcept>
 
@@ -6,7 +6,7 @@
 #include <rfl/json.hpp>
 #include <rfl/yaml.hpp>
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 
 ParsedConfig loadConfig(const std::string& path, bool strict) {
   std::string content;
@@ -26,8 +26,8 @@ ParsedConfig loadConfig(const std::string& path, bool strict) {
 
 std::string generateSchema() {
   return rfl::json::to_schema<
-      rfl::Description<"Configuration schema for the o-rly relay.", ParsedConfig>>(rfl::json::pretty
+      rfl::Description<"Configuration schema for the moqx relay.", ParsedConfig>>(rfl::json::pretty
   );
 }
 
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,9 @@
-#include <o_rly/ORelayServer.h>
-#include <o_rly/admin/AdminServer.h>
-#include <o_rly/admin/BuiltinRoutes.h>
-#include <o_rly/admin/MetricsHandler.h>
-#include <o_rly/config/loader/config_init.h>
-#include <o_rly/stats/StatsRegistry.h>
+#include <moqx/MoqxRelayServer.h>
+#include <moqx/admin/AdminServer.h>
+#include <moqx/admin/BuiltinRoutes.h>
+#include <moqx/admin/MetricsHandler.h>
+#include <moqx/config/loader/config_init.h>
+#include <moqx/stats/StatsRegistry.h>
 
 #include <csignal>
 
@@ -19,7 +19,7 @@ DEFINE_bool(strict_config, false, "Reject unknown config fields");
 
 namespace {
 
-namespace cfg = openmoq::o_rly::config;
+namespace cfg = openmoq::moqx::config;
 
 constexpr std::string_view kServeCommand = "serve";
 
@@ -36,21 +36,21 @@ public:
   }
 };
 
-std::shared_ptr<openmoq::o_rly::ORelayServer> createServer(const cfg::Config& config) {
+std::shared_ptr<openmoq::moqx::MoqxRelayServer> createServer(const cfg::Config& config) {
   const auto& listener = config.listener;
   auto services = config.services; // copy for move into constructor
 
   return std::visit(
-      [&](const auto& tls) -> std::shared_ptr<openmoq::o_rly::ORelayServer> {
+      [&](const auto& tls) -> std::shared_ptr<openmoq::moqx::MoqxRelayServer> {
         using T = std::decay_t<decltype(tls)>;
         if constexpr (std::is_same_v<T, cfg::Insecure>) {
-          return std::make_shared<openmoq::o_rly::ORelayServer>(
+          return std::make_shared<openmoq::moqx::MoqxRelayServer>(
               listener.endpoint,
               listener.moqtVersions,
               std::move(services)
           );
         } else {
-          return std::make_shared<openmoq::o_rly::ORelayServer>(
+          return std::make_shared<openmoq::moqx::MoqxRelayServer>(
               tls.certFile,
               tls.keyFile,
               listener.endpoint,
@@ -70,10 +70,10 @@ int main(int argc, char* argv[]) {
   // === 1. Parse command-line flags/config ===
   // CLI args, config files, env vars
   google::SetUsageMessage(
-      "o-rly MoQ relay server\n\n"
+      "moqx MoQ relay server\n\n"
       "Subcommands:\n"
       "  serve                Start the relay (default)\n" +
-      cfg::configSubcommandUsage() + "\nUsage: o_rly [subcommand] --config <path>"
+      cfg::configSubcommandUsage() + "\nUsage: moqx [subcommand] --config <path>"
   );
   folly::Init init(&argc, &argv, true);
 
@@ -114,17 +114,17 @@ int main(int argc, char* argv[]) {
 
   // === 6. Initialize services ===
   // Construct and configure the application's own services
-  // (ORelayServer, ORelay, etc.)
+  // (MoqxRelayServer, MoqxRelay, etc.)
   auto server = createServer(config);
 
   // === 6a. Stats registry ===
-  auto statsRegistry = std::make_shared<openmoq::o_rly::stats::StatsRegistry>();
+  auto statsRegistry = std::make_shared<openmoq::moqx::stats::StatsRegistry>();
   server->setStatsRegistry(statsRegistry);
 
   // === 7. Start health checks / admin endpoints ===
-  openmoq::o_rly::admin::AdminServer adminServer;
-  openmoq::o_rly::admin::registerBuiltinRoutes(adminServer);
-  openmoq::o_rly::admin::registerMetricsRoute(adminServer, statsRegistry);
+  openmoq::moqx::admin::AdminServer adminServer;
+  openmoq::moqx::admin::registerBuiltinRoutes(adminServer);
+  openmoq::moqx::admin::registerMetricsRoute(adminServer, statsRegistry);
   if (config.admin) {
     if (!adminServer.start(*config.admin)) {
       XLOG(FATAL) << "Failed to start admin server on " << config.admin->address.describe();

--- a/src/stats/MoQStatsCollector.cpp
+++ b/src/stats/MoQStatsCollector.cpp
@@ -1,8 +1,8 @@
-#include <o_rly/stats/MoQStatsCollector.h>
+#include <moqx/stats/MoQStatsCollector.h>
 
 #include <folly/logging/xlog.h>
 
-namespace openmoq::o_rly::stats {
+namespace openmoq::moqx::stats {
 
 /* static */
 std::shared_ptr<MoQStatsCollector> MoQStatsCollector::create_moq_stats_collector(
@@ -313,4 +313,4 @@ void MoQStatsCollector::SubscriberCallback::onPublishError(moxygen::PublishError
   ++parent_.subPublishErrorByCodes_[requestErrorCodeIndex(errorCode)];
 }
 
-} // namespace openmoq::o_rly::stats
+} // namespace openmoq::moqx::stats

--- a/src/stats/StatsRegistry.cpp
+++ b/src/stats/StatsRegistry.cpp
@@ -1,4 +1,4 @@
-#include <o_rly/stats/StatsRegistry.h>
+#include <moqx/stats/StatsRegistry.h>
 
 #include <folly/Conv.h>
 #include <folly/io/Cursor.h>
@@ -10,7 +10,7 @@
 #include <folly/experimental/coro/Task.h>
 #include <folly/logging/xlog.h>
 
-namespace openmoq::o_rly::stats {
+namespace openmoq::moqx::stats {
 
 StatsSnapshot& StatsSnapshot::operator+=(const StatsSnapshot& o) {
 #define ADD_FIELD(type, name) name += o.name;
@@ -58,9 +58,9 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
 
   // --- Counters ---
 #define EMIT_COUNTER(type, name)                                                                   \
-  app("# HELP orly_" #name "_total\n"                                                              \
-      "# TYPE orly_" #name "_total counter\n"                                                      \
-      "orly_" #name "_total ");                                                                    \
+  app("# HELP moqx_" #name "_total\n"                                                              \
+      "# TYPE moqx_" #name "_total counter\n"                                                      \
+      "moqx_" #name "_total ");                                                                    \
   appNum(snap.name);                                                                               \
   app("\n\n");
   STATS_COUNTER_FIELDS(EMIT_COUNTER)
@@ -68,9 +68,9 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
 
   // --- Gauges ---
 #define EMIT_GAUGE(type, name)                                                                     \
-  app("# HELP orly_" #name "\n"                                                                    \
-      "# TYPE orly_" #name " gauge\n"                                                              \
-      "orly_" #name " ");                                                                          \
+  app("# HELP moqx_" #name "\n"                                                                    \
+      "# TYPE moqx_" #name " gauge\n"                                                              \
+      "moqx_" #name " ");                                                                          \
   appNum(snap.name);                                                                               \
   app("\n\n");
   STATS_GAUGE_FIELDS(EMIT_GAUGE)
@@ -78,26 +78,26 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
 
   // --- Histograms ---
 #define EMIT_HISTOGRAM(name, bounds)                                                               \
-  app("# HELP orly_" #name "_microseconds\n"                                                       \
-      "# TYPE orly_" #name "_microseconds histogram\n");                                           \
+  app("# HELP moqx_" #name "_microseconds\n"                                                       \
+      "# TYPE moqx_" #name "_microseconds histogram\n");                                           \
   {                                                                                                \
     const auto& bvals = (bounds);                                                                  \
     const auto& bcounts = snap.name##Buckets;                                                      \
     for (size_t i = 0; i < bvals.size(); ++i) {                                                    \
-      app("orly_" #name "_microseconds_bucket{le=\"");                                             \
+      app("moqx_" #name "_microseconds_bucket{le=\"");                                             \
       appNum(bvals[i]);                                                                            \
       app("\"} ");                                                                                 \
       appNum(bcounts[i]);                                                                          \
       app("\n");                                                                                   \
     }                                                                                              \
-    app("orly_" #name "_microseconds_bucket{le=\"+Inf\"} ");                                       \
+    app("moqx_" #name "_microseconds_bucket{le=\"+Inf\"} ");                                       \
     appNum(bcounts.back());                                                                        \
     app("\n");                                                                                     \
   }                                                                                                \
-  app("orly_" #name "_microseconds_sum ");                                                         \
+  app("moqx_" #name "_microseconds_sum ");                                                         \
   appNum(snap.name##Sum);                                                                          \
   app("\n"                                                                                         \
-      "orly_" #name "_microseconds_count ");                                                       \
+      "moqx_" #name "_microseconds_count ");                                                       \
   appNum(snap.name##Count);                                                                        \
   app("\n\n");
   STATS_HISTOGRAM_FIELDS(EMIT_HISTOGRAM)
@@ -105,13 +105,13 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
 
   // --- Per-RequestErrorCode breakdowns ---
   // Each field emits one labelled counter series:
-  //   orly_<name>_by_code_total{code="<label>"}
+  //   moqx_<name>_by_code_total{code="<label>"}
 #define EMIT_ERROR_COUNTER(name)                                                                   \
-  app("# HELP orly_" #name "_by_code_total"                                                        \
+  app("# HELP moqx_" #name "_by_code_total"                                                        \
       " Error count broken down by RequestErrorCode\n"                                             \
-      "# TYPE orly_" #name "_by_code_total counter\n");                                            \
+      "# TYPE moqx_" #name "_by_code_total counter\n");                                            \
   for (size_t i = 0; i < kRequestErrorCodeCount; ++i) {                                            \
-    app("orly_" #name "_by_code_total{code=\"");                                                   \
+    app("moqx_" #name "_by_code_total{code=\"");                                                   \
     app(kRequestErrorCodeLabels[i]);                                                               \
     app("\"} ");                                                                                   \
     appNum(snap.name##ByCodes[i]);                                                                 \
@@ -164,4 +164,4 @@ folly::coro::Task<StatsSnapshot> StatsRegistry::aggregateAsync() {
   co_return combined;
 }
 
-} // namespace openmoq::o_rly::stats
+} // namespace openmoq::moqx::stats

--- a/tests/MoqxRelayTest.cpp
+++ b/tests/MoqxRelayTest.cpp
@@ -6,6 +6,8 @@
  * Copyright (c) OpenMOQ contributors.
  */
 
+#include <moqx/MoqxRelay.h>
+
 #include <folly/coro/BlockingWait.h>
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/GMock.h>
@@ -15,7 +17,6 @@
 #include <moxygen/test/MockMoQSession.h>
 #include <moxygen/test/Mocks.h>
 #include <moxygen/test/TestUtils.h>
-#include <moqx/MoqxRelay.h>
 
 using namespace testing;
 using namespace moxygen;

--- a/tests/MoqxRelayTest.cpp
+++ b/tests/MoqxRelayTest.cpp
@@ -15,11 +15,11 @@
 #include <moxygen/test/MockMoQSession.h>
 #include <moxygen/test/Mocks.h>
 #include <moxygen/test/TestUtils.h>
-#include <o_rly/ORelay.h>
+#include <moqx/MoqxRelay.h>
 
 using namespace testing;
 using namespace moxygen;
-using namespace openmoq::o_rly;
+using namespace openmoq::moqx;
 
 namespace moxygen::test {
 
@@ -48,15 +48,15 @@ private:
   folly::EventBase evb_;
 };
 
-// Test fixture for ORelay tests
-// This provides a skeleton for testing ORelay functionality.
+// Test fixture for MoqxRelay tests
+// This provides a skeleton for testing MoqxRelay functionality.
 // Full integration tests with real sessions will be added when implementing
 // multi-publisher support.
 class MoQRelayTest : public ::testing::Test {
 protected:
   void SetUp() override {
     exec_ = std::make_shared<TestMoQExecutor>();
-    relay_ = std::make_shared<ORelay>(/*enableCache=*/false);
+    relay_ = std::make_shared<MoqxRelay>(/*enableCache=*/false);
     relay_->setAllowedNamespacePrefix(kAllowedPrefix);
   }
 
@@ -311,7 +311,7 @@ protected:
   }
 
   std::shared_ptr<TestMoQExecutor> exec_;
-  std::shared_ptr<ORelay> relay_;
+  std::shared_ptr<MoqxRelay> relay_;
 };
 
 // Test: Basic relay construction
@@ -323,7 +323,7 @@ TEST_F(MoQRelayTest, Construction) {
 TEST_F(MoQRelayTest, AllowedNamespacePrefix) {
   // This just verifies the relay can be constructed with a namespace prefix
   // More detailed testing requires full session setup
-  auto relay2 = std::make_shared<ORelay>(/*enableCache=*/true);
+  auto relay2 = std::make_shared<MoqxRelay>(/*enableCache=*/true);
   relay2->setAllowedNamespacePrefix(kTestNamespace);
   EXPECT_NE(relay2, nullptr);
 }

--- a/tests/ServiceMatcherTest.cpp
+++ b/tests/ServiceMatcherTest.cpp
@@ -1,8 +1,8 @@
-#include <o_rly/ServiceMatcher.h>
+#include <moqx/ServiceMatcher.h>
 
 #include <gtest/gtest.h>
 
-namespace openmoq::o_rly {
+namespace openmoq::moqx {
 namespace {
 
 using namespace config;
@@ -396,4 +396,4 @@ TEST(ServiceMatcher, AuthorityMatchButPathMismatchFallsToAny) {
 }
 
 } // namespace
-} // namespace openmoq::o_rly
+} // namespace openmoq::moqx

--- a/tests/config/config_resolver_test.cpp
+++ b/tests/config/config_resolver_test.cpp
@@ -1,9 +1,9 @@
-#include <o_rly/config/loader/config_resolver.h>
+#include <moqx/config/loader/config_resolver.h>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 namespace {
 
 using ::testing::HasSubstr;
@@ -789,4 +789,4 @@ TEST(ResolveConfig, AdminTlsCustomAlpn) {
 }
 
 } // namespace
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/tests/config/loader_test.cpp
+++ b/tests/config/loader_test.cpp
@@ -1,4 +1,4 @@
-#include <o_rly/config/loader/loader.h>
+#include <moqx/config/loader/loader.h>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -6,7 +6,7 @@
 
 #include "test_utils.h"
 
-namespace openmoq::o_rly::config {
+namespace openmoq::moqx::config {
 namespace {
 
 using test::TempYamlFile;
@@ -417,4 +417,4 @@ TEST(ConfigLoader, ExampleYamlValid) {
 #endif
 
 } // namespace
-} // namespace openmoq::o_rly::config
+} // namespace openmoq::moqx::config

--- a/tests/config/test_utils.h
+++ b/tests/config/test_utils.h
@@ -13,8 +13,8 @@ class TempYamlFile {
 public:
   explicit TempYamlFile(std::string_view content) {
     static std::atomic<int> counter{0};
-    path_ = std::filesystem::temp_directory_path() / ("moqx_test_" + std::to_string(::getpid()) +
-                                                      "_" + std::to_string(counter++) + ".yaml");
+    path_ = std::filesystem::temp_directory_path() /
+            ("moqx_test_" + std::to_string(::getpid()) + "_" + std::to_string(counter++) + ".yaml");
     std::ofstream ofs(path_);
     ofs << content;
   }

--- a/tests/config/test_utils.h
+++ b/tests/config/test_utils.h
@@ -6,14 +6,14 @@
 #include <string>
 #include <string_view>
 
-namespace openmoq::o_rly::config::test {
+namespace openmoq::moqx::config::test {
 
 // RAII helper: writes YAML content to a unique temp file, removes it on destruction.
 class TempYamlFile {
 public:
   explicit TempYamlFile(std::string_view content) {
     static std::atomic<int> counter{0};
-    path_ = std::filesystem::temp_directory_path() / ("o_rly_test_" + std::to_string(::getpid()) +
+    path_ = std::filesystem::temp_directory_path() / ("moqx_test_" + std::to_string(::getpid()) +
                                                       "_" + std::to_string(counter++) + ".yaml");
     std::ofstream ofs(path_);
     ofs << content;
@@ -29,4 +29,4 @@ private:
   std::filesystem::path path_;
 };
 
-} // namespace openmoq::o_rly::config::test
+} // namespace openmoq::moqx::config::test

--- a/tests/stats/BoundedHistogramTest.cpp
+++ b/tests/stats/BoundedHistogramTest.cpp
@@ -1,9 +1,9 @@
 #include <array>
 #include <gtest/gtest.h>
 
-#include <o_rly/stats/BoundedHistogram.h>
+#include <moqx/stats/BoundedHistogram.h>
 
-namespace openmoq::o_rly::stats {
+namespace openmoq::moqx::stats {
 
 class BoundedHistogramTest : public ::testing::Test {
 protected:
@@ -118,4 +118,4 @@ TEST_F(BoundedHistogramTest, ZeroValues) {
   EXPECT_EQ(hist.buckets[0], 3); // All go to first bucket
 }
 
-} // namespace openmoq::o_rly::stats
+} // namespace openmoq::moqx::stats

--- a/tests/test_admin_info.sh
+++ b/tests/test_admin_info.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BINARY="${1:-$(dirname "$0")/../build/o_rly}"
+BINARY="${1:-$(dirname "$0")/../build/moqx}"
 TESTDIR="$(cd "$(dirname "$0")" && pwd)"
 ADMIN_PORT=9669
 ADMIN_URL="http://localhost:${ADMIN_PORT}/info"
@@ -11,10 +11,10 @@ if [[ ! -x "$BINARY" ]]; then
   exit 1
 fi
 
-# Start o_rly with test config in the background.
+# Start moqx with test config in the background.
 "$BINARY" --config="$TESTDIR/test.config.yaml" &
-O_RLY_PID=$!
-trap 'kill "$O_RLY_PID" 2>/dev/null; wait "$O_RLY_PID" 2>/dev/null || true' EXIT
+MOQX_PID=$!
+trap 'kill "$MOQX_PID" 2>/dev/null; wait "$MOQX_PID" 2>/dev/null || true' EXIT
 
 # Wait for the admin server to become ready (up to 5 s).
 for i in $(seq 1 50); do
@@ -33,8 +33,8 @@ RESPONSE=$(curl -sf "$ADMIN_URL")
 echo "Response: $RESPONSE"
 
 # Validate expected fields.
-if ! echo "$RESPONSE" | grep -q '"service":"o-rly"'; then
-  echo "FAIL: missing \"service\":\"o-rly\" in response" >&2
+if ! echo "$RESPONSE" | grep -q '"service":"moqx"'; then
+  echo "FAIL: missing \"service\":\"moqx\" in response" >&2
   exit 1
 fi
 

--- a/tests/test_admin_metrics.sh
+++ b/tests/test_admin_metrics.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BINARY="${1:-$(dirname "$0")/../build/o_rly}"
+BINARY="${1:-$(dirname "$0")/../build/moqx}"
 TESTDIR="$(cd "$(dirname "$0")" && pwd)"
 ADMIN_PORT=9669
 METRICS_URL="http://localhost:${ADMIN_PORT}/metrics"
@@ -12,16 +12,16 @@ if [[ ! -x "$BINARY" ]]; then
   exit 1
 fi
 
-# Start o_rly with test config in the background.
+# Start moqx with test config in the background.
 "$BINARY" --config="$TESTDIR/test.config.yaml" &
-O_RLY_PID=$!
+MOQX_PID=$!
 
 # Cleanup function that ensures the process exits and port is released.
 cleanup() {
-  if [[ -n "${O_RLY_PID:-}" ]]; then
-    kill "$O_RLY_PID" 2>/dev/null || true
+  if [[ -n "${MOQX_PID:-}" ]]; then
+    kill "$MOQX_PID" 2>/dev/null || true
     # Wait for process to exit and ensure port is released
-    wait "$O_RLY_PID" 2>/dev/null || true
+    wait "$MOQX_PID" 2>/dev/null || true
   fi
 }
 trap cleanup EXIT
@@ -78,13 +78,13 @@ fi
 
 # Validate a representative set of expected metric names.
 EXPECTED_METRICS=(
-  "orly_moqActiveSessions"
-  "orly_pubActiveSubscriptions"
-  "orly_pubActivePublishers"
-  "orly_pubSubscribeSuccess_total"
-  "orly_moqPublishSuccess_total"
-  "orly_moqSubscribeLatency_microseconds"
-  "orly_moqFetchLatency_microseconds"
+  "moqx_moqActiveSessions"
+  "moqx_pubActiveSubscriptions"
+  "moqx_pubActivePublishers"
+  "moqx_pubSubscribeSuccess_total"
+  "moqx_moqPublishSuccess_total"
+  "moqx_moqSubscribeLatency_microseconds"
+  "moqx_moqFetchLatency_microseconds"
 )
 
 for metric in "${EXPECTED_METRICS[@]}"; do

--- a/tests/test_admin_tls.sh
+++ b/tests/test_admin_tls.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BINARY="${1:-$(dirname "$0")/../build/o_rly}"
+BINARY="${1:-$(dirname "$0")/../build/moqx}"
 TESTDIR="$(cd "$(dirname "$0")" && pwd)"
 ADMIN_PORT=9671
 LISTEN_PORT=9666
@@ -15,9 +15,9 @@ CERT="${TESTDIR}/test_cert.pem"
 KEY="${TESTDIR}/test_key.pem"
 
 TMPDIR=$(mktemp -d)
-O_RLY_PID=""
+MOQX_PID=""
 cleanup() {
-  [[ -n "$O_RLY_PID" ]] && kill "$O_RLY_PID" 2>/dev/null; wait "$O_RLY_PID" 2>/dev/null || true
+  [[ -n "$MOQX_PID" ]] && kill "$MOQX_PID" 2>/dev/null; wait "$MOQX_PID" 2>/dev/null || true
   rm -rf "$TMPDIR"
 }
 trap cleanup EXIT
@@ -53,7 +53,7 @@ EOF
 ADMIN_URL="https://localhost:${ADMIN_PORT}/info"
 
 "$BINARY" --config="$TMPDIR/config.yaml" &
-O_RLY_PID=$!
+MOQX_PID=$!
 
 # Wait up to 5s for the admin server to become ready.
 deadline=$(( $(date +%s) + 5 ))
@@ -68,8 +68,8 @@ done
 check_response() {
   local label="$1"
   local response="$2"
-  if ! echo "$response" | grep -q '"service":"o-rly"'; then
-    echo "FAIL [${label}]: missing \"service\":\"o-rly\" in response" >&2
+  if ! echo "$response" | grep -q '"service":"moqx"'; then
+    echo "FAIL [${label}]: missing \"service\":\"moqx\" in response" >&2
     exit 1
   fi
   echo "PASS [${label}]"


### PR DESCRIPTION
## Summary

Full rename of the relay project from o-rly to moqx across all code, build, Docker, workflows, and docs.

- C++: namespace, classes (MoqxRelay, MoqxRelayServer), include paths, metrics prefix
- CMake: project name, all targets and options
- Docker: binary path, env vars (MOQX_*), compose service name, image reference
- Workflows: artifact names, smoke test, deploy, email subjects
- 57 files changed, balanced insertions/deletions

After this merges, the GitHub repo rename (o-rly -> moqx) and moxygen cross-repo dispatch fix follow immediately.

## Test plan

- [ ] ci-pr passes (format, linux build+test, asan build+test)
- [ ] /info returns "service":"moqx"
- [ ] /metrics returns moqx_* prefixed metrics
- [ ] Docker smoke test passes with new binary name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/86)
<!-- Reviewable:end -->
