### PR TITLE
Clean up lingering o-rly references

### DIFF
--- a/cmake/Lint.cmake
+++ b/cmake/Lint.cmake
@@ -2,7 +2,7 @@
 find_program(CLANG_FORMAT clang-format)
 find_program(CLANG_TIDY clang-tidy)
 
-file(GLOB_RECURSE ORLY_LINT_SOURCES
+file(GLOB_RECURSE MOQX_LINT_SOURCES
   CONFIGURE_DEPENDS
   ${PROJECT_SOURCE_DIR}/include/*.h
   ${PROJECT_SOURCE_DIR}/include/*.hpp
@@ -19,7 +19,7 @@ file(GLOB_RECURSE ORLY_LINT_SOURCES
 
 if(CLANG_FORMAT)
   add_custom_target(format
-    COMMAND ${CLANG_FORMAT} -i ${ORLY_LINT_SOURCES}
+    COMMAND ${CLANG_FORMAT} -i ${MOQX_LINT_SOURCES}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     COMMENT "Running clang-format"
   )
@@ -27,7 +27,7 @@ endif()
 
 if(CLANG_TIDY)
   add_custom_target(lint
-    COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} ${ORLY_LINT_SOURCES}
+    COMMAND ${CLANG_TIDY} -p ${CMAKE_BINARY_DIR} ${MOQX_LINT_SOURCES}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     COMMENT "Running clang-tidy"
   )

--- a/design/configuration.example.yaml
+++ b/design/configuration.example.yaml
@@ -97,4 +97,4 @@ services:
       type: local-only
 
 services_include:
-  - /etc/o-rly/services.d/*.yaml
+  - /etc/moqx/services.d/*.yaml

--- a/scripts/config-schema-to-markdown.sh
+++ b/scripts/config-schema-to-markdown.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Generate markdown config reference from o-rly JSON schema on stdin.
-# Usage: o_rly dump-config-schema | scripts/gen-config-reference.sh
+# Generate markdown config reference from moqx JSON schema on stdin.
+# Usage: moqx dump-config-schema | scripts/gen-config-reference.sh
 set -euo pipefail
 
 if ! command -v jq &>/dev/null; then
@@ -11,7 +11,7 @@ fi
 SCHEMA=$(cat)
 
 cat <<'HEADER'
-# o-rly Configuration Reference
+# moqx Configuration Reference
 
 > Auto-generated from JSON schema. Do not edit manually.
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-IMAGE=${1:-o-rly-ubuntu20}
+IMAGE=${1:-moqx-ubuntu}
 
 docker build -t "${IMAGE}" -f "$PROJECT_ROOT"/docker/Dockerfile "$PROJECT_ROOT"

--- a/scripts/docker-shell.sh
+++ b/scripts/docker-shell.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMAGE=${1:-o-rly-ubuntu20}
+IMAGE=${1:-moqx-ubuntu}
 
 docker run --rm -it \
   -v "$(pwd)":/workspace \


### PR DESCRIPTION
## Summary

Missed in the rename PR:
- `cmake/Lint.cmake`: `ORLY_LINT_SOURCES` -> `MOQX_LINT_SOURCES`
- `design/configuration.example.yaml`: `/etc/o-rly/` -> `/etc/moqx/`
- `scripts/docker-build.sh`, `docker-shell.sh`: old image name
- `scripts/config-schema-to-markdown.sh`: old binary/project name

## Test plan
- [x] CI passes
- [x] `grep -r "o-rly\|o_rly\|ORLY_" . --include='*.sh' --include='*.cmake' --include='*.yaml'` returns nothing (excluding deps/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/94)
<!-- Reviewable:end -->
