### PR TITLE
Create IOThreadPoolExecutor in main and wire into MoqxRelayServer

### DIFF
--- a/include/moqx/MoqxRelayServer.h
+++ b/include/moqx/MoqxRelayServer.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <folly/executors/IOThreadPoolExecutor.h>
 #include <moqx/MoqxRelay.h>
 #include <moqx/ServiceMatcher.h>
 #include <moqx/UpstreamProvider.h>
@@ -21,7 +22,8 @@ public:
       const std::string& endpoint,
       const std::string& versions,
       folly::F14FastMap<std::string, config::ServiceConfig> services,
-      const std::string& relayID = {}
+      const std::string& relayID,
+      std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
   );
 
   // Used when the insecure flag is true
@@ -29,7 +31,8 @@ public:
       const std::string& endpoint,
       const std::string& versions,
       folly::F14FastMap<std::string, config::ServiceConfig> services,
-      const std::string& relayID = {}
+      const std::string& relayID,
+      std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
   );
 
   ~MoqxRelayServer() override;
@@ -38,10 +41,7 @@ public:
 
   // Binds listeners then initialises per-service upstream providers (requires
   // draft 16+ for relay chaining).
-  void start(const folly::SocketAddress& addr) {
-    MoQServer::start(addr);
-    initUpstreams();
-  }
+  void start(const folly::SocketAddress& addr) override;
 
   void onNewSession(std::shared_ptr<moxygen::MoQSession> clientSession) override;
 
@@ -73,6 +73,7 @@ private:
   folly::F14FastMap<std::string, ServiceEntry> services_;
   ServiceMatcher serviceMatcher_;
   std::string relayID_;
+  std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
   std::shared_ptr<stats::StatsRegistry> statsRegistry_;
   std::shared_ptr<stats::MoQStatsCollector> statsCollector_;
 };

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -47,7 +47,8 @@ MoqxRelayServer::MoqxRelayServer(
     const std::string& endpoint,
     const std::string& versions,
     folly::F14FastMap<std::string, config::ServiceConfig> services,
-    const std::string& relayID
+    const std::string& relayID,
+    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
 )
     : MoQServer(
           quic::samples::createFizzServerContext(
@@ -58,7 +59,7 @@ MoqxRelayServer::MoqxRelayServer(
           ),
           endpoint
       ),
-      serviceMatcher_(services), relayID_(relayID) {
+      serviceMatcher_(services), relayID_(relayID), ioExecutor_(std::move(ioExecutor)) {
   initServices(services, relayID);
 }
 
@@ -66,7 +67,8 @@ MoqxRelayServer::MoqxRelayServer(
     const std::string& endpoint,
     const std::string& versions,
     folly::F14FastMap<std::string, config::ServiceConfig> services,
-    const std::string& relayID
+    const std::string& relayID,
+    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
 )
     : MoQServer(
           quic::samples::createFizzServerContextWithInsecureDefault(
@@ -77,7 +79,7 @@ MoqxRelayServer::MoqxRelayServer(
           ),
           endpoint
       ),
-      serviceMatcher_(services), relayID_(relayID) {
+      serviceMatcher_(services), relayID_(relayID), ioExecutor_(std::move(ioExecutor)) {
   initServices(services, relayID);
 }
 
@@ -90,6 +92,17 @@ MoqxRelayServer::~MoqxRelayServer() {
   // 2. Close incoming connections, drain worker EVBs (terminateClientSession
   //    and ~MoQSession complete here), then destroy EVBs.
   MoQServer::stop();
+}
+
+void MoqxRelayServer::start(const folly::SocketAddress& addr) {
+  auto evbKAs = ioExecutor_->getAllEventBases();
+  std::vector<folly::EventBase*> evbs;
+  evbs.reserve(evbKAs.size());
+  for (auto& ka : evbKAs) {
+    evbs.push_back(ka.get());
+  }
+  MoQServer::start(addr, std::move(evbs));
+  initUpstreams();
 }
 
 void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,8 @@
 #include <chrono>
 #include <thread>
 
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <folly/init/Init.h>
 #include <folly/io/async/AsyncSignalHandler.h>
 #include <folly/logging/xlog.h>
@@ -39,7 +41,8 @@ public:
   }
 };
 
-std::shared_ptr<openmoq::moqx::MoqxRelayServer> createServer(const cfg::Config& config) {
+std::shared_ptr<openmoq::moqx::MoqxRelayServer>
+createServer(const cfg::Config& config, std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor) {
   const auto& listener = config.listener;
   auto services = config.services; // copy for move into constructor
 
@@ -51,7 +54,8 @@ std::shared_ptr<openmoq::moqx::MoqxRelayServer> createServer(const cfg::Config& 
               listener.endpoint,
               listener.moqtVersions,
               std::move(services),
-              config.relayID
+              config.relayID,
+              ioExecutor
           );
         } else {
           return std::make_shared<openmoq::moqx::MoqxRelayServer>(
@@ -60,7 +64,8 @@ std::shared_ptr<openmoq::moqx::MoqxRelayServer> createServer(const cfg::Config& 
               listener.endpoint,
               listener.moqtVersions,
               std::move(services),
-              config.relayID
+              config.relayID,
+              ioExecutor
           );
         }
       },
@@ -112,7 +117,10 @@ int main(int argc, char* argv[]) {
   ShutdownSignalHandler signalHandler(&evb);
 
   // === 4. Initialize resources ===
-  // TODO: thread pools, event loops, IO contexts
+  auto ioExecutor = std::make_shared<folly::IOThreadPoolExecutor>(
+      1,
+      std::make_shared<folly::NamedThreadFactory>("moqx-io")
+  );
 
   // === 5. Initialize dependencies ===
   // TODO: TBD
@@ -120,7 +128,7 @@ int main(int argc, char* argv[]) {
   // === 6. Initialize services ===
   // Construct and configure the application's own services
   // (MoqxRelayServer, MoqxRelay, etc.)
-  auto server = createServer(config);
+  auto server = createServer(config, ioExecutor);
 
   // === 6a. Stats registry ===
   auto statsRegistry = std::make_shared<openmoq::moqx::stats::StatsRegistry>();


### PR DESCRIPTION
Owns the IO thread pool at the top level (main) so lifecycle and thread-count configuration live in one place. MoqxRelayServer now accepts a shared_ptr<IOThreadPoolExecutor>, extracts worker EVBs, and passes them to MoQServer::start() — bypassing the internal single-thread pool that HQServer would otherwise create.

Hardcoded to 1 thread for now; Phase 2 will add a config field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/108)
<!-- Reviewable:end -->
