### PR TITLE
Add picoquic QUIC stack support via per-listener quic_stack config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(moqx_core STATIC
   src/MoqxRelay.cpp
   src/MoqxRelayContext.cpp
   src/MoqxRelayServer.cpp
+  src/MoqxPicoRelayServer.cpp
   src/ServiceMatcher.cpp
   src/admin/AdminServer.cpp
   src/admin/BuiltinRoutes.cpp
@@ -96,6 +97,7 @@ target_link_libraries(moqx_core PUBLIC
   moxygen::moxygen_relay_moq_cache
   moxygen::moxygen_moq_relay_session
   moxygen::moxygen_moq_server
+  moxygen::openmoq_pico_evb_server_transport
   proxygen::proxygenhttpserver
   # Workaround: wangle::wangle_acceptor_acceptor_core uses AsyncFdSocket from
   # FizzAcceptorHandshakeHelper but omits this dep from its cmake config.

--- a/include/moqx/MoqxPicoRelayServer.h
+++ b/include/moqx/MoqxPicoRelayServer.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <memory>
+
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <moqx/MoqxRelayContext.h>
+#include <moqx/config/config.h>
+#include <moxygen/events/MoQExecutor.h>
+#include <moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.h>
+#include <proxygen/lib/http/webtransport/WebTransport.h>
+
+namespace openmoq::moqx {
+
+// MoQ relay server backed by the picoquic QUIC stack.
+//
+// Picoquic lacks packet steering across threads, so even though the full
+// IOThreadPoolExecutor is passed in (for API symmetry with MoqxRelayServer),
+// the server always pins itself to evbKAs[0] internally.
+class MoqxPicoRelayServer : public moxygen::MoQPicoQuicEventBaseServer {
+public:
+  MoqxPicoRelayServer(
+      const config::ListenerConfig& listenerCfg,
+      std::shared_ptr<MoqxRelayContext> context,
+      std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
+  );
+
+  ~MoqxPicoRelayServer() override;
+
+  // Preferred entry point: binds the address from the stored ListenerConfig.
+  void start();
+
+  // Satisfies MoQServerBase pure virtual; delegates to start().
+  void start(const folly::SocketAddress& addr) override;
+
+  void onNewSession(std::shared_ptr<moxygen::MoQSession> clientSession) override;
+
+  void terminateClientSession(std::shared_ptr<moxygen::MoQSession> session) override;
+
+  folly::Expected<folly::Unit, moxygen::SessionCloseErrorCode> validateAuthority(
+      const moxygen::ClientSetup& clientSetup,
+      uint64_t negotiatedVersion,
+      std::shared_ptr<moxygen::MoQSession> session
+  ) override;
+
+protected:
+  std::shared_ptr<moxygen::MoQSession> createSession(
+      folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+      std::shared_ptr<moxygen::MoQExecutor> executor
+  ) override;
+
+private:
+  config::ListenerConfig listenerCfg_;
+  std::shared_ptr<MoqxRelayContext> context_;
+};
+
+} // namespace openmoq::moqx

--- a/include/moqx/MoqxServerFactory.h
+++ b/include/moqx/MoqxServerFactory.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <moqx/MoqxPicoRelayServer.h>
+#include <moqx/MoqxRelayContext.h>
+#include <moqx/MoqxRelayServer.h>
+#include <moqx/config/config.h>
+#include <moxygen/MoQServerBase.h>
+
+namespace openmoq::moqx {
+
+// Creates the appropriate relay server for the given listener config.
+// Both stack paths accept the same ioExecutor for a uniform call site.
+inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
+    const config::ListenerConfig& listenerCfg,
+    std::shared_ptr<MoqxRelayContext> context,
+    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
+) {
+  if (listenerCfg.quicStack == config::QuicStack::Picoquic) {
+    return std::make_shared<MoqxPicoRelayServer>(
+        listenerCfg,
+        std::move(context),
+        std::move(ioExecutor)
+    );
+  }
+  return std::make_shared<MoqxRelayServer>(listenerCfg, std::move(context), std::move(ioExecutor));
+}
+
+} // namespace openmoq::moqx

--- a/include/moqx/config/config.h
+++ b/include/moqx/config/config.h
@@ -28,12 +28,15 @@ struct CacheConfig {
   size_t maxCachedGroupsPerTrack;
 };
 
+enum class QuicStack { Mvfst, Picoquic };
+
 struct ListenerConfig {
   std::string name;
   folly::SocketAddress address;
   TlsMode tlsMode;
   std::string endpoint;
   std::string moqtVersions; // comma-separated string
+  QuicStack quicStack{QuicStack::Mvfst};
 };
 
 struct UpstreamTlsConfig {

--- a/include/moqx/config/loader/parsed_config.h
+++ b/include/moqx/config/loader/parsed_config.h
@@ -47,6 +47,10 @@ struct ParsedListenerConfig {
       "MOQT draft versions (empty = all supported)",
       std::optional<std::vector<uint32_t>>>
       moqt_versions;
+  rfl::Description<
+      "QUIC stack to use: \"mvfst\" (default) or \"picoquic\"",
+      std::optional<std::string>>
+      quic_stack;
 };
 
 struct ParsedCacheConfig {

--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -1,0 +1,103 @@
+#include <moqx/MoqxPicoRelayServer.h>
+
+#include <folly/io/async/EventBase.h>
+#include <folly/logging/xlog.h>
+#include <moxygen/MoQRelaySession.h>
+
+using namespace moxygen;
+
+namespace openmoq::moqx {
+
+namespace {
+
+std::string resolveCert(const config::ListenerConfig& cfg) {
+  return std::visit(
+      [](const auto& tls) -> std::string {
+        using T = std::decay_t<decltype(tls)>;
+        if constexpr (std::is_same_v<T, config::Insecure>) {
+          return "";
+        } else {
+          return tls.certFile;
+        }
+      },
+      cfg.tlsMode
+  );
+}
+
+std::string resolveKey(const config::ListenerConfig& cfg) {
+  return std::visit(
+      [](const auto& tls) -> std::string {
+        using T = std::decay_t<decltype(tls)>;
+        if constexpr (std::is_same_v<T, config::Insecure>) {
+          return "";
+        } else {
+          return tls.keyFile;
+        }
+      },
+      cfg.tlsMode
+  );
+}
+
+} // namespace
+
+MoqxPicoRelayServer::MoqxPicoRelayServer(
+    const config::ListenerConfig& listenerCfg,
+    std::shared_ptr<MoqxRelayContext> context,
+    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
+)
+    : MoQPicoQuicEventBaseServer(
+          resolveCert(listenerCfg),
+          resolveKey(listenerCfg),
+          listenerCfg.endpoint,
+          ioExecutor->getAllEventBases()[0],
+          listenerCfg.moqtVersions
+      ),
+      listenerCfg_(listenerCfg), context_(std::move(context)) {}
+
+MoqxPicoRelayServer::~MoqxPicoRelayServer() {
+  context_->stop();
+  MoQPicoQuicEventBaseServer::stop();
+}
+
+void MoqxPicoRelayServer::start() {
+  MoQPicoQuicEventBaseServer::start(listenerCfg_.address);
+}
+
+void MoqxPicoRelayServer::start(const folly::SocketAddress& /*addr*/) {
+  start();
+}
+
+void MoqxPicoRelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
+  context_->onNewSession(std::move(clientSession));
+}
+
+void MoqxPicoRelayServer::terminateClientSession(std::shared_ptr<MoQSession> session) {
+  context_->onSessionEnd();
+  MoQPicoQuicEventBaseServer::terminateClientSession(std::move(session));
+}
+
+folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxPicoRelayServer::validateAuthority(
+    const ClientSetup& clientSetup,
+    uint64_t negotiatedVersion,
+    std::shared_ptr<MoQSession> session
+) {
+  auto base =
+      MoQPicoQuicEventBaseServer::validateAuthority(clientSetup, negotiatedVersion, session);
+  if (!base.hasValue()) {
+    return base;
+  }
+  return context_->validateAuthority(clientSetup, negotiatedVersion, std::move(session));
+}
+
+std::shared_ptr<MoQSession> MoqxPicoRelayServer::createSession(
+    folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+    std::shared_ptr<MoQExecutor> executor
+) {
+  return std::make_shared<MoQRelaySession>(
+      folly::MaybeManagedPtr<proxygen::WebTransport>(std::move(wt)),
+      *this,
+      std::move(executor)
+  );
+}
+
+} // namespace openmoq::moqx

--- a/src/config/config_resolver.cpp
+++ b/src/config/config_resolver.cpp
@@ -132,6 +132,21 @@ void validateListener(
       errors,
       warnings
   );
+
+  // quic_stack validation
+  const auto& stackOpt = listener.quic_stack.value();
+  if (stackOpt.has_value() && *stackOpt != "mvfst" && *stackOpt != "picoquic") {
+    errors.push_back(
+        "Listener '" + listener.name.value() + "': unknown quic_stack '" + *stackOpt +
+        "' (expected \"mvfst\" or \"picoquic\")"
+    );
+  }
+  if (stackOpt.value_or("mvfst") == "picoquic" && listener.tls.value().insecure.value()) {
+    errors.push_back(
+        "Listener '" + listener.name.value() +
+        "': quic_stack \"picoquic\" requires real TLS credentials (insecure: true is not supported)"
+    );
+  }
 }
 
 // --- Admin validation ---
@@ -356,12 +371,16 @@ ListenerConfig resolveListener(const ParsedListenerConfig& listener) {
     tlsMode = resolveTlsConfig(tls);
   }
 
+  const auto& stackStr = listener.quic_stack.value().value_or("mvfst");
+  auto quicStack = (stackStr == "picoquic") ? QuicStack::Picoquic : QuicStack::Mvfst;
+
   return ListenerConfig{
       .name = listener.name.value(),
       .address = folly::SocketAddress(sock.address.value(), sock.port.value()),
       .tlsMode = std::move(tlsMode),
       .endpoint = listener.endpoint.value(),
       .moqtVersions = moqtVersionsToString(listener),
+      .quicStack = quicStack,
   };
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include <moqx/MoqxRelayContext.h>
-#include <moqx/MoqxRelayServer.h>
+#include <moqx/MoqxServerFactory.h>
 #include <moqx/admin/AdminServer.h>
 #include <moqx/admin/BuiltinRoutes.h>
 #include <moqx/admin/MetricsHandler.h>
@@ -104,11 +104,13 @@ int main(int argc, char* argv[]) {
   // === 6a. Stats registry ===
   auto statsRegistry = std::make_shared<stats::StatsRegistry>();
 
-  std::vector<std::shared_ptr<MoqxRelayServer>> servers;
+  std::vector<std::shared_ptr<moxygen::MoQServerBase>> servers;
   for (const auto& listenerCfg : config.listeners) {
-    auto& server =
-        servers.emplace_back(std::make_shared<MoqxRelayServer>(listenerCfg, context, ioExecutor));
-    server->setStatsRegistry(statsRegistry);
+    auto server = makeRelayServer(listenerCfg, context, ioExecutor);
+    if (auto relayServer = std::dynamic_pointer_cast<MoqxRelayServer>(server)) {
+      relayServer->setStatsRegistry(statsRegistry);
+    }
+    servers.emplace_back(std::move(server));
   }
 
   // === 7. Start health checks / admin endpoints ===
@@ -125,11 +127,12 @@ int main(int argc, char* argv[]) {
 
   // === 8. Start serving ===
   for (auto& server : servers) {
-    server->start();
+    // addr ignored — each server binds its own listenerCfg address
+    server->start(folly::SocketAddress{});
   }
 
   if (!servers.empty()) {
-    context->initUpstreams(servers[0]->getWorkerEvbs()[0]);
+    context->initUpstreams(ioExecutor->getAllEventBases()[0].get());
   }
 
   evb.loopForever();

--- a/tests/config/config_resolver_test.cpp
+++ b/tests/config/config_resolver_test.cpp
@@ -128,6 +128,15 @@ TEST(ResolveConfig, InsecureFalseNoCerts) {
   EXPECT_THAT(result.error(), HasSubstr("cert_file"));
 }
 
+TEST(ResolveConfig, PicoquicInsecureRejected) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.listeners.value()[0].quic_stack = std::string("picoquic");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("insecure: true is not supported"));
+}
+
 TEST(ResolveConfig, PortZero) {
   auto cfg = makeMinimalInsecureConfig();
   cfg.listeners.value()[0].udp.value().socket.value().port = uint16_t{0};


### PR DESCRIPTION
Adds the ability to run listeners on the picoquic QUIC stack alongside the existing mvfst default.                          

- Config (ListenerConfig): new optional quic_stack field ("mvfst" | "picoquic", default "mvfst"). Validation rejects unknown values and blocks picoquic + insecure: true (picoquic requires real TLS credentials).                                    
- Server (MoqxPicoRelayServer): wraps MoQPicoQuicEventBaseServer with the same relay callbacks as MoqxRelayServer. Pins to evbKAs[0] since picoquic lacks packet steering. MoqxServerFactory::makeRelayServer() selects the implementation based on quicStack, giving main.cpp a uniform call site.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/119)
<!-- Reviewable:end -->
