### PR TITLE
Server layer: MoqxRelayContext + N servers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ FetchContent_MakeAvailable(reflectcpp)
 
 add_library(moqx_core STATIC
   src/MoqxRelay.cpp
+  src/MoqxRelayContext.cpp
   src/MoqxRelayServer.cpp
   src/ServiceMatcher.cpp
   src/admin/AdminServer.cpp
@@ -256,6 +257,18 @@ if(MOQX_BUILD_TESTS)
     GTest::gmock
   )
   gtest_discover_tests(moqx_service_matcher_test)
+
+  add_executable(moqx_relay_context_test
+    tests/MoqxRelayContextTest.cpp
+  )
+  target_link_libraries(moqx_relay_context_test PRIVATE
+    moqx_core
+    moqx_test_utils
+    moqx_test_main
+    GTest::gmock
+    moxygen::moxygen_events_moq_folly_executor_impl
+  )
+  gtest_discover_tests(moqx_relay_context_test)
 
   add_test(
     NAME relay_chain

--- a/include/moqx/MoqxRelayContext.h
+++ b/include/moqx/MoqxRelayContext.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <memory>
+
+#include <moqx/MoqxRelay.h>
+#include <moqx/ServiceMatcher.h>
+#include <moqx/UpstreamProvider.h>
+#include <moqx/config/config.h>
+#include <moqx/stats/MoQStatsCollector.h>
+#include <moqx/stats/StatsRegistry.h>
+#include <moxygen/MoQServerBase.h>
+#include <moxygen/MoQSession.h>
+
+#include <folly/Expected.h>
+#include <folly/container/F14Map.h>
+#include <folly/io/async/EventBase.h>
+
+namespace openmoq::moqx {
+
+// Holds relay state shared across all listener instances.
+// A single MoqxRelayContext is shared by every MoqxRelayServer so that
+// publishers and subscribers connecting on different listeners can exchange
+// data through the same MoqxRelay instances.
+class MoqxRelayContext {
+public:
+  struct ServiceEntry {
+    config::ServiceConfig config;
+    std::shared_ptr<MoqxRelay> relay;
+  };
+
+  MoqxRelayContext(
+      const folly::F14FastMap<std::string, config::ServiceConfig>& services,
+      const std::string& relayID
+  );
+
+  void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
+
+  // Must be called once, after all MoqxRelayServer instances have been started,
+  // so that worker EVBs are available. workerEvb is used for upstream connections.
+  void initUpstreams(folly::EventBase* workerEvb);
+
+  // Signals all relay upstreams to stop. Call before destroying servers so
+  // reconnect coroutines can exit before worker EVBs are drained.
+  void stop();
+
+  // --- Delegation targets for MoqxRelayServer virtual overrides ---
+
+  void onNewSession(std::shared_ptr<moxygen::MoQSession> session);
+  void onSessionEnd();
+
+  folly::Expected<folly::Unit, moxygen::SessionCloseErrorCode> validateAuthority(
+      const moxygen::ClientSetup& clientSetup,
+      uint64_t negotiatedVersion,
+      std::shared_ptr<moxygen::MoQSession> session
+  );
+
+private:
+  folly::F14FastMap<std::string, ServiceEntry> services_;
+  ServiceMatcher serviceMatcher_;
+  std::string relayID_;
+  std::shared_ptr<stats::StatsRegistry> statsRegistry_;
+  std::shared_ptr<stats::MoQStatsCollector> statsCollector_;
+};
+
+} // namespace openmoq::moqx

--- a/include/moqx/MoqxRelayServer.h
+++ b/include/moqx/MoqxRelayServer.h
@@ -3,11 +3,8 @@
 #include <memory>
 
 #include <folly/executors/IOThreadPoolExecutor.h>
-#include <moqx/MoqxRelay.h>
-#include <moqx/ServiceMatcher.h>
-#include <moqx/UpstreamProvider.h>
+#include <moqx/MoqxRelayContext.h>
 #include <moqx/config/config.h>
-#include <moqx/stats/MoQStatsCollector.h>
 #include <moqx/stats/StatsRegistry.h>
 #include <moxygen/MoQServer.h>
 
@@ -15,23 +12,9 @@ namespace openmoq::moqx {
 
 class MoqxRelayServer : public moxygen::MoQServer {
 public:
-  // Used when the insecure flag is false
   MoqxRelayServer(
-      const std::string& cert,
-      const std::string& key,
-      const std::string& endpoint,
-      const std::string& versions,
-      folly::F14FastMap<std::string, config::ServiceConfig> services,
-      const std::string& relayID,
-      std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
-  );
-
-  // Used when the insecure flag is true
-  MoqxRelayServer(
-      const std::string& endpoint,
-      const std::string& versions,
-      folly::F14FastMap<std::string, config::ServiceConfig> services,
-      const std::string& relayID,
+      const config::ListenerConfig& listenerCfg,
+      std::shared_ptr<MoqxRelayContext> context,
       std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
   );
 
@@ -39,8 +22,10 @@ public:
 
   void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
 
-  // Binds listeners then initialises per-service upstream providers (requires
-  // draft 16+ for relay chaining).
+  // Preferred entry point: binds the address from the stored ListenerConfig.
+  void start();
+
+  // Satisfies MoQServerBase pure virtual; delegates to start().
   void start(const folly::SocketAddress& addr) override;
 
   void onNewSession(std::shared_ptr<moxygen::MoQSession> clientSession) override;
@@ -60,22 +45,9 @@ protected:
   ) override;
 
 private:
-  void initServices(
-      const folly::F14FastMap<std::string, config::ServiceConfig>& services,
-      const std::string& relayID
-  );
-  void initUpstreams();
-
-  struct ServiceEntry {
-    config::ServiceConfig config;
-    std::shared_ptr<MoqxRelay> relay;
-  };
-  folly::F14FastMap<std::string, ServiceEntry> services_;
-  ServiceMatcher serviceMatcher_;
-  std::string relayID_;
+  config::ListenerConfig listenerCfg_;
+  std::shared_ptr<MoqxRelayContext> context_;
   std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
-  std::shared_ptr<stats::StatsRegistry> statsRegistry_;
-  std::shared_ptr<stats::MoQStatsCollector> statsCollector_;
 };
 
 } // namespace openmoq::moqx

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -1,0 +1,143 @@
+#include <moqx/MoqxRelayContext.h>
+#include <moqx/stats/MoQStatsCollector.h>
+#include <moxygen/events/MoQFollyExecutorImpl.h>
+#include <moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h>
+
+#include <folly/logging/xlog.h>
+
+using namespace moxygen;
+
+namespace openmoq::moqx {
+
+MoqxRelayContext::MoqxRelayContext(
+    const folly::F14FastMap<std::string, config::ServiceConfig>& services,
+    const std::string& relayID
+)
+    : serviceMatcher_(services), relayID_(relayID) {
+  for (const auto& [name, svc] : services) {
+    services_.emplace(
+        name,
+        ServiceEntry{
+            svc,
+            std::make_shared<MoqxRelay>(
+                svc.cache.maxCachedTracks,
+                svc.cache.maxCachedGroupsPerTrack,
+                relayID
+            )
+        }
+    );
+  }
+}
+
+void MoqxRelayContext::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
+  statsRegistry_ = std::move(registry);
+}
+
+namespace {
+
+// Relay chaining requires draft 16+ for wildcard subscribeNamespace and
+// NAMESPACE messages on the bidi stream. Connections negotiating an earlier
+// draft will not receive namespace announcements from the upstream relay.
+std::shared_ptr<fizz::CertificateVerifier> makeUpstreamVerifier(const config::UpstreamTlsConfig& tls
+) {
+  if (tls.insecure) {
+    return std::make_shared<moxygen::test::InsecureVerifierDangerousDoNotUseInProduction>();
+  }
+  if (tls.caCertFile) {
+    // TODO: load custom CA cert via fizz OpenSSLCertUtils / X509 store
+    XLOG(WARN) << "upstream.tls.ca_cert is not yet implemented; using system CAs";
+  }
+  return nullptr; // nullptr = fizz uses system CAs
+}
+
+} // namespace
+
+void MoqxRelayContext::initUpstreams(folly::EventBase* workerEvb) {
+  CHECK(workerEvb) << "initUpstreams: workerEvb must not be null";
+
+  // Use the provided worker EVB for all upstream connections.
+  // Per-EVB providers (one per worker thread) are a follow-up.
+  auto exec = std::make_shared<MoQFollyExecutorImpl>(workerEvb);
+
+  for (auto& [name, entry] : services_) {
+    if (!entry.config.upstream) {
+      continue;
+    }
+    const auto& cfg = *entry.config.upstream;
+    auto verifier = makeUpstreamVerifier(cfg.tls);
+    auto relay = entry.relay;
+    auto onConnect = [relay](std::shared_ptr<MoQSession> session) -> folly::coro::Task<void> {
+      co_await relay->onUpstreamConnect(session);
+    };
+    auto onDisconnect = [relay]() { relay->onUpstreamDisconnect(); };
+    auto provider = std::make_shared<UpstreamProvider>(
+        exec,
+        proxygen::URL(cfg.url),
+        /*publishHandler=*/entry.relay,
+        /*subscribeHandler=*/entry.relay,
+        verifier,
+        std::move(onConnect),
+        std::move(onDisconnect),
+        cfg.connectTimeout,
+        cfg.idleTimeout
+    );
+    entry.relay->setUpstreamProvider(provider);
+
+    // Eagerly connect so the peering handshake fires before any subscribers
+    // arrive. The connection is lazy in UpstreamProvider but we kick it off
+    // now so the upstream namespace tree is ready.
+    co_withExecutor(workerEvb, provider->start()).start();
+  }
+}
+
+void MoqxRelayContext::stop() {
+  for (auto& [name, entry] : services_) {
+    entry.relay->stop();
+  }
+}
+
+void MoqxRelayContext::onNewSession(std::shared_ptr<MoQSession> clientSession) {
+  if (statsRegistry_) {
+    if (!statsCollector_) {
+      statsCollector_ = stats::MoQStatsCollector::create_moq_stats_collector(statsRegistry_);
+    }
+    if (!statsCollector_->owningExecutor()) {
+      statsCollector_->setExecutor(clientSession->getExecutor());
+    }
+
+    clientSession->setPublisherStatsCallback(statsCollector_->publisherCallback());
+    clientSession->setSubscriberStatsCallback(statsCollector_->subscriberCallback());
+
+    statsCollector_->onSessionStart();
+  }
+}
+
+void MoqxRelayContext::onSessionEnd() {
+  if (statsCollector_) {
+    statsCollector_->onSessionEnd();
+  }
+}
+
+folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayContext::validateAuthority(
+    const ClientSetup& /*clientSetup*/,
+    uint64_t /*negotiatedVersion*/,
+    std::shared_ptr<MoQSession> session
+) {
+  // Match service by authority + path
+  const auto& authority = session->getAuthority();
+  const auto& path = session->getPath();
+  auto matchedName = serviceMatcher_.match(authority, path);
+  if (!matchedName) {
+    XLOG(ERR) << "No service matched authority=" << authority << " path=" << path;
+    return folly::makeUnexpected(SessionCloseErrorCode::INVALID_AUTHORITY);
+  }
+
+  // Route: set per-service relay as handler
+  auto it = services_.find(*matchedName);
+  CHECK(it != services_.end()) << "Service '" << *matchedName << "' matched but no entry found";
+  session->setPublishHandler(it->second.relay);
+  session->setSubscribeHandler(it->second.relay);
+  return folly::unit;
+}
+
+} // namespace openmoq::moqx

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -1,9 +1,9 @@
 #include <moqx/MoqxRelayServer.h>
