### PR TITLE
fix: restore MoQServer optimized defaults and enable pacing in buildTransportSettings

### DIFF
--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -54,7 +54,17 @@ buildFizzContext(const config::ListenerConfig& cfg) {
 }
 
 quic::TransportSettings buildTransportSettings(const config::QuicConfig& quic) {
+  // Start with MoQServer's optimized defaults, then apply config overrides.
   quic::TransportSettings ts;
+  ts.defaultCongestionController = quic::CongestionControlType::Copa;
+  ts.copaDeltaParam = 0.05;
+  ts.pacingEnabled = true;
+  ts.maxCwndInMss = quic::kLargeMaxCwndInMss;
+  ts.batchingMode = quic::QuicBatchingMode::BATCHING_MODE_GSO;
+  ts.maxBatchSize = 48;
+  ts.dataPathType = quic::DataPathType::ContinuousMemory;
+  ts.maxServerRecvPacketsPerLoop = 10;
+  ts.writeConnectionDataPacketsLimit = 48;
   ts.advertisedInitialConnectionFlowControlWindow = quic.maxData;
   ts.advertisedInitialBidiLocalStreamFlowControlWindow = quic.maxStreamData;
   ts.advertisedInitialBidiRemoteStreamFlowControlWindow = quic.maxStreamData;


### PR DESCRIPTION
Supplying a TransportSettings to MoQServer bypasses its optimized defaults (GSO batching, ContinuousMemory data path, large cwnd, etc.). Replicate those defaults explicitly before applying config overrides so nothing is silently lost.

Also enables pacingEnabled unconditionally — BBR requires it (mvfst falls back to Cubic without it), and pacing is beneficial for all supported CC algorithms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/148)
<!-- Reviewable:end -->
