### PR TITLE
Add conformance test suite to CI

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -118,7 +118,8 @@ jobs:
           fail-on-empty: ${{ job.status == 'success' && 'true' || 'false' }}
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Conformance: mvfst × {d14, d16} × {Q, WT} (mirrors ci-pr.yml)
+  # Conformance: mvfst × {d14, d16} × {Q, WT} + pico × {d14, d16} × Q
+  # (mirrors ci-pr.yml)
   # ════════════════════════════════════════════════════════════════════════════
 
   conformance:
@@ -129,7 +130,8 @@ jobs:
         include:
           # mvfst — both transports for d14 and d16. d14+WT was unblocked by
           # facebookexperimental/moxygen#151 (Accept moq-00 in WT-Available-Protocols).
-          # picoquic stack to follow in a separate PR.
+          # pico — raw QUIC for d14 and d16. WT cells deferred until pico
+          # WT CONNECT (openmoq/moxygen#172 / PR #173) syncs in.
           - name: mvfst d14 Q
             versions: "14"
             transport: "Q"
@@ -146,6 +148,14 @@ jobs:
             versions: "16"
             transport: ""
             stack: "mvfst"
+          - name: pico d14 Q
+            versions: "14"
+            transport: "Q"
+            stack: "pico"
+          - name: pico d16 Q
+            versions: "16"
+            transport: "Q"
+            stack: "pico"
     name: conformance (${{ matrix.name }})
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -118,7 +118,7 @@ jobs:
           fail-on-empty: ${{ job.status == 'success' && 'true' || 'false' }}
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Conformance: mvfst × {d14 raw QUIC, d16 WT} (mirrors ci-pr.yml)
+  # Conformance: mvfst × {d14, d16} × {Q, WT} (mirrors ci-pr.yml)
   # ════════════════════════════════════════════════════════════════════════════
 
   conformance:
@@ -127,15 +127,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # d14 over Q only for now: moxygen moqtest_client/server self-test
-          # rig can't do d14+WT (sends d16-era WT subprotocol header on a d14
-          # session — non-conformant per spec). Pending upstream fix.
+          # mvfst — both transports for d14 and d16. d14+WT was unblocked by
+          # facebookexperimental/moxygen#151 (Accept moq-00 in WT-Available-Protocols).
+          # picoquic stack to follow in a separate PR.
           - name: mvfst d14 Q
             versions: "14"
             transport: "Q"
+            stack: "mvfst"
+          - name: mvfst d14 WT
+            versions: "14"
+            transport: ""
+            stack: "mvfst"
+          - name: mvfst d16 Q
+            versions: "16"
+            transport: "Q"
+            stack: "mvfst"
           - name: mvfst d16 WT
             versions: "16"
             transport: ""
+            stack: "mvfst"
     name: conformance (${{ matrix.name }})
     runs-on: ubuntu-22.04
     steps:
@@ -162,7 +172,7 @@ jobs:
         run: bash scripts/build.sh
 
       - name: Run conformance tests
-        run: bash test/test_conformance.sh ./build/moqx ${{ matrix.versions }} ${{ matrix.transport }}
+        run: bash test/test_conformance.sh ./build/moqx ${{ matrix.versions }} ${{ matrix.transport }} ${{ matrix.stack }}
 
   # ════════════════════════════════════════════════════════════════════════════
   # Publish: build moqx, Docker image + smoke test, push

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -118,6 +118,53 @@ jobs:
           fail-on-empty: ${{ job.status == 'success' && 'true' || 'false' }}
 
   # ════════════════════════════════════════════════════════════════════════════
+  # Conformance: mvfst × {d14 raw QUIC, d16 WT} (mirrors ci-pr.yml)
+  # ════════════════════════════════════════════════════════════════════════════
+
+  conformance:
+    needs: [check-format]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # d14 over Q only for now: moxygen moqtest_client/server self-test
+          # rig can't do d14+WT (sends d16-era WT subprotocol header on a d14
+          # session — non-conformant per spec). Pending upstream fix.
+          - name: mvfst d14 Q
+            versions: "14"
+            transport: "Q"
+          - name: mvfst d16 WT
+            versions: "16"
+            transport: ""
+    name: conformance (${{ matrix.name }})
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install system dependencies
+        run: sudo deps/moxygen/standalone/install-system-deps.sh
+
+      - name: Setup dependencies
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: bash scripts/build.sh setup
+
+      - name: Build
+        run: bash scripts/build.sh
+
+      - name: Run conformance tests
+        run: bash test/test_conformance.sh ./build/moqx ${{ matrix.versions }} ${{ matrix.transport }}
+
+  # ════════════════════════════════════════════════════════════════════════════
   # Publish: build moqx, Docker image + smoke test, push
   # ════════════════════════════════════════════════════════════════════════════
 
