### PR TITLE
Config: extend QuicConfig with shared transport settings, wire pico path

### DIFF
--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -4,12 +4,29 @@
 #include <folly/io/async/EventBase.h>
 #include <folly/logging/xlog.h>
 #include <moxygen/MoQRelaySession.h>
+#include <moxygen/openmoq/transport/pico/PicoTransportConfig.h>
 
 using namespace moxygen;
 
 namespace openmoq::moqx {
 
 namespace {
+
+moxygen::PicoTransportConfig picoTransportConfigFromQuicConfig(const config::QuicConfig& quic) {
+  return moxygen::PicoTransportConfig{
+      .maxData = quic.maxData,
+      .maxStreamData = quic.maxStreamData,
+      .maxUniStreams = quic.maxUniStreams,
+      .maxBidiStreams = quic.maxBidiStreams,
+      .maxDatagramFrameSize = 1280, // not user-configurable; MoQ requires datagrams
+      .idleTimeoutMs = quic.idleTimeoutMs,
+      .maxAckDelayUs = quic.maxAckDelayUs,
+      .minAckDelayUs = quic.minAckDelayUs,
+      .defaultStreamPriority = quic.defaultStreamPriority,
+      .defaultDatagramPriority = quic.defaultDatagramPriority,
+      .ccAlgo = quic.ccAlgo,
+  };
+}
 
 std::string resolveCert(const config::ListenerConfig& cfg) {
   return std::visit(
@@ -51,7 +68,8 @@ MoqxPicoRelayServer::MoqxPicoRelayServer(
           resolveKey(listenerCfg),
           listenerCfg.endpoint,
           ioExecutor->getAllEventBases()[0],
-          listenerCfg.moqtVersions
+          listenerCfg.moqtVersions,
+          picoTransportConfigFromQuicConfig(listenerCfg.quic)
       ),
       listenerCfg_(listenerCfg), context_(std::move(context)),
       evb_(ioExecutor->getAllEventBases()[0].get()) {}

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -6,6 +6,7 @@
 #include <proxygen/httpserver/samples/hq/FizzContext.h>
 
 #include <folly/logging/xlog.h>
+#include <quic/QuicConstants.h>
 
 using namespace moxygen;
 
@@ -54,6 +55,18 @@ quic::TransportSettings buildTransportSettings(const config::QuicConfig& quic) {
   ts.advertisedInitialUniStreamFlowControlWindow = quic.maxStreamData;
   ts.advertisedInitialMaxStreamsBidi = quic.maxBidiStreams;
   ts.advertisedInitialMaxStreamsUni = quic.maxUniStreams;
+  ts.idleTimeout = std::chrono::milliseconds(quic.idleTimeoutMs);
+  ts.minAckDelay = std::chrono::microseconds(quic.minAckDelayUs);
+  if (quic.maxAckDelayUs != config::QuicConfig{}.maxAckDelayUs) {
+    XLOG(DBG1) << "quic.max_ack_delay_us is set but mvfst does not support it; ignoring";
+  }
+  auto ccType = quic::congestionControlStrToType(quic.ccAlgo);
+  XDCHECK(ccType) << "cc_algo '" << quic.ccAlgo << "' passed validation but is unknown to mvfst";
+  if (ccType) {
+    ts.defaultCongestionController = *ccType;
+  }
+  // TODO: wire defaultStreamPriority / defaultDatagramPriority for mvfst once
+  // moxygen exposes a function to construct a PriorityQueue::Priority from an integer.
   return ts;
 }
 

--- a/src/MoqxServerFactory.h
+++ b/src/MoqxServerFactory.h
@@ -9,7 +9,6 @@
 #include "stats/StatsRegistry.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <moxygen/MoQServerBase.h>
-
 namespace openmoq::moqx {
 
 // Creates the appropriate relay server for the given listener config and wires
@@ -21,10 +20,6 @@ inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
     std::shared_ptr<stats::StatsRegistry> statsRegistry
 ) {
   if (listenerCfg.quicStack == config::QuicStack::Picoquic) {
-    // TODO: pass listenerCfg.quic settings to PicoRelayServer.
-    // Requires moxygen to expose a PicoTransportParams struct (parallel to
-    // PicoWebTransportConfig) so createQuicContext() can call
-    // picoquic_set_default_tp_value() for each field.
     auto server = std::make_shared<MoqxPicoRelayServer>(
         listenerCfg,
         std::move(context),

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -31,10 +31,19 @@ struct CacheConfig {
 enum class QuicStack { Mvfst, Picoquic };
 
 struct QuicConfig {
+  // Flow control
   uint64_t maxData{67108864};       // connection flow control window (bytes)
   uint64_t maxStreamData{16777216}; // per-stream flow control window (bytes)
   uint64_t maxUniStreams{8192};     // max concurrent unidirectional streams
   uint64_t maxBidiStreams{16};      // max concurrent bidirectional streams
+
+  // Transport settings
+  uint64_t idleTimeoutMs{30000};      // idle timeout (ms)
+  uint32_t maxAckDelayUs{25000};      // max ACK delay (us); mvfst ignores (logs DBG1)
+  uint32_t minAckDelayUs{1000};       // min ACK delay (microseconds)
+  uint8_t defaultStreamPriority{2};   // default stream priority
+  uint8_t defaultDatagramPriority{1}; // default datagram priority
+  std::string ccAlgo{"bbr"};          // congestion control algorithm name
 };
 
 struct ListenerConfig {

--- a/src/config/config_resolver.cpp
+++ b/src/config/config_resolver.cpp
@@ -370,6 +370,18 @@ void applyQuicOverride(QuicConfig& base, const ParsedQuicConfig& overlay) {
     base.maxUniStreams = *v;
   if (auto v = overlay.max_bidi_streams.value())
     base.maxBidiStreams = *v;
+  if (auto v = overlay.idle_timeout_ms.value())
+    base.idleTimeoutMs = *v;
+  if (auto v = overlay.max_ack_delay_us.value())
+    base.maxAckDelayUs = *v;
+  if (auto v = overlay.min_ack_delay_us.value())
+    base.minAckDelayUs = *v;
+  if (auto v = overlay.default_stream_priority.value())
+    base.defaultStreamPriority = *v;
+  if (auto v = overlay.default_datagram_priority.value())
+    base.defaultDatagramPriority = *v;
+  if (auto v = overlay.cc_algo.value())
+    base.ccAlgo = *v;
 }
 
 // Merge listener_defaults.quic and per-listener quic override into a resolved QuicConfig.
@@ -387,6 +399,7 @@ QuicConfig mergeQuicConfig(
 
 void validateQuicConfig(
     const QuicConfig& quic,
+    QuicStack stack,
     const std::string& context,
     std::vector<std::string>& errors,
     std::vector<std::string>& warnings
@@ -407,6 +420,35 @@ void validateQuicConfig(
     warnings.push_back(
         context + " quic: max_bidi_streams (" + std::to_string(quic.maxBidiStreams) +
         ") is very low (< 16)"
+    );
+  }
+  if (quic.idleTimeoutMs < 5000) {
+    warnings.push_back(
+        context + " quic: idle_timeout_ms (" + std::to_string(quic.idleTimeoutMs) +
+        ") is very aggressive (< 5000ms)"
+    );
+  }
+  if (quic.maxAckDelayUs < quic.minAckDelayUs) {
+    errors.push_back(
+        context + " quic: max_ack_delay_us (" + std::to_string(quic.maxAckDelayUs) +
+        ") must be >= min_ack_delay_us (" + std::to_string(quic.minAckDelayUs) + ")"
+    );
+  }
+  // (excluded: mvfst "custom"/"staticcwnd" require programmatic setup; "none" disables CC)
+  static const std::unordered_set<std::string> kPicoCcAlgos =
+      {"bbr", "bbr1", "c4", "cubic", "dcubic", "fast", "newreno", "prague", "reno"};
+  static const std::unordered_set<std::string> kMvfstCcAlgos =
+      {"bbr", "bbr2", "bbr2modular", "copa", "cubic", "newreno"};
+  const auto& validAlgos = (stack == QuicStack::Picoquic) ? kPicoCcAlgos : kMvfstCcAlgos;
+  const auto& validList = (stack == QuicStack::Picoquic)
+                              ? "bbr, bbr1, c4, cubic, dcubic, fast, newreno, prague, reno"
+                              : "bbr, bbr2, bbr2modular, copa, cubic, newreno";
+  if (!validAlgos.count(quic.ccAlgo)) {
+    errors.push_back(
+        context + " quic: cc_algo '" + quic.ccAlgo +
+        "' is not valid for this stack"
+        " (valid: " +
+        validList + ")"
     );
   }
 }
@@ -511,7 +553,9 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
         errors.push_back("Duplicate listener address: " + addr);
       }
       auto quic = mergeQuicConfig(quicDefaults, listener.quic.value());
-      validateQuicConfig(quic, "Listener '" + listener.name.value() + "'", errors, warnings);
+      const auto stackStr = listener.quic_stack.value().value_or("mvfst");
+      const auto stack = (stackStr == "picoquic") ? QuicStack::Picoquic : QuicStack::Mvfst;
+      validateQuicConfig(quic, stack, "Listener '" + listener.name.value() + "'", errors, warnings);
       mergedQuicConfigs.push_back(quic);
     }
   }

--- a/src/config/loader/parsed_config.h
+++ b/src/config/loader/parsed_config.h
@@ -39,6 +39,7 @@ struct ParsedAdminTlsConfig {
 };
 
 struct ParsedQuicConfig {
+  // Flow control
   rfl::Description<
       "Connection flow control window in bytes (default: 64MB)",
       std::optional<uint64_t>>
@@ -51,6 +52,27 @@ struct ParsedQuicConfig {
       max_uni_streams;
   rfl::Description<"Max concurrent bidirectional streams (default: 16)", std::optional<uint64_t>>
       max_bidi_streams;
+
+  // Transport settings
+  rfl::Description<"Idle timeout in milliseconds (default: 30000)", std::optional<uint64_t>>
+      idle_timeout_ms;
+  rfl::Description<
+      "Max ACK delay in microseconds (default: 25000, QUIC spec default); "
+      "mvfst ignores this field (logs DBG1 if set)",
+      std::optional<uint32_t>>
+      max_ack_delay_us;
+  rfl::Description<"Min ACK delay in microseconds (default: 1000)", std::optional<uint32_t>>
+      min_ack_delay_us;
+  rfl::Description<"Default stream priority (default: 2)", std::optional<uint8_t>>
+      default_stream_priority;
+  rfl::Description<"Default datagram priority (default: 1)", std::optional<uint8_t>>
+      default_datagram_priority;
+  rfl::Description<
+      "Congestion control algorithm (default: bbr). "
+      "picoquic: bbr, bbr1, c4, cubic, dcubic, fast, newreno, prague, reno. "
+      "mvfst: bbr, bbr2, bbr2modular, copa, cubic, newreno.",
+      std::optional<std::string>>
+      cc_algo;
 };
 
 struct ParsedListenerConfig {

--- a/test/config/config_resolver_test.cpp
+++ b/test/config/config_resolver_test.cpp
@@ -1001,6 +1001,12 @@ TEST(ResolveConfig, QuicDefaultsUsedWhenNoneSpecified) {
   EXPECT_EQ(quic.maxStreamData, 16777216u);
   EXPECT_EQ(quic.maxUniStreams, 8192u);
   EXPECT_EQ(quic.maxBidiStreams, 16u);
+  EXPECT_EQ(quic.idleTimeoutMs, 30000u);
+  EXPECT_EQ(quic.maxAckDelayUs, 25000u);
+  EXPECT_EQ(quic.minAckDelayUs, 1000u);
+  EXPECT_EQ(quic.defaultStreamPriority, 2u);
+  EXPECT_EQ(quic.defaultDatagramPriority, 1u);
+  EXPECT_EQ(quic.ccAlgo, "bbr");
 }
 
 TEST(ResolveConfig, ListenerDefaultsQuicApplied) {
@@ -1111,6 +1117,97 @@ TEST(ResolveConfig, QuicValidationUseMergedValues) {
   auto result = resolveConfig(cfg);
   ASSERT_TRUE(result.hasError());
   EXPECT_THAT(result.error(), HasSubstr("max_data"));
+}
+
+TEST(ResolveConfig, QuicIdleTimeoutLowWarning) {
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedQuicConfig quicCfg;
+  quicCfg.idle_timeout_ms = std::optional<uint64_t>{1000};
+  cfg.listeners.value()[0].quic = std::optional<ParsedQuicConfig>{std::move(quicCfg)};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_FALSE(result.value().warnings.empty());
+  EXPECT_THAT(result.value().warnings[0], HasSubstr("idle_timeout_ms"));
+}
+
+TEST(ResolveConfig, QuicMaxAckDelayLessThanMinIsError) {
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedQuicConfig quicCfg;
+  quicCfg.max_ack_delay_us = std::optional<uint32_t>{500};
+  quicCfg.min_ack_delay_us = std::optional<uint32_t>{1000};
+  cfg.listeners.value()[0].quic = std::optional<ParsedQuicConfig>{std::move(quicCfg)};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("max_ack_delay_us"));
+  EXPECT_THAT(result.error(), HasSubstr("min_ack_delay_us"));
+}
+
+TEST(ResolveConfig, QuicUnknownCcAlgoIsError) {
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedQuicConfig quicCfg;
+  quicCfg.cc_algo = std::optional<std::string>{"notanalgo"};
+  cfg.listeners.value()[0].quic = std::optional<ParsedQuicConfig>{std::move(quicCfg)};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("cc_algo"));
+  EXPECT_THAT(result.error(), HasSubstr("notanalgo"));
+}
+
+TEST(ResolveConfig, QuicCcAlgoPicoOnlyRejectedByMvfst) {
+  // dcubic is pico-only; rejected on mvfst (default stack), accepted on picoquic
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedQuicConfig quicCfg;
+  quicCfg.cc_algo = std::optional<std::string>{"dcubic"};
+  cfg.listeners.value()[0].quic = std::optional<ParsedQuicConfig>{quicCfg};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("cc_algo"));
+  EXPECT_THAT(result.error(), HasSubstr("dcubic"));
+
+  cfg.listeners.value()[0].quic_stack = std::optional<std::string>{"picoquic"};
+  cfg.listeners.value()[0].tls.value().insecure = false;
+  cfg.listeners.value()[0].tls.value().cert_file = std::optional<std::string>{"cert.pem"};
+  cfg.listeners.value()[0].tls.value().key_file = std::optional<std::string>{"key.pem"};
+  auto result2 = resolveConfig(cfg);
+  ASSERT_TRUE(result2.hasValue());
+  EXPECT_EQ(result2.value().config.listeners[0].quic.ccAlgo, "dcubic");
+}
+
+TEST(ResolveConfig, QuicCcAlgoMvfstOnlyRejectedByPico) {
+  // bbr2 is mvfst-only; rejected on picoquic, accepted on mvfst (default stack)
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedQuicConfig quicCfg;
+  quicCfg.cc_algo = std::optional<std::string>{"bbr2"};
+  cfg.listeners.value()[0].quic = std::optional<ParsedQuicConfig>{quicCfg};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(result.value().config.listeners[0].quic.ccAlgo, "bbr2");
+
+  cfg.listeners.value()[0].quic_stack = std::optional<std::string>{"picoquic"};
+  cfg.listeners.value()[0].tls.value().insecure = false;
+  cfg.listeners.value()[0].tls.value().cert_file = std::optional<std::string>{"cert.pem"};
+  cfg.listeners.value()[0].tls.value().key_file = std::optional<std::string>{"key.pem"};
+  cfg.listeners.value()[0].quic = std::optional<ParsedQuicConfig>{quicCfg};
+  auto result2 = resolveConfig(cfg);
+  ASSERT_TRUE(result2.hasError());
+  EXPECT_THAT(result2.error(), HasSubstr("cc_algo"));
+  EXPECT_THAT(result2.error(), HasSubstr("bbr2"));
+}
+
+TEST(ResolveConfig, QuicCcAlgoRoundTrips) {
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedQuicConfig quicCfg;
+  quicCfg.cc_algo = std::optional<std::string>{"cubic"};
+  cfg.listeners.value()[0].quic = std::optional<ParsedQuicConfig>{std::move(quicCfg)};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(result.value().config.listeners[0].quic.ccAlgo, "cubic");
 }
 
 } // namespace


### PR DESCRIPTION
Adds idleTimeoutMs, maxAckDelayUs, minAckDelayUs, defaultStreamPriority, defaultDatagramPriority, and ccAlgo to QuicConfig (shared by both stacks). All fields are parsed via ParsedQuicConfig and merged through the existing listener_defaults → per-listener override chain.

Wires the new fields for picoquic via picoTransportConfigFromQuicConfig (maxDatagramFrameSize hardcoded to 1280; MoQ requires datagrams). Wires idleTimeout, minAckDelay, and ccAlgo for mvfst in buildTransportSettings; maxAckDelayUs logs DBG1 if non-default (mvfst does not yet expose this knob). Priority fields are wired for pico; mvfst has a TODO pending a helper to construct PriorityQueue::Priority from an integer.

Config validation now checks cc_algo against per-stack valid name lists (picoquic and mvfst have partially overlapping sets). Adds tests for the new validation rules and stack-specific cc_algo rejection.

Bumps deps/moxygen to feature/pico-transport-config (PicoTransportConfig).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/131)
<!-- Reviewable:end -->
