### PR TITLE
pico: enable WebTransport and wire WT paths from service config

### DIFF
--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -69,7 +69,14 @@ MoqxPicoRelayServer::MoqxPicoRelayServer(
           listenerCfg.endpoint,
           ioExecutor->getAllEventBases()[0],
           listenerCfg.moqtVersions,
-          picoTransportConfigFromQuicConfig(listenerCfg.quic)
+          picoTransportConfigFromQuicConfig(listenerCfg.quic),
+          moxygen::PicoWebTransportConfig{
+              .enableWebTransport = true,
+              .enableQuicTransport = true,
+              .wtEndpoints = context->getExactServicePaths(),
+              // pico doesn't support session flow control, so limit to one per connection
+              .wtMaxSessions = 1,
+          }
       ),
       listenerCfg_(listenerCfg), context_(std::move(context)),
       evb_(ioExecutor->getAllEventBases()[0].get()) {}

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -140,4 +140,8 @@ folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayContext::validateAu
   return folly::unit;
 }
 
+std::vector<std::string> MoqxRelayContext::getExactServicePaths() const {
+  return serviceMatcher_.allExactPaths();
+}
+
 } // namespace openmoq::moqx

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -43,6 +43,10 @@ public:
   // reconnect coroutines can exit before worker EVBs are drained.
   void stop();
 
+  // Returns the unique set of exact paths registered across all services.
+  // Used by pico listeners to populate the h3zero WebTransport path table.
+  std::vector<std::string> getExactServicePaths() const;
+
   // --- Delegation targets for MoqxRelayServer virtual overrides ---
 
   void onNewSession(std::shared_ptr<moxygen::MoQSession> session);

--- a/src/ServiceMatcher.cpp
+++ b/src/ServiceMatcher.cpp
@@ -1,6 +1,7 @@
 #include "ServiceMatcher.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 #include <folly/logging/xlog.h>
 
@@ -114,6 +115,26 @@ ServiceMatcher::match(std::string_view authority, std::string_view path) const {
 
   // 3. Any-authority fallback (path matching still applies)
   return anyAuthorityRules_.match(effectivePath);
+}
+
+std::vector<std::string> ServiceMatcher::allExactPaths() const {
+  std::unordered_set<std::string> seen;
+  std::vector<std::string> result;
+  auto collect = [&](const PathRuleSet& rs) {
+    for (const auto& [path, _] : rs.exactPaths) {
+      if (seen.insert(path).second) {
+        result.push_back(path);
+      }
+    }
+  };
+  for (const auto& [_, rs] : exactAuthorityRules_) {
+    collect(rs);
+  }
+  for (const auto& [_, rs] : wildcardAuthorityRules_) {
+    collect(rs);
+  }
+  collect(anyAuthorityRules_);
+  return result;
 }
 
 } // namespace openmoq::moqx

--- a/src/ServiceMatcher.h
+++ b/src/ServiceMatcher.h
@@ -20,6 +20,10 @@ public:
   // Within each authority tier: exact path > longest prefix > any path.
   std::optional<std::string_view> match(std::string_view authority, std::string_view path) const;
 
