### PR TITLE
Add --profile san support to from-source dep build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@
 #   --from-source   — build moxygen + all Meta deps from source (~15-30 min)
 #
 # Usage:
-#   ./scripts/build.sh setup [--from-release [SHA]|--from-source [SHA]] [--no-fallback] [--clean]
+#   ./scripts/build.sh setup [--from-release [SHA]|--from-source [SHA]] [--profile NAME] [--no-fallback] [--clean]
 #   ./scripts/build.sh [--profile NAME] [--build-dir DIR]
 #   ./scripts/build.sh test [--build-dir DIR] [-- CTEST_ARGS...]
 #
@@ -41,7 +41,7 @@ die() { echo "Error: $*" >&2; exit 1; }
 usage() {
   cat <<'EOF'
 Usage:
-  build.sh setup [--from-release [SHA]|--from-source [SHA]] [--no-fallback] [--clean]
+  build.sh setup [--from-release [SHA]|--from-source [SHA]] [--profile NAME] [--no-fallback] [--clean]
   build.sh [--profile NAME] [--build-dir DIR]
   build.sh test [--build-dir DIR] [-- CTEST_ARGS...]
 
@@ -57,6 +57,7 @@ Setup options:
                         Optional SHA overrides submodule commit
   --moxygen-dir DIR     Use a local moxygen directory instead of the submodule
                         (--from-source only; mutually exclusive with SHA)
+  --profile NAME        Build profile for deps: "default" or "san" (--from-source only)
   --no-fallback         Fail if requested mode unavailable (don't auto-switch)
   --clean               Remove .scratch and start fresh
 
@@ -189,6 +190,7 @@ checkout_submodule() {
 
 cmd_setup() {
   local mode="from-release"
+  local profile="default"
   local no_fallback=false
   local clean=false
   local target_sha=""
@@ -196,6 +198,7 @@ cmd_setup() {
 
   while (( $# > 0 )); do
     case "$1" in
+      --profile)     profile="$2"; shift 2 ;;
       --from-release)
         mode="from-release"; shift
         # Optional SHA argument (next arg that doesn't start with --)
@@ -270,7 +273,7 @@ cmd_setup() {
   if [[ "$mode" == "from-source" ]]; then
     echo ""
     echo "==> Setting up dependencies (from source)..."
-    bash "$SCRIPT_DIR/setup-deps-standalone.sh"
+    bash "$SCRIPT_DIR/setup-deps-standalone.sh" --profile "$profile"
     echo "from-source" > "$DEPS_MODE_FILE"
   fi
 
@@ -303,14 +306,20 @@ cmd_build() {
     esac
   fi
 
-  if [[ ! -f "$PREFIX_PATH_FILE" ]]; then
+  # Use profile-specific prefix path if available, fall back to default
+  local prefix_path_file="$PREFIX_PATH_FILE"
+  if [[ "$profile" != "default" && -f "${SCRATCH}/cmake_prefix_path-${profile}.txt" ]]; then
+    prefix_path_file="${SCRATCH}/cmake_prefix_path-${profile}.txt"
+  fi
+
+  if [[ ! -f "$prefix_path_file" ]]; then
     die "Dependencies not set up. Run: ./scripts/build.sh setup"
   fi
 
   check_submodule
 
   local prefix_path
-  prefix_path=$(cat "$PREFIX_PATH_FILE")
+  prefix_path=$(cat "$prefix_path_file")
 
   local nproc
   nproc=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)

--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -22,8 +22,24 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCRATCH="${MOQX_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
 MOXYGEN_DIR="${MOQX_MOXYGEN_DIR:-${PROJECT_ROOT}/deps/moxygen}"
 STANDALONE_SRC="${MOXYGEN_DIR}/standalone"
-BUILD_DIR="${SCRATCH}/standalone-build"
-INSTALL_DIR="${SCRATCH}/moxygen-install"
+
+PROFILE="default"
+while (( $# > 0 )); do
+  case "$1" in
+    --profile) PROFILE="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ "$PROFILE" == "default" ]]; then
+  BUILD_DIR="${SCRATCH}/standalone-build"
+  INSTALL_DIR="${SCRATCH}/moxygen-install"
+  PREFIX_PATH_FILE="${SCRATCH}/cmake_prefix_path.txt"
+else
+  BUILD_DIR="${SCRATCH}/standalone-build-${PROFILE}"
+  INSTALL_DIR="${SCRATCH}/moxygen-install-${PROFILE}"
+  PREFIX_PATH_FILE="${SCRATCH}/cmake_prefix_path-${PROFILE}.txt"
+fi
 
 if [[ -z "${MOQX_MOXYGEN_DIR:-}" ]] && [[ ! -e "$MOXYGEN_DIR/.git" ]]; then
     echo "Error: deps/moxygen submodule not initialized." >&2
@@ -38,14 +54,32 @@ fi
 
 NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 
-echo "==> Configuring standalone moxygen build..."
+# Profile-specific cmake flags
+CMAKE_BUILD_TYPE="RelWithDebInfo"
+EXTRA_CMAKE_ARGS=()
+if [[ "$PROFILE" == "san" ]]; then
+  CMAKE_BUILD_TYPE="Debug"
+  # ASAN only (no UBSAN): folly uses static_assert on syscall function addresses
+  # (recvmmsg, sendmmsg) which become non-constant under UBSAN's function
+  # interposition. ASAN alone is sufficient for memory safety in deps.
+  SAN_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+  EXTRA_CMAKE_ARGS+=(
+    "-DCMAKE_C_FLAGS=${SAN_FLAGS}"
+    "-DCMAKE_CXX_FLAGS=${SAN_FLAGS}"
+    "-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address"
+    "-DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=address"
+  )
+fi
+
+echo "==> Configuring standalone moxygen build (profile: ${PROFILE})..."
 cmake -S "$STANDALONE_SRC" -B "$BUILD_DIR" \
     -G Ninja \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
     -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
     -DINSTALL_DEPS=ON \
     -DBUILD_TESTS=OFF \
-    -DBUILD_SHARED_LIBS=OFF
+    -DBUILD_SHARED_LIBS=OFF \
+    "${EXTRA_CMAKE_ARGS[@]+"${EXTRA_CMAKE_ARGS[@]}"}"
 
 echo "==> Building ($NPROC jobs)..."
 cmake --build "$BUILD_DIR" -j"$NPROC"
@@ -57,7 +91,7 @@ cmake --install "$BUILD_DIR"
 # ── Write cmake_prefix_path.txt ───────────────────────────────────────────────
 
 mkdir -p "$SCRATCH"
-echo "$INSTALL_DIR" > "${SCRATCH}/cmake_prefix_path.txt"
+echo "$INSTALL_DIR" > "$PREFIX_PATH_FILE"
 
 echo "from-source" > "${SCRATCH}/deps-mode"
 


### PR DESCRIPTION
Passes --profile to setup-deps-standalone.sh, which uses a separate build/install dir (standalone-build-san, moxygen-install-san) and compiles deps with ASAN. UBSAN is excluded from deps because folly's static_assert on ::recvmmsg/::sendmmsg becomes non-constant under UBSAN's function interposition. The moqx san preset retains full ASAN+UBSAN as before.

cmd_build prefers cmake_prefix_path-<profile>.txt when present, falling back to the default prefix path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/98)
<!-- Reviewable:end -->
