### PR TITLE
Config for number of threads, multiple listeners

### DIFF
--- a/include/moqx/config/config.h
+++ b/include/moqx/config/config.h
@@ -81,7 +81,7 @@ struct AdminConfig {
 };
 
 struct Config {
-  ListenerConfig listener;
+  std::vector<ListenerConfig> listeners;
   folly::F14FastMap<std::string, ServiceConfig> services;
   std::optional<AdminConfig> admin;
   std::string relayID; // always set: from config or randomly generated

--- a/include/moqx/config/config.h
+++ b/include/moqx/config/config.h
@@ -85,6 +85,7 @@ struct Config {
   folly::F14FastMap<std::string, ServiceConfig> services;
   std::optional<AdminConfig> admin;
   std::string relayID; // always set: from config or randomly generated
+  uint32_t threads{1};
 };
 
 } // namespace openmoq::moqx::config

--- a/include/moqx/config/loader/parsed_config.h
+++ b/include/moqx/config/loader/parsed_config.h
@@ -146,6 +146,7 @@ struct ParsedConfig {
       "Relay identity string (optional; random string generated if absent)",
       std::optional<std::string>>
       relay_id;
+  rfl::Description<"Number of IO worker threads (default: 1)", std::optional<uint32_t>> threads;
 };
 
 } // namespace openmoq::moqx::config

--- a/src/config/config_resolver.cpp
+++ b/src/config/config_resolver.cpp
@@ -422,15 +422,18 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
   if (config.listeners.value().empty()) {
     return folly::makeUnexpected(std::string("At least one listener is required"));
   }
-  if (config.listeners.value().size() > 1) {
-    return folly::makeUnexpected(
-        "Currently only one listener is supported, got " +
-        std::to_string(config.listeners.value().size())
-    );
-  }
 
-  const auto& listener = config.listeners.value()[0];
-  validateListener(listener, errors, warnings);
+  {
+    std::unordered_set<std::string> listenerAddrs;
+    for (const auto& listener : config.listeners.value()) {
+      validateListener(listener, errors, warnings);
+      auto addr = listener.udp.value().socket.value().address.value() + ":" +
+                  std::to_string(listener.udp.value().socket.value().port.value());
+      if (!listenerAddrs.insert(addr).second) {
+        errors.push_back("Duplicate listener address: " + addr);
+      }
+    }
+  }
 
   // === Validate admin ===
   validateAdmin(config, errors);