@@ -523,7 +570,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   notify:
-    needs: [check-format, build, publish, manifest, release, deploy]
+    needs: [check-format, build, conformance, publish, manifest, release, deploy]
     if: always()
     runs-on: ubuntu-22.04
     steps:
@@ -556,11 +603,12 @@ jobs:
             VER_RESULT="skipped"
           fi
           VER=$(fmt_status "$VER_RESULT")
+          CONF=$(fmt_status "${{ needs.conformance.result }}")
           PUB=$(fmt_status "${{ needs.publish.result }}")
           REL=$(fmt_status "${{ needs.release.result }}")
           DEP=$(fmt_status "${{ needs.deploy.result }}")
 
-          STATUS="verify:${VER} publish:${PUB} release:${REL} deploy:${DEP}"
+          STATUS="verify:${VER} conformance:${CONF} publish:${PUB} release:${REL} deploy:${DEP}"
 
           if [ "${{ needs.release.result }}" = "success" ]; then
             REL_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.release.outputs.tag || 'snapshot-latest' }}"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -114,10 +114,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: mvfst d14
+          # d14 over Q only for now: moxygen moqtest_client/server self-test
+          # rig can't do d14+WT (sends d16-era WT subprotocol header on a d14
+          # session — non-conformant per spec). Pending upstream fix.
+          - name: mvfst d14 Q
             versions: "14"
-            transport: ""
-          - name: mvfst d16
+            transport: "Q"
+          - name: mvfst d16 WT
             versions: "16"
             transport: ""
     name: conformance (${{ matrix.name }})

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -116,7 +116,8 @@ jobs:
         include:
           # mvfst — both transports for d14 and d16. d14+WT was unblocked by
           # facebookexperimental/moxygen#151 (Accept moq-00 in WT-Available-Protocols).
-          # picoquic stack to follow in a separate PR.
+          # pico — raw QUIC for d14 and d16. WT cells deferred until pico
+          # WT CONNECT (openmoq/moxygen#172 / PR #173) syncs in.
           - name: mvfst d14 Q
             versions: "14"
             transport: "Q"
@@ -133,6 +134,14 @@ jobs:
             versions: "16"
             transport: ""
             stack: "mvfst"
+          - name: pico d14 Q
+            versions: "14"
+            transport: "Q"
+            stack: "pico"
+          - name: pico d16 Q
+            versions: "16"
+            transport: "Q"
+            stack: "pico"
     name: conformance (${{ matrix.name }})
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -114,15 +114,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # d14 over Q only for now: moxygen moqtest_client/server self-test
-          # rig can't do d14+WT (sends d16-era WT subprotocol header on a d14
-          # session — non-conformant per spec). Pending upstream fix.
+          # mvfst — both transports for d14 and d16. d14+WT was unblocked by
+          # facebookexperimental/moxygen#151 (Accept moq-00 in WT-Available-Protocols).
+          # picoquic stack to follow in a separate PR.
           - name: mvfst d14 Q
             versions: "14"
             transport: "Q"
+            stack: "mvfst"
+          - name: mvfst d14 WT
+            versions: "14"
+            transport: ""
+            stack: "mvfst"
+          - name: mvfst d16 Q
+            versions: "16"
+            transport: "Q"
+            stack: "mvfst"
           - name: mvfst d16 WT
             versions: "16"
             transport: ""
+            stack: "mvfst"
     name: conformance (${{ matrix.name }})
     runs-on: ubuntu-22.04
     steps:
@@ -149,4 +159,4 @@ jobs:
         run: bash scripts/build.sh
 
       - name: Run conformance tests
