### PR TITLE
Guard shutdown hangs and speed up relay chain test

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,9 @@
 
 #include <csignal>
 
+#include <chrono>
+#include <thread>
+
 #include <folly/init/Init.h>
 #include <folly/io/async/AsyncSignalHandler.h>
 #include <folly/logging/xlog.h>
@@ -138,6 +141,13 @@ int main(int argc, char* argv[]) {
   // === 8. Start serving ===
   server->start(config.listener.address);
   evb.loopForever();
+
+  // Hard shutdown watchdog: if teardown hangs, force-exit after 10 seconds.
+  std::thread([relayID = config.relayID] {
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    XLOG(ERR) << "Shutdown timed out after 10s (relay_id=" << relayID << "), forcing exit";
+    std::_Exit(1);
+  }).detach();
 
   // ============================================
   // Teardown (reverse order, on signal/shutdown)

--- a/tests/test_relay_chain.sh
+++ b/tests/test_relay_chain.sh
@@ -33,13 +33,15 @@ DATESERVER="$MOQBIN/moqdateserver"
 TEXTCLIENT="$MOQBIN/moqtextclient"
 
 UPSTREAM_PORT=19668
+UPSTREAM_ADMIN_PORT=19669
 DOWNSTREAM_PORT=19670
+DOWNSTREAM_ADMIN_PORT=19671
 UPSTREAM_RELAY_ID="upstream-test"
 DOWNSTREAM_RELAY_ID="downstream-test"
 NAMESPACE="moq-date"
 NAMESPACE2="moq-date-2"
 NAMESPACE3="moq-publish"  # for --publish push-mode test
-TIMEOUT=5   # seconds to wait for data
+TIMEOUT=2   # seconds to wait for data
 
 # ── Prereq checks ──────────────────────────────────────────────────────────────
 for f in "$BINARY" "$DATESERVER" "$TEXTCLIENT"; do
@@ -49,7 +51,7 @@ for f in "$BINARY" "$DATESERVER" "$TEXTCLIENT"; do
   fi
 done
 
-for port in "$UPSTREAM_PORT" "$DOWNSTREAM_PORT"; do
+for port in "$UPSTREAM_PORT" "$UPSTREAM_ADMIN_PORT" "$DOWNSTREAM_PORT" "$DOWNSTREAM_ADMIN_PORT"; do
   if ss -ulnp 2>/dev/null | grep -q ":$port "; then
     echo "ERROR: port $port already in use (stale relay process?)" >&2
     ss -ulnp 2>/dev/null | grep ":$port " >&2
@@ -101,6 +103,32 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# ── Readiness helpers ──────────────────────────────────────────────────────────
+# wait_ready <admin_port> <label>: wait for admin /info to return 200.
+wait_ready() {
+  local port="$1" label="$2"
+  local deadline=$(( $(date +%s) + 10 ))
+  until curl -sf "http://localhost:$port/info" >/dev/null 2>&1; do
+    (( $(date +%s) >= deadline )) && { echo "ERROR: $label not ready after 10s" >&2; exit 1; }
+    sleep 0.1
+  done
+}
+
+# wait_sessions <admin_port> <min> <label>: wait for moqActiveSessions >= min.
+wait_sessions() {
+  local port="$1" min="$2" label="$3"
+  local deadline=$(( $(date +%s) + 10 ))
+  local val
+  until val=$(curl -sf "http://localhost:$port/metrics" 2>/dev/null \
+        | grep "^moqx_moqActiveSessions " | awk '{print $2}') \
+        && [[ -n "$val" && "$val" -ge "$min" ]]; do
+    (( $(date +%s) >= deadline )) && {
+      echo "ERROR: $label: moqActiveSessions=${val:-?} < $min after 10s" >&2; exit 1;
+    }
+    sleep 0.1
+  done
+}
+
 # ── Configs ────────────────────────────────────────────────────────────────────
 cat >"$UPSTREAM_CFG" <<EOF
 relay_id: "$UPSTREAM_RELAY_ID"
@@ -122,6 +150,10 @@ services:
       enabled: false
       max_tracks: 100
       max_groups_per_track: 3
+admin:
+  port: $UPSTREAM_ADMIN_PORT
+  address: "::"
+  plaintext: true
 EOF
 
 cat >"$DOWNSTREAM_CFG" <<EOF
@@ -149,6 +181,10 @@ services:
       tls:
         insecure: true
       idle_timeout_ms: 60000
+admin:
+  port: $DOWNSTREAM_ADMIN_PORT
+  address: "::"
+  plaintext: true
 EOF
 
 # ── Start relays ───────────────────────────────────────────────────────────────
@@ -176,8 +212,10 @@ echo "Starting downstream relay on port $DOWNSTREAM_PORT..."
 "$BINARY" --config="$DOWNSTREAM_CFG" $RELAY_LOG_ARGS >"$DOWNSTREAM_LOG" 2>&1 &
 RELAY_PIDS+=($!)
 
-# Give relays time to start and complete the peering handshake.
-sleep 1
+# Wait for relays to start and complete the peering handshake.
+wait_ready "$UPSTREAM_ADMIN_PORT" "upstream"
+wait_ready "$DOWNSTREAM_ADMIN_PORT" "downstream"
+wait_sessions "$UPSTREAM_ADMIN_PORT" 1 "peering"
 
 check_received() {
   local label="$1" out="$2"
@@ -208,7 +246,7 @@ echo "Direction 1: moqdateserver → upstream, subscribe via downstream"
   >"$DATESERVER_LOG" 2>&1 &
 PIDS+=($!)
 
-sleep 1
+wait_sessions "$UPSTREAM_ADMIN_PORT" 2 "dir1 dateserver"
 
 timeout "$TIMEOUT" "$TEXTCLIENT" \
   --connect_url="https://localhost:$DOWNSTREAM_PORT/moq-relay" \
@@ -226,7 +264,7 @@ echo "Direction 2: moqdateserver → downstream, subscribe via upstream"
   >"$DATESERVER_LOG2" 2>&1 &
 PIDS+=($!)
 
-sleep 1
+wait_sessions "$DOWNSTREAM_ADMIN_PORT" 1 "dir2 dateserver"
 
 timeout "$TIMEOUT" "$TEXTCLIENT" \
   --connect_url="https://localhost:$UPSTREAM_PORT/moq-relay" \
@@ -272,7 +310,7 @@ timeout "$TIMEOUT" "$TEXTCLIENT" \
   >"$CLIENT_OUT3" 2>&1 &
 TCPID=$!
 
-sleep 1
+wait_sessions "$DOWNSTREAM_ADMIN_PORT" 2 "dir4 textclient"
 
 # dateserver --publish: connects to upstream and pushes via PUBLISH.
 "$DATESERVER" \

--- a/tests/test_relay_chain.sh
+++ b/tests/test_relay_chain.sh
@@ -68,14 +68,35 @@ DATESERVER_LOG="$TMPDIR_SCRIPT/dateserver.log"
 DATESERVER_LOG2="$TMPDIR_SCRIPT/dateserver2.log"
 
 # ── Cleanup ────────────────────────────────────────────────────────────────────
-PIDS=()
+PIDS=()        # non-relay processes (dateserver, etc.) — 2s grace then SIGKILL
+RELAY_PIDS=()  # relay processes — wait indefinitely (relay binary has hard 10s watchdog)
 cleanup() {
-  for pid in "${PIDS[@]:-}"; do
+  # Signal everyone.
+  for pid in "${PIDS[@]:-}" "${RELAY_PIDS[@]:-}"; do
     kill "$pid" 2>/dev/null || true
   done
-  for pid in "${PIDS[@]:-}"; do
-    wait "$pid" 2>/dev/null || true
+  # Give non-relay helpers 2s to exit cleanly, then hard-kill survivors.
+  local deadline=$(( $(date +%s) + 2 ))
+  while true; do
+    local any_alive=false
+    for pid in "${PIDS[@]:-}"; do
+      kill -0 "$pid" 2>/dev/null && { any_alive=true; break; }
+    done
+    [[ "$any_alive" == true ]] || break
+    if (( $(date +%s) >= deadline )); then
+      echo "WARNING: helpers did not exit after 2s, sending SIGKILL" >&2
+      break
+    fi
+    sleep 0.2
   done
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "WARNING: SIGKILL $pid ($(cat /proc/$pid/cmdline 2>/dev/null | tr '\0' ' ' || echo '?'))" >&2
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+  done
+  # Relays: wait indefinitely — relay's hard shutdown watchdog handles any hang.
+  wait "${PIDS[@]:-}" "${RELAY_PIDS[@]:-}" 2>/dev/null || true
   rm -rf "$TMPDIR_SCRIPT"
 }
 trap cleanup EXIT
@@ -149,11 +170,11 @@ fi
 
 echo "Starting upstream relay on port $UPSTREAM_PORT..."
 "$BINARY" --config="$UPSTREAM_CFG" $RELAY_LOG_ARGS >"$UPSTREAM_LOG" 2>&1 &
-PIDS+=($!)
+RELAY_PIDS+=($!)
 
 echo "Starting downstream relay on port $DOWNSTREAM_PORT..."
 "$BINARY" --config="$DOWNSTREAM_CFG" $RELAY_LOG_ARGS >"$DOWNSTREAM_LOG" 2>&1 &
-PIDS+=($!)
+RELAY_PIDS+=($!)
 
 # Give relays time to start and complete the peering handshake.
 sleep 1


### PR DESCRIPTION
Addresses intermittent shutdown hangs observed in the relay chain test and tightens the test harness around them.                   

- Watchdog (3de68f5): Add a hard 10s force-exit backstop in main.cpp that fires if the EVB teardown hangs. Logs relay_id so a stuck instance can be identified in test output.  I don't think the relay is currently hanging on shutdown, but this is a good safety net.
- Cleanup robustness (ebaf4f8): Separate relay processes from helper processes (dateserver, textclient) in the test cleanup. Relays get SIGTERM and are waited on indefinitely — the watchdog is their backstop. Helpers get SIGTERM, a 2s grace period, then SIGKILL with cmdline logged if they don't exit.  
 **This is likely the problem - dateserver has some shutdown issues**
- Test speed (19d52c4): Replace all sleep 1 waits with admin endpoint polling (/info for readiness, /metrics for session counts).   Add admin servers to both relay configs. Test runs in ~9s instead of ~20s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/112)
<!-- Reviewable:end -->
