### PR TITLE
feat: forward NEW_GROUP_REQUEST upstream through relay

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -7,8 +7,8 @@
  */
 
 #include "MoqxRelay.h"
-
 #include <moxygen/MoQFilters.h>
+#include <moxygen/MoQTrackProperties.h>
 
 namespace {
 constexpr uint8_t kDefaultUpstreamPriority = 128;
@@ -87,6 +87,24 @@ MoqxRelay::doSubscribeUpdate(std::shared_ptr<Publisher::SubscriptionHandle> hand
   );
   if (updateRes.hasError()) {
     XLOG(ERR) << "requestUpdate failed: " << updateRes.error().reasonPhrase;
+  }
+}
+
+// Sends a REQUEST_UPDATE that carries only the NEW_GROUP_REQUEST parameter.
+folly::coro::Task<void> MoqxRelay::doNewGroupRequestUpdate(
+    std::shared_ptr<Publisher::SubscriptionHandle> handle,
+    uint64_t newGroupRequestValue
+) {
+  XLOG(DBG4) << "Sending NEW_GROUP_REQUEST update: " << newGroupRequestValue;
+  RequestUpdate update;
+  update.requestID = RequestID(0);
+  update.existingRequestID = handle->subscribeOk().requestID;
+  update.params.insertParam(
+      Parameter(folly::to_underlying(TrackRequestParamKey::NEW_GROUP_REQUEST), newGroupRequestValue)
+  );
+  auto updateRes = co_await handle->requestUpdate(std::move(update));
+  if (updateRes.hasError()) {
+    XLOG(ERR) << "NEW_GROUP_REQUEST update failed: " << updateRes.error().reasonPhrase;
   }
 }
 
@@ -563,12 +581,10 @@ folly::coro::Task<void> MoqxRelay::publishToSession(
   guard.dismiss();
   XLOG(DBG1) << "Publish OK sess=" << session.get();
   auto& pubOk = pubResult.value().value();
-  std::optional<AbsoluteLocation> end;
-  if (pubOk.endGroup) {
-    end = AbsoluteLocation{*pubOk.endGroup, 0};
-  }
-  subscriber->range = toSubscribeRange(pubOk.start, end, pubOk.locType, forwarder->largest());
-  subscriber->shouldForward = pubOk.forward;
+
+  // Process the PUBLISH_OK response - updates range, forward flag, and
+  // handles NEW_GROUP_REQUEST forwarding via callback
+  subscriber->onPublishOk(pubOk);
 }
 
 class MoqxRelay::NamespaceSubscription : public Publisher::SubscribeNamespaceHandle {
@@ -936,6 +952,8 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
     auto& rsub = it->second;
     rsub.requestID = subRes.value()->subscribeOk().requestID;
     rsub.handle = std::move(subRes.value());
+    // Record NGR as outstanding (no fire — it rides the outgoing SUBSCRIBE).
+    forwarder->tryProcessNewGroupRequest(subReq.params, /*fire=*/false);
     rsub.promise.setValue(folly::unit);
     co_return subscriber;
   } else {
@@ -972,6 +990,8 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
       co_withExecutor(exec, doSubscribeUpdate(subscriptionIt->second.handle, /*forward=*/true))
           .start();
     }
+
+    forwarder->tryProcessNewGroupRequest(subReq.params);
     co_return subscriber;
   }
 }
@@ -1163,6 +1183,25 @@ void MoqxRelay::forwardChanged(MoQForwarder* forwarder) {
       )
   )
       .start();
+}
+
+void MoqxRelay::newGroupRequested(MoQForwarder* forwarder, uint64_t group) {
+  auto subscriptionIt = subscriptions_.find(forwarder->fullTrackName());
+  if (subscriptionIt == subscriptions_.end()) {
+    return;
+  }
+  auto& subscription = subscriptionIt->second;
+  // Check if handle is still valid (publisher may have terminated)
+  if (!subscription.handle) {
+    XLOG(DBG4) << "Ignoring NEW_GROUP_REQUEST for " << subscriptionIt->first
+               << " - publisher terminated";
+    return;
+  }
+  XLOG(INFO) << "New group request detected for " << subscriptionIt->first;
+
+  auto exec = subscription.upstream->getExecutor();
+  auto handle = subscription.handle;
+  co_withExecutor(exec, doNewGroupRequestUpdate(std::move(handle), group)).start();
 }
 
 } // namespace openmoq::moqx

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -234,6 +234,7 @@ private:
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
   void forwardChanged(moxygen::MoQForwarder* forwarder) override;
