### PR TITLE
Fix Dockerfile: remove deleted include/ directory

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,6 @@ COPY .docker-deps/moxygen /opt/moxygen
 COPY CMakeLists.txt CMakePresets.json ./
 COPY cmake/ cmake/
 COPY src/ src/
-COPY include/ include/
 COPY deps/moxygen/build/fbcode_builder/CMake deps/moxygen/build/fbcode_builder/CMake
 
 RUN cmake -S . -B _build --preset default \


### PR DESCRIPTION
PR #122 (source tree cleanup) moved headers from `include/` to `src/` but the Dockerfile still had `COPY include/ include/`, breaking the Docker build on main.

One-line fix: remove the deleted COPY.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/128)
<!-- Reviewable:end -->
