### PR TITLE
copyright: add Apache 2.0 headers; fix MIT references

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -25,10 +25,40 @@ if [[ -z "${FILES}" ]]; then
   exit 0
 fi
 
+APACHE_HEADER='/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */'
+
 if [[ "${1:-}" == "--check" ]]; then
+  echo "Checking copyright headers..."
+  header_errors=0
+  for f in ${FILES}; do
+    if ! head -1 "$f" | grep -q '^/\*'; then
+      echo "  missing copyright header: $f"
+      header_errors=1
+    fi
+  done
+
   echo "Checking formatting..."
-  ${CF_BIN} --dry-run -Werror ${FILES}
+  cf_exit=0
+  ${CF_BIN} --dry-run -Werror ${FILES} || cf_exit=$?
+
+  if [[ $header_errors -ne 0 ]]; then
+    echo "error: files missing copyright headers (run scripts/format.sh to fix)" >&2
+  fi
+  if [[ $header_errors -ne 0 || $cf_exit -ne 0 ]]; then
+    exit 1
+  fi
 else
+  echo "Adding missing copyright headers..."
+  for f in ${FILES}; do
+    if ! head -1 "$f" | grep -q '^/\*'; then
+      printf '%s\n\n' "${APACHE_HEADER}" | cat - "$f" > /tmp/hdr_tmp && mv /tmp/hdr_tmp "$f"
+    fi
+  done
+
   echo "Formatting files..."
   ${CF_BIN} -i ${FILES}
 fi

--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "MoqxPicoRelayServer.h"
 
 #include "stats/PicoQuicStatsCollector.h"

--- a/src/MoqxPicoRelayServer.h
+++ b/src/MoqxPicoRelayServer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <memory>

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "MoqxRelayContext.h"
 #include "stats/MoQStatsCollector.h"
 #include <moxygen/events/MoQFollyExecutorImpl.h>

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <memory>

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "MoqxRelayServer.h"
 #include "stats/QuicStatsCollector.h"
 #include <moxygen/MoQRelaySession.h>

--- a/src/MoqxRelayServer.h
+++ b/src/MoqxRelayServer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <memory>

--- a/src/MoqxServerFactory.h
+++ b/src/MoqxServerFactory.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <memory>

--- a/src/ServiceMatcher.cpp
+++ b/src/ServiceMatcher.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "ServiceMatcher.h"
 
 #include <algorithm>

--- a/src/ServiceMatcher.h
+++ b/src/ServiceMatcher.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include "config/Config.h"

--- a/src/UpstreamProvider.cpp
+++ b/src/UpstreamProvider.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) OpenMOQ contributors.
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/src/UpstreamProvider.h
+++ b/src/UpstreamProvider.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) OpenMOQ contributors.
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/src/admin/AdminServer.cpp
+++ b/src/admin/AdminServer.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "admin/AdminServer.h"
 
 #include <list>

--- a/src/admin/AdminServer.h
+++ b/src/admin/AdminServer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <functional>

--- a/src/admin/BuiltinRoutes.cpp
+++ b/src/admin/BuiltinRoutes.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "admin/BuiltinRoutes.h"
 
 #include <folly/io/IOBuf.h>

--- a/src/admin/BuiltinRoutes.h
+++ b/src/admin/BuiltinRoutes.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 namespace openmoq::moqx::admin {

--- a/src/admin/MetricsHandler.cpp
+++ b/src/admin/MetricsHandler.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "admin/MetricsHandler.h"
 
 #include <folly/CancellationToken.h>

--- a/src/admin/MetricsHandler.h
+++ b/src/admin/MetricsHandler.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <memory>

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <chrono>

--- a/src/config/ConfigInit.cpp
+++ b/src/config/ConfigInit.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "config/loader/ConfigInit.h"
 
 #include "config/loader/ConfigResolver.h"

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "config/loader/ConfigResolver.h"
 
 #include <iomanip>

--- a/src/config/Loader.cpp
+++ b/src/config/Loader.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "config/loader/Loader.h"
 
 #include <stdexcept>

--- a/src/config/ResolvedConfig.h
+++ b/src/config/ResolvedConfig.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <string>

--- a/src/config/loader/ConfigInit.h
+++ b/src/config/loader/ConfigInit.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <string>

--- a/src/config/loader/ConfigResolver.h
+++ b/src/config/loader/ConfigResolver.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <string>

--- a/src/config/loader/Loader.h
+++ b/src/config/loader/Loader.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <string>

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/src/config/loader/StringLiteral.h
+++ b/src/config/loader/StringLiteral.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Compile-time string utilities for building rfl::Description strings

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "MoqxRelayContext.h"
 #include "MoqxServerFactory.h"
 #include "admin/AdminServer.h"

--- a/src/stats/BoundedHistogram.h
+++ b/src/stats/BoundedHistogram.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <array>

--- a/src/stats/MoQStatsCollector.cpp
+++ b/src/stats/MoQStatsCollector.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "stats/MoQStatsCollector.h"
 
 #include <folly/logging/xlog.h>

--- a/src/stats/MoQStatsCollector.h
+++ b/src/stats/MoQStatsCollector.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <array>

--- a/src/stats/PicoQuicStatsCollector.cpp
+++ b/src/stats/PicoQuicStatsCollector.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "stats/PicoQuicStatsCollector.h"
 
 namespace openmoq::moqx::stats {

--- a/src/stats/PicoQuicStatsCollector.h
+++ b/src/stats/PicoQuicStatsCollector.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <memory>

--- a/src/stats/QuicStatsCollector.cpp
+++ b/src/stats/QuicStatsCollector.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "stats/QuicStatsCollector.h"
 
 #include <folly/io/async/EventBaseManager.h>

--- a/src/stats/QuicStatsCollector.h
+++ b/src/stats/QuicStatsCollector.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <atomic>

--- a/src/stats/StatsRegistry.cpp
+++ b/src/stats/StatsRegistry.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "stats/StatsRegistry.h"
 
 #include <algorithm>

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <array>

--- a/test/MoQIntegrationTestFixture.h
+++ b/test/MoQIntegrationTestFixture.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) OpenMOQ contributors.
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/test/MoqxRelayContextTest.cpp
+++ b/test/MoqxRelayContextTest.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "MoqxRelayContext.h"
 
 #include <folly/portability/GMock.h>

--- a/test/ServiceMatcherTest.cpp
+++ b/test/ServiceMatcherTest.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "ServiceMatcher.h"
 
 #include <gtest/gtest.h>

--- a/test/UpstreamProviderTest.cpp
+++ b/test/UpstreamProviderTest.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) OpenMOQ contributors.
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the Apache 2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/test/config/config_resolver_test.cpp
+++ b/test/config/config_resolver_test.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "config/loader/ConfigResolver.h"
 
 #include <gmock/gmock.h>

--- a/test/config/loader_test.cpp
+++ b/test/config/loader_test.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "config/loader/Loader.h"
 
 #include <gmock/gmock.h>

--- a/test/config/test_utils.h
+++ b/test/config/test_utils.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <atomic>

--- a/test/stats/BoundedHistogramTest.cpp
+++ b/test/stats/BoundedHistogramTest.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <array>
 #include <gtest/gtest.h>
 

--- a/test/stats/PicoQuicStatsCollectorTest.cpp
+++ b/test/stats/PicoQuicStatsCollectorTest.cpp
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <gtest/gtest.h>
 
 #include "stats/PicoQuicStatsCollector.h"


### PR DESCRIPTION
Also a format.sh will add the header for you automatically now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/143)
<!-- Reviewable:end -->
