### PR TITLE
Cache: accept CacheConfig struct; add extended cache config knobs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,9 +20,17 @@ service_defaults:
   # Default cache settings inherited by all services.
   # Per-service cache merges field-by-field: set only the fields you want to override.
   cache:
-    enabled: true               # Enable relay cache
-    max_tracks: 100             # Max number of cached tracks
-    max_groups_per_track: 3     # Max groups per track in cache
+    enabled: true                        # Enable relay cache
+    max_tracks: 100                      # Max number of cached tracks
+    max_groups_per_track: 3              # Max cached groups per track
+    # max_cached_mb: 16                  # Max total cache size in MB. Default: 16. 0 is invalid.
+    # min_eviction_kb: 64                # Eviction batch floor in KB. Default: 64.
+    # max_cache_duration_s: 86400        # Max TTL (seconds) for any track; clamps publisher-set values.
+                                         # Also the default when default_max_cache_duration_s is absent.
+                                         # Default: 86400 (1 day). 0 is invalid.
+    # default_max_cache_duration_s: 300  # Default TTL (seconds) for tracks without a publisher-set duration.
+                                         # Absent: use max_cache_duration_s.
+                                         # 0: opt-in-only (don't cache tracks unless publisher sets a duration).
 
 services:
   live-streaming:
@@ -37,6 +45,11 @@ services:
       max_tracks: 500             # Override: 100 → 500
       max_groups_per_track: 10    # Override: 3 → 10
       # enabled: inherited (true) from service_defaults
+      # max_cached_mb: 100                  # Override: cap this service at 100 MB
+      # min_eviction_kb: 200               # Override: larger eviction batch floor for this service
+      # max_cache_duration_s: 3600         # Override: tighter max TTL for this service
+      # default_max_cache_duration_s: 60   # Override: tighter default TTL for this service
+      # default_max_cache_duration_s: 0    # Override: opt-in-only for this service
     # upstream:                   # Optional: enable relay chaining for this service
     #   url: "moqt://origin.example.com:4433/moq-relay"
     #   tls:

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "UpstreamProvider.h"
+#include "config/Config.h"
 #include <folly/coro/SharedPromise.h>
 #include <moxygen/MoQSession.h>
 #include <moxygen/relay/MoQCache.h>