-#include <moqx/stats/MoQStatsCollector.h>
 #include <moqx/stats/QuicStatsCollector.h>
 #include <moxygen/MoQRelaySession.h>
 #include <moxygen/events/MoQFollyExecutorImpl.h>
 #include <moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h>
+#include <proxygen/httpserver/samples/hq/FizzContext.h>
 
 #include <folly/logging/xlog.h>
 
@@ -20,182 +20,72 @@ std::vector<std::string> buildAlpns(const std::string& versions) {
   return alpns;
 }
 
+std::shared_ptr<const fizz::server::FizzServerContext>
+buildFizzContext(const config::ListenerConfig& cfg) {
+  auto alpns = buildAlpns(cfg.moqtVersions);
+  return std::visit(
+      [&alpns](const auto& tls) -> std::shared_ptr<const fizz::server::FizzServerContext> {
+        using T = std::decay_t<decltype(tls)>;
+        if constexpr (std::is_same_v<T, config::Insecure>) {
+          return quic::samples::createFizzServerContextWithInsecureDefault(
+              alpns,
+              fizz::server::ClientAuthMode::None,
+              "",
+              ""
+          );
+        } else {
+          return quic::samples::createFizzServerContext(
+              alpns,
+              fizz::server::ClientAuthMode::Optional,
+              tls.certFile,
+              tls.keyFile
+          );
+        }
+      },
+      cfg.tlsMode
+  );
+}
+
 } // namespace
 
