### PR TITLE
admin: add GET /state endpoint with relay state visitor pattern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(moqx_core STATIC
   src/admin/AdminServer.cpp
   src/admin/BuiltinRoutes.cpp
   src/admin/MetricsHandler.cpp
+  src/admin/StateHandler.cpp
   src/stats/StatsRegistry.cpp
   src/stats/MoQStatsCollector.cpp
   src/stats/PicoQuicStatsCollector.cpp

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -735,8 +735,9 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   // Relay peering: if the incoming subNs carries a relay auth token, the peer
   // is a relay. Reciprocate with our own peer subNs so the peer gets our
   // namespace announcements as publishers connect.
-  if (!relayID_.empty() && isPeerSubNs(subNs)) {
-    XLOG(INFO) << __func__ << ": peer relay detected, reciprocating peer subNs";
+  if (auto peerID = !relayID_.empty() ? getPeerRelayID(subNs) : std::nullopt) {
+    XLOG(INFO) << __func__ << ": peer relay detected peer_id=" << *peerID
+               << ", reciprocating peer subNs";
     auto handle = makeNamespaceBridgeHandle(weak_from_this(), session);
     auto recipResult = co_await session->subscribeNamespace(
         makePeerSubNs(),
@@ -745,7 +746,10 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
     if (recipResult.hasError()) {
       XLOG(ERR) << "Reciprocal peer subNs failed: " << recipResult.error().reasonPhrase;
     } else {
-      peerSubNsHandles_.emplace(session.get(), std::move(recipResult.value()));
+      peerSubNsHandles_.emplace(
+          session.get(),
+          PeerInfo{std::move(recipResult.value()), std::move(*peerID)}
+      );
     }
     // Fall through: register the peer as a normal subNs subscriber so it
     // receives namespace announcements as publishers connect.
@@ -1467,6 +1471,54 @@ void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSess
       PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "evicted"},
       "onTrackEvicted"
   );
+}
+
+void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
+  visitor.onPeersBegin();
+  for (const auto& [sess, peer] : peerSubNsHandles_) {
+    visitor.onPeer(sess->getPeerAddress().describe(), sess->getAuthority(), peer.relayID);
+  }
+  visitor.onPeersEnd();
+
+  visitor.onSubscriptionsBegin();
+  for (const auto& [ftn, sub] : subscriptions_) {
+    std::string sourceAddr;
+    if (sub.upstream) {
+      sourceAddr = sub.upstream->getPeerAddress().describe();
+    }
+    RelayStateVisitor::SubscriptionInfo info{
+        .ftn = ftn,
+        .isPublish = sub.isPublish,
+        .subscribers = sub.forwarder->subscriberCount(),
+        .forwardingSubscribers = sub.forwarder->numForwardingSubscribers(),
+        .largest = sub.forwarder->largest(),
+        .totalGroupsReceived = sub.forwarder->totalGroupsReceived(),
+        .totalObjectsReceived = sub.forwarder->totalObjectsReceived(),
+        .sourceAddress = sourceAddr,
+    };
+    visitor.onSubscription(info);
+  }
+  visitor.onSubscriptionsEnd();
+
+  visitor.onNamespaceTreeBegin();
+  std::function<void(std::string_view, const NamespaceNode&)> walkNode;
+  walkNode = [&](std::string_view childKey, const NamespaceNode& node) {
+    visitor.beginNamespaceNode(childKey, node.trackNamespace_, node.sessions.size());
+    for (const auto& [key, child] : node.children) {
+      walkNode(key, *child);
+    }
+    visitor.endNamespaceNode();
+  };
+  walkNode("", publishNamespaceRoot_);
+  visitor.onNamespaceTreeEnd();
+
+  if (cache_) {
+    visitor.onCacheStats(
+        cache_->totalCachedBytes(),
+        cache_->getTrackStats(),
+        moxygen::MoQCache::SteadyClock::now()
+    );
+  }
 }
 
 } // namespace openmoq::moqx

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -19,9 +19,70 @@
 
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace openmoq::moqx {
+
+// Visitor interface for relay state inspection.
+// MoqxRelay::dumpState() calls these methods while walking internal state.
+// Implement this to serialize state into any format without adding format
+// dependencies to MoqxRelay itself.
+//
+// Section callbacks bracket each group of items so visitors never need to
+// track whether a section was empty or infer ordering from call patterns.
+class RelayStateVisitor {
+public:
+  virtual ~RelayStateVisitor() = default;
+
+  // --- Downstream peer section ---
+  virtual void onPeersBegin() = 0;
+  // Called for each connected downstream peer relay.
+  virtual void onPeer(
+      std::string_view address,
+      std::string_view authority,
+      std::string_view relayID // empty if peer didn't include one
+  ) = 0;
+  virtual void onPeersEnd() = 0;
+
+  // --- Subscription section ---
+  virtual void onSubscriptionsBegin() = 0;
+  // Called for each track with an active subscription or publish.
+  struct SubscriptionInfo {
+    const moxygen::FullTrackName& ftn;
+    bool isPublish;
+    size_t subscribers;
+    uint64_t forwardingSubscribers;
+    std::optional<moxygen::AbsoluteLocation> largest;
+    uint64_t totalGroupsReceived;
+    uint64_t totalObjectsReceived;
+    std::string_view sourceAddress;
+  };
+  virtual void onSubscription(const SubscriptionInfo& info) = 0;
+  virtual void onSubscriptionsEnd() = 0;
+
+  // --- Namespace tree section ---
+  virtual void onNamespaceTreeBegin() = 0;
+  // Depth-first traversal. childKey is the map key in the parent's children
+  // map; empty string for the root node.
+  virtual void beginNamespaceNode(
+      std::string_view childKey,
+      const moxygen::TrackNamespace& ns,
+      size_t sessionCount
+  ) = 0;
+  virtual void endNamespaceNode() = 0;
+  virtual void onNamespaceTreeEnd() = 0;
+
+  // --- Cache section ---
+  // Called once with cache state; not called if cache is disabled.
+  virtual void onCacheStats(
+      size_t totalBytes,
+      const std::vector<moxygen::MoQCache::TrackStats>& tracks,
+      moxygen::MoQCache::TimePoint now
+  ) = 0;
+};
 
 class MoqxRelay : public moxygen::Publisher,
                   public moxygen::Subscriber,
@@ -140,6 +201,13 @@ public:
       const moxygen::TrackNamespace& trackNamespace,
       std::shared_ptr<moxygen::MoQSession> session
   );