-        run: bash test/test_conformance.sh ./build/moqx ${{ matrix.versions }} ${{ matrix.transport }}
+        run: bash test/test_conformance.sh ./build/moqx ${{ matrix.versions }} ${{ matrix.transport }} ${{ matrix.stack }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -107,3 +107,43 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           echo "::notice::Publish test results skipped — fork-PR GITHUB_TOKEN lacks checks:write. Test-log output above is authoritative."
+
+  conformance:
+    needs: [check-format]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: mvfst d14
+            versions: "14"
+            transport: ""
+          - name: mvfst d16
+            versions: "16"
+            transport: ""
+    name: conformance (${{ matrix.name }})
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install system dependencies
+        run: sudo deps/moxygen/standalone/install-system-deps.sh
+
+      - name: Setup dependencies
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: bash scripts/build.sh setup
+
+      - name: Build
+        run: bash scripts/build.sh
+
+      - name: Run conformance tests
+        run: bash test/test_conformance.sh ./build/moqx ${{ matrix.versions }} ${{ matrix.transport }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = deps/moxygen
 	url = git@github.com:openmoq/moxygen.git
 	branch = main
+	ignore = untracked

--- a/test/test_conformance.sh
+++ b/test/test_conformance.sh
@@ -73,10 +73,14 @@ ADMIN_PORT=$((RELAY_PORT + 1))
 
 # picoquic dual-stack v6 bind doesn't currently receive v4-mapped packets
 # (openmoq/moxygen#170). Bind v4 explicitly when stack=pico; mvfst is fine on "::".
-# picoquic also requires real TLS credentials — insecure mode is unsupported.
+# picoquic also requires real TLS credentials — insecure mode is unsupported
+# (openmoq/moxygen#176). URL_HOST is the matching client-side address — must
+# agree with the bind family or 'localhost' may resolve to ::1 and miss the
+# v4-only listener (CI's /etc/hosts lists ::1 first).
 TMPDIR=$(mktemp -d)
 if [[ "$QUIC_STACK" = "pico" ]]; then
   BIND_ADDRESS="0.0.0.0"
+  URL_HOST="127.0.0.1"
   STACK_LINE="    quic_stack: picoquic"
   # Generate ephemeral self-signed cert valid for localhost.
   openssl req -newkey rsa:2048 -nodes \
@@ -89,6 +93,7 @@ if [[ "$QUIC_STACK" = "pico" ]]; then
       key_file: \"$TMPDIR/cert.key\""
 else
   BIND_ADDRESS="::"
+  URL_HOST="localhost"
   STACK_LINE=""
   TLS_BLOCK="    tls:
       insecure: true"
@@ -147,7 +152,7 @@ echo "==> Starting moqtest_server..."
 # different MoQ versions / transports and the relay can't bridge them
 # (every client invocation then hangs to its 30s transaction timeout).
 "$MOQBIN/moqtest_server" \
-  --relay_url="https://localhost:${RELAY_PORT}/moq-relay" \
+  --relay_url="https://${URL_HOST}:${RELAY_PORT}/moq-relay" \
   "${SERVER_VERSIONS_FLAG[@]}" \
   "${SERVER_TRANSPORT_FLAG[@]}" \
   --logtostderr &
@@ -162,7 +167,7 @@ fi
 echo "==> moqtest_server ready (PID=${SERVER_PID})"
 
 echo "==> Running conformance tests..."
-RELAY_URL="https://localhost:${RELAY_PORT}/moq-relay"
+RELAY_URL="https://${URL_HOST}:${RELAY_PORT}/moq-relay"
 
 # conformance_test.sh expects moqtest_client at $MOXYGEN_DIR/moxygen/moqtest/moqtest_client
 # Create a symlink tree matching the expected layout

--- a/test/test_conformance.sh
+++ b/test/test_conformance.sh
@@ -89,21 +89,29 @@ done
 echo "==> Relay ready (PID=${RELAY_PID})"
 
 echo "==> Starting moqtest_server..."
-# moqtest_server's --versions must match the client's --versions, otherwise
-# server-relay ALPN negotiates draft-16 (default) while client-relay
-# negotiates draft-14, and the relay can't bridge across versions →
-# every client invocation hangs to its connect/transaction timeout.
+# moqtest_server's --versions and --quic_transport must match the client's,
+# otherwise the server-relay session and client-relay session land on
+# different MoQ versions / transports and the relay can't bridge them
+# (every client invocation then hangs to its 30s transaction timeout).
+#
+# Notes on draft / transport pairings (moxygen MoQServer.cpp:84-86):
+#   - draft-14 uses the legacy "moq-00" ALPN, which is *excluded* from the
+#     WebTransport subprotocol list, so d14 conformance MUST use raw QUIC.
+#   - draft-16 (and later) ALPNs work in both WT and raw QUIC.
 SERVER_VERSIONS_FLAG=()
+SERVER_TRANSPORT_FLAG=()
 for arg in "${EXTRA_ARGS[@]}"; do
   if [[ "$arg" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
     SERVER_VERSIONS_FLAG=(--versions="$arg")
-    break
+  elif [ "$arg" = "Q" ]; then
+    SERVER_TRANSPORT_FLAG=(--quic_transport=true)
   fi
 done
 
 "$MOQBIN/moqtest_server" \
   --relay_url="https://localhost:${RELAY_PORT}/moq-relay" \
   "${SERVER_VERSIONS_FLAG[@]}" \
+  "${SERVER_TRANSPORT_FLAG[@]}" \
   --logtostderr &
 SERVER_PID=$!
 sleep 2

--- a/test/test_conformance.sh
+++ b/test/test_conformance.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Run the moxygen conformance test suite against a moqx relay.
+#
+# Usage: test_conformance.sh <moqx_binary> [versions] [Q]
+#
+# Environment:
+#   MOQBIN — path to moxygen install bin/ (for moqtest_client, moqtest_server)
+#            defaults to .scratch/moxygen-install/bin
+#
+# Examples:
+#   test_conformance.sh ./build/moqx
+#   test_conformance.sh ./build/moqx 16
+#   test_conformance.sh ./build/moqx 14 Q    # QUIC transport, draft-14
+#   test_conformance.sh ./build/moqx 16 Q    # QUIC transport, draft-16
+
+set -euo pipefail
+
+MOQX_BIN="${1:?Usage: $0 <moqx_binary> [versions] [Q]}"
+shift
+EXTRA_ARGS=("$@")
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MOQBIN="${MOQBIN:-${PROJECT_ROOT}/.scratch/moxygen-install/bin}"
+CONFIG="${PROJECT_ROOT}/test/test.config.yaml"
+CONFORMANCE_SCRIPT="${PROJECT_ROOT}/deps/moxygen/moxygen/moqtest/conformance_test.sh"
+
+# Validate binaries exist
+for bin in "$MOQX_BIN" "$MOQBIN/moqtest_client" "$MOQBIN/moqtest_server"; do
+  if [[ ! -x "$bin" ]]; then
+    echo "Error: binary not found or not executable: $bin" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -x "$CONFORMANCE_SCRIPT" ]]; then
+  echo "Error: conformance script not found: $CONFORMANCE_SCRIPT" >&2
+  exit 1
+fi
+
+# Pick a random port range to avoid collisions with parallel runs
+RELAY_PORT=$((19700 + RANDOM % 100))
+ADMIN_PORT=$((RELAY_PORT + 1))
+
+# Generate a temp config with our ports
+TMPCONFIG=$(mktemp)
+trap 'rm -f "$TMPCONFIG"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
+
+cat > "$TMPCONFIG" <<EOF
+listeners:
+  - name: conformance
+    udp:
+      socket:
+        address: "::"
+        port: ${RELAY_PORT}
+    tls:
+      insecure: true
+    endpoint: "/moq-relay"
+services:
+  default:
+    match:
+      - authority: {any: true}
+        path: {prefix: "/"}
+    cache:
+      enabled: true
+      max_tracks: 1000
+      max_groups_per_track: 100
+admin:
+  port: ${ADMIN_PORT}
+  address: "::1"
+  plaintext: true
+EOF
+
+echo "==> Starting moqx relay on port ${RELAY_PORT}..."
+"$MOQX_BIN" --config "$TMPCONFIG" --logtostderr &
+RELAY_PID=$!
+
+# Wait for admin endpoint
+for i in $(seq 1 40); do
+  if curl -sf "http://[::1]:${ADMIN_PORT}/info" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+  if [[ "$i" -eq 40 ]]; then
+    echo "Error: relay did not start within 10s" >&2
+    exit 1
+  fi
+done
+echo "==> Relay ready (PID=${RELAY_PID})"
+
+echo "==> Starting moqtest_server..."
+"$MOQBIN/moqtest_server" \
+  --relay_url="https://localhost:${RELAY_PORT}/moq-relay" \
+  --logtostderr &
+SERVER_PID=$!
+sleep 2
+
+# Verify server connected
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+  echo "Error: moqtest_server exited prematurely" >&2
+  exit 1
+fi
+echo "==> moqtest_server ready (PID=${SERVER_PID})"
+
+echo "==> Running conformance tests..."
+RELAY_URL="https://localhost:${RELAY_PORT}/moq-relay"
+
+# conformance_test.sh expects moqtest_client at $MOXYGEN_DIR/moxygen/moqtest/moqtest_client
+# Create a symlink tree matching the expected layout
+MOXYGEN_SHIM=$(mktemp -d)
+mkdir -p "$MOXYGEN_SHIM/moxygen/moqtest"
+ln -s "$MOQBIN/moqtest_client" "$MOXYGEN_SHIM/moxygen/moqtest/moqtest_client"
+export MOXYGEN_DIR="$MOXYGEN_SHIM"
+trap 'rm -rf "$MOXYGEN_SHIM" "$TMPCONFIG"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
+
+bash "$CONFORMANCE_SCRIPT" "$RELAY_URL" "${EXTRA_ARGS[@]}"
+EXIT_CODE=$?
+
+echo "==> Conformance tests finished (exit code: $EXIT_CODE)"
+exit $EXIT_CODE

--- a/test/test_conformance.sh
+++ b/test/test_conformance.sh
@@ -89,8 +89,21 @@ done
 echo "==> Relay ready (PID=${RELAY_PID})"
 
 echo "==> Starting moqtest_server..."
+# moqtest_server's --versions must match the client's --versions, otherwise
+# server-relay ALPN negotiates draft-16 (default) while client-relay
+# negotiates draft-14, and the relay can't bridge across versions →
+# every client invocation hangs to its connect/transaction timeout.
+SERVER_VERSIONS_FLAG=()
+for arg in "${EXTRA_ARGS[@]}"; do
+  if [[ "$arg" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+    SERVER_VERSIONS_FLAG=(--versions="$arg")
+    break
+  fi
+done
+
 "$MOQBIN/moqtest_server" \
   --relay_url="https://localhost:${RELAY_PORT}/moq-relay" \
+  "${SERVER_VERSIONS_FLAG[@]}" \
   --logtostderr &
 SERVER_PID=$!
 sleep 2

--- a/test/test_conformance.sh
+++ b/test/test_conformance.sh
@@ -113,8 +113,19 @@ ln -s "$MOQBIN/moqtest_client" "$MOXYGEN_SHIM/moxygen/moqtest/moqtest_client"
 export MOXYGEN_DIR="$MOXYGEN_SHIM"
 trap 'rm -rf "$MOXYGEN_SHIM" "$TMPCONFIG"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
 
+set +e
 bash "$CONFORMANCE_SCRIPT" "$RELAY_URL" "${EXTRA_ARGS[@]}"
 EXIT_CODE=$?
+set -e
 
 echo "==> Conformance tests finished (exit code: $EXIT_CODE)"
+
+# Clean up before exiting so background process kills don't affect exit code
+kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null
+wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null || true
+rm -rf "$MOXYGEN_SHIM" "$TMPCONFIG"
+
+# Disable the trap — we already cleaned up
+trap - EXIT
+
 exit $EXIT_CODE

--- a/test/test_conformance.sh
+++ b/test/test_conformance.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 # Run the moxygen conformance test suite against a moqx relay.
 #
-# Usage: test_conformance.sh <moqx_binary> [versions] [Q]
+# Usage: test_conformance.sh <moqx_binary> [versions] [Q] [stack]
+#
+#   versions — "14", "16", or "14,16" (default: moxygen default)
+#   Q        — literal "Q" to use raw QUIC transport (default: WebTransport)
+#   stack    — "mvfst" (default) or "pico" — selects the relay's QUIC stack
+#
+# Args are positional but order-independent: each is identified by content.
 #
 # Environment:
 #   MOQBIN — path to moxygen install bin/ (for moqtest_client, moqtest_server)
@@ -10,19 +16,19 @@
 # Examples:
 #   test_conformance.sh ./build/moqx
 #   test_conformance.sh ./build/moqx 16
-#   test_conformance.sh ./build/moqx 14 Q    # QUIC transport, draft-14
-#   test_conformance.sh ./build/moqx 16 Q    # QUIC transport, draft-16
+#   test_conformance.sh ./build/moqx 14 Q          # mvfst, draft-14, raw QUIC
+#   test_conformance.sh ./build/moqx 16 Q pico     # picoquic, draft-16, raw QUIC
+#   test_conformance.sh ./build/moqx 14 pico       # picoquic, draft-14, WT
 
 set -euo pipefail
 
-MOQX_BIN="${1:?Usage: $0 <moqx_binary> [versions] [Q]}"
+MOQX_BIN="${1:?Usage: $0 <moqx_binary> [versions] [Q] [stack]}"
 shift
 EXTRA_ARGS=("$@")
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MOQBIN="${MOQBIN:-${PROJECT_ROOT}/.scratch/moxygen-install/bin}"
-CONFIG="${PROJECT_ROOT}/test/test.config.yaml"
 CONFORMANCE_SCRIPT="${PROJECT_ROOT}/deps/moxygen/moxygen/moqtest/conformance_test.sh"
 
 # Validate binaries exist
@@ -38,40 +44,87 @@ if [[ ! -x "$CONFORMANCE_SCRIPT" ]]; then
   exit 1
 fi
 
+# Parse args. Each one is identified by content so order doesn't matter.
+QUIC_STACK="mvfst"
+DOWNSTREAM_ARGS=()
+SERVER_VERSIONS_FLAG=()
+SERVER_TRANSPORT_FLAG=()
+for arg in "${EXTRA_ARGS[@]}"; do
+  case "$arg" in
+    mvfst|pico)
+      QUIC_STACK="$arg"
+      ;;
+    Q)
+      SERVER_TRANSPORT_FLAG=(--quic_transport=true)
+      DOWNSTREAM_ARGS+=("$arg")
+      ;;
+    *)
+      if [[ "$arg" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+        SERVER_VERSIONS_FLAG=(--versions="$arg")
+      fi
+      DOWNSTREAM_ARGS+=("$arg")
+      ;;
+  esac
+done
+
 # Pick a random port range to avoid collisions with parallel runs
 RELAY_PORT=$((19700 + RANDOM % 100))
 ADMIN_PORT=$((RELAY_PORT + 1))
 
+# picoquic dual-stack v6 bind doesn't currently receive v4-mapped packets
+# (openmoq/moxygen#170). Bind v4 explicitly when stack=pico; mvfst is fine on "::".
+# picoquic also requires real TLS credentials — insecure mode is unsupported.
+TMPDIR=$(mktemp -d)
+if [[ "$QUIC_STACK" = "pico" ]]; then
+  BIND_ADDRESS="0.0.0.0"
+  STACK_LINE="    quic_stack: picoquic"
+  # Generate ephemeral self-signed cert valid for localhost.
+  openssl req -newkey rsa:2048 -nodes \
+    -keyout "$TMPDIR/cert.key" -x509 -out "$TMPDIR/cert.pem" \
+    -subj '/CN=conformance-test' -addext 'subjectAltName=DNS:localhost' \
+    >/dev/null 2>&1
+  TLS_BLOCK="    tls:
+      insecure: false
+      cert_file: \"$TMPDIR/cert.pem\"
+      key_file: \"$TMPDIR/cert.key\""
+else
+  BIND_ADDRESS="::"
+  STACK_LINE=""
+  TLS_BLOCK="    tls:
+      insecure: true"
+fi
+
 # Generate a temp config with our ports
-TMPCONFIG=$(mktemp)
-trap 'rm -f "$TMPCONFIG"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
+TMPCONFIG="$TMPDIR/config.yaml"
+trap 'rm -rf "$TMPDIR"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
 
 cat > "$TMPCONFIG" <<EOF
 listeners:
   - name: conformance
+${STACK_LINE}
     udp:
       socket:
-        address: "::"
+        address: "${BIND_ADDRESS}"
         port: ${RELAY_PORT}
-    tls:
-      insecure: true
+${TLS_BLOCK}
     endpoint: "/moq-relay"
 services:
   default:
     match:
       - authority: {any: true}
-        path: {prefix: "/"}
-    cache:
-      enabled: true
-      max_tracks: 1000
-      max_groups_per_track: 100
+        path: {exact: "/moq-relay"}
+service_defaults:
+  cache:
+    enabled: true
+    max_tracks: 1000
+    max_groups_per_track: 100
 admin:
   port: ${ADMIN_PORT}
   address: "::1"
   plaintext: true
 EOF
 
-echo "==> Starting moqx relay on port ${RELAY_PORT}..."
+echo "==> Starting moqx relay (stack=${QUIC_STACK}) on port ${RELAY_PORT}..."
 "$MOQX_BIN" --config "$TMPCONFIG" --logtostderr &
 RELAY_PID=$!
 
@@ -93,21 +146,6 @@ echo "==> Starting moqtest_server..."
 # otherwise the server-relay session and client-relay session land on
 # different MoQ versions / transports and the relay can't bridge them
 # (every client invocation then hangs to its 30s transaction timeout).
-#
-# Notes on draft / transport pairings (moxygen MoQServer.cpp:84-86):
-#   - draft-14 uses the legacy "moq-00" ALPN, which is *excluded* from the
-#     WebTransport subprotocol list, so d14 conformance MUST use raw QUIC.
-#   - draft-16 (and later) ALPNs work in both WT and raw QUIC.
-SERVER_VERSIONS_FLAG=()
-SERVER_TRANSPORT_FLAG=()
-for arg in "${EXTRA_ARGS[@]}"; do
-  if [[ "$arg" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
-    SERVER_VERSIONS_FLAG=(--versions="$arg")
-  elif [ "$arg" = "Q" ]; then
-    SERVER_TRANSPORT_FLAG=(--quic_transport=true)
-  fi
-done
-
 "$MOQBIN/moqtest_server" \
   --relay_url="https://localhost:${RELAY_PORT}/moq-relay" \
   "${SERVER_VERSIONS_FLAG[@]}" \
@@ -132,10 +170,10 @@ MOXYGEN_SHIM=$(mktemp -d)
 mkdir -p "$MOXYGEN_SHIM/moxygen/moqtest"
 ln -s "$MOQBIN/moqtest_client" "$MOXYGEN_SHIM/moxygen/moqtest/moqtest_client"
 export MOXYGEN_DIR="$MOXYGEN_SHIM"
-trap 'rm -rf "$MOXYGEN_SHIM" "$TMPCONFIG"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
+trap 'rm -rf "$MOXYGEN_SHIM" "$TMPDIR"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
 
 set +e
-bash "$CONFORMANCE_SCRIPT" "$RELAY_URL" "${EXTRA_ARGS[@]}"
+bash "$CONFORMANCE_SCRIPT" "$RELAY_URL" "${DOWNSTREAM_ARGS[@]}"
 EXIT_CODE=$?
 set -e
 
@@ -144,7 +182,7 @@ echo "==> Conformance tests finished (exit code: $EXIT_CODE)"
 # Clean up before exiting so background process kills don't affect exit code
 kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null
 wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null || true
-rm -rf "$MOXYGEN_SHIM" "$TMPCONFIG"
+rm -rf "$MOXYGEN_SHIM" "$TMPDIR"
 
 # Disable the trap — we already cleaned up
 trap - EXIT


### PR DESCRIPTION
## Summary

Add moxygen conformance test suite to moqx CI. Runs 41 protocol conformance tests against a live moqx relay.

### Architecture
1. Start moqx relay (insecure, random port)
2. Start moqtest_server (connects to relay, publishes test namespace)
3. Run conformance_test.sh (41 tests covering forwarding preferences, object sizes, extensions, end-of-group markers, delivery timeouts, etc.)

### CI Matrix
Runs in parallel with build/test (needs: check-format only):
- `mvfst d14` — draft-14 QUIC
- `mvfst d16` — draft-16 WebTransport

NOTE: existing issue in `moqtest_client` is blocking d14/WebTransport run

Future additions:
- `pico d14` / `pico d16` — picoquic stack (once pico conformance is validated)
- `moqperf` — performance regression tracking (separate job, pending mode selection)

## Testing
- 41/41 passing locally on both d14 and d16
- Wrapper script: `test/test_conformance.sh ./build/moqx [version] [Q]`

## Test plan
- [x] d14 passes locally (41/41)
- [x] d16 passes locally (41/41)
- [x] CI runs on ubuntu-22.04

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/134)
<!-- Reviewable:end -->