-void MoqxRelayServer::initServices(
-    const folly::F14FastMap<std::string, config::ServiceConfig>& services,
-    const std::string& relayID
-) {
-  for (const auto& [name, svc] : services) {
-    services_.emplace(
-        name,
-        ServiceEntry{
-            svc,
-            std::make_shared<MoqxRelay>(
-                svc.cache.maxCachedTracks,
-                svc.cache.maxCachedGroupsPerTrack,
-                relayID
-            )
-        }
-    );
-  }
-}
-
 MoqxRelayServer::MoqxRelayServer(
-    const std::string& cert,
-    const std::string& key,
-    const std::string& endpoint,
-    const std::string& versions,
-    folly::F14FastMap<std::string, config::ServiceConfig> services,
-    const std::string& relayID,
+    const config::ListenerConfig& listenerCfg,
+    std::shared_ptr<MoqxRelayContext> context,
     std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
 )
-    : MoQServer(
-          quic::samples::createFizzServerContext(
-              buildAlpns(versions),
-              fizz::server::ClientAuthMode::Optional,
-              cert,
-              key
-          ),
-          endpoint
-      ),
-      serviceMatcher_(services), relayID_(relayID), ioExecutor_(std::move(ioExecutor)) {
-  initServices(services, relayID);
-}
-
-MoqxRelayServer::MoqxRelayServer(
-    const std::string& endpoint,
-    const std::string& versions,
-    folly::F14FastMap<std::string, config::ServiceConfig> services,
-    const std::string& relayID,
-    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
-)
-    : MoQServer(
-          quic::samples::createFizzServerContextWithInsecureDefault(
-              buildAlpns(versions),
-              fizz::server::ClientAuthMode::None,
-              "" /* cert */,
-              "" /* key */
-          ),
-          endpoint
-      ),
-      serviceMatcher_(services), relayID_(relayID), ioExecutor_(std::move(ioExecutor)) {
-  initServices(services, relayID);
-}
+    : MoQServer(buildFizzContext(listenerCfg), listenerCfg.endpoint), listenerCfg_(listenerCfg),
+      context_(std::move(context)), ioExecutor_(std::move(ioExecutor)) {}
 
 MoqxRelayServer::~MoqxRelayServer() {
-  // 1. Signal upstreams to stop — cancels reconnect backoff sleep so the
-  //    reconnect coroutine on the worker EVB can exit cleanly.
-  for (auto& [name, entry] : services_) {
-    entry.relay->stop();
-  }
-  // 2. Close incoming connections, drain worker EVBs (terminateClientSession
-  //    and ~MoQSession complete here), then destroy EVBs.
+  // Close incoming connections, drain worker EVBs, then destroy EVBs.
   MoQServer::stop();
 }
 