+  // Returns the unique set of exact paths registered across all services and
+  // authority tiers. Used by pico listeners to populate h3zero's WT path table.
+  std::vector<std::string> allExactPaths() const;
+
 private:
   struct PathRuleSet {
     folly::F14FastMap<std::string, std::string> exactPaths; // path → service name

--- a/src/config/config_resolver.cpp
+++ b/src/config/config_resolver.cpp
@@ -12,6 +12,9 @@ namespace openmoq::moqx::config {
 
 namespace {
 
+constexpr const char* kStackMvfst = "mvfst";
+constexpr const char* kStackPicoquic = "picoquic";
+
 // Format a label for error messages: "Service 'name' match[j]"
 std::string matchRuleErrorLabel(const std::string& name, size_t j) {
   return "Service '" + name + "' match[" + std::to_string(j) + "]";
@@ -135,13 +138,13 @@ void validateListener(
 
   // quic_stack validation
   const auto& stackOpt = listener.quic_stack.value();
-  if (stackOpt.has_value() && *stackOpt != "mvfst" && *stackOpt != "picoquic") {
+  if (stackOpt.has_value() && *stackOpt != kStackMvfst && *stackOpt != kStackPicoquic) {
     errors.push_back(
         "Listener '" + listener.name.value() + "': unknown quic_stack '" + *stackOpt +
         "' (expected \"mvfst\" or \"picoquic\")"
     );
   }
-  if (stackOpt.value_or("mvfst") == "picoquic" && listener.tls.value().insecure.value()) {
+  if (stackOpt.value_or(kStackMvfst) == kStackPicoquic && listener.tls.value().insecure.value()) {
     errors.push_back(
         "Listener '" + listener.name.value() +
         "': quic_stack \"picoquic\" requires real TLS credentials (insecure: true is not supported)"
@@ -453,6 +456,47 @@ void validateQuicConfig(
   }
 }
 
+// For pico listeners, h3zero routes WebTransport CONNECT by prefix-up-to-'?'
+// path matching. Only exact service paths can be registered as WT endpoints;
+// prefix-path service rules will not route any pico connections.
+// Warnings are emitted once, naming all affected pico listeners, since services
+// are shared across all listeners.
+void validatePicoServicePaths(
+    const std::map<std::string, ParsedServiceConfig>& services,
+    const std::vector<std::string>& picoListenerNames,
+    std::vector<std::string>& warnings
+) {
+  auto listenerLabel = "Picoquic listener" + std::string(picoListenerNames.size() > 1 ? "s" : "") +
+                       " '" + folly::join("', '", picoListenerNames) + "'";
+
+  size_t exactPathCount = 0;
+  for (const auto& [svcName, svc] : services) {
+    const auto& matchRules = svc.match.value();
+    for (size_t j = 0; j < matchRules.size(); ++j) {
+      matchRules[j].path.value().visit([&](const auto& alt) {
+        using P = std::decay_t<decltype(alt)>;
+        if constexpr (std::is_same_v<P, ParsedServiceConfig::MatchRule::PrefixPath>) {
+          warnings.push_back(
+              listenerLabel + ": service '" + svcName + "' match[" + std::to_string(j) +
+              "] has prefix path '" + alt.prefix.value() +
+              "' — pico listeners only support exact path routing; "
+              "clients using this prefix may fail to connect."
+          );
+        } else {
+          ++exactPathCount;
+        }
+      });
+    }
+  }
+  if (exactPathCount == 0) {
+    warnings.push_back(
+        listenerLabel +
+        ": no exact-path service match rules found — "
+        "no WebTransport endpoints will be registered and all client connections will be rejected."
+    );
+  }
+}
+
 ListenerConfig resolveListener(const ParsedListenerConfig& listener, const QuicConfig& quic) {
   const auto& sock = listener.udp.value().socket.value();
   const auto& tls = listener.tls.value();
@@ -464,8 +508,8 @@ ListenerConfig resolveListener(const ParsedListenerConfig& listener, const QuicC
     tlsMode = resolveTlsConfig(tls);
   }
 
-  const auto& stackStr = listener.quic_stack.value().value_or("mvfst");
-  auto quicStack = (stackStr == "picoquic") ? QuicStack::Picoquic : QuicStack::Mvfst;
+  const auto& stackStr = listener.quic_stack.value().value_or(kStackMvfst);
+  auto quicStack = (stackStr == kStackPicoquic) ? QuicStack::Picoquic : QuicStack::Mvfst;
 
   return ListenerConfig{
       .name = listener.name.value(),
@@ -553,10 +597,24 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
         errors.push_back("Duplicate listener address: " + addr);
       }
       auto quic = mergeQuicConfig(quicDefaults, listener.quic.value());
-      const auto stackStr = listener.quic_stack.value().value_or("mvfst");
-      const auto stack = (stackStr == "picoquic") ? QuicStack::Picoquic : QuicStack::Mvfst;
+      const auto stackStr = listener.quic_stack.value().value_or(kStackMvfst);
+      const auto stack = (stackStr == kStackPicoquic) ? QuicStack::Picoquic : QuicStack::Mvfst;
       validateQuicConfig(quic, stack, "Listener '" + listener.name.value() + "'", errors, warnings);
       mergedQuicConfigs.push_back(quic);
+    }
+  }
+
+  // === Validate pico listeners against service paths ===
+  // Services are shared, so warnings are emitted once naming all pico listeners.
+  {
+    std::vector<std::string> picoListenerNames;
+    for (const auto& listener : config.listeners.value()) {
+      if (listener.quic_stack.value().value_or(kStackMvfst) == kStackPicoquic) {
+        picoListenerNames.push_back(listener.name.value());
+      }
+    }
+    if (!picoListenerNames.empty()) {
+      validatePicoServicePaths(config.services.value(), picoListenerNames, warnings);
     }
   }
 

--- a/test/ServiceMatcherTest.cpp
+++ b/test/ServiceMatcherTest.cpp
@@ -395,5 +395,100 @@ TEST(ServiceMatcher, AuthorityMatchButPathMismatchFallsToAny) {
   EXPECT_EQ(matcher.match("foo.com", "/other"), "any-svc");
 }
 
+// --- allExactPaths() tests ---
+
+TEST(ServiceMatcher, AllExactPathsEmpty) {
+  // Only prefix paths — allExactPaths should return nothing.
+  folly::F14FastMap<std::string, ServiceConfig> services = {
+      makeAnyAuthorityService("svc", ME::PrefixPath{"/"})
+  };
+  ServiceMatcher matcher(services);
+  EXPECT_TRUE(matcher.allExactPaths().empty());
+}
+
+TEST(ServiceMatcher, AllExactPathsCollectsAcrossAuthorityTiers) {
+  folly::F14FastMap<std::string, ServiceConfig> services;
+
+  // exact authority, exact path
+  services.insert(
+      {"svc-exact",
+       ServiceConfig{
+           .match =
+               {ME{.authority = ME::ExactAuthority{"live.example.com"},
+                   .path = ME::ExactPath{"/moq-relay"}}},
+           .cache = {100, 3}
+       }}
+  );
+
+  // wildcard authority, exact path
+  services.insert(
+      {"svc-wild",
+       ServiceConfig{
+           .match =
+               {ME{.authority = ME::WildcardAuthority{"*.cdn.com"}, .path = ME::ExactPath{"/cdn"}}},
+           .cache = {100, 3}
+       }}
+  );
+
+  // any authority, exact path
+  services.insert(
+      {"svc-any",
+       ServiceConfig{
+           .match = {ME{.authority = ME::AnyAuthority{}, .path = ME::ExactPath{"/fallback"}}},
+           .cache = {100, 3}
+       }}
+  );
+
+  ServiceMatcher matcher(services);
+  auto paths = matcher.allExactPaths();
+  std::sort(paths.begin(), paths.end());
+  EXPECT_EQ(paths, (std::vector<std::string>{"/cdn", "/fallback", "/moq-relay"}));
+}
+
+TEST(ServiceMatcher, AllExactPathsDeduplicates) {
+  // Same exact path registered under two different authority tiers.
+  folly::F14FastMap<std::string, ServiceConfig> services;
+  services.insert(
+      {"svc1",
+       ServiceConfig{
+           .match =
+               {ME{.authority = ME::ExactAuthority{"a.example.com"}, .path = ME::ExactPath{"/moq"}}
+               },
+           .cache = {100, 3}
+       }}
+  );
+  services.insert(
+      {"svc2",
+       ServiceConfig{
+           .match = {ME{.authority = ME::AnyAuthority{}, .path = ME::ExactPath{"/moq"}}},
+           .cache = {100, 3}
+       }}
+  );
+
+  ServiceMatcher matcher(services);
+  auto paths = matcher.allExactPaths();
+  EXPECT_EQ(paths.size(), 1u);
+  EXPECT_EQ(paths[0], "/moq");
+}
+
+TEST(ServiceMatcher, AllExactPathsIgnoresPrefixPaths) {
+  folly::F14FastMap<std::string, ServiceConfig> services;
+  services.insert(
+      {"svc",
+       ServiceConfig{
+           .match =
+               {
+                   ME{.authority = ME::AnyAuthority{}, .path = ME::ExactPath{"/exact"}},
+                   ME{.authority = ME::AnyAuthority{}, .path = ME::PrefixPath{"/prefix/"}},
+               },
+           .cache = {100, 3}
+       }}
+  );
+
+  ServiceMatcher matcher(services);
+  auto paths = matcher.allExactPaths();
+  EXPECT_EQ(paths, (std::vector<std::string>{"/exact"}));
+}
+
 } // namespace
 } // namespace openmoq::moqx

--- a/test/config/config_resolver_test.cpp
+++ b/test/config/config_resolver_test.cpp
@@ -1210,5 +1210,78 @@ TEST(ResolveConfig, QuicCcAlgoRoundTrips) {
   EXPECT_EQ(result.value().config.listeners[0].quic.ccAlgo, "cubic");
 }
 
+// --- Pico WebTransport path validation tests ---
+
+// Helper: make a minimal pico listener config (TLS required for picoquic).
+ParsedConfig makeMinimalPicoConfig() {
+  auto cfg = makeMinimalInsecureConfig();
+  auto& lc = cfg.listeners.value()[0];
+  lc.quic_stack = std::optional<std::string>{"picoquic"};
+  lc.tls.value().insecure = false;
+  lc.tls.value().cert_file = std::optional<std::string>{"cert.pem"};
+  lc.tls.value().key_file = std::optional<std::string>{"key.pem"};
+  return cfg;
+}
+
+TEST(ResolveConfig, PicoPrefixPathServiceWarning) {
+  // The default service uses only a prefix path — pico warns about the prefix
+  // rule AND about having no exact-path endpoints registered.
+  auto cfg = makeMinimalPicoConfig();
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& warnings = result.value().warnings;
+  EXPECT_THAT(warnings, ::testing::Contains(HasSubstr("prefix path")));
+  EXPECT_THAT(warnings, ::testing::Contains(HasSubstr("no WebTransport endpoints")));
+}
+
+TEST(ResolveConfig, PicoNoExactPathsWarning) {
+  // A pico listener with no services at all that have exact paths should warn
+  // that no WT endpoints will be registered.
+  auto cfg = makeMinimalPicoConfig();
+  // Replace default service with one that has only a prefix path.
+  cfg.services.value().clear();
+  ParsedServiceConfig svc;
+  ParsedServiceConfig::MatchRule entry;
+  entry.authority = AuthMatch{ParsedServiceConfig::MatchRule::AnyAuthority{true}};
+  entry.path = PMatch{ParsedServiceConfig::MatchRule::PrefixPath{"/"}};
+  svc.match.value().push_back(std::move(entry));
+  svc.cache = makeDefaultCache();
+  cfg.services.value().emplace("prefix-only-svc", std::move(svc));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_THAT(result.value().warnings, ::testing::Contains(HasSubstr("no WebTransport endpoints")));
+}
+
+TEST(ResolveConfig, PicoExactPathServiceNoWarning) {
+  auto cfg = makeMinimalPicoConfig();
+  // Replace the default prefix-path service with an exact-path one.
+  cfg.services.value().clear();
+  ParsedServiceConfig svc;
+  ParsedServiceConfig::MatchRule entry;
+  entry.authority = AuthMatch{ParsedServiceConfig::MatchRule::AnyAuthority{true}};
+  entry.path = PMatch{ParsedServiceConfig::MatchRule::ExactPath{"/moq-relay"}};
+  svc.match.value().push_back(std::move(entry));
+  svc.cache = makeDefaultCache();
+  cfg.services.value().emplace("exact-svc", std::move(svc));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  // No pico path warnings
+  for (const auto& w : result.value().warnings) {
+    EXPECT_THAT(w, ::testing::Not(HasSubstr("Picoquic listener")));
+  }
+}
+
+TEST(ResolveConfig, MvfstPrefixPathServiceNoWarning) {
+  // Prefix paths on mvfst listeners are fine — no pico warning.
+  auto cfg = makeMinimalInsecureConfig(); // default stack = mvfst
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  for (const auto& w : result.value().warnings) {
+    EXPECT_THAT(w, ::testing::Not(HasSubstr("Picoquic listener")));
+  }
+}
+
 } // namespace
 } // namespace openmoq::moqx::config


### PR DESCRIPTION
Pico listeners now run with WebTransport over H3 enabled (enableWebTransport=true, enableQuicTransport=true, wtMaxSessions=1). The h3zero WT path table is populated from the exact-path service match entries via ServiceMatcher::allExactPaths(), so no additional YAML config is needed — the service definitions already encode which paths clients will CONNECT to.

Config validator warns when a pico listener has services with prefix-path match rules, since h3zero routes WebTransport CONNECT by prefix-up-to-'?' matching only; sub-path routing is not supported and clients matching only a prefix rule may fail to connect.

Also bumps deps/moxygen to feature/pico-wt-multi-path which extends PicoWebTransportConfig.wtEndpoints to a vector and sizes the h3zero path table dynamically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/135)
<!-- Reviewable:end -->
