### PR TITLE
fix: null deref in publish() when publisher reconnects with draining subscriber

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -460,13 +460,20 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
     // multipublisher
     XLOG(DBG1) << "New publisher for existing subscription";
     nodePtr->publishes.erase(pub.fullTrackName.trackName);
-    it->second.handle->unsubscribe();
-    it->second.forwarder->publishDone(
-        {RequestID(0),
-         PublishDoneStatusCode::SUBSCRIPTION_ENDED,
-         0, // filled in by session
-         "upstream disconnect"}
-    );
+    // handle is null when the previous publisher already terminated (e.g.
+    // reconnect after a dropped connection with subscribers still draining open
+    // subgroups).  onPublishDone() already reset handle and drained the
+    // forwarder, so skip both calls to avoid a null deref and a double
+    // publishDone.
+    if (it->second.handle) {
+      it->second.handle->unsubscribe();
+      it->second.forwarder->publishDone(
+          {RequestID(0),
+           PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+           0, // filled in by session
+           "upstream disconnect"}
+      );
+    }
     XLOG(DBG4) << "Erasing subscription to " << it->first;
     subscriptions_.erase(it);
   }

--- a/test/MoqxRelayTest.cpp
+++ b/test/MoqxRelayTest.cpp
@@ -2188,4 +2188,70 @@ TEST_F(MoQRelayTest, NamespaceBridgeHandleForwardsDoneMsg) {
   removeSession(peerSession);
 }
 
+// Regression test: publisher reconnect after disconnect with active subscriber
+// crashes with SIGSEGV at MoqxRelay.cpp:463.
+//
+// Scenario (relay chain with downstream subscriber that has an open subgroup):
+//   1. Publisher session A publishes a track and opens a subgroup.
+//   2. Subscriber session B subscribes; the open subgroup is forwarded to B,
+//      so B has a live subgroup entry in the forwarder.
+//   3. Session A's connection breaks: publishDone fires, onPublishDone() resets
+//      handle to null.  The forwarder does NOT remove B because B still has an
+//      open subgroup (drainSubscriber marks B as receivedPublishDone_ instead).
+//      The subscriptions_ entry therefore survives with handle == nullptr.
+//   4. Session A reconnects and re-publishes the same track.  The multipublisher
+//      check finds the surviving entry and calls it->second.handle->unsubscribe()
+//      — null-pointer dereference, SIGSEGV.
+TEST_F(MoQRelayTest, PublisherReconnectWithOpenSubgroupNoSegfault) {
+  auto publisherSession = createMockSession();
+  auto subscriberSession = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Step 1: publisher session A publishes the track.
+  // Don't add consumer to state — we control cleanup manually.
+  auto consumer = doPublish(publisherSession, kTestTrackName, /*addToState=*/false);
+  ASSERT_NE(consumer, nullptr);
+
+  // Step 2: subscriber session B subscribes.  Wire its mock consumer to return
+  // a live SubgroupConsumer so the forwarder stores an open subgroup for B.
+  auto mockSubgroupConsumer = createMockSubgroupConsumer();
+  auto mockConsumer = createMockConsumer();
+  ON_CALL(*mockConsumer, beginSubgroup(_, _, _, _))
+      .WillByDefault(Return(folly::makeExpected<MoQPublishError>(
+          std::static_pointer_cast<SubgroupConsumer>(mockSubgroupConsumer)
+      )));
+  auto subHandle = subscribeToTrack(subscriberSession, kTestTrackName, mockConsumer);
+  ASSERT_NE(subHandle, nullptr);
+
+  // Open a subgroup through the publisher consumer so that B gets a live entry
+  // in its subgroups map inside the forwarder.
+  withSessionContext(publisherSession, [&]() {
+    auto sgRes = consumer->beginSubgroup(/*groupID=*/0, /*subgroupID=*/0, /*priority=*/0, false);
+    ASSERT_TRUE(sgRes.hasValue()) << "beginSubgroup should succeed";
+  });
+
+  // Step 3: session A's connection drops WITHOUT closing the subgroup.
+  // publishDone → onPublishDone (handle = null) + forwarder drainSubscriber.
+  // Because B has an open subgroup, B stays in the forwarder
+  // (receivedPublishDone_ = true) — subscriptions_ entry survives with
+  // handle == nullptr.
+  withSessionContext(publisherSession, [&]() {
+    consumer->publishDone(
+        {RequestID(0), PublishDoneStatusCode::SESSION_CLOSED, 0, "upstream disconnect"}
+    );
+  });
+
+  // Step 4: session A reconnects and re-publishes the same track.
+  // Before the fix this crashes (null handle->unsubscribe()).
+  auto reconnectedSession = createMockSession();
+  doPublishNamespace(reconnectedSession, kTestNamespace);
+  auto consumer2 = doPublish(reconnectedSession, kTestTrackName);
+  EXPECT_NE(consumer2, nullptr) << "re-publish after reconnect should succeed";
+
+  removeSession(publisherSession);
+  removeSession(subscriberSession);
+  removeSession(reconnectedSession);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
When a publisher terminates while a subscriber has an open subgroup, onPublishDone() resets handle to null but keeps the subscriptions_ entry alive (the forwarder marks the subscriber receivedPublishDone_ and waits for subgroups to close). If the publisher then reconnects and re-publishes the same track, the multipublisher path calls handle->unsubscribe() on the null handle — SIGSEGV.

Guard both handle->unsubscribe() and forwarder->publishDone() on the null check: when handle is null the previous publisher already terminated and the forwarder was already drained, so both calls are wrong.

Adds a regression test that reproduces the crash by opening a subgroup before dropping the publisher connection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/144)
<!-- Reviewable:end -->
