### PR TITLE
Add macOS build to CI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -63,6 +63,8 @@ jobs:
         run: |
           if [[ "$(uname)" == "Darwin" ]]; then
             deps/moxygen/standalone/install-system-deps.sh
+            brew install coreutils
+            echo "/opt/homebrew/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
           else
             sudo deps/moxygen/standalone/install-system-deps.sh
           fi

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -37,6 +37,10 @@ jobs:
             preset: default
             build_dir: build
             runner: ubuntu-22.04
+          - name: macos
+            preset: default
+            build_dir: build
+            runner: macos-latest
           - name: asan debug
             preset: san
             build_dir: build-san
@@ -56,7 +60,12 @@ jobs:
           submodules: true
 
       - name: Install system dependencies
-        run: sudo deps/moxygen/standalone/install-system-deps.sh
+        run: |
+          if [[ "$(uname)" == "Darwin" ]]; then
+            deps/moxygen/standalone/install-system-deps.sh
+          else
+            sudo deps/moxygen/standalone/install-system-deps.sh
+          fi
 
       - name: Setup dependencies
         env:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -114,7 +114,7 @@ check_system_deps() {
   # CMake version check (need 3.25+)
   if command -v cmake >/dev/null 2>&1; then
     local ver
-    ver=$(cmake --version | head -1 | grep -oP '\d+\.\d+' | head -1)
+    ver=$(cmake --version | head -1 | sed 's/[^0-9]*\([0-9]*\.[0-9]*\).*/\1/')
     local major minor
     major=$(echo "$ver" | cut -d. -f1)
     minor=$(echo "$ver" | cut -d. -f2)
@@ -334,6 +334,12 @@ cmd_build() {
   [[ -f "$DEPS_MODE_FILE" ]] && deps_mode=$(cat "$DEPS_MODE_FILE")
   if [[ "$deps_mode" == "from-source" ]]; then
     extra_cmake_args+=("-DCMAKE_FIND_LIBRARY_SUFFIXES=.so;.a")
+    extra_cmake_args+=("-DGFLAGS_SHARED=ON")
+  fi
+
+  # macOS: prefer shared gflags from brew to avoid conflict with static
+  # gflags symbols bundled in the moxygen tarball (see openmoq/moxygen#114).
+  if [[ "$(uname)" == "Darwin" ]]; then
     extra_cmake_args+=("-DGFLAGS_SHARED=ON")
   fi
 


### PR DESCRIPTION
## Summary
Add `macos-latest` to the ci-pr build matrix so moqx is built and tested on macOS.

## Changes
- Add `macos-latest` entry to ci-pr.yml build matrix
- Fix `install-system-deps.sh` invocation (no `sudo` on macOS)
- Fix `grep -P` → `sed` for cmake version check (macOS `grep` lacks `-P`)
- Add `GFLAGS_SHARED=ON` on Darwin to avoid static/shared gflags conflict between brew and moxygen tarball (see openmoq/moxygen#114)

## Dependencies
- Overlaps with PR #115 (benchmark) which has the same `build.sh` fixes. Whichever merges first, the other will need a trivial rebase.

## Known issues
- macOS test discovery may fail for `moqx_config_test` due to gflags conflict at test enumeration time (same issue #115 solved by using `MOQX_BUILD_TESTS=OFF` for benchmarks). If tests fail, we may need `GFLAGS_SHARED=ON` set at the CMakeLists level rather than just in build.sh.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/124)
<!-- Reviewable:end -->
