### PR TITLE
Fix stale paths and entrypoint from source tree cleanup

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -143,7 +143,7 @@ jobs:
           fi
           echo "==> Start container with test config"
           docker run -d --name moqx-smoke --network host \
-            -v "$PWD/tests/test.config.yaml:/etc/moqx/config.yaml:ro" \
+            -v "$PWD/test/test.config.yaml:/etc/moqx/config.yaml:ro" \
             "${IMAGE}" --config=/etc/moqx/config.yaml
           echo "==> Wait for admin /info"
           for i in $(seq 1 50); do

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,6 @@ COPY .docker-deps/moxygen /opt/moxygen
 COPY CMakeLists.txt CMakePresets.json ./
 COPY cmake/ cmake/
 COPY src/ src/
-COPY include/ include/
 COPY deps/moxygen/build/fbcode_builder/CMake deps/moxygen/build/fbcode_builder/CMake
 
 RUN cmake -S . -B _build --preset default \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,9 +24,9 @@ export GLOG_logtostderr=1
 export GLOG_minloglevel="${MOQX_LOG_LEVEL:-0}"
 export GLOG_v="${MOQX_VERBOSE:-0}"
 
-# Enable core dumps (requires ulimits.core=-1 in compose)
-if [ -d /var/coredumps ]; then
-  echo "/var/coredumps/core.%e.%p.%t" > /proc/sys/kernel/core_pattern 2>/dev/null || true
+# Enable core dumps (requires ulimits.core=-1 and --privileged in compose)
+if [ -d /var/coredumps ] && [ -w /proc/sys/kernel/core_pattern ]; then
+  echo "/var/coredumps/core.%e.%p.%t" > /proc/sys/kernel/core_pattern
 fi
 
 # Use custom config if mounted, otherwise generate from env vars

--- a/scripts/sync-relay.sh
+++ b/scripts/sync-relay.sh
@@ -7,7 +7,7 @@
 # Transforms:
 #   MoQRelay.h            -> include/moqx/MoqxRelay.h
 #   MoQRelay.cpp          -> src/MoqxRelay.cpp
-#   test/MoQRelayTest.cpp -> tests/MoqxRelayTest.cpp
+#   test/MoQRelayTest.cpp -> test/MoqxRelayTest.cpp
 #
 # Name/namespace mappings applied:
 #   class MoQRelay           -> class MoqxRelay
@@ -163,10 +163,10 @@ process_source() {
 # ─────────────────────────────────────────────────────────────────────────────
 process_test() {
   local src="${MOXYGEN_RELAY}/test/MoQRelayTest.cpp"
-  local dst="${REPO_ROOT}/tests/MoqxRelayTest.cpp"
+  local dst="${REPO_ROOT}/test/MoqxRelayTest.cpp"
   local tmp="${TMP_DIR}/MoqxRelayTest.cpp"
 
-  echo "  test/MoQRelayTest.cpp -> tests/MoqxRelayTest.cpp"
+  echo "  test/MoQRelayTest.cpp -> test/MoqxRelayTest.cpp"
   cp "$src" "$tmp"
 
   replace_copyright "$tmp"


### PR DESCRIPTION
Fixes remaining issues from #122 (source tree cleanup).

- **ci-main.yml**: `tests/test.config.yaml` → `test/test.config.yaml` in Docker smoke test mount (this is why main CI publish fails)
- **sync-relay.sh**: `tests/` → `test/` references
- **entrypoint.sh**: check `-w` before writing core_pattern (silences error on non-privileged containers)

Tested locally:
- Docker build passes with fresh bookworm tarball
- Smoke test passes (relay starts, `/info` responds correctly)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/132)
<!-- Reviewable:end -->