-void MoqxRelayServer::start(const folly::SocketAddress& addr) {
+void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
+  context_->setStatsRegistry(registry);
+  setQuicStatsFactory(std::make_unique<stats::QuicStatsCollector::Factory>(std::move(registry)));
+}
+
+void MoqxRelayServer::start() {
   auto evbKAs = ioExecutor_->getAllEventBases();
   std::vector<folly::EventBase*> evbs;
   evbs.reserve(evbKAs.size());
   for (auto& ka : evbKAs) {
     evbs.push_back(ka.get());
   }
-  MoQServer::start(addr, std::move(evbs));
-  initUpstreams();
+  MoQServer::start(listenerCfg_.address, std::move(evbs));
 }
 
-void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
-  statsRegistry_ = std::move(registry);
-
-  if (statsRegistry_) {
-    // Register the MoQ collector
-    statsCollector_ = stats::MoQStatsCollector::create_moq_stats_collector(statsRegistry_);
-
-    // Wire up QUIC transport stats factory
-    setQuicStatsFactory(std::make_unique<stats::QuicStatsCollector::Factory>(statsRegistry_));
-  }
-}
-
-namespace {
-
-// Relay chaining requires draft 16+ for wildcard subscribeNamespace and
-// NAMESPACE messages on the bidi stream. Connections negotiating an earlier
-// draft will not receive namespace announcements from the upstream relay.
-std::shared_ptr<fizz::CertificateVerifier> makeUpstreamVerifier(const config::UpstreamTlsConfig& tls
-) {
-  if (tls.insecure) {
-    return std::make_shared<moxygen::test::InsecureVerifierDangerousDoNotUseInProduction>();
-  }
-  if (tls.caCertFile) {
-    // TODO: load custom CA cert via fizz OpenSSLCertUtils / X509 store
-    XLOG(WARN) << "upstream.tls.ca_cert is not yet implemented; "
-                  "using system CAs";
-  }
-  return nullptr; // nullptr = fizz uses system CAs
-}
-
-} // namespace
-
-void MoqxRelayServer::initUpstreams() {
-  auto evbs = getWorkerEvbs();
-  CHECK(!evbs.empty()) << "initUpstreams must be called after start()";
-
-  // Use the first worker EVB for all upstream connections.
-  // Per-EVB providers (one per worker thread) are a follow-up.
-  auto exec = std::make_shared<MoQFollyExecutorImpl>(evbs[0]);
-
-  for (auto& [name, entry] : services_) {
-    if (!entry.config.upstream) {
-      continue;
-    }
-    const auto& cfg = *entry.config.upstream;
-    auto verifier = makeUpstreamVerifier(cfg.tls);
-    auto relay = entry.relay;
-    auto onConnect = [relay](std::shared_ptr<MoQSession> session) -> folly::coro::Task<void> {
-      co_await relay->onUpstreamConnect(session);
-    };
-    auto onDisconnect = [relay]() { relay->onUpstreamDisconnect(); };
-    auto provider = std::make_shared<UpstreamProvider>(
-        exec,
-        proxygen::URL(cfg.url),
-        /*publishHandler=*/entry.relay,
-        /*subscribeHandler=*/entry.relay,
-        verifier,
-        std::move(onConnect),
-        std::move(onDisconnect),
-        cfg.connectTimeout,
-        cfg.idleTimeout
-    );
-    entry.relay->setUpstreamProvider(provider);
-
-    // Eagerly connect so the peering handshake fires before any subscribers
-    // arrive. The connection is lazy in UpstreamProvider but we kick it off
-    // now so the upstream namespace tree is ready.
-    co_withExecutor(evbs[0], provider->start()).start();
-  }
+void MoqxRelayServer::start(const folly::SocketAddress& /*addr*/) {
+  start();
 }
 
 void MoqxRelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
-  // Relay handler routing deferred to validateAuthority() where authority is available
-
-  if (statsRegistry_) {
-    if (!statsCollector_->owningExecutor()) {
-      // First session: bind the executor now that we have one.
-      statsCollector_->setExecutor(clientSession->getExecutor());
-    }
-
-    clientSession->setPublisherStatsCallback(statsCollector_->publisherCallback());
-    clientSession->setSubscriberStatsCallback(statsCollector_->subscriberCallback());
-
-    statsCollector_->onSessionStart();
-  }
+  context_->onNewSession(std::move(clientSession));
 }
 
 void MoqxRelayServer::terminateClientSession(std::shared_ptr<MoQSession> session) {
-  if (statsCollector_) {
-    statsCollector_->onSessionEnd();
-  }
+  context_->onSessionEnd();
   MoQServer::terminateClientSession(std::move(session));
 }
 