+
+  // Returns the upstream provider, or null if none is configured.
+  std::shared_ptr<UpstreamProvider> upstreamProvider() const { return upstream_; }
+
+  // Walks relay state by calling visitor methods.
+  // MUST be called on the relay's worker EVB.
+  void dumpState(RelayStateVisitor& visitor) const;
 
   // Test accessor: check if a publish exists and return node/publish state
   struct PublishState {
@@ -333,13 +401,14 @@ private:
   // Kept alive so the subscription is not cancelled when onUpstreamConnect returns.
   std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle> upstreamSubNsHandle_;
 
+  struct PeerInfo {
+    std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle> handle;
+    std::string relayID; // from peer auth token; empty if not provided
+  };
   // Reciprocal peer subNs handles: one per peer relay session that has
   // connected to us. Kept alive so the subscription is not immediately
   // cancelled. Keyed by raw session pointer (valid for session lifetime).
-  folly::F14FastMap<
-      moxygen::MoQSession*,
-      std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle>>
-      peerSubNsHandles_;
+  folly::F14FastMap<moxygen::MoQSession*, PeerInfo> peerSubNsHandles_;
   folly::F14NodeMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
       subscriptions_;
 

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -50,6 +50,7 @@ std::shared_ptr<fizz::CertificateVerifier> makeUpstreamVerifier(const config::Up
 
 void MoqxRelayContext::initUpstreams(folly::EventBase* workerEvb) {
   CHECK(workerEvb) << "initUpstreams: workerEvb must not be null";
+  workerEvb_ = workerEvb;
 
   // Use the provided worker EVB for all upstream connections.
   // Per-EVB providers (one per worker thread) are a follow-up.
@@ -138,6 +139,28 @@ folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayContext::validateAu
 
 std::vector<std::string> MoqxRelayContext::getExactServicePaths() const {
   return serviceMatcher_.allExactPaths();
+}
+
+void MoqxRelayContext::dumpState(RelayContextVisitor& visitor) const {
+  int64_t activeSessions = 0;
+  if (statsCollector_) {
+    activeSessions = statsCollector_->snapshot().moqActiveSessions;
+  }
+
+  visitor.onRelayBegin(relayID_, activeSessions);
+  for (const auto& [name, entry] : services_) {
+    RelayStateVisitor& rv = visitor.onServiceBegin(name);
+    entry.relay->dumpState(rv);
+    if (entry.config.upstream) {
+      auto up = entry.relay->upstreamProvider();
+      visitor.onServiceUpstream(
+          entry.config.upstream->url,
+          up ? up->stateString() : "disconnected"
+      );
+    }
+    visitor.onServiceEnd();
+  }
+  visitor.onRelayEnd();
 }
 
 } // namespace openmoq::moqx

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -23,6 +23,20 @@
 
 namespace openmoq::moqx {
 
+// Visitor interface for the top-level relay context state dump.
+// onServiceBegin returns the RelayStateVisitor to use for that service's relay.
+class RelayContextVisitor {
+public:
+  virtual ~RelayContextVisitor() = default;
+  virtual void onRelayBegin(std::string_view relayID, int64_t activeSessions) = 0;
+  // Called before relay->dumpState(). Returns the visitor to pass into dumpState.
+  virtual RelayStateVisitor& onServiceBegin(std::string_view name) = 0;
+  // Called after relay->dumpState() if an upstream is configured for this service.
+  virtual void onServiceUpstream(std::string_view url, std::string_view state) = 0;
+  virtual void onServiceEnd() = 0;
+  virtual void onRelayEnd() = 0;
+};
+
 // Holds relay state shared across all listener instances.
 // A single MoqxRelayContext is shared by every MoqxRelayServer so that
 // publishers and subscribers connecting on different listeners can exchange
@@ -44,6 +58,14 @@ public:
   // Must be called once, after all MoqxRelayServer instances have been started,
   // so that worker EVBs are available. workerEvb is used for upstream connections.
   void initUpstreams(folly::EventBase* workerEvb);
+
+  // Returns the worker EVB used for upstream connections.
+  // Null until initUpstreams() is called.
+  folly::EventBase* workerEvb() const { return workerEvb_; }
+
+  // Dumps a snapshot of relay state by calling visitor methods.
+  // MUST be called on workerEvb() to avoid data races.
+  void dumpState(RelayContextVisitor& visitor) const;
 
   // Signals all relay upstreams to stop. Call before destroying servers so
   // reconnect coroutines can exit before worker EVBs are drained.
@@ -70,6 +92,7 @@ private:
   std::string relayID_;
   std::shared_ptr<stats::StatsRegistry> statsRegistry_;
   std::shared_ptr<stats::MoQStatsCollector> statsCollector_;
+  folly::EventBase* workerEvb_{nullptr};
 };
 
 } // namespace openmoq::moqx

--- a/src/UpstreamProvider.cpp
+++ b/src/UpstreamProvider.cpp
@@ -18,14 +18,14 @@ namespace openmoq::moqx {
 // Must fit in a QUIC variable-length integer (top 2 bits must be 00, i.e. < 2^62).
 static constexpr uint64_t kRelayAuthTokenType = 0x1B2C'3D4E'5F6A'7B8CULL;
 
-bool isPeerSubNs(const SubscribeNamespace& subNs) {
+std::optional<std::string> getPeerRelayID(const SubscribeNamespace& subNs) {
   const uint64_t authKey = static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN);
   for (const auto& param : subNs.params) {
     if (param.key == authKey && param.asAuthToken.tokenType == kRelayAuthTokenType) {
-      return true;
+      return param.asAuthToken.tokenValue;
     }
   }
-  return false;
+  return std::nullopt;
 }
 
 SubscribeNamespace makePeerSubNs(std::optional<std::string> relayID) {

--- a/src/UpstreamProvider.h
+++ b/src/UpstreamProvider.h
@@ -27,8 +27,10 @@ namespace openmoq::moqx {
 // --- Relay peering auth helpers ---
 // Used by UpstreamProvider (initiating peer subNs) and MoqxRelay (reciprocation).
 
-// Returns true if subNs carries a relay peer auth token.
-bool isPeerSubNs(const moxygen::SubscribeNamespace& subNs);
+// If subNs carries a relay peer auth token, returns the relay ID encoded in
+// the token (may be empty string if the peer didn't include one).
+// Returns std::nullopt if subNs is not a peer subNs at all.
+std::optional<std::string> getPeerRelayID(const moxygen::SubscribeNamespace& subNs);
 
 // Builds a wildcard SubscribeNamespace(prefix={}, BOTH).
 // With relayID: includes the relay auth token (initiating peer).
@@ -116,6 +118,18 @@ public:
 
   // Access the current session (may be null)
   std::shared_ptr<moxygen::MoQSession> currentSession() const { return session_; }
+
+  std::string stateString() const {
+    switch (state_) {
+    case State::Disconnected:
+      return "disconnected";
+    case State::Connecting:
+      return "connecting";
+    case State::Connected:
+      return "connected";
+    }
+    return "unknown";
+  }
 
 private:
   enum class State { Disconnected, Connecting, Connected };

--- a/src/admin/JsonWriter.h
+++ b/src/admin/JsonWriter.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <string_view>
+
+#include <folly/io/Cursor.h>
+
+namespace openmoq::moqx::admin {
+
+// Minimal streaming JSON emitter backed by a folly::io::QueueAppender.
+// No intermediate representation is built — bytes are written directly
+// to the appender as each method is called.
+//
+// Comma state is tracked by a single instance, so the same JsonWriter
+// must be shared across nested helper classes (e.g. a context visitor
+// and its per-service relay visitor) to keep commas correct across layers.
+class JsonWriter {
+public:
+  explicit JsonWriter(folly::io::QueueAppender& app) : app_(app) {}
+
+  void beginObject() {
+    maybeComma();
+    append('{');
+    needsComma_ = false;
+  }
+  void endObject() {
+    append('}');
+    needsComma_ = true;
+  }
+  void beginArray() {
+    maybeComma();
+    append('[');
+    needsComma_ = false;
+  }
+  void endArray() {
+    append(']');
+    needsComma_ = true;
+  }
+
+  // Writes "key": — no comma after; caller writes the value immediately after.
+  void key(std::string_view k) {
+    maybeComma();
+    writeString(k);
+    append(':');
+    needsComma_ = false;
+  }
+
+  void strVal(std::string_view v) {
+    maybeComma();
+    writeString(v);
+    needsComma_ = true;
+  }
+  void boolVal(bool v) {
+    maybeComma();
+    append(v ? "true" : "false");
+    needsComma_ = true;
+  }
+  void intVal(int64_t v) {
+    maybeComma();
+    append(std::to_string(v));
+    needsComma_ = true;
+  }
+  void uintVal(uint64_t v) {
+    maybeComma();
+    append(std::to_string(v));
+    needsComma_ = true;
+  }
+
+  void field(std::string_view k, std::string_view v) {
+    key(k);
+    strVal(v);
+  }
+  void field(std::string_view k, bool v) {
+    key(k);
+    boolVal(v);
+  }
+  void field(std::string_view k, int64_t v) {
+    key(k);
+    intVal(v);
+  }
+  void field(std::string_view k, uint64_t v) {
+    key(k);
+    uintVal(v);
+  }
+
+private:
+  void maybeComma() {
+    if (needsComma_) {
+      append(',');
+    }
+  }
+
+  void append(char c) { app_.write(static_cast<uint8_t>(c)); }
+
+  void append(std::string_view s) {
+    app_.push(reinterpret_cast<const uint8_t*>(s.data()), s.size());
+  }
+
+  void writeString(std::string_view s) {
+    append('"');
+    for (unsigned char c : s) {
+      if (c == '"') {
+        append("\\\"");
+      } else if (c == '\\') {
+        append("\\\\");
+      } else if (c == '\n') {
+        append("\\n");
+      } else if (c == '\r') {
+        append("\\r");
+      } else if (c == '\t') {
+        append("\\t");
+      } else if (c < 0x20) {
+        char buf[7];
+        std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+        append(std::string_view(buf, 6));
+      } else {
+        append(static_cast<char>(c));
+      }
+    }
+    append('"');
+  }
+
+  folly::io::QueueAppender& app_;
+  bool needsComma_{false};
+};
+
+} // namespace openmoq::moqx::admin

--- a/src/admin/StateHandler.cpp
+++ b/src/admin/StateHandler.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "admin/StateHandler.h"
+
+#include <chrono>
+#include <folly/CancellationToken.h>
+#include <folly/coro/Task.h>
+#include <folly/experimental/coro/WithCancellation.h>
+#include <folly/io/IOBuf.h>
+#include <folly/io/IOBufQueue.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <folly/logging/xlog.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <proxygen/lib/http/HTTPMessage.h>
+
+#include "MoqxRelayContext.h"
+#include "admin/AdminServer.h"
+#include "admin/JsonWriter.h"
+
+namespace openmoq::moqx::admin {
+
+namespace {
+
+// RelayStateVisitor that writes JSON directly via a shared JsonWriter.
+// Section begin/end callbacks map directly to JSON array/object open/close,
+// so no state tracking or deferred finalization is needed here.
+class JsonRelayStateVisitor : public RelayStateVisitor {
+  JsonWriter& w_;
+
+public:
+  explicit JsonRelayStateVisitor(JsonWriter& w) : w_(w) {}
+
+  void onPeersBegin() override {
+    w_.key("downstream_peers");
+    w_.beginArray();
+  }
+  void
+  onPeer(std::string_view address, std::string_view authority, std::string_view relayID) override {
+    w_.beginObject();
+    w_.field("address", address);
+    w_.field("authority", authority);
+    if (!relayID.empty()) {
+      w_.field("relay_id", relayID);
+    }
+    w_.endObject();
+  }
+  void onPeersEnd() override { w_.endArray(); }
+
+  void onSubscriptionsBegin() override {
+    w_.key("subscriptions");
+    w_.beginArray();
+  }
+  void onSubscription(const SubscriptionInfo& info) override {
+    w_.beginObject();
+    w_.key("namespace");
+    w_.beginArray();
+    for (const auto& t : info.ftn.trackNamespace.trackNamespace) {
+      w_.strVal(t);
+    }
+    w_.endArray();
+    w_.field("track_name", info.ftn.trackName);
+    w_.field("is_publish", info.isPublish);
+    w_.key("subscribers");
+    w_.uintVal(static_cast<uint64_t>(info.subscribers));
+    w_.field("forwarding_subscribers", info.forwardingSubscribers);
+    w_.field("total_groups_received", info.totalGroupsReceived);
+    w_.field("total_objects_received", info.totalObjectsReceived);
+    w_.field("source_address", info.sourceAddress);
+    if (info.largest) {
+      w_.key("largest");
+      w_.beginObject();
+      w_.field("group", info.largest->group);
+      w_.field("object", info.largest->object);
+      w_.endObject();
+    }
+    w_.endObject();
+  }
+  void onSubscriptionsEnd() override { w_.endArray(); }
+
+  void onNamespaceTreeBegin() override {
+    w_.key("namespace_tree");
+    // The root beginNamespaceNode call immediately follows and opens the object.
+  }
+  void beginNamespaceNode(
+      std::string_view childKey,
+      const moxygen::TrackNamespace& ns,
+      size_t sessionCount
+  ) override {
+    if (!childKey.empty()) {
+      w_.key(childKey);
+    }
+    w_.beginObject();
+    w_.key("full_namespace");
+    w_.beginArray();
+    for (const auto& t : ns.trackNamespace) {
+      w_.strVal(t);
+    }
+    w_.endArray();
+    w_.key("namespace_subscribers");
+    w_.uintVal(static_cast<uint64_t>(sessionCount));
+    w_.key("children");
+    w_.beginObject();
+  }
+  void endNamespaceNode() override {
+    w_.endObject(); // children
+    w_.endObject(); // node
+  }
+  void onNamespaceTreeEnd() override {}
+
+  void onCacheStats(
+      size_t totalBytes,
+      const std::vector<moxygen::MoQCache::TrackStats>& tracks,
+      moxygen::MoQCache::TimePoint now
+  ) override {
+    w_.key("cache");
+    w_.beginObject();
+    w_.key("total_bytes");
+    w_.uintVal(static_cast<uint64_t>(totalBytes));
+    w_.key("tracks");
+    w_.beginArray();
+    for (const auto& t : tracks) {
+      w_.beginObject();
+      w_.key("namespace");
+      w_.beginArray();
+      for (const auto& s : t.name.trackNamespace.trackNamespace) {
+        w_.strVal(s);
+      }
+      w_.endArray();
+      w_.field("track_name", t.name.trackName);
+      w_.field("end_of_track", t.endOfTrack);
+      auto msAgo = std::chrono::duration_cast<std::chrono::milliseconds>(now - t.lastWrite).count();
+      w_.field("last_write_ms_ago", static_cast<int64_t>(msAgo));
+      w_.key("groups");
+      w_.beginArray();
+      for (const auto& g : t.groups) {
+        w_.beginObject();
+        w_.field("group_id", g.groupId);
+        w_.key("objects");
+        w_.uintVal(static_cast<uint64_t>(g.objects));
+        w_.endObject();
+      }
+      w_.endArray();
+      w_.endObject();
+    }
+    w_.endArray();
+    w_.endObject();
+  }
+};
+
+// RelayContextVisitor that builds the top-level JSON envelope.
+// A single JsonWriter is shared with JsonRelayStateVisitor so comma state
+// remains consistent across the two visitor layers.
+class JsonRelayContextVisitor : public RelayContextVisitor {
+  folly::IOBufQueue queue_{folly::IOBufQueue::cacheChainLength()};
+  folly::io::QueueAppender app_{&queue_, 4096};
+  JsonWriter w_{app_};
+  JsonRelayStateVisitor relayVisitor_{w_};
+
+public:
+  void onRelayBegin(std::string_view relayID, int64_t activeSessions) override {
+    w_.beginObject();
+    w_.field("relay_id", relayID);
+    w_.field("active_sessions", activeSessions);
+    w_.key("services");
+    w_.beginObject();
+  }
+
+  RelayStateVisitor& onServiceBegin(std::string_view name) override {
+    w_.key(name);
+    w_.beginObject();
+    return relayVisitor_;
+  }
+
+  void onServiceUpstream(std::string_view url, std::string_view state) override {
+    w_.key("upstream");
+    w_.beginObject();
+    w_.field("url", url);
+    w_.field("state", state);
+    w_.endObject();
+  }
+
+  void onServiceEnd() override { w_.endObject(); }
+
+  void onRelayEnd() override {
+    w_.endObject(); // services
+    w_.endObject(); // relay
+    static constexpr uint8_t kNewline = '\n';
+    app_.write(kNewline);
+  }
+
+  std::unique_ptr<folly::IOBuf> move() { return queue_.move(); }
+};
+
+// Runs on the relay worker EVB. Dumps state and returns the serialized body.
+folly::coro::Task<std::unique_ptr<folly::IOBuf>>
+buildStateBody(std::shared_ptr<MoqxRelayContext> ctx) {
+  JsonRelayContextVisitor visitor;
+  ctx->dumpState(visitor);
+  co_return visitor.move();
+}
+
+} // namespace
+
+void registerStateRoute(AdminServer& adminServer, std::shared_ptr<MoqxRelayContext> context) {
+  adminServer.addRoute(
+      "GET",
+      "/state",
+      [context = std::move(context
+       )](auto /*req*/, auto /*body*/, auto* downstream, folly::CancellationToken cancelToken) {
+        auto* workerEvb = context->workerEvb();
+        if (!workerEvb) {
+          proxygen::ResponseBuilder(downstream)
+              .status(503, proxygen::HTTPMessage::getDefaultReason(503))
+              .body(folly::IOBuf::copyBuffer("relay not ready\n"))
+              .sendWithEOM();
+          return;
+        }
+
+        // Outer coroutine stays on the admin EVB so sendWithEOM is thread-safe.
+        // buildStateBody switches to workerEvb and returns the IOBuf; after the
+        // co_await completes execution resumes here on the admin EVB.
+        folly::coro::co_withCancellation(
+            cancelToken,
+            folly::coro::co_withExecutor(
+                folly::EventBaseManager::get()->getEventBase(),
+                [](auto ctx, auto* ds, auto* wEvb, auto token) -> folly::coro::Task<void> {
+                  if (token.isCancellationRequested()) {
+                    co_return;
+                  }
+                  std::unique_ptr<folly::IOBuf> body;
+                  try {
+                    body = co_await folly::coro::co_withExecutor(wEvb, buildStateBody(ctx));
+                  } catch (const std::exception& e) {
+                    XLOG(ERR) << "StateHandler: dumpState threw: " << e.what();
+                    if (!token.isCancellationRequested()) {
+                      proxygen::ResponseBuilder(ds)
+                          .status(500, proxygen::HTTPMessage::getDefaultReason(500))
+                          .body(folly::IOBuf::copyBuffer("internal error\n"))
+                          .sendWithEOM();
+                    }
+                    co_return;
+                  }
+                  if (token.isCancellationRequested()) {
+                    co_return;
+                  }
+                  proxygen::ResponseBuilder(ds)
+                      .status(200, proxygen::HTTPMessage::getDefaultReason(200))
+                      .header("Content-Type", "application/json")
+                      .body(std::move(body))
+                      .sendWithEOM();
+                }(context, downstream, workerEvb, cancelToken)
+            )
+        )
+            .start();
+      }
+  );
+}
+
+} // namespace openmoq::moqx::admin

--- a/src/admin/StateHandler.h
+++ b/src/admin/StateHandler.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace openmoq::moqx {
+
+class MoqxRelayContext;
+
+namespace admin {
+class AdminServer;
+
+// Registers GET /state on the given admin server.
+//
+// The handler runs dumpState() on the relay worker EVB via co_withExecutor,
+// then serializes the result to JSON and sends it to the client.
+void registerStateRoute(AdminServer& adminServer, std::shared_ptr<MoqxRelayContext> context);
+
+} // namespace admin
+
+} // namespace openmoq::moqx

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "admin/AdminServer.h"
 #include "admin/BuiltinRoutes.h"
 #include "admin/MetricsHandler.h"
+#include "admin/StateHandler.h"
 #include "config/loader/ConfigInit.h"
 #include "stats/StatsRegistry.h"
 
@@ -119,6 +120,7 @@ int main(int argc, char* argv[]) {
   admin::AdminServer adminServer;
   admin::registerBuiltinRoutes(adminServer);
   admin::registerMetricsRoute(adminServer, statsRegistry);
+  admin::registerStateRoute(adminServer, context);
   if (config.admin) {
     if (!adminServer.start(*config.admin)) {
       XLOG(FATAL) << "Failed to start admin server on " << config.admin->address.describe();

--- a/test/UpstreamProviderTest.cpp
+++ b/test/UpstreamProviderTest.cpp
@@ -90,25 +90,27 @@ struct NoopObjectCallback : public ObjectReceiverCallback {
 
 } // namespace
 
-// --- Pure function tests: isPeerSubNs / makePeerSubNs ---
+// --- Pure function tests: getPeerRelayID / makePeerSubNs ---
 // These don't need a fixture or event loop.
 
 TEST(PeerSubNsHelpers, PeerSubNsRoundTrip) {
-  // A subNs built with a relayID is detected as a peer subNs; without it is not.
+  // A subNs built with a relayID returns that ID; without one returns nullopt.
   auto withID = makePeerSubNs("my-relay-id");
-  EXPECT_TRUE(isPeerSubNs(withID));
+  auto id = getPeerRelayID(withID);
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(*id, "my-relay-id");
   EXPECT_EQ(withID.trackNamespacePrefix, TrackNamespace{});
   EXPECT_EQ(withID.options, SubscribeNamespaceOptions::BOTH);
 
   auto withoutID = makePeerSubNs();
-  EXPECT_FALSE(isPeerSubNs(withoutID));
+  EXPECT_FALSE(getPeerRelayID(withoutID).has_value());
 }
 
 TEST(PeerSubNsHelpers, NormalSubNsIsNotPeer) {
   SubscribeNamespace subNs;
   subNs.trackNamespacePrefix = TrackNamespace{{"test"}};
   subNs.options = SubscribeNamespaceOptions::BOTH;
-  EXPECT_FALSE(isPeerSubNs(subNs));
+  EXPECT_FALSE(getPeerRelayID(subNs).has_value());
 }
 
 // --- Integration fixture tests ---
@@ -323,7 +325,7 @@ TEST_F(UpstreamProviderTest, PeerSubNsHandshakeOnConnect) {
       .WillOnce(
           [](SubscribeNamespace subNs, std::shared_ptr<Publisher::NamespacePublishHandle>)
               -> folly::coro::Task<Publisher::SubscribeNamespaceResult> {
-            EXPECT_TRUE(isPeerSubNs(subNs));
+            EXPECT_TRUE(getPeerRelayID(subNs).has_value());
             EXPECT_EQ(subNs.trackNamespacePrefix, TrackNamespace{});
             co_return makeSubscribeNamespaceOk(subNs);
           }

--- a/test/test_relay_chain.sh
+++ b/test/test_relay_chain.sh
@@ -114,6 +114,51 @@ wait_ready() {
   done
 }
 
+# check_state <admin_port> <expected_relay_id> <label>: fetch /state, validate JSON
+# structure, and echo a summary line.  Exits 1 on failure.
+check_state() {
+  local port="$1" expected_id="$2" label="$3"
+  local url="http://localhost:$port/state"
+  local http_code response raw
+  raw=$(curl -sf --write-out '\n%{http_code}' "$url" 2>/dev/null) || {
+    echo "FAIL [$label /state]: curl failed (exit $?)" >&2; return 1;
+  }
+  http_code=$(printf '%s' "$raw" | tail -1)
+  response=$(printf '%s' "$raw" | head -n -1)
+  if [[ "$http_code" != "200" ]]; then
+    echo "FAIL [$label /state]: HTTP $http_code" >&2; return 1;
+  fi
+  if ! printf '%s' "$response" | jq . >/dev/null 2>&1; then
+    echo "FAIL [$label /state]: not valid JSON" >&2
+    echo "  raw byte count: ${#raw}" >&2
+    echo "  http_code: $(printf '%s' "$http_code" | cat -v)" >&2
+    echo "  response byte count: ${#response}" >&2
+    echo "  response (cat -v): $(printf '%s' "$response" | cat -v)" >&2
+    echo "  jq error: $(printf '%s' "$response" | jq . 2>&1 || true)" >&2
+    return 1;
+  fi
+  local relay_id
+  relay_id=$(printf '%s' "$response" | jq -r '.relay_id')
+  if [[ "$relay_id" != "$expected_id" ]]; then
+    echo "FAIL [$label /state]: relay_id=$relay_id, want $expected_id" >&2; return 1;
+  fi
+  for field in downstream_peers subscriptions; do
+    local t
+    t=$(printf '%s' "$response" | jq -r ".services.default.${field} | type")
+    if [[ "$t" != "array" ]]; then
+      echo "FAIL [$label /state]: services.default.$field is $t, want array" >&2; return 1;
+    fi
+  done
+  local tree_type
+  tree_type=$(printf '%s' "$response" | jq -r '.services.default.namespace_tree | type')
+  if [[ "$tree_type" != "object" ]]; then
+    echo "FAIL [$label /state]: namespace_tree is $tree_type, want object" >&2; return 1;
+  fi
+  local sessions
+  sessions=$(printf '%s' "$response" | jq '.active_sessions')
+  echo "PASS [$label /state]: relay_id=$relay_id active_sessions=$sessions"
+}
+
 # wait_sessions <admin_port> <min> <label>: wait for moqActiveSessions >= min.
 wait_sessions() {
   local port="$1" min="$2" label="$3"
@@ -225,8 +270,8 @@ check_received() {
     echo "--- dateserver log ---" >&2
     cat "$DATESERVER_LOG" 2>/dev/null >&2 || true
     return 1
-  elif grep -q "Largest=" "$out" 2>/dev/null; then
-    echo "PASS [$label]: $(grep 'Largest=' "$out" | head -1)"
+  elif grep -qE "^[0-9]" "$out" 2>/dev/null; then
+    echo "PASS [$label]: $(grep -E "^[0-9]" "$out" | head -1)"
     return 0
   else
     echo "FAIL [$label]: no data received" >&2
@@ -254,6 +299,38 @@ timeout "$TIMEOUT" "$TEXTCLIENT" \
   >"$CLIENT_OUT" 2>&1 || true
 
 check_received "upstream→downstream" "$CLIENT_OUT" || exit 1
+
+# ── /state snapshot: publisher connected, peering active ──────────────────────
+# dateserver is still publishing to upstream; downstream is still peered.
+# Upstream should show: the publish subscription, "moq-date" in namespace_tree,
+# and the downstream relay in downstream_peers.
+# Downstream should show: upstream.state=connected.
+echo "Checking /state on both relays while publisher is active..."
+check_state "$UPSTREAM_ADMIN_PORT" "$UPSTREAM_RELAY_ID" "upstream"
+check_state "$DOWNSTREAM_ADMIN_PORT" "$DOWNSTREAM_RELAY_ID" "downstream"
+
+# Upstream-specific: downstream relay must appear as a peer.
+UP_STATE=$(curl -sf "http://localhost:$UPSTREAM_ADMIN_PORT/state")
+PEER_COUNT=$(printf '%s' "$UP_STATE" | jq '.services.default.downstream_peers | length')
+if [[ "$PEER_COUNT" -lt 1 ]]; then
+  echo "FAIL [upstream /state]: expected >=1 downstream_peers, got $PEER_COUNT" >&2; exit 1;
+fi
+echo "PASS [upstream /state]: downstream_peers=$PEER_COUNT"
+
+# Upstream-specific: "moq-date" namespace must appear in the tree.
+NS_PRESENT=$(printf '%s' "$UP_STATE" | jq '.services.default.namespace_tree.children | has("moq-date")')
+if [[ "$NS_PRESENT" != "true" ]]; then
+  echo "FAIL [upstream /state]: namespace_tree missing moq-date child" >&2; exit 1;
+fi
+echo "PASS [upstream /state]: namespace_tree contains moq-date"
+
+# Downstream-specific: upstream must be reported connected.
+DOWN_STATE=$(curl -sf "http://localhost:$DOWNSTREAM_ADMIN_PORT/state")
+UP_CONN=$(printf '%s' "$DOWN_STATE" | jq -r '.services.default.upstream.state')
+if [[ "$UP_CONN" != "connected" ]]; then
+  echo "FAIL [downstream /state]: upstream.state=$UP_CONN, want connected" >&2; exit 1;
+fi
+echo "PASS [downstream /state]: upstream.state=connected"
 
 # ── Direction 2: publisher → downstream, subscriber via upstream ───────────────
 echo "Direction 2: moqdateserver → downstream, subscribe via upstream"
@@ -289,8 +366,8 @@ if grep -qE "SubscribeError|Fetch.*failed" "$CLIENT_OUT" 2>/dev/null; then
   echo "FAIL [joining fetch via downstream]: error" >&2
   cat "$CLIENT_OUT" >&2
   exit 1
-elif grep -q "Largest=" "$CLIENT_OUT" 2>/dev/null; then
-  echo "PASS [joining fetch via downstream]: $(grep 'Largest=' "$CLIENT_OUT" | head -1)"
+elif grep -qE "^[0-9]" "$CLIENT_OUT" 2>/dev/null; then
+  echo "PASS [joining fetch via downstream]: $(grep -E "^[0-9]" "$CLIENT_OUT" | head -1)"
 else
   echo "FAIL [joining fetch via downstream]: no data" >&2
   cat "$CLIENT_OUT" >&2
@@ -322,8 +399,8 @@ PIDS+=($!)
 wait $TCPID || true
 
 # Success: textclient received date objects printed to stdout by onObject().
-if grep -qE "^[0-9]|PublishDone" "$CLIENT_OUT3" 2>/dev/null; then
-  echo "PASS [--publish mode]: data received via PUBLISH push"
+if grep -qE "^[0-9]" "$CLIENT_OUT3" 2>/dev/null; then
+  echo "PASS [--publish mode]: $(grep -E "^[0-9]" "$CLIENT_OUT3" | head -1)"
 else
   echo "FAIL [--publish mode]: no data" >&2
   cat "$CLIENT_OUT3" >&2


### PR DESCRIPTION
Adds a /state JSON endpoint to the admin server that dumps live relay state: active sessions, downstream peers (with relay ID), per-track subscriptions (subscriber counts, counters, largest), namespace announcement tree, and cache stats.

Design uses a visitor pattern (RelayStateVisitor / RelayContextVisitor) so MoqxRelay and MoqxRelayContext have no JSON dependency — all serialization lives in StateHandler.cpp via a streaming JsonWriter backed by folly::IOBufQueue.

Also:
- getPeerRelayID() replaces isPeerSubNs(), extracting the peer relay ID from the auth token so it appears in /state output
- UpstreamProvider::stateString() exposes upstream connection state
- test_relay_chain.sh gains check_state() and /state assertions after Direction 1 (peer count, namespace tree, upstream.state=connected)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/146)
<!-- Reviewable:end -->