@@ -24,14 +25,16 @@ class MoqxRelay : public moxygen::Publisher,
                   public std::enable_shared_from_this<MoqxRelay>,
                   public moxygen::MoQForwarder::Callback {
 public:
-  explicit MoqxRelay(
-      size_t maxCachedTracks = moxygen::kDefaultMaxCachedTracks,
-      size_t maxCachedGroupsPerTrack = moxygen::kDefaultMaxCachedGroupsPerTrack,
-      std::string relayID = {}
-  )
+  explicit MoqxRelay(config::CacheConfig cache = {}, std::string relayID = {})
       : relayID_(std::move(relayID)) {
-    if (maxCachedTracks > 0) {
-      cache_ = std::make_unique<moxygen::MoQCache>(maxCachedTracks, maxCachedGroupsPerTrack);
+    if (cache.maxCachedTracks > 0) {
+      cache_ =
+          std::make_unique<moxygen::MoQCache>(cache.maxCachedTracks, cache.maxCachedGroupsPerTrack);
+      cache_->setMaxCachedBytes(static_cast<size_t>(cache.maxCachedMb) * 1024 * 1024);
+      cache_->setMinEvictionBytes(static_cast<size_t>(cache.minEvictionKb) * 1024);
+      cache_->setDefaultMaxCacheDuration(cache.defaultMaxCacheDuration);
+      // TODO: wire cache.maxCacheDuration once MoQCache supports clamping
+      // publisher-set track durations.
     }
   }
 

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -21,17 +21,7 @@ MoqxRelayContext::MoqxRelayContext(
 )
     : serviceMatcher_(services), relayID_(relayID) {
   for (const auto& [name, svc] : services) {
-    services_.emplace(
-        name,
-        ServiceEntry{
-            svc,
-            std::make_shared<MoqxRelay>(
-                svc.cache.maxCachedTracks,
-                svc.cache.maxCachedGroupsPerTrack,
-                relayID
-            )
-        }
-    );
+    services_.emplace(name, ServiceEntry{svc, std::make_shared<MoqxRelay>(svc.cache, relayID)});
   }
 }
 

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -32,6 +32,11 @@ using TlsMode = std::variant<Insecure, TlsConfig>;
 struct CacheConfig {
   size_t maxCachedTracks; // 0 when cache disabled
   size_t maxCachedGroupsPerTrack;
+  uint32_t maxCachedMb{16};   // code default: 16 MB; 0 invalid
+  uint32_t minEvictionKb{64}; // eviction batch floor in KB
+  std::chrono::milliseconds maxCacheDuration{std::chrono::hours(24)}; // cap on any track duration
+  std::optional<std::chrono::milliseconds>
+      defaultMaxCacheDuration; // nullopt = use maxCacheDuration; 0ms = opt-in only
 };
 
 enum class QuicStack { Mvfst, Picoquic };

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -44,6 +44,17 @@ mergeCacheConfigs(const ParsedCacheConfig& base, const ParsedCacheConfig& overla
   merged.max_groups_per_track = overlay.max_groups_per_track.value().has_value()
                                     ? overlay.max_groups_per_track.value()
                                     : base.max_groups_per_track.value();
+  merged.max_cached_mb = overlay.max_cached_mb.value().has_value() ? overlay.max_cached_mb.value()
+                                                                   : base.max_cached_mb.value();
+  merged.min_eviction_kb = overlay.min_eviction_kb.value().has_value()
+                               ? overlay.min_eviction_kb.value()
+                               : base.min_eviction_kb.value();
+  merged.max_cache_duration_s = overlay.max_cache_duration_s.value().has_value()
+                                    ? overlay.max_cache_duration_s.value()
+                                    : base.max_cache_duration_s.value();
+  merged.default_max_cache_duration_s = overlay.default_max_cache_duration_s.value().has_value()
+                                            ? overlay.default_max_cache_duration_s.value()
+                                            : base.default_max_cache_duration_s.value();
   return merged;
 }
 
@@ -97,10 +108,27 @@ TlsConfig resolveAdminTlsConfig(
 
 CacheConfig resolveCacheConfig(const ParsedCacheConfig& cache) {
   // All fields must be present after merging (validated earlier).
+  // max_cache_duration_s: absent → 1 day default.
+  constexpr uint32_t kDefaultMaxCacheDurationS = 86400;
+  const std::chrono::milliseconds maxCacheDuration =
+      std::chrono::seconds(cache.max_cache_duration_s.value().value_or(kDefaultMaxCacheDurationS));
+  // default_max_cache_duration_s: absent → use maxCacheDuration; 0 → 0ms (opt-in only);
+  // N → N seconds for tracks without a publisher-set cache duration.
+  std::optional<std::chrono::milliseconds> defaultMaxCacheDuration;
+  const auto& defaultDurationOpt = cache.default_max_cache_duration_s.value();
+  if (defaultDurationOpt.has_value()) {
+    defaultMaxCacheDuration = std::chrono::seconds(*defaultDurationOpt);
+  } else {
+    defaultMaxCacheDuration = maxCacheDuration;
+  }
   return CacheConfig{
       .maxCachedTracks =
           *cache.enabled.value() ? static_cast<size_t>(*cache.max_tracks.value()) : 0,
       .maxCachedGroupsPerTrack = static_cast<size_t>(*cache.max_groups_per_track.value()),
+      .maxCachedMb = cache.max_cached_mb.value().value_or(16),
+      .minEvictionKb = cache.min_eviction_kb.value().value_or(64),
+      .maxCacheDuration = maxCacheDuration,
+      .defaultMaxCacheDuration = defaultMaxCacheDuration,
   };
 }
 
@@ -349,6 +377,13 @@ void validateService(
     errors.push_back(
         "Service '" + name + "': cache.max_groups_per_track must be >= 1 when cache is enabled"
     );
+  }
+  if (merged.max_cache_duration_s.value().has_value() &&
+      *merged.max_cache_duration_s.value() == 0) {
+    errors.push_back("Service '" + name + "': cache.max_cache_duration_s must not be 0");
+  }
+  if (merged.max_cached_mb.value().has_value() && *merged.max_cached_mb.value() == 0) {
+    errors.push_back("Service '" + name + "': cache.max_cached_mb must not be 0");
   }
 
   mergedCaches.emplace(name, std::move(merged));

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -105,6 +105,32 @@ struct ParsedCacheConfig {
   rfl::Description<"Max cached tracks, ignored when disabled", std::optional<uint32_t>> max_tracks;
   rfl::Description<"Max cached groups per track, ignored when disabled", std::optional<uint32_t>>
       max_groups_per_track;
+  rfl::Description<
+      "Max total cache size in megabytes across all tracks. Default: 16. 0 is invalid. "
+      "Ignored when cache is disabled.",
+      std::optional<uint32_t>>
+      max_cached_mb;
+  rfl::Description<
+      "Eviction batch floor in kilobytes: when the cache exceeds the byte limit, "
+      "evict LRU tracks until usage falls to max_cached_mb - min_eviction_kb. "
+      "Default: 64. Ignored when cache is disabled.",
+      std::optional<uint32_t>>
+      min_eviction_kb;
+  rfl::Description<
+      "Maximum cache duration (seconds) for any track; clamps publisher-set values. "
+      "Also used as the default for tracks without a publisher-set duration when "
+      "default_max_cache_duration_s is absent. Default: 86400 (1 day). 0 is invalid. "
+      "Ignored when cache is disabled.",
+      std::optional<uint32_t>>
+      max_cache_duration_s;
+  rfl::Description<
+      "Default max cache duration (seconds) for tracks without a publisher-set cache duration. "
+      "Absent: use max_cache_duration_s as the default. "
+      "0: opt-in-only — do not cache tracks unless the publisher sets a cache duration. "
+      "N: use N seconds as the default for tracks without a publisher-set cache duration. "
+      "Ignored when cache is disabled.",
+      std::optional<uint32_t>>
+      default_max_cache_duration_s;
 };
 
 struct ParsedAdminConfig {

--- a/test/MoqxRelayTest.cpp
+++ b/test/MoqxRelayTest.cpp
@@ -59,7 +59,7 @@ class MoQRelayTest : public ::testing::Test {
 protected:
   void SetUp() override {
     exec_ = std::make_shared<TestMoQExecutor>();
-    relay_ = std::make_shared<MoqxRelay>(/*enableCache=*/false);
+    relay_ = std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0});
     relay_->setAllowedNamespacePrefix(kAllowedPrefix);
   }
 
@@ -326,7 +326,10 @@ TEST_F(MoQRelayTest, Construction) {
 TEST_F(MoQRelayTest, AllowedNamespacePrefix) {
   // This just verifies the relay can be constructed with a namespace prefix
   // More detailed testing requires full session setup
-  auto relay2 = std::make_shared<MoqxRelay>(/*enableCache=*/true);
+  auto relay2 = std::make_shared<MoqxRelay>(config::CacheConfig{
+      .maxCachedTracks = moxygen::kDefaultMaxCachedTracks,
+      .maxCachedGroupsPerTrack = moxygen::kDefaultMaxCachedGroupsPerTrack,
+  });
   relay2->setAllowedNamespacePrefix(kTestNamespace);
   EXPECT_NE(relay2, nullptr);
 }

--- a/test/config/config_resolver_test.cpp
+++ b/test/config/config_resolver_test.cpp
@@ -1289,5 +1289,167 @@ TEST(ResolveConfig, MvfstPrefixPathServiceNoWarning) {
   }
 }
 
+// --- maxCacheDuration tests ---
+
+TEST(ResolveConfig, MaxCacheDurationDefaultIs1Day) {
+  // When max_cache_duration_s is absent, code default of 1 day is used.
+  auto cfg = makeMinimalInsecureConfig();
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(
+      result.value().config.services.at("default").cache.maxCacheDuration,
+      std::chrono::hours(24)
+  );
+}
+
+TEST(ResolveConfig, CacheDurationExplicitValues) {
+  // Both max_cache_duration_s and default_max_cache_duration_s resolve to correct values.
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.services.value().at("default").cache.value()->max_cache_duration_s =
+      std::optional<uint32_t>{3600};
+  cfg.services.value().at("default").cache.value()->default_max_cache_duration_s =
+      std::optional<uint32_t>{60};
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& cache = result.value().config.services.at("default").cache;
+  EXPECT_EQ(cache.maxCacheDuration, std::chrono::seconds(3600));
+  EXPECT_EQ(*cache.defaultMaxCacheDuration, std::chrono::seconds(60));
+}
+
+TEST(ResolveConfig, MaxCacheDurationZeroIsInvalid) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.services.value().at("default").cache.value()->max_cache_duration_s =
+      std::optional<uint32_t>{0};
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("max_cache_duration_s must not be 0"));
+}
+
+// --- defaultMaxCacheDuration tests ---
+
+TEST(ResolveConfig, DefaultCacheDurationAbsentUsesMaxCacheDuration) {
+  // When default_max_cache_duration_s is absent, defaultMaxCacheDuration falls back to
+  // maxCacheDuration (1 day by default).
+  auto cfg = makeMinimalInsecureConfig();
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(
+      *result.value().config.services.at("default").cache.defaultMaxCacheDuration,
+      std::chrono::hours(24)
+  );
+}
+
+TEST(ResolveConfig, DefaultCacheDurationZeroMeansOptInOnly) {
+  // 0 → 0ms: tracks without a publisher-set cache duration are not cached.
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.services.value().at("default").cache.value()->default_max_cache_duration_s =
+      std::optional<uint32_t>{0};
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(
+      *result.value().config.services.at("default").cache.defaultMaxCacheDuration,
+      std::chrono::milliseconds(0)
+  );
+}
+
+TEST(ResolveConfig, CacheDurationMergesWithDefaults) {
+  // Both max_cache_duration_s and default_max_cache_duration_s inherit and can be overridden.
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.services.value().clear();
+
+  ParsedServiceDefaultsConfig defaults;
+  ParsedCacheConfig defaultCache;
+  defaultCache.enabled = std::optional<bool>{true};
+  defaultCache.max_tracks = std::optional<uint32_t>{50};
+  defaultCache.max_groups_per_track = std::optional<uint32_t>{2};
+  defaultCache.max_cache_duration_s = std::optional<uint32_t>{7200};
+  defaultCache.default_max_cache_duration_s = std::optional<uint32_t>{120};
+  defaults.cache = std::move(defaultCache);
+  cfg.service_defaults = std::move(defaults);
+
+  // "inheritor" takes both defaults; "overrider" replaces both.
+  ParsedServiceConfig inheritor;
+  inheritor.match.value().push_back(makeAnyAuthorityMatch());
+  cfg.services.value().emplace("inheritor", std::move(inheritor));
+
+  ParsedServiceConfig overrider;
+  overrider.match.value().push_back(makeExactAuthorityMatch("override.example.com"));
+  ParsedCacheConfig svcCache;
+  svcCache.max_cache_duration_s = std::optional<uint32_t>{1800};
+  svcCache.default_max_cache_duration_s = std::optional<uint32_t>{30};
+  overrider.cache = std::move(svcCache);
+  cfg.services.value().emplace("overrider", std::move(overrider));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& resolved = result.value().config;
+  EXPECT_EQ(resolved.services.at("inheritor").cache.maxCacheDuration, std::chrono::seconds(7200));
+  EXPECT_EQ(
+      *resolved.services.at("inheritor").cache.defaultMaxCacheDuration,
+      std::chrono::seconds(120)
+  );
+  EXPECT_EQ(resolved.services.at("overrider").cache.maxCacheDuration, std::chrono::seconds(1800));
+  EXPECT_EQ(
+      *resolved.services.at("overrider").cache.defaultMaxCacheDuration,
+      std::chrono::seconds(30)
+  );
+}
+
+// --- maxCachedMb / minEvictionKb tests ---
+
+TEST(ResolveConfig, CacheByteLimitsDefaults) {
+  // max_cached_mb absent → 16 MB; min_eviction_kb absent → 64 KB.
+  auto cfg = makeMinimalInsecureConfig();
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& cache = result.value().config.services.at("default").cache;
+  EXPECT_EQ(cache.maxCachedMb, 16u);
+  EXPECT_EQ(cache.minEvictionKb, 64u);
+}
+
+TEST(ResolveConfig, CacheMbZeroIsInvalid) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.services.value().at("default").cache.value()->max_cached_mb = std::optional<uint32_t>{0};
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("max_cached_mb must not be 0"));
+}
+
+TEST(ResolveConfig, CacheByteLimitsMergeWithDefaults) {
+  // Both max_cached_mb and min_eviction_kb inherit and can be overridden.
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.services.value().clear();
+
+  ParsedServiceDefaultsConfig defaults;
+  ParsedCacheConfig defaultCache;
+  defaultCache.enabled = std::optional<bool>{true};
+  defaultCache.max_tracks = std::optional<uint32_t>{50};
+  defaultCache.max_groups_per_track = std::optional<uint32_t>{2};
+  defaultCache.max_cached_mb = std::optional<uint32_t>{256};
+  defaultCache.min_eviction_kb = std::optional<uint32_t>{200};
+  defaults.cache = std::move(defaultCache);
+  cfg.service_defaults = std::move(defaults);
+
+  ParsedServiceConfig inheritor;
+  inheritor.match.value().push_back(makeAnyAuthorityMatch());
+  cfg.services.value().emplace("inheritor", std::move(inheritor));
+
+  ParsedServiceConfig overrider;
+  overrider.match.value().push_back(makeExactAuthorityMatch("override.example.com"));
+  ParsedCacheConfig svcCache;
+  svcCache.max_cached_mb = std::optional<uint32_t>{64};
+  svcCache.min_eviction_kb = std::optional<uint32_t>{512};
+  overrider.cache = std::move(svcCache);
+  cfg.services.value().emplace("overrider", std::move(overrider));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& resolved = result.value().config;
+  EXPECT_EQ(resolved.services.at("inheritor").cache.maxCachedMb, 256u);
+  EXPECT_EQ(resolved.services.at("inheritor").cache.minEvictionKb, 200u);
+  EXPECT_EQ(resolved.services.at("overrider").cache.maxCachedMb, 64u);
+  EXPECT_EQ(resolved.services.at("overrider").cache.minEvictionKb, 512u);
+}
+
 } // namespace
 } // namespace openmoq::moqx::config


### PR DESCRIPTION
Cache: accept CacheConfig struct; add extended cache config knobs
- Refactor MoqxRelay constructor to accept a CacheConfig struct
  (replaces 3-arg maxCachedTracks/maxCachedGroupsPerTrack/relayID API)
- Wire setMaxCachedBytes and setMinEvictionBytes from CacheConfig
- Add maxCachedMb (default 16 MB; 0 invalid), minEvictionKb (default
  64 KB), maxCacheDuration (default 1 day; clamps publisher-set values;
  TODO: wire to MoQCache), and defaultMaxCacheDuration (absent → use
  maxCacheDuration; 0 → opt-in-only; N → N-second default for tracks
  without a publisher-set duration) to CacheConfig
- Plumb all new fields through parsed_config, config_resolver, and
  config.example.yaml; add validation and inheritance tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/140)
<!-- Reviewable:end -->
