### PR TITLE
stats: add PicoQuicStatsCollector for picoquic transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(moqx_core STATIC
   src/admin/MetricsHandler.cpp
   src/stats/StatsRegistry.cpp
   src/stats/MoQStatsCollector.cpp
+  src/stats/PicoQuicStatsCollector.cpp
   src/stats/QuicStatsCollector.cpp
   src/UpstreamProvider.cpp
 )

--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -1,5 +1,6 @@
 #include "MoqxPicoRelayServer.h"
 
+#include "stats/PicoQuicStatsCollector.h"
 #include <folly/io/async/EventBase.h>
 #include <folly/logging/xlog.h>
 #include <moxygen/MoQRelaySession.h>
@@ -52,11 +53,18 @@ MoqxPicoRelayServer::MoqxPicoRelayServer(
           ioExecutor->getAllEventBases()[0],
           listenerCfg.moqtVersions
       ),
-      listenerCfg_(listenerCfg), context_(std::move(context)) {}
+      listenerCfg_(listenerCfg), context_(std::move(context)),
+      evb_(ioExecutor->getAllEventBases()[0].get()) {}
 
 MoqxPicoRelayServer::~MoqxPicoRelayServer() {
   context_->stop();
   MoQPicoQuicEventBaseServer::stop();
+}
+
+void MoqxPicoRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
+  context_->setStatsRegistry(registry);
+  auto collector = stats::PicoQuicStatsCollector::create(std::move(registry), evb_);
+  setPicoQuicStatsCallback(std::move(collector));
 }
 
 void MoqxPicoRelayServer::start() {

--- a/src/MoqxPicoRelayServer.h
+++ b/src/MoqxPicoRelayServer.h
@@ -4,6 +4,7 @@
 
 #include "MoqxRelayContext.h"
 #include "config/config.h"
+#include "stats/StatsRegistry.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <moxygen/events/MoQExecutor.h>
 #include <moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.h>
@@ -25,6 +26,8 @@ public:
   );
 
   ~MoqxPicoRelayServer() override;
+
+  void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
 
   // Preferred entry point: binds the address from the stored ListenerConfig.
   void start();
@@ -51,6 +54,7 @@ protected:
 private:
   config::ListenerConfig listenerCfg_;
   std::shared_ptr<MoqxRelayContext> context_;
+  folly::EventBase* evb_;
 };
 
 } // namespace openmoq::moqx

--- a/src/MoqxServerFactory.h
+++ b/src/MoqxServerFactory.h
@@ -6,30 +6,37 @@
 #include "MoqxRelayContext.h"
 #include "MoqxRelayServer.h"
 #include "config/config.h"