@@ -491,7 +494,15 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
   return ResolvedConfig{
       .config =
           Config{
-              .listener = resolveListener(listener),
+              .listeners =
+                  [&] {
+                    std::vector<ListenerConfig> v;
+                    v.reserve(config.listeners.value().size());
+                    for (const auto& l : config.listeners.value()) {
+                      v.push_back(resolveListener(l));
+                    }
+                    return v;
+                  }(),
               .services = std::move(resolvedServices),
               .admin = std::move(adminConfig),
               .relayID = std::move(relayID),

--- a/src/config/config_resolver.cpp
+++ b/src/config/config_resolver.cpp
@@ -450,6 +450,14 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
     validateService(name, svc, config, compositeKeys, mergedCaches, errors);
   }
 
+  // === Validate threads ===
+  const uint32_t threads = config.threads.value().value_or(1);
+  if (threads == 0) {
+    errors.push_back("threads must be >= 1");
+  } else if (threads > 1) {
+    errors.push_back("threads > 1 is not yet supported");
+  }
+
   if (!errors.empty()) {
     return folly::makeUnexpected("Config validation failed:\n  - " + folly::join("\n  - ", errors));
   }
@@ -487,6 +495,7 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
               .services = std::move(resolvedServices),
               .admin = std::move(adminConfig),
               .relayID = std::move(relayID),
+              .threads = threads,
           },
       .warnings = std::move(warnings),
   };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,7 @@ int main(int argc, char* argv[]) {
 
   // === 4. Initialize resources ===
   auto ioExecutor = std::make_shared<folly::IOThreadPoolExecutor>(
-      1,
+      config.threads,
       std::make_shared<folly::NamedThreadFactory>("moqx-io")
   );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ public:
 
 std::shared_ptr<openmoq::moqx::MoqxRelayServer>
 createServer(const cfg::Config& config, std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor) {
-  const auto& listener = config.listener;
+  const auto& listener = config.listeners[0];
   auto services = config.services; // copy for move into constructor
 
   return std::visit(
@@ -147,7 +147,7 @@ int main(int argc, char* argv[]) {
   }
 
   // === 8. Start serving ===
-  server->start(config.listener.address);
+  server->start(config.listeners[0].address);
   evb.loopForever();
 
   // Hard shutdown watchdog: if teardown hangs, force-exit after 10 seconds.

--- a/tests/config/config_resolver_test.cpp
+++ b/tests/config/config_resolver_test.cpp
@@ -377,11 +377,11 @@ TEST(ResolveConfig, MinimalInsecure) {
   ASSERT_TRUE(result.hasValue());
   const auto& resolved = result.value().config;
 
-  EXPECT_EQ(resolved.listener.name, "main");
-  EXPECT_EQ(resolved.listener.address.getPort(), 9668);
-  EXPECT_TRUE(std::holds_alternative<Insecure>(resolved.listener.tlsMode));
-  EXPECT_EQ(resolved.listener.endpoint, "/moq-relay");
-  EXPECT_EQ(resolved.listener.moqtVersions, "");
+  EXPECT_EQ(resolved.listeners[0].name, "main");
+  EXPECT_EQ(resolved.listeners[0].address.getPort(), 9668);
+  EXPECT_TRUE(std::holds_alternative<Insecure>(resolved.listeners[0].tlsMode));
+  EXPECT_EQ(resolved.listeners[0].endpoint, "/moq-relay");
+  EXPECT_EQ(resolved.listeners[0].moqtVersions, "");
   EXPECT_THAT(result.value().warnings, IsEmpty());
 
   ASSERT_EQ(resolved.services.size(), 1);
@@ -414,13 +414,13 @@ TEST(ResolveConfig, FullTls) {
   ASSERT_TRUE(result.hasValue());
   const auto& resolved = result.value().config;
 
-  EXPECT_EQ(resolved.listener.name, "production");
-  EXPECT_EQ(resolved.listener.address.getPort(), 4443);
-  EXPECT_EQ(resolved.listener.endpoint, "/relay");
-  EXPECT_EQ(resolved.listener.moqtVersions, "14,16");
+  EXPECT_EQ(resolved.listeners[0].name, "production");
+  EXPECT_EQ(resolved.listeners[0].address.getPort(), 4443);
+  EXPECT_EQ(resolved.listeners[0].endpoint, "/relay");
+  EXPECT_EQ(resolved.listeners[0].moqtVersions, "14,16");
 
-  ASSERT_TRUE(std::holds_alternative<TlsConfig>(resolved.listener.tlsMode));
-  const auto& creds = std::get<TlsConfig>(resolved.listener.tlsMode);
+  ASSERT_TRUE(std::holds_alternative<TlsConfig>(resolved.listeners[0].tlsMode));
+  const auto& creds = std::get<TlsConfig>(resolved.listeners[0].tlsMode);
   EXPECT_EQ(creds.certFile, "/etc/ssl/cert.pem");
   EXPECT_EQ(creds.keyFile, "/etc/ssl/key.pem");
 }
@@ -649,7 +649,7 @@ TEST(ResolveConfig, VersionsEmpty) {
   auto cfg = makeMinimalInsecureConfig();
   auto result = resolveConfig(cfg);
   ASSERT_TRUE(result.hasValue());
-  EXPECT_EQ(result.value().config.listener.moqtVersions, "");
+  EXPECT_EQ(result.value().config.listeners[0].moqtVersions, "");
 }
 
 TEST(ResolveConfig, VersionsPopulated) {
@@ -657,7 +657,7 @@ TEST(ResolveConfig, VersionsPopulated) {
   cfg.listeners.value()[0].moqt_versions = std::vector<uint32_t>{14};
   auto result = resolveConfig(cfg);
   ASSERT_TRUE(result.hasValue());
-  EXPECT_EQ(result.value().config.listener.moqtVersions, "14");
+  EXPECT_EQ(result.value().config.listeners[0].moqtVersions, "14");
 }
 
 TEST(ResolveConfig, AddressResolution) {
@@ -668,8 +668,8 @@ TEST(ResolveConfig, AddressResolution) {
   auto result = resolveConfig(cfg);
   ASSERT_TRUE(result.hasValue());
   const auto& resolved = result.value().config;
-  EXPECT_EQ(resolved.listener.address.getPort(), 8080);
-  EXPECT_EQ(resolved.listener.address.getAddressStr(), "127.0.0.1");
+  EXPECT_EQ(resolved.listeners[0].address.getPort(), 8080);
+  EXPECT_EQ(resolved.listeners[0].address.getAddressStr(), "127.0.0.1");
 }
 
 // --- Admin validation tests ---
@@ -911,6 +911,74 @@ TEST(ResolveConfig, ThreadsGreaterThanOneRejected) {
   auto result = resolveConfig(cfg);
   ASSERT_TRUE(result.hasError());
   EXPECT_THAT(result.error(), HasSubstr("threads > 1 is not yet supported"));
+}
+
+// --- multiple listeners tests ---
+
+TEST(ResolveConfig, MultipleListeners) {
+  auto cfg = makeMinimalInsecureConfig("first");
+
+  ParsedListenerConfig lc2;
+  lc2.name = std::string("second");
+  ParsedSocketConfig sock2;
+  sock2.address = std::string("::");
+  sock2.port = uint16_t{9669};
+  ParsedUdpConfig udp2;
+  udp2.socket = std::move(sock2);
+  lc2.udp = std::move(udp2);
+  ParsedListenerTlsConfig tls2;
+  tls2.insecure = true;
+  lc2.tls = std::move(tls2);
+  lc2.endpoint = std::string("/moq-relay");
+  cfg.listeners.value().push_back(std::move(lc2));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_EQ(result.value().config.listeners.size(), 2u);
+  EXPECT_EQ(result.value().config.listeners[0].name, "first");
+  EXPECT_EQ(result.value().config.listeners[0].address.getPort(), 9668);
+  EXPECT_EQ(result.value().config.listeners[1].name, "second");
+  EXPECT_EQ(result.value().config.listeners[1].address.getPort(), 9669);
+}
+
+TEST(ResolveConfig, MultipleListenersDuplicateAddress) {
+  auto cfg = makeMinimalInsecureConfig("first");
+
+  ParsedListenerConfig lc2;
+  lc2.name = std::string("second");
+  lc2.udp = cfg.listeners.value()[0].udp; // same address as first
+  ParsedListenerTlsConfig tls2;
+  tls2.insecure = true;
+  lc2.tls = std::move(tls2);
+  lc2.endpoint = std::string("/moq-relay");
+  cfg.listeners.value().push_back(std::move(lc2));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("Duplicate listener address"));
+}
+
+TEST(ResolveConfig, MultipleListenersInvalidPort) {
+  auto cfg = makeMinimalInsecureConfig("first");
+
+  ParsedListenerConfig lc2;
+  lc2.name = std::string("bad");
+  ParsedSocketConfig sock2;
+  sock2.address = std::string("::");
+  sock2.port = uint16_t{0};
+  ParsedUdpConfig udp2;
+  udp2.socket = std::move(sock2);
+  lc2.udp = std::move(udp2);
+  ParsedListenerTlsConfig tls2;
+  tls2.insecure = true;
+  lc2.tls = std::move(tls2);
+  lc2.endpoint = std::string("/moq-relay");
+  cfg.listeners.value().push_back(std::move(lc2));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("bad"));
+  EXPECT_THAT(result.error(), HasSubstr("port"));
 }
 
 } // namespace

--- a/tests/config/config_resolver_test.cpp
+++ b/tests/config/config_resolver_test.cpp
@@ -880,5 +880,38 @@ TEST(ResolveConfig, RelayIDExplicitPreserved) {
   EXPECT_EQ(result.value().config.relayID, "my-relay-1");
 }
 
+// --- threads tests ---
+
+TEST(ResolveConfig, ThreadsAbsentDefaultsToOne) {
+  auto cfg = makeMinimalInsecureConfig();
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(result.value().config.threads, 1u);
+}
+
+TEST(ResolveConfig, ThreadsExplicitOneAccepted) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.threads = std::optional<uint32_t>{1};
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(result.value().config.threads, 1u);
+}
+
+TEST(ResolveConfig, ThreadsZeroRejected) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.threads = std::optional<uint32_t>{0};
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("threads must be >= 1"));
+}
+
+TEST(ResolveConfig, ThreadsGreaterThanOneRejected) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.threads = std::optional<uint32_t>{2};
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("threads > 1 is not yet supported"));
+}
+
 } // namespace
 } // namespace openmoq::moqx::config


### PR DESCRIPTION
This adds the config options for the number of I/O threads (currently capped at 1) and also allows > 1 listener, but only starts the first.  Follow up diffs will actually start all the listeners.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/109)
<!-- Reviewable:end -->