+  void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override;
 
   folly::coro::Task<void> publishNamespaceToSession(
       std::shared_ptr<moxygen::MoQSession> session,
@@ -249,6 +250,11 @@ private:
 
   folly::coro::Task<void>
   doSubscribeUpdate(std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle, bool forward);
+
+  folly::coro::Task<void> doNewGroupRequestUpdate(
+      std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+      uint64_t newGroupRequestValue
+  );
 
   void publishNamespaceDone(const moxygen::TrackNamespace& trackNamespace, NamespaceNode* node);
 

--- a/test/MoqxRelayTest.cpp
+++ b/test/MoqxRelayTest.cpp
@@ -7,12 +7,12 @@
  */
 
 #include "MoqxRelay.h"
-
 #include "TestUtils.h"
 #include <folly/coro/BlockingWait.h>
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
+#include <moxygen/MoQTrackProperties.h>
 #include <moxygen/events/MoQFollyExecutorImpl.h>
 #include <moxygen/relay/MoQForwarder.h>
 #include <moxygen/test/MockMoQSession.h>
@@ -1118,7 +1118,7 @@ TEST_F(MoQRelayTest, SubscribeNamespaceDoesntAddDrainingPublish) {
   // Publish first track - subscriber 1 should receive it
   auto mockConsumer1 = createMockConsumer();
   EXPECT_CALL(*subscriber1, publish(testing::_, testing::_))
-      .WillOnce([mockConsumer1](auto pubReq, auto subHandle) {
+      .WillOnce([mockConsumer1](const auto& /*pubReq*/, auto /*subHandle*/) {
         return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
             mockConsumer1,
             []() -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
@@ -1169,12 +1169,12 @@ TEST_F(MoQRelayTest, SubscribeNamespaceDoesntAddDrainingPublish) {
   // second track
   // Expect publish calls on both subscribers, just fail them.
   EXPECT_CALL(*subscriber1, publish(testing::_, testing::_))
-      .WillOnce([](auto /*pubReq*/, auto /*subHandle*/) {
+      .WillOnce([](const auto& /*pubReq*/, auto /*subHandle*/) {
         return folly::makeUnexpected(PublishError{});
       });
 
   EXPECT_CALL(*subscriber2, publish(testing::_, testing::_))
-      .WillOnce([](auto /*pubReq*/, auto /*subHandle*/) {
+      .WillOnce([](const auto& /*pubReq*/, auto /*subHandle*/) {
         return folly::makeUnexpected(PublishError{});
       });
 
@@ -1845,6 +1845,10 @@ TEST_F(MoQRelayTest, ResetDuringDrainingMultipleSubscribersDoesNotCrash) {
   EXPECT_EQ(forwarder, nullptr);
 }
 
+// ============================================================
+// Extensions Tests
+// ============================================================
+
 // Test: Extensions from publish are forwarded to subscribers via
 // subscribeNamespace
 TEST_F(MoQRelayTest, PublishExtensionsForwardedToSubscribers) {
@@ -1855,7 +1859,8 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToSubscribers) {
   auto mockConsumer = createMockConsumer();
   Extensions receivedExtensions;
   EXPECT_CALL(*subscriber, publish(testing::_, testing::_))
-      .WillOnce([&mockConsumer, &receivedExtensions](PublishRequest pubReq, auto subHandle) {
+      .WillOnce([&mockConsumer,
+                 &receivedExtensions](const PublishRequest& pubReq, auto /*subHandle*/) {
         receivedExtensions = pubReq.extensions;
         return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
             mockConsumer,
@@ -1898,6 +1903,40 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToSubscribers) {
   removeSession(subscriber);
 }
 
+// ============================================================
+// Dynamic Groups Extension Tests
+// ============================================================
+
+// Test: relay PUBLISH path – dynamic groups from PublishRequest extensions
+// is stored in the forwarder and forwarded to every downstream subscriber
+TEST_F(MoQRelayTest, RelayPublishPropagatesDynamicGroupsToSubscribers) {
+  auto publisherSession = createMockSession();
+  auto subscriberSession = createMockSession();
+
+  // Build a PublishRequest with DYNAMIC_GROUPS enabled
+  PublishRequest pub;
+  pub.fullTrackName = kTestTrackName;
+  setPublisherDynamicGroups(pub, true);
+
+  withSessionContext(publisherSession, [&]() {
+    auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+    ASSERT_TRUE(res.hasValue());
+    getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
+  });
+
+  auto consumer = createMockConsumer();
+  auto handle = subscribeToTrack(subscriberSession, kTestTrackName, consumer, RequestID(1));
+  ASSERT_NE(handle, nullptr);
+
+  auto dynGroups = getPublisherDynamicGroups(handle->subscribeOk());
+  ASSERT_TRUE(dynGroups.has_value());
+  EXPECT_TRUE(*dynGroups);
+
+  removeSession(subscriberSession);
+  exec_->drive();
+  removeSession(publisherSession);
+}
+
 // Test: Extensions from publish are forwarded to late-joining subscribers
 TEST_F(MoQRelayTest, PublishExtensionsForwardedToLateJoiners) {
   auto publisherSession = createMockSession();
@@ -1906,22 +1945,23 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToLateJoiners) {
 
   // Subscriber 1 subscribes first
   auto mockConsumer1 = createMockConsumer();
-  EXPECT_CALL(*subscriber1, publish(testing::_, testing::_)).WillOnce([&mockConsumer1](auto, auto) {
-    return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
-        mockConsumer1,
-        []() -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
-          co_return PublishOk{
-              RequestID(1),
-              true,
-              0,
-              GroupOrder::OldestFirst,
-              LocationType::LargestObject,
-              std::nullopt,
-              std::nullopt
-          };
-        }()
-    });
-  });
+  EXPECT_CALL(*subscriber1, publish(testing::_, testing::_))
+      .WillOnce([&mockConsumer1](const auto&, auto) {
+        return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
+            mockConsumer1,
+            []() -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
+              co_return PublishOk{
+                  RequestID(1),
+                  true,
+                  0,
+                  GroupOrder::OldestFirst,
+                  LocationType::LargestObject,
+                  std::nullopt,
+                  std::nullopt
+              };
+            }()
+        });
+      });
 
   doSubscribeNamespace(subscriber1, kTestNamespace);
 
@@ -1944,7 +1984,7 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToLateJoiners) {
   Extensions receivedExtensions;
   auto mockConsumer2 = createMockConsumer();
   EXPECT_CALL(*subscriber2, publish(testing::_, testing::_))
-      .WillOnce([&mockConsumer2, &receivedExtensions](PublishRequest pubReq, auto) {
+      .WillOnce([&mockConsumer2, &receivedExtensions](const PublishRequest& pubReq, auto) {
         receivedExtensions = pubReq.extensions;
         return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
             mockConsumer2,
@@ -1968,6 +2008,54 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToLateJoiners) {
   // Verify late-joiner received extensions
   EXPECT_EQ(receivedExtensions.getIntExtension(kDeliveryTimeoutExtensionType), 3000);
   EXPECT_EQ(receivedExtensions.getIntExtension(0xCAFE'0000), 99);
+
+  removeSession(publisherSession);
+  removeSession(subscriber1);
+  removeSession(subscriber2);
+}
+
+// Test: relay SUBSCRIBE path – dynamic groups from the upstream SubscribeOk is
+// stored in the forwarder and forwarded to both the first and late-joining
+// downstream subscribers
+TEST_F(MoQRelayTest, RelaySubscribePropagatesDynamicGroupsToAllSubscribers) {
+  auto publisherSession = createMockSession();
+  auto subscriber1 = createMockSession();
+  auto subscriber2 = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Upstream returns a SubscribeOk with DYNAMIC_GROUPS = true
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(1);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+  setPublisherDynamicGroups(upstreamOk, true);
+
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce([upstreamOk](const auto& /*req*/, auto /*consumer*/) {
+        auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+        return folly::coro::makeTask<Publisher::SubscribeResult>(
+            folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(handle)
+        );
+      });
+
+  // First subscriber
+  auto consumer1 = createMockConsumer();
+  auto handle1 = subscribeToTrack(subscriber1, kTestTrackName, consumer1, RequestID(1));
+  ASSERT_NE(handle1, nullptr);
+  auto dynGroups1 = getPublisherDynamicGroups(handle1->subscribeOk());
+  ASSERT_TRUE(dynGroups1.has_value());
+  EXPECT_TRUE(*dynGroups1);
+
+  // Late-joining second subscriber – forwarder should propagate the stored
+  // dynamic groups value without another upstream roundtrip
+  auto consumer2 = createMockConsumer();
+  auto handle2 = subscribeToTrack(subscriber2, kTestTrackName, consumer2, RequestID(2));
+  ASSERT_NE(handle2, nullptr);
+  auto dynGroups2 = getPublisherDynamicGroups(handle2->subscribeOk());
+  ASSERT_TRUE(dynGroups2.has_value());
+  EXPECT_TRUE(*dynGroups2);
 
   removeSession(publisherSession);
   removeSession(subscriber1);
@@ -2133,7 +2221,7 @@ TEST_F(MoQRelayTest, TrackStatusViaPrefixMatching) {
   statusOk.trackAlias = TrackAlias(0);
   statusOk.largest = AbsoluteLocation{50, 25};
 
-  EXPECT_CALL(*publisher, trackStatus(_)).WillOnce([statusOk](auto /*ts*/) {
+  EXPECT_CALL(*publisher, trackStatus(_)).WillOnce([statusOk](const auto& /*ts*/) {
     return folly::coro::makeTask<Publisher::TrackStatusResult>(statusOk);
   });
 
@@ -2252,6 +2340,488 @@ TEST_F(MoQRelayTest, PublisherReconnectWithOpenSubgroupNoSegfault) {
   removeSession(publisherSession);
   removeSession(subscriberSession);
   removeSession(reconnectedSession);
+}
+
+// ============================================================
+// New Group Request (NGR) Tests
+// ============================================================
+
+namespace {
+// Simple callback that records every newGroupRequested call.
+struct TestNGRCallback : public MoQForwarder::Callback {
+  void onEmpty(MoQForwarder*) override {}
+  void newGroupRequested(MoQForwarder*, uint64_t group) override { calls.push_back(group); }
+  std::vector<uint64_t> calls;
+};
+
+// Build a minimal params object carrying NEW_GROUP_REQUEST=val.
+auto makeNGRParams(uint64_t val) {
+  RequestUpdate upd;
+  upd.params.insertParam(
+      Parameter(folly::to_underlying(TrackRequestParamKey::NEW_GROUP_REQUEST), val)
+  );
+  return upd.params;
+}
+} // namespace
+
+// Forwarder unit test: tryProcessNewGroupRequest gating and clearing logic.
+// Verifies all three gates (dynamic groups, largest visibility, outstanding
+// deduplication) and that updateLargest clears the outstanding request.
+TEST_F(MoQRelayTest, ForwarderNGRGatingAndClearingLogic) {
+  auto cb = std::make_shared<TestNGRCallback>();
+  auto forwarder = std::make_shared<MoQForwarder>(kTestTrackName);
+  forwarder->setCallback(cb);
+
+  // Gate 1: dynamic groups not enabled — never fires
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(5));
+  EXPECT_TRUE(cb->calls.empty());
+
+  // Enable dynamic groups
+  PublishRequest pub;
+  setPublisherDynamicGroups(pub, true);
+  forwarder->setExtensions(pub.extensions);
+
+  // Baseline: no largest, no outstanding — fires for group 5
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(5));
+  ASSERT_EQ(cb->calls.size(), 1u);
+  EXPECT_EQ(cb->calls[0], 5u);
+  cb->calls.clear();
+
+  // Deduplication: outstanding=5 blocks re-requesting group 5
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(5));
+  EXPECT_TRUE(cb->calls.empty());
+
+  // Gate 2: setLargest(10) blocks groups <= 10; group 11 fires (outstanding=5
+  // is superseded)
+  forwarder->setLargest({10, 0});
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(5));
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(10));
+  EXPECT_TRUE(cb->calls.empty());
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(11));
+  ASSERT_EQ(cb->calls.size(), 1u);
+  EXPECT_EQ(cb->calls[0], 11u);
+  cb->calls.clear();
+
+  // Gate 3: outstanding=11 blocks values <= 11; group 12 fires
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(11));
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(10));
+  EXPECT_TRUE(cb->calls.empty());
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(12));
+  ASSERT_EQ(cb->calls.size(), 1u);
+  EXPECT_EQ(cb->calls[0], 12u);
+  cb->calls.clear();
+
+  // updateLargest past outstanding clears it — group 14 can fire again
+  forwarder->updateLargest(13, 0);
+  forwarder->tryProcessNewGroupRequest(makeNGRParams(14));
+  ASSERT_EQ(cb->calls.size(), 1u);
+  EXPECT_EQ(cb->calls[0], 14u);
+}
+
+// Relay test: When a late-joining subscriber sends NEW_GROUP_REQUEST in its
+// SUBSCRIBE, the relay forwards it upstream via REQUEST_UPDATE
+TEST_F(MoQRelayTest, RelaySubscribeLateJoinerNGRForwardedUpstream) {
+  auto publisherSession = createMockSession();
+  auto subscriber1 = createMockSession();
+  auto subscriber2 = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Upstream SubscribeOk advertises DYNAMIC_GROUPS = true
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(100);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+  setPublisherDynamicGroups(upstreamOk, true);
+
+  auto upstreamHandle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+  ON_CALL(*upstreamHandle, requestUpdateResult())
+      .WillByDefault(Return(folly::makeExpected<RequestError>(
+          RequestOk{RequestID(0), TrackRequestParameters(FrameType::REQUEST_OK), {}}
+      )));
+
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce([&upstreamHandle](const auto& /*req*/, auto /*consumer*/) {
+        return folly::coro::makeTask<Publisher::SubscribeResult>(
+            folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(upstreamHandle)
+        );
+      });
+
+  // First subscriber establishes the upstream subscription (no NGR)
+  auto consumer1 = createMockConsumer();
+  auto handle1 = subscribeToTrack(subscriber1, kTestTrackName, consumer1, RequestID(1));
+  ASSERT_NE(handle1, nullptr);
+
+  // Second subscriber includes NEW_GROUP_REQUEST=8
+  auto consumer2 = createMockConsumer();
+  SubscribeRequest sub2;
+  sub2.fullTrackName = kTestTrackName;
+  sub2.requestID = RequestID(2);
+  sub2.locType = LocationType::LargestObject;
+  sub2.params.insertParam(
+      Parameter(folly::to_underlying(TrackRequestParamKey::NEW_GROUP_REQUEST), uint64_t(8))
+  );
+
+  // The relay must forward NGR=8 upstream via REQUEST_UPDATE
+  EXPECT_CALL(*upstreamHandle, requestUpdateCalled(_)).WillOnce([](const RequestUpdate& update) {
+    auto ngrValue = getFirstIntParam(update.params, TrackRequestParamKey::NEW_GROUP_REQUEST);
+    ASSERT_TRUE(ngrValue.has_value());
+    EXPECT_EQ(*ngrValue, 8);
+  });
+
+  std::shared_ptr<SubscriptionHandle> handle2{nullptr};
+  withSessionContext(subscriber2, [&]() {
+    auto task = relay_->subscribe(std::move(sub2), consumer2);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    ASSERT_TRUE(res.hasValue());
+    handle2 = *res;
+  });
+  exec_->drive();
+
+  // Register handle2 so removeSession(subscriber2) will unsubscribe it,
+  // allowing the forwarder to become empty and release the upstream handle.
+  getOrCreateMockState(subscriber2)->subscribeHandles.push_back(handle2);
+
+  removeSession(publisherSession);
+  removeSession(subscriber1);
+  removeSession(subscriber2);
+  exec_->drive();
+}
+
+// Relay test: A downstream subscriber sending REQUEST_UPDATE with
+// NEW_GROUP_REQUEST causes the relay to cascade the NGR upstream
+TEST_F(MoQRelayTest, RelayRequestUpdateNGRCascadedUpstream) {
+  auto publisherSession = createMockSession();
+  auto subscriberSession = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Upstream SubscribeOk advertises DYNAMIC_GROUPS = true
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(100);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+  setPublisherDynamicGroups(upstreamOk, true);
+
+  auto upstreamHandle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+  ON_CALL(*upstreamHandle, requestUpdateResult())
+      .WillByDefault(Return(folly::makeExpected<RequestError>(
+          RequestOk{RequestID(0), TrackRequestParameters(FrameType::REQUEST_OK), {}}
+      )));
+
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce([&upstreamHandle](const auto& /*req*/, auto /*consumer*/) {
+        return folly::coro::makeTask<Publisher::SubscribeResult>(
+            folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(upstreamHandle)
+        );
+      });
+
+  // Subscribe downstream session - triggers upstream subscribe
+  auto consumer = createMockConsumer();
+  auto handle = subscribeToTrack(subscriberSession, kTestTrackName, consumer, RequestID(1));
+  ASSERT_NE(handle, nullptr);
+
+  auto* subscriber = dynamic_cast<MoQForwarder::Subscriber*>(handle.get());
+  ASSERT_NE(subscriber, nullptr);
+
+  // The relay must cascade NGR=9 upstream via REQUEST_UPDATE
+  EXPECT_CALL(*upstreamHandle, requestUpdateCalled(_)).WillOnce([](const RequestUpdate& update) {
+    auto ngrValue = getFirstIntParam(update.params, TrackRequestParamKey::NEW_GROUP_REQUEST);
+    ASSERT_TRUE(ngrValue.has_value());
+    EXPECT_EQ(*ngrValue, 9);
+  });
+
+  // Downstream subscriber sends REQUEST_UPDATE carrying NEW_GROUP_REQUEST=9
+  RequestUpdate update;
+  update.requestID = RequestID(2);
+  update.existingRequestID = RequestID(1);
+  update.params.insertParam(
+      Parameter(folly::to_underlying(TrackRequestParamKey::NEW_GROUP_REQUEST), uint64_t(9))
+  );
+  folly::coro::blockingWait(subscriber->requestUpdate(std::move(update)));
+  exec_->drive();
+
+  removeSession(publisherSession);
+  removeSession(subscriberSession);
+}
+
+// Unit test: Subscriber::onPublishOk postprocessing
+// Verifies that onPublishOk correctly updates:
+// 1. Subscriber range based on PublishOk fields
+// 2. shouldForward flag
+// 3. NEW_GROUP_REQUEST forwarding when it passes gating checks
+TEST_F(MoQRelayTest, SubscriberOnPublishOkPostprocessing) {
+  auto publisherSession = createMockSession();
+  auto subscriberSession = createMockSession();
+
+  // Publish track and subscribe
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  auto consumer = createMockConsumer();
+  auto handle = subscribeToTrack(subscriberSession, kTestTrackName, consumer, RequestID(1));
+  ASSERT_NE(handle, nullptr);
+
+  // Cast to access Subscriber internals
+  auto* subscriber = dynamic_cast<MoQForwarder::Subscriber*>(handle.get());
+  ASSERT_NE(subscriber, nullptr);
+
+  // Test 1: Range update from PublishOk
+  // Create a PublishOk with specific start/end locations
+  PublishOk pubOk1{
+      RequestID(1),                // requestID
+      true,                        // forward
+      0,                           // subscriberPriority
+      GroupOrder::OldestFirst,     // groupOrder
+      LocationType::AbsoluteStart, // locType
+      AbsoluteLocation{5, 0},      // start
+      uint64_t(15),                // endGroup
+      TrackRequestParameters(FrameType::PUBLISH_OK)
+  };
+
+  // Apply the postprocessing
+  subscriber->onPublishOk(pubOk1);
+
+  // Verify range was updated
+  EXPECT_EQ(subscriber->range.start.group, 5);
+
+  // Test 2: Forward flag update
+  subscriber->shouldForward = true;
+  PublishOk pubOk2{
+      RequestID(2),
+      false, // forward = false
+      0,
+      GroupOrder::OldestFirst,
+      LocationType::AbsoluteStart,
+      AbsoluteLocation{5, 0},
+      uint64_t(15),
+      TrackRequestParameters(FrameType::PUBLISH_OK)
+  };
+  subscriber->onPublishOk(pubOk2);
+  EXPECT_FALSE(subscriber->shouldForward) << "Forward flag should be updated to false";
+
+  subscriber->shouldForward = false;
+  PublishOk pubOk3{
+      RequestID(3),
+      true, // forward = true
+      0,
+      GroupOrder::OldestFirst,
+      LocationType::AbsoluteStart,
+      AbsoluteLocation{5, 0},
+      uint64_t(15),
+      TrackRequestParameters(FrameType::PUBLISH_OK)
+  };
+  subscriber->onPublishOk(pubOk3);
+  EXPECT_TRUE(subscriber->shouldForward) << "Forward flag should be updated to true";
+
+  // Test 3: NEW_GROUP_REQUEST forwarding via onPublishOk
+  // Enable dynamic groups and attach a callback to observe NGR fires
+  PublishRequest pub;
+  setPublisherDynamicGroups(pub, true);
+  subscriber->forwarder.setExtensions(pub.extensions);
+
+  auto cb = std::make_shared<TestNGRCallback>();
+  subscriber->forwarder.setCallback(cb);
+
+  // Build a PublishOk carrying NEW_GROUP_REQUEST=20
+  TrackRequestParameters ngrParams(FrameType::PUBLISH_OK);
+  ngrParams.insertParam(
+      Parameter(folly::to_underlying(TrackRequestParamKey::NEW_GROUP_REQUEST), uint64_t(20))
+  );
+  PublishOk pubOk4{
+      RequestID(4),
+      true,
+      0,
+      GroupOrder::OldestFirst,
+      LocationType::AbsoluteStart,
+      AbsoluteLocation{10, 0},
+      std::nullopt,
+      std::move(ngrParams)
+  };
+
+  // onPublishOk should fire the NGR callback for group 20
+  subscriber->onPublishOk(pubOk4);
+  ASSERT_EQ(cb->calls.size(), 1u);
+  EXPECT_EQ(cb->calls[0], 20u);
+  cb->calls.clear();
+
+  // outstanding=20: re-requesting group 20 is a no-op; group 21 fires
+  subscriber->forwarder.tryProcessNewGroupRequest(makeNGRParams(20));
+  EXPECT_TRUE(cb->calls.empty()) << "Group 20 already outstanding";
+  subscriber->forwarder.tryProcessNewGroupRequest(makeNGRParams(21));
+  ASSERT_EQ(cb->calls.size(), 1u);
+  EXPECT_EQ(cb->calls[0], 21u);
+
+  removeSession(publisherSession);
+  removeSession(subscriberSession);
+}
+
+// Test: Duplicate beginSubgroup with active consumers resets them and creates
+// new ones.
+// Sequence: publish, 2 subscribers, beginSubgroup, beginSubgroup again ->
+// first consumers get reset, both subscribers get new consumers.
+TEST_F(MoQRelayTest, DuplicateSubgroupReplacesActiveConsumers) {
+  auto publisherSession = createMockSession();
+  auto sub1 = createMockSession();
+  auto sub2 = createMockSession();
+
+  auto mockConsumer1 = createMockConsumer();
+  auto mockConsumer2 = createMockConsumer();
+
+  auto sg1v1 = createMockSubgroupConsumer();
+  auto sg2v1 = createMockSubgroupConsumer();
+  auto sg1v2 = createMockSubgroupConsumer();
+  auto sg2v2 = createMockSubgroupConsumer();
+
+  // First beginSubgroup gives v1 consumers; second call gives v2 consumers
+  EXPECT_CALL(*mockConsumer1, beginSubgroup(0, 0, _, _))
+      .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg1v1);
+      })
+      .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg1v2);
+      });
+  EXPECT_CALL(*mockConsumer2, beginSubgroup(0, 0, _, _))
+      .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg2v1);
+      })
+      .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg2v2);
+      });
+
+  // v1 consumers should be reset when duplicate arrives
+  EXPECT_CALL(*sg1v1, reset(ResetStreamErrorCode::CANCELLED)).Times(1);
+  EXPECT_CALL(*sg2v1, reset(ResetStreamErrorCode::CANCELLED)).Times(1);
+  // v2 consumers should not be reset during duplicate handling; they will be
+  // closed cleanly via endOfSubgroup before teardown
+  EXPECT_CALL(*sg1v2, reset(_)).Times(0);
+  EXPECT_CALL(*sg2v2, reset(_)).Times(0);
+
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  subscribeToTrack(sub1, kTestTrackName, mockConsumer1, RequestID(1));
+  subscribeToTrack(sub2, kTestTrackName, mockConsumer2, RequestID(2));
+
+  auto sgForwarder1 = publishConsumer->beginSubgroup(0, 0, 0);
+  EXPECT_TRUE(sgForwarder1.hasValue());
+
+  // Duplicate beginSubgroup - should reset v1 consumers and return new
+  // forwarder
+  auto sgForwarder2 = publishConsumer->beginSubgroup(0, 0, 0);
+  EXPECT_TRUE(sgForwarder2.hasValue());
+  EXPECT_NE(sgForwarder1.value(), sgForwarder2.value());
+
+  // Close the new subgroup cleanly before teardown to avoid reset during
+  // cleanup
+  EXPECT_TRUE(sgForwarder2.value()->endOfSubgroup().hasValue());
+
+  removeSession(publisherSession);
+  removeSession(sub1);
+  removeSession(sub2);
+}
+
+// Test: Duplicate beginSubgroup after all subscribers have stop_sending'd
+// returns CANCELLED to propagate the signal back to the publisher.
+TEST_F(MoQRelayTest, DuplicateSubgroupCancelledWhenNoActiveConsumers) {
+  auto publisherSession = createMockSession();
+  auto subscriber = createMockSession();
+
+  auto mockConsumer = createMockConsumer();
+  auto mockSg = std::make_shared<NiceMock<MockSubgroupConsumer>>();
+
+  EXPECT_CALL(*mockConsumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(mockSg);
+      });
+
+  // Subscriber's object() returns CANCELLED to simulate stop_sending
+  EXPECT_CALL(*mockSg, object(_, _, _, _))
+      .WillOnce(
+          Return(folly::makeUnexpected(MoQPublishError(MoQPublishError::CANCELLED, "stop sending")))
+      );
+
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  subscribeToTrack(subscriber, kTestTrackName, mockConsumer, RequestID(1));
+
+  auto sgRes = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(sgRes.hasValue());
+  auto sg = sgRes.value();
+
+  // Trigger stop_sending tombstone via CANCELLED error from object()
+  sg->object(0, nullptr, {}, false);
+
+  // Duplicate beginSubgroup - all consumers tombstoned, should return CANCELLED
+  auto dupRes = publishConsumer->beginSubgroup(0, 0, 0);
+  EXPECT_TRUE(dupRes.hasError());
+  EXPECT_EQ(dupRes.error().code, MoQPublishError::CANCELLED);
+
+  removeSession(publisherSession);
+  removeSession(subscriber);
+}
+
+// Test: Duplicate beginSubgroup with partial stop_sending - active subscriber
+// gets reset and new consumer; tombstoned subscriber is skipped.
+TEST_F(MoQRelayTest, DuplicateSubgroupSkipsTombstonedSubscriber) {
+  auto publisherSession = createMockSession();
+  auto subA = createMockSession();
+  auto subB = createMockSession();
+
+  auto consumerA = createMockConsumer();
+  auto consumerB = createMockConsumer();
+
+  auto sgAv1 = createMockSubgroupConsumer();
+  auto sgBv1 = createMockSubgroupConsumer();
+  auto sgAv2 = createMockSubgroupConsumer();
+
+  // First beginSubgroup: both A and B get consumers
+  EXPECT_CALL(*consumerA, beginSubgroup(0, 0, _, _))
+      .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sgAv1);
+      })
+      .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sgAv2);
+      });
+  EXPECT_CALL(*consumerB, beginSubgroup(0, 0, _, _))
+      .WillOnce([&](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sgBv1);
+      });
+
+  // object() is forwarded to both A and B; sub A succeeds, sub B returns
+  // CANCELLED to simulate stop_sending
+  EXPECT_CALL(*sgAv1, object(_, _, _, _))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  EXPECT_CALL(*sgBv1, object(_, _, _, _))
+      .WillOnce(
+          Return(folly::makeUnexpected(MoQPublishError(MoQPublishError::CANCELLED, "stop sending")))
+      );
+
+  // On duplicate: sub A's v1 consumer gets reset; sub B is tombstoned (no
+  // reset)
+  EXPECT_CALL(*sgAv1, reset(ResetStreamErrorCode::CANCELLED)).Times(1);
+  EXPECT_CALL(*sgBv1, reset(_)).Times(0);
+  EXPECT_CALL(*sgAv2, reset(_)).Times(0);
+
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  subscribeToTrack(subA, kTestTrackName, consumerA, RequestID(1));
+  subscribeToTrack(subB, kTestTrackName, consumerB, RequestID(2));
+
+  auto sgForwarder1 = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(sgForwarder1.hasValue());
+
+  // Trigger tombstone for sub B via CANCELLED from object()
+  sgForwarder1.value()->object(0, nullptr, {}, false);
+
+  // Duplicate beginSubgroup: sub A gets reset+new, sub B is skipped
+  // (tombstoned)
+  auto sgForwarder2 = publishConsumer->beginSubgroup(0, 0, 0);
+  EXPECT_TRUE(sgForwarder2.hasValue());
+  EXPECT_NE(sgForwarder1.value(), sgForwarder2.value());
+
+  // Close the new subgroup cleanly before teardown
+  EXPECT_TRUE(sgForwarder2.value()->endOfSubgroup().hasValue());
+
+  removeSession(publisherSession);
+  removeSession(subA);
+  removeSession(subB);
 }
 
 } // namespace moxygen::test


### PR DESCRIPTION
Port of moxygen 0b901a83 ("Implement dynamic groups and new group request in relay", #112). When a downstream subscriber includes NEW_GROUP_REQUEST in a SUBSCRIBE or REQUEST_UPDATE, the relay cascades it upstream via REQUEST_UPDATE. Adds newGroupRequested() callback, doNewGroupRequestUpdate() coroutine, and replaces inline publishToSession post-processing with onPublishOk().

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/149)
<!-- Reviewable:end -->
