### PR TITLE
Remove deps/moxygen usage from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,15 +156,23 @@ if(MOQX_BUILD_TESTS)
   enable_testing()
   find_package(GTest REQUIRED CONFIG)
 
+  add_library(moqx_test_utils STATIC
+    tests/TestUtils.cpp
+  )
+  target_include_directories(moqx_test_utils PUBLIC
+    ${PROJECT_SOURCE_DIR}/tests
+  )
+  target_link_libraries(moqx_test_utils PUBLIC
+    Folly::folly_io_iobuf
+    Folly::folly_random
+  )
+
   add_executable(moqx_relay_test
     tests/MoqxRelayTest.cpp
-    ${PROJECT_SOURCE_DIR}/deps/moxygen/moxygen/test/TestUtils.cpp
-  )
-  target_include_directories(moqx_relay_test PRIVATE
-    ${PROJECT_SOURCE_DIR}/deps/moxygen
   )
   target_link_libraries(moqx_relay_test PRIVATE
     moqx_core
+    moqx_test_utils
     moxygen::moxygen_events_moq_folly_executor_impl
     GTest::gtest_main
     GTest::gmock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,15 +167,23 @@ if(MOQX_BUILD_TESTS)
     Folly::folly_random
   )
 
+  add_library(moqx_test_main STATIC
+    tests/TestMain.cpp
+  )
+  target_link_libraries(moqx_test_main PUBLIC
+    Folly::folly_init_init
+    GTest::gtest
+  )
+
   add_executable(moqx_relay_test
     tests/MoqxRelayTest.cpp
   )
   target_link_libraries(moqx_relay_test PRIVATE
     moqx_core
     moqx_test_utils
-    moxygen::moxygen_events_moq_folly_executor_impl
-    GTest::gtest_main
+    moqx_test_main
     GTest::gmock
+    moxygen::moxygen_events_moq_folly_executor_impl
   )
   include(GoogleTest)
   gtest_discover_tests(moqx_relay_test)

--- a/scripts/sync-relay.sh
+++ b/scripts/sync-relay.sh
@@ -174,6 +174,9 @@ process_test() {
   # Replace MoQRelay include with MoqxRelay
   sed -i 's|#include <moxygen/relay/MoQRelay\.h>|#include <moqx/MoqxRelay.h>|g' "$tmp"
 
+  # Use moqx's own TestUtils instead of moxygen's
+  sed -i 's|#include <moxygen/test/TestUtils\.h>|#include "TestUtils.h"|g' "$tmp"
+
   # Relay class under test
   sed -i 's/\bMoQRelay\b/MoqxRelay/g' "$tmp"
 
@@ -181,6 +184,9 @@ process_test() {
   # The test lives in namespace moxygen::test, but globals defined before that
   # namespace block need explicit usings.
   sed -i 's/^using namespace testing;$/using namespace testing;\nusing namespace moxygen;\nusing namespace openmoq::moqx;/' "$tmp"
+
+  # Bring makeBuf into scope inside namespace moxygen::test
+  sed -i 's/^namespace moxygen::test {$/namespace moxygen::test {\n\nusing openmoq::moqx::test::makeBuf;/' "$tmp"
 
   cp "$tmp" "$dst"
 }

--- a/tests/MoqxRelayTest.cpp
+++ b/tests/MoqxRelayTest.cpp
@@ -8,6 +8,7 @@
 
 #include <moqx/MoqxRelay.h>
 
+#include "TestUtils.h"
 #include <folly/coro/BlockingWait.h>
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/GMock.h>
@@ -16,13 +17,14 @@
 #include <moxygen/relay/MoQForwarder.h>
 #include <moxygen/test/MockMoQSession.h>
 #include <moxygen/test/Mocks.h>
-#include <moxygen/test/TestUtils.h>
 
 using namespace testing;
 using namespace moxygen;
 using namespace openmoq::moqx;
 
 namespace moxygen::test {
+
+using openmoq::moqx::test::makeBuf;
 
 const TrackNamespace kTestNamespace{{"test", "namespace"}};
 const TrackNamespace kAllowedPrefix{{"test"}};

--- a/tests/TestMain.cpp
+++ b/tests/TestMain.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/init/Init.h>
+#include <folly/portability/GFlags.h>
+#include <folly/portability/GTest.h>
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, true);
+  return RUN_ALL_TESTS();
+}

--- a/tests/TestUtils.cpp
+++ b/tests/TestUtils.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "TestUtils.h"
+
+#include <folly/Random.h>
+#include <folly/io/Cursor.h>
+
+namespace openmoq::moqx::test {
+
+std::unique_ptr<folly::IOBuf> makeBuf(uint32_t size) {
+  auto out = folly::IOBuf::create(size);
+  out->append(size);
+  folly::io::RWPrivateCursor cursor(out.get());
+  while (cursor.length() >= 8) {
+    cursor.write<uint64_t>(folly::Random::rand64());
+  }
+  while (cursor.length()) {
+    cursor.write<uint8_t>((uint8_t)folly::Random::rand32());
+  }
+  return out;
+}
+
+} // namespace openmoq::moqx::test

--- a/tests/TestUtils.h
+++ b/tests/TestUtils.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/io/IOBuf.h>
+
+#include <cstdint>
+#include <memory>
+
+namespace openmoq::moqx::test {
+
+std::unique_ptr<folly::IOBuf> makeBuf(uint32_t size = 10);
+
+} // namespace openmoq::moqx::test


### PR DESCRIPTION
This can be overridden at build time so can't use directly.

Just copy TestMain and the makeBuf util from moxygen into our repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/101)
<!-- Reviewable:end -->
