### PR TITLE
Fix missed ORLY_PLATFORM rename — Docker was downloading wrong tarball

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-SCRATCH_PATH="${ORLY_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
+SCRATCH_PATH="${MOQX_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
 PREFIX_PATH_FILE="${SCRATCH_PATH}/cmake_prefix_path.txt"
 
 BUILD_DIR=${1:-build}

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-SCRATCH="${ORLY_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
+SCRATCH="${MOQX_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
 MOXYGEN_DIR="${PROJECT_ROOT}/deps/moxygen"
 
 if [[ ! -e "$MOXYGEN_DIR/.git" ]]; then
@@ -60,7 +60,7 @@ detect_platform() {
     fi
 }
 
-PLATFORM="${ORLY_PLATFORM:-$(detect_platform)}"
+PLATFORM="${MOQX_PLATFORM:-$(detect_platform)}"
 echo "==> Platform: $PLATFORM"
 
 # ── Find publish run matching submodule SHA ───────────────────────────────────


### PR DESCRIPTION
## Summary

The rename PR missed `ORLY_PLATFORM` in `scripts/setup-deps-tarball.sh`.
CI sets `MOQX_PLATFORM=bookworm-amd64` but the script read `ORLY_PLATFORM`,
fell back to `detect_platform()` which returned `ubuntu-22.04-amd64`.

This caused the Docker publish to download the ubuntu tarball instead of
bookworm, leading to the glog ABI link failure.

Also fixes `ORLY_SCRATCH_PATH` in `setup-deps-tarball.sh` and `configure.sh`.

## Test plan

- [ ] CI passes
- [ ] Docker publish downloads bookworm tarball
- [ ] Docker build + deploy succeeds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/90)
<!-- Reviewable:end -->