+#include "stats/StatsRegistry.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <moxygen/MoQServerBase.h>
 
 namespace openmoq::moqx {
 
-// Creates the appropriate relay server for the given listener config.
-// Both stack paths accept the same ioExecutor for a uniform call site.
+// Creates the appropriate relay server for the given listener config and wires
+// stats. Both stack paths accept the same ioExecutor for a uniform call site.
 inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
     const config::ListenerConfig& listenerCfg,
     std::shared_ptr<MoqxRelayContext> context,
-    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
+    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor,
+    std::shared_ptr<stats::StatsRegistry> statsRegistry
 ) {
   if (listenerCfg.quicStack == config::QuicStack::Picoquic) {
     // TODO: pass listenerCfg.quic settings to PicoRelayServer.
     // Requires moxygen to expose a PicoTransportParams struct (parallel to
     // PicoWebTransportConfig) so createQuicContext() can call
     // picoquic_set_default_tp_value() for each field.
-    return std::make_shared<MoqxPicoRelayServer>(
+    auto server = std::make_shared<MoqxPicoRelayServer>(
         listenerCfg,
         std::move(context),
         std::move(ioExecutor)
     );
+    server->setStatsRegistry(std::move(statsRegistry));
+    return server;
   }
-  return std::make_shared<MoqxRelayServer>(listenerCfg, std::move(context), std::move(ioExecutor));
+  auto server =
+      std::make_shared<MoqxRelayServer>(listenerCfg, std::move(context), std::move(ioExecutor));
+  server->setStatsRegistry(std::move(statsRegistry));
+  return server;
 }
 
 } // namespace openmoq::moqx

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,11 +106,7 @@ int main(int argc, char* argv[]) {
 
   std::vector<std::shared_ptr<moxygen::MoQServerBase>> servers;
   for (const auto& listenerCfg : config.listeners) {
-    auto server = makeRelayServer(listenerCfg, context, ioExecutor);
-    if (auto relayServer = std::dynamic_pointer_cast<MoqxRelayServer>(server)) {
-      relayServer->setStatsRegistry(statsRegistry);
-    }
-    servers.emplace_back(std::move(server));
+    servers.emplace_back(makeRelayServer(listenerCfg, context, ioExecutor, statsRegistry));
   }
 
   // === 7. Start health checks / admin endpoints ===

--- a/src/stats/PicoQuicStatsCollector.cpp
+++ b/src/stats/PicoQuicStatsCollector.cpp
@@ -1,0 +1,63 @@
+#include "stats/PicoQuicStatsCollector.h"
+
+namespace openmoq::moqx::stats {
+
+/* static */
+std::shared_ptr<PicoQuicStatsCollector>
+PicoQuicStatsCollector::create(std::shared_ptr<StatsRegistry> registry, folly::EventBase* evb) {
+  auto collector = std::shared_ptr<PicoQuicStatsCollector>(new PicoQuicStatsCollector(evb));
+  registry->registerCollector(collector);
+  return collector;
+}
+
+PicoQuicStatsCollector::PicoQuicStatsCollector(folly::EventBase* evb) : evb_(evb) {}
+
+void PicoQuicStatsCollector::onConnectionCreated() {
+  ++quicConnectionsCreated_;
+  ++quicActiveConnections_;
+}
+
+void PicoQuicStatsCollector::onConnectionClosed() {
+  ++quicConnectionsClosed_;
+  --quicActiveConnections_;
+}
+
+void PicoQuicStatsCollector::onStreamCreated() {
+  ++quicStreamsCreated_;
+}
+
+void PicoQuicStatsCollector::onStreamClosed() {
+  ++quicStreamsClosed_;
+}
+
+void PicoQuicStatsCollector::onStreamReset() {
+  ++quicStreamsReset_;
+}
+
+void PicoQuicStatsCollector::onPathQualityDelta(const PathQualityDelta& d) {
+  quicPacketsSent_ += d.packetsSent;
+  quicPacketLoss_ += d.packetsLost;
+  quicBytesWritten_ += d.bytesSent;
+  quicBytesRead_ += d.bytesReceived;
+  quicPacketRetransmissions_ += d.timerLosses + d.spuriousLosses;
+  if (d.cwndBlocked) {
+    ++quicCwndBlocked_;
+  }
+}
+
+StatsSnapshot PicoQuicStatsCollector::snapshot() const {
+  StatsSnapshot snap;
+
+#define COPY_FIELD(type, name) snap.name = name##_;
+  STATS_QUIC_COUNTER_FIELDS(COPY_FIELD)
+  STATS_QUIC_GAUGE_FIELDS(COPY_FIELD)
+#undef COPY_FIELD
+
+  return snap;
+}
+
+folly::Executor* PicoQuicStatsCollector::owningExecutor() const {
+  return evb_;
+}
+
+} // namespace openmoq::moqx::stats

--- a/src/stats/PicoQuicStatsCollector.h
+++ b/src/stats/PicoQuicStatsCollector.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+
+#include <folly/Executor.h>
+#include <folly/io/async/EventBase.h>
+#include <moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h>
+
+#include "stats/StatsRegistry.h"
+
+namespace openmoq::moqx::stats {
+
+/**
+ * Collects transport-layer QUIC statistics from a picoquic-based server.
+ *
+ * Implements moxygen::PicoQuicStatsCallback — register with
+ * MoQPicoServerBase::setPicoQuicStatsCallback after constructing via create().
+ *
+ * Threading: All callback methods fire on the server's single EventBase;
+ * counters need no synchronization. The EventBase is supplied at construction.
+ */
+class PicoQuicStatsCollector : public StatsCollectorBase, public moxygen::PicoQuicStatsCallback {
+public:
+  static std::shared_ptr<PicoQuicStatsCollector>
+  create(std::shared_ptr<StatsRegistry> registry, folly::EventBase* evb);
+
+  ~PicoQuicStatsCollector() override = default;
+
+  // StatsCollectorBase
+  StatsSnapshot snapshot() const override;
+  folly::Executor* owningExecutor() const override;
+
+  // moxygen::PicoQuicStatsCallback
+  void onConnectionCreated() override;
+  void onConnectionClosed() override;
+  void onStreamCreated() override;
+  void onStreamClosed() override;
+  void onStreamReset() override;
+  void onPathQualityDelta(const PathQualityDelta& d) override;
+
+private:
+  PicoQuicStatsCollector(folly::EventBase* evb);
+
+  folly::EventBase* evb_;
+
+  // Counters and gauges — all writes on evb_, no sync needed.
+#define DEFINE_FIELD(type, name) type name##_{0};
+  STATS_QUIC_COUNTER_FIELDS(DEFINE_FIELD)
+  STATS_QUIC_GAUGE_FIELDS(DEFINE_FIELD)
+#undef DEFINE_FIELD
+};
+
+} // namespace openmoq::moqx::stats

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,19 @@ target_link_libraries(moqx_bounded_histogram_test PRIVATE
 )
 gtest_discover_tests(moqx_bounded_histogram_test)
 
+add_executable(moqx_pico_quic_stats_test
+  stats/PicoQuicStatsCollectorTest.cpp
+)
+target_include_directories(moqx_pico_quic_stats_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(moqx_pico_quic_stats_test PRIVATE
+  moqx_core
+  GTest::gtest_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_pico_quic_stats_test)
+
 add_executable(moqx_service_matcher_test
   ServiceMatcherTest.cpp
 )

--- a/test/stats/PicoQuicStatsCollectorTest.cpp
+++ b/test/stats/PicoQuicStatsCollectorTest.cpp
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+
+#include "stats/PicoQuicStatsCollector.h"
+#include "stats/StatsRegistry.h"
+
+namespace openmoq::moqx::stats {
+
+class PicoQuicStatsCollectorTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    registry_ = std::make_shared<StatsRegistry>();
+    collector_ = PicoQuicStatsCollector::create(registry_, &evb_);
+  }
+
+  // Dummy EventBase — not driven; only used as an identity for owningExecutor.
+  folly::EventBase evb_;
+  std::shared_ptr<StatsRegistry> registry_;
+  std::shared_ptr<PicoQuicStatsCollector> collector_;
+};
+
+TEST_F(PicoQuicStatsCollectorTest, ConnectionLifecycle) {
+  collector_->onConnectionCreated();
+  collector_->onConnectionCreated();
+
+  {
+    auto snap = collector_->snapshot();
+    EXPECT_EQ(snap.quicConnectionsCreated, 2);
+    EXPECT_EQ(snap.quicConnectionsClosed, 0);
+    EXPECT_EQ(snap.quicActiveConnections, 2);
+  }
+
+  collector_->onConnectionClosed();
+
+  {
+    auto snap = collector_->snapshot();
+    EXPECT_EQ(snap.quicConnectionsCreated, 2);
+    EXPECT_EQ(snap.quicConnectionsClosed, 1);
+    EXPECT_EQ(snap.quicActiveConnections, 1);
+  }
+}
+
+TEST_F(PicoQuicStatsCollectorTest, PathQualityDeltaAccumulation) {
+  using Delta = moxygen::PicoQuicStatsCallback::PathQualityDelta;
+
+  Delta d1{};
+  d1.packetsSent = 10;
+  d1.packetsLost = 1;
+  d1.bytesSent = 1000;
+  d1.bytesReceived = 800;
+  d1.timerLosses = 1;
+  d1.spuriousLosses = 0;
+  d1.cwndBlocked = false;
+  collector_->onPathQualityDelta(d1);
+
+  Delta d2{};
+  d2.packetsSent = 5;
+  d2.packetsLost = 0;
+  d2.bytesSent = 500;
+  d2.bytesReceived = 400;
+  d2.timerLosses = 0;
+  d2.spuriousLosses = 1;
+  d2.cwndBlocked = true;
+  collector_->onPathQualityDelta(d2);
+
+  auto snap = collector_->snapshot();
+  EXPECT_EQ(snap.quicPacketsSent, 15);
+  EXPECT_EQ(snap.quicPacketLoss, 1);
+  EXPECT_EQ(snap.quicBytesWritten, 1500);
+  EXPECT_EQ(snap.quicBytesRead, 1200);
+  EXPECT_EQ(snap.quicPacketRetransmissions, 2); // timerLosses + spuriousLosses
+  EXPECT_EQ(snap.quicCwndBlocked, 1);
+}
+
+TEST_F(PicoQuicStatsCollectorTest, CwndBlockedCountsEachEvent) {
+  using Delta = moxygen::PicoQuicStatsCallback::PathQualityDelta;
+
+  Delta d{};
+  d.cwndBlocked = true;
+  collector_->onPathQualityDelta(d);
+  collector_->onPathQualityDelta(d);
+
+  Delta notBlocked{};
+  notBlocked.cwndBlocked = false;
+  collector_->onPathQualityDelta(notBlocked);
+
+  auto snap = collector_->snapshot();
+  EXPECT_EQ(snap.quicCwndBlocked, 2);
+}
+
+TEST_F(PicoQuicStatsCollectorTest, StreamLifecycle) {
+  collector_->onStreamCreated();
+  collector_->onStreamCreated();
+  collector_->onStreamClosed();
+  collector_->onStreamReset();
+
+  auto snap = collector_->snapshot();
+  EXPECT_EQ(snap.quicStreamsCreated, 2);
+  EXPECT_EQ(snap.quicStreamsClosed, 1);
+  EXPECT_EQ(snap.quicStreamsReset, 1);
+}
+
+TEST_F(PicoQuicStatsCollectorTest, OwningExecutorIsEvb) {
+  EXPECT_EQ(collector_->owningExecutor(), &evb_);
+}
+
+} // namespace openmoq::moqx::stats


### PR DESCRIPTION
Implements moxygen::PicoQuicStatsCallback as PicoQuicStatsCollector, populating the QUIC transport counters (packets, bytes, connections, streams, retransmissions, cwnd-blocked) when the picoquic stack is in use. Counters that picoquic does not expose publicly (flow-control blocked, stream-limit saturated) remain zero.

- PicoQuicStatsCollector: StatsCollectorBase + PicoQuicStatsCallback implementation; registered with StatsRegistry at creation
- MoqxPicoRelayServer: add setStatsRegistry to create and wire the collector via MoQPicoServerBase::setPicoQuicStatsCallback
- MoqxServerFactory: accept statsRegistry and call setStatsRegistry on both server types, eliminating the dynamic_cast from main
- deps/moxygen: update to d801159 (PicoQuicStatsCallback interface)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/130)
<!-- Reviewable:end -->