@@ -209,22 +99,7 @@ folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayServer::validateAut
   if (!base.hasValue()) {
     return base;
   }
-
-  // Match service by authority + path
-  const auto& authority = session->getAuthority();
-  const auto& path = session->getPath();
-  auto matchedName = serviceMatcher_.match(authority, path);
-  if (!matchedName) {
-    XLOG(ERR) << "No service matched authority=" << authority << " path=" << path;
-    return folly::makeUnexpected(SessionCloseErrorCode::INVALID_AUTHORITY);
-  }
-
-  // Route: set per-service relay as handler
-  auto it = services_.find(*matchedName);
-  CHECK(it != services_.end()) << "Service '" << *matchedName << "' matched but no entry found";
-  session->setPublishHandler(it->second.relay);
-  session->setSubscribeHandler(it->second.relay);
-  return folly::unit;
+  return context_->validateAuthority(clientSetup, negotiatedVersion, std::move(session));
 }
 
 std::shared_ptr<MoQSession> MoqxRelayServer::createSession(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <moqx/MoqxRelayContext.h>
 #include <moqx/MoqxRelayServer.h>
 #include <moqx/admin/AdminServer.h>
 #include <moqx/admin/BuiltinRoutes.h>
@@ -22,9 +23,11 @@
 DEFINE_string(config, "", "Path to config file (required)");
 DEFINE_bool(strict_config, false, "Reject unknown config fields");
 
+using namespace openmoq::moqx;
+
 namespace {
 
-namespace cfg = openmoq::moqx::config;
+namespace cfg = config;
 
 constexpr std::string_view kServeCommand = "serve";
 
@@ -40,38 +43,6 @@ public:
     getEventBase()->terminateLoopSoon();
   }
 };
-
-std::shared_ptr<openmoq::moqx::MoqxRelayServer>
-createServer(const cfg::Config& config, std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor) {
-  const auto& listener = config.listeners[0];
-  auto services = config.services; // copy for move into constructor
-
-  return std::visit(
-      [&](const auto& tls) -> std::shared_ptr<openmoq::moqx::MoqxRelayServer> {
-        using T = std::decay_t<decltype(tls)>;
-        if constexpr (std::is_same_v<T, cfg::Insecure>) {
-          return std::make_shared<openmoq::moqx::MoqxRelayServer>(
-              listener.endpoint,
-              listener.moqtVersions,
-              std::move(services),
-              config.relayID,
-              ioExecutor
-          );
-        } else {
-          return std::make_shared<openmoq::moqx::MoqxRelayServer>(
-              tls.certFile,
-              tls.keyFile,
-              listener.endpoint,
-              listener.moqtVersions,
-              std::move(services),
-              config.relayID,
-              ioExecutor
-          );
-        }
-      },
-      listener.tlsMode
-  );
-}
 
 } // namespace
 
@@ -127,17 +98,23 @@ int main(int argc, char* argv[]) {
 
   // === 6. Initialize services ===
   // Construct and configure the application's own services
-  // (MoqxRelayServer, MoqxRelay, etc.)
-  auto server = createServer(config, ioExecutor);
+  // (MoqxRelayContext, MoqxRelayServer, etc.)
+  auto context = std::make_shared<MoqxRelayContext>(config.services, config.relayID);
 
   // === 6a. Stats registry ===
-  auto statsRegistry = std::make_shared<openmoq::moqx::stats::StatsRegistry>();
-  server->setStatsRegistry(statsRegistry);
+  auto statsRegistry = std::make_shared<stats::StatsRegistry>();
+
+  std::vector<std::shared_ptr<MoqxRelayServer>> servers;
+  for (const auto& listenerCfg : config.listeners) {
+    auto& server =
+        servers.emplace_back(std::make_shared<MoqxRelayServer>(listenerCfg, context, ioExecutor));
+    server->setStatsRegistry(statsRegistry);
+  }
 
   // === 7. Start health checks / admin endpoints ===
-  openmoq::moqx::admin::AdminServer adminServer;
-  openmoq::moqx::admin::registerBuiltinRoutes(adminServer);
-  openmoq::moqx::admin::registerMetricsRoute(adminServer, statsRegistry);
+  admin::AdminServer adminServer;
+  admin::registerBuiltinRoutes(adminServer);
+  admin::registerMetricsRoute(adminServer, statsRegistry);
   if (config.admin) {
     if (!adminServer.start(*config.admin)) {
       XLOG(FATAL) << "Failed to start admin server on " << config.admin->address.describe();
@@ -147,7 +124,14 @@ int main(int argc, char* argv[]) {
   }
 
   // === 8. Start serving ===
-  server->start(config.listeners[0].address);
+  for (auto& server : servers) {
+    server->start();
+  }
+
+  if (!servers.empty()) {
+    context->initUpstreams(servers[0]->getWorkerEvbs()[0]);
+  }
+
   evb.loopForever();
 
   // Hard shutdown watchdog: if teardown hangs, force-exit after 10 seconds.
@@ -162,6 +146,9 @@ int main(int argc, char* argv[]) {
   // ============================================
 
   // === 9. Stop accepting new connections ===
+  // Signal upstreams to stop — cancels reconnect backoff so worker EVBs can
+  // exit cleanly before servers drain them.
+  context->stop();
   // TODO: close listeners
 
   // === 10. Drain in-flight requests ===

--- a/tests/MoqxRelayContextTest.cpp
+++ b/tests/MoqxRelayContextTest.cpp
@@ -1,0 +1,146 @@
+#include <moqx/MoqxRelayContext.h>
+
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/MoQTypes.h>
+#include <moxygen/events/MoQFollyExecutorImpl.h>
+#include <moxygen/test/MockMoQSession.h>
+
+using namespace testing;
+using namespace moxygen;
+using namespace openmoq::moqx;
+
+namespace {
+
+using MatchEntry = config::ServiceConfig::MatchEntry;
+
+config::ServiceConfig makeService(std::string authority) {
+  return config::ServiceConfig{
+      .match = {MatchEntry{
+          .authority = MatchEntry::ExactAuthority{std::move(authority)},
+          .path = MatchEntry::PrefixPath{"/"},
+      }},
+      .cache = {100, 3},
+  };
+}
+
+// Build a MockMoQSession with the given authority and path.
+// Uses a shared executor so the session doesn't spin up its own thread.
+std::shared_ptr<NiceMock<test::MockMoQSession>>
+makeSession(std::shared_ptr<MoQExecutor> exec, std::string authority, std::string path = "") {
+  auto session = std::make_shared<NiceMock<test::MockMoQSession>>(exec);
+  session->setAuthority(std::move(authority));
+  session->setPath(std::move(path));
+  return session;
+}
+
+class MoqxRelayContextTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    folly::EventBase* evb = &evb_;
+    exec_ = std::make_shared<MoQFollyExecutorImpl>(evb);
+  }
+
+  folly::EventBase evb_;
+  std::shared_ptr<MoQExecutor> exec_;
+  ClientSetup emptySetup_;
+  uint64_t anyVersion_{0};
+};
+
+// --- validateAuthority ---
+
+TEST_F(MoqxRelayContextTest, ValidateAuthority_Hit) {
+  folly::F14FastMap<std::string, config::ServiceConfig> services = {
+      {"svc", makeService("live.example.com")},
+  };
+  MoqxRelayContext ctx(services, "test-relay");
+
+  auto session = makeSession(exec_, "live.example.com");
+  auto result = ctx.validateAuthority(emptySetup_, anyVersion_, session);
+
+  EXPECT_TRUE(result.hasValue());
+}
+
+TEST_F(MoqxRelayContextTest, ValidateAuthority_Miss) {
+  folly::F14FastMap<std::string, config::ServiceConfig> services = {
+      {"svc", makeService("live.example.com")},
+  };
+  MoqxRelayContext ctx(services, "test-relay");
+
+  auto session = makeSession(exec_, "unknown.example.com");
+  auto result = ctx.validateAuthority(emptySetup_, anyVersion_, session);
+
+  ASSERT_FALSE(result.hasValue());
+  EXPECT_EQ(result.error(), SessionCloseErrorCode::INVALID_AUTHORITY);
+}
+
+TEST_F(MoqxRelayContextTest, ValidateAuthority_EmptyAuthority_Miss) {
+  folly::F14FastMap<std::string, config::ServiceConfig> services = {
+      {"svc", makeService("live.example.com")},
+  };
+  MoqxRelayContext ctx(services, "test-relay");
+
+  auto session = makeSession(exec_, "");
+  auto result = ctx.validateAuthority(emptySetup_, anyVersion_, session);
+
+  ASSERT_FALSE(result.hasValue());
+  EXPECT_EQ(result.error(), SessionCloseErrorCode::INVALID_AUTHORITY);
+}
+
+// Two services with distinct authorities: each session is routed to the right
+// one (and the wrong authority still misses).
+TEST_F(MoqxRelayContextTest, ValidateAuthority_TwoServices) {
+  folly::F14FastMap<std::string, config::ServiceConfig> services = {
+      {"svc-a", makeService("a.example.com")},
+      {"svc-b", makeService("b.example.com")},
+  };
+  MoqxRelayContext ctx(services, "test-relay");
+
+  auto sessionA = makeSession(exec_, "a.example.com");
+  auto sessionB = makeSession(exec_, "b.example.com");
+  auto sessionC = makeSession(exec_, "c.example.com");
+
+  EXPECT_TRUE(ctx.validateAuthority(emptySetup_, anyVersion_, sessionA).hasValue());
+  EXPECT_TRUE(ctx.validateAuthority(emptySetup_, anyVersion_, sessionB).hasValue());
+
+  auto miss = ctx.validateAuthority(emptySetup_, anyVersion_, sessionC);
+  ASSERT_FALSE(miss.hasValue());
+  EXPECT_EQ(miss.error(), SessionCloseErrorCode::INVALID_AUTHORITY);
+}
+
+// Path matching: sessions on the same authority but different paths route to
+// the right service.
+TEST_F(MoqxRelayContextTest, ValidateAuthority_PathRouting) {
+  folly::F14FastMap<std::string, config::ServiceConfig> services = {
+      {"relay",
+       config::ServiceConfig{
+           .match = {MatchEntry{
+               .authority = MatchEntry::AnyAuthority{},
+               .path = MatchEntry::ExactPath{"/moq-relay"},
+           }},
+           .cache = {100, 3},
+       }},
+      {"live",
+       config::ServiceConfig{
+           .match = {MatchEntry{
+               .authority = MatchEntry::AnyAuthority{},
+               .path = MatchEntry::PrefixPath{"/live/"},
+           }},
+           .cache = {100, 3},
+       }},
+  };
+  MoqxRelayContext ctx(services, "test-relay");
+
+  auto sessionRelay = makeSession(exec_, "any.host", "/moq-relay");
+  auto sessionLive = makeSession(exec_, "any.host", "/live/stream");
+  auto sessionOther = makeSession(exec_, "any.host", "/other");
+
+  EXPECT_TRUE(ctx.validateAuthority(emptySetup_, anyVersion_, sessionRelay).hasValue());
+  EXPECT_TRUE(ctx.validateAuthority(emptySetup_, anyVersion_, sessionLive).hasValue());
+
+  auto miss = ctx.validateAuthority(emptySetup_, anyVersion_, sessionOther);
+  ASSERT_FALSE(miss.hasValue());
+  EXPECT_EQ(miss.error(), SessionCloseErrorCode::INVALID_AUTHORITY);
+}
+
+} // namespace


### PR DESCRIPTION
Extract shared relay state (services, ServiceMatcher, relayID, stats, upstreams) into MoqxRelayContext so multiple MoqxRelayServer instances can share it. main() now loops config.listeners and creates one server per listener, all sharing a single IOThreadPoolExecutor and context. initUpstreams() is called once after all servers are started.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/111)
<!-- Reviewable:end -->
