### PR TITLE
MoqxRelay: fix TOCTOU race in subscribe() causing PromiseAlreadySatisfied crash

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -852,6 +852,18 @@ folly::coro::Task<Publisher::SubscribeResult>
 MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
   auto subscriptionIt = subscriptions_.find(subReq.fullTrackName);
+  // TOCTOU fix: if we might be the first subscriber, wait for the upstream
+  // connection before branching.  waitForConnected() is a suspension point —
+  // a concurrent coroutine may emplace this subscription while we are
+  // suspended.  Re-checking subscriptionIt afterwards ensures we take the
+  // second-subscriber path if that happened, avoiding a double
+  // promise.setValue() crash (folly::PromiseAlreadySatisfied → std::terminate).
+  if (subscriptionIt == subscriptions_.end() && upstream_) {
+    if (!findPublishNamespaceSession(subReq.fullTrackName.trackNamespace)) {
+      co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
+      subscriptionIt = subscriptions_.find(subReq.fullTrackName);
+    }
+  }
   if (subscriptionIt == subscriptions_.end()) {
     // first subscriber
 
@@ -864,10 +876,6 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
       ));
     }
     auto upstreamSession = findPublishNamespaceSession(subReq.fullTrackName.trackNamespace);
-    if (!upstreamSession && upstream_) {
-      co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
-      upstreamSession = findPublishNamespaceSession(subReq.fullTrackName.trackNamespace);
-    }
     if (!upstreamSession) {
       // no such namespace has been published
       co_return folly::makeUnexpected(SubscribeError(

--- a/test/UpstreamProviderTest.cpp
+++ b/test/UpstreamProviderTest.cpp
@@ -6,6 +6,7 @@
 
 #include "UpstreamProvider.h"
 #include "MoQIntegrationTestFixture.h"
+#include "MoqxRelay.h"
 
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Collect.h>
@@ -15,7 +16,9 @@
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
 #include <moxygen/MoQSession.h>
+#include <moxygen/MoQVersions.h>
 #include <moxygen/ObjectReceiver.h>
+#include <moxygen/test/MockMoQSession.h>
 #include <moxygen/test/Mocks.h>
 
 using namespace moxygen;
@@ -601,6 +604,172 @@ TEST_F(UpstreamProviderTest, StopSuppressesReconnectAfterSessionClose) {
 
         co_await folly::coro::sleep(std::chrono::milliseconds(50));
         EXPECT_EQ(provider_->currentSession(), nullptr);
+      }(),
+      &clientEvb()
+  );
+}
+
+// ===== RelayUpstreamSubscribeRaceTest =============================================
+//
+// Regression test for the TOCTOU race in MoqxRelay::subscribe() that caused
+// folly::PromiseAlreadySatisfied → std::terminate (crash of 2026-04-10).
+//
+// Root cause: two concurrent subscribers both pass subscriptions_.find()==end()
+// before either calls subscriptions_.emplace(), because the only suspension
+// point between the find() and emplace() is
+//   co_await upstream_->waitForConnected().
+// Both coroutines suspend there, both resume with a valid upstreamSession, both
+// call emplace() for the same key (the second emplace silently returns the
+// existing entry), and both eventually call rsub.promise.setValue() on the same
+// subscriptions_ entry — the second call throws PromiseAlreadySatisfied.
+//
+// Fix: after waitForConnected() returns, re-check subscriptions_.find() and
+// fall through to the second-subscriber path if another coroutine already
+// emplaced the entry while we were waiting.
+//
+// Test setup:
+//   provider_->start() is launched FIRST in collectAll so that it runs first,
+//   creating connectPromise_ (state=Connecting) before the two subscribe tasks
+//   start.  The QUIC handshake is async, so start() suspends at network I/O.
+//   subscribeTask(1) and subscribeTask(2) then enter waitForConnected() and
+//   block on connectPromise_.  After the handshake completes,
+//   relay.onUpstreamConnect → session.subscribeNamespace; the server mock
+//   calls nsHandle->namespaceMsg(kTestNamespace) which invokes
+//   MoqxRelayNamespaceHandle::namespaceMsg → relay.doPublishNamespace
+//   synchronously, so the namespace is in the relay tree before
+//   connectPromise_ is fulfilled.  Both subscribe coroutines then resume with
+//   a valid upstreamSession and the race is triggered.
+
+class RelayUpstreamSubscribeRaceTest : public MoQIntegrationTestFixture {
+protected:
+  std::shared_ptr<Publisher> createServerPublishHandler() override { return serverPublisher_; }
+
+  void SetUp() override {
+    serverPublisher_ = std::make_shared<NiceMock<MockPublisher>>();
+    MoQIntegrationTestFixture::SetUp();
+
+    relay_ = std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0});
+    relay_->setAllowedNamespacePrefix(TrackNamespace{}); // allow all namespaces
+
+    auto onConnect = [relay = relay_](std::shared_ptr<MoQSession> session
+                     ) -> folly::coro::Task<void> { co_await relay->onUpstreamConnect(session); };
+    auto onDisconnect = [relay = relay_]() { relay->onUpstreamDisconnect(); };
+
+    provider_ = std::make_shared<UpstreamProvider>(
+        clientExec(),
+        serverUrl(),
+        relay_, // publishHandler: upstream NAMESPACE messages enter relay tree
+        relay_, // subscribeHandler: relay's publishes forwarded upstream
+        std::make_shared<moxygen::test::InsecureVerifierDangerousDoNotUseInProduction>(),
+        std::move(onConnect),
+        std::move(onDisconnect)
+    );
+    relay_->setUpstreamProvider(provider_);
+
+    // Mock sessions representing two downstream subscribers.
+    subSession1_ = std::make_shared<NiceMock<moxygen::test::MockMoQSession>>(clientExec());
+    ON_CALL(*subSession1_, getNegotiatedVersion())
+        .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));
+    subSession2_ = std::make_shared<NiceMock<moxygen::test::MockMoQSession>>(clientExec());
+    ON_CALL(*subSession2_, getNegotiatedVersion())
+        .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));
+  }
+
+  void TearDown() override {
+    relay_->stop();
+    MoQIntegrationTestFixture::TearDown();
+  }
+
+  SubscribeRequest makeSubscribeRequest() {
+    return SubscribeRequest::make(
+        kTestTrack,
+        kDefaultPriority,
+        GroupOrder::OldestFirst,
+        /*forward=*/true,
+        LocationType::LargestObject
+    );
+  }
+
+  // Runs relay_->subscribe() with `sess` set as the request session in the
+  // folly RequestContext (required by MoQSession::getRequestSession() inside
+  // the relay).  The RequestContextScopeGuard is a coroutine-local variable and
+  // is preserved across suspension / resumption by folly's coro framework.
+  folly::coro::Task<void> subscribeTask(std::shared_ptr<MoQSession> sess, SubscribeRequest req) {
+    folly::RequestContextScopeGuard ctx;
+    folly::RequestContext::get()->setContextData(
+        folly::RequestToken("moq_session"),
+        std::make_unique<MoQSession::MoQSessionRequestData>(std::move(sess))
+    );
+    auto consumer = std::make_shared<ObjectReceiver>(
+        ObjectReceiver::SUBSCRIBE,
+        std::make_shared<NoopObjectCallback>()
+    );
+    auto result = co_await relay_->subscribe(std::move(req), std::move(consumer));
+    // With the fix: both subscribes succeed (the second falls through to the
+    // second-subscriber path and waits for the first's promise).
+    // Without the fix: std::terminate before we reach this line.
+    EXPECT_TRUE(result.hasValue()) << "subscribe unexpectedly failed: "
+                                   << (result.hasError() ? result.error().reasonPhrase : "");
+  }
+
+  std::shared_ptr<NiceMock<MockPublisher>> serverPublisher_;
+  std::shared_ptr<MoqxRelay> relay_;
+  std::shared_ptr<UpstreamProvider> provider_;
+  std::shared_ptr<NiceMock<moxygen::test::MockMoQSession>> subSession1_;
+  std::shared_ptr<NiceMock<moxygen::test::MockMoQSession>> subSession2_;
+};
+
+// Without the fix this test crashes with PromiseAlreadySatisfied → std::terminate.
+// With the fix both subscribes complete successfully.
+TEST_F(RelayUpstreamSubscribeRaceTest, ConcurrentSubscribesSameTrack) {
+  // Server accepts the peer subNs sent by relay.onUpstreamConnect and
+  // immediately announces kTestNamespace so it appears in the relay tree before
+  // connectPromise_ is fulfilled.  The trackNamespacePrefix of the peer subNs
+  // is {} (wildcard), so the suffix passed to namespaceMsg IS the full namespace.
+  EXPECT_CALL(*serverPublisher_, subscribeNamespace(_, _))
+      .WillOnce(
+          [](SubscribeNamespace subNs, std::shared_ptr<Publisher::NamespacePublishHandle> nsHandle
+          ) -> folly::coro::Task<Publisher::SubscribeNamespaceResult> {
+            // Calling namespaceMsg here invokes
+            // MoqxRelayNamespaceHandle::namespaceMsg → relay.doPublishNamespace
+            // synchronously, so the namespace is in the relay tree by the time
+            // subscribeNamespace returns (and before connectPromise_ is set).
+            nsHandle->namespaceMsg(kTestNamespace);
+            co_return makeSubscribeNamespaceOk(subNs);
+          }
+      );
+
+  // Both relay→upstream SUBSCRIBE requests succeed.  Without the fix, both
+  // coroutines reach this point for the same subscriptions_ entry and call
+  // rsub.promise.setValue() twice → PromiseAlreadySatisfied → crash.
+  EXPECT_CALL(*serverPublisher_, subscribe(_, _))
+      .WillRepeatedly(
+          [](SubscribeRequest sub,
+             std::shared_ptr<TrackConsumer>) -> folly::coro::Task<Publisher::SubscribeResult> {
+            co_return makeSubscribeOk(sub);
+          }
+      );
+
+  SubscribeRequest subReq1 = makeSubscribeRequest();
+  subReq1.requestID = RequestID(1);
+  SubscribeRequest subReq2 = makeSubscribeRequest();
+  subReq2.requestID = RequestID(2);
+
+  folly::coro::blockingWait(
+      [&]() -> folly::coro::Task<void> {
+        // collectAll launch order is deterministic:
+        //   [0] provider_->start(): suspends at QUIC handshake after setting
+        //       state=Connecting and creating connectPromise_.
+        //   [1] subscribeTask(1): enters waitForConnected(), blocks on
+        //       connectPromise_ — connectPromise_ is now set (state=Connecting).
+        //   [2] subscribeTask(2): same.
+        // After the handshake, onUpstreamConnect fires, namespace enters the
+        // relay tree, connectPromise_ is fulfilled, and both tasks resume.
+        co_await folly::coro::collectAll(
+            provider_->start(),
+            subscribeTask(subSession1_, std::move(subReq1)),
+            subscribeTask(subSession2_, std::move(subReq2))
+        );
       }(),
       &clientEvb()
   );


### PR DESCRIPTION
Two concurrent coroutines both passed subscriptions_.find()==end() before either emplaced, because the only suspension between the find() and emplace() was co_await upstream_->waitForConnected().  Both then called rsub.promise.setValue() on the same entry, throwing PromiseAlreadySatisfied → std::terminate.

Fix: after waitForConnected() returns, re-check subscriptions_.find().  If another coroutine emplaced the entry while we were suspended, update subscriptionIt and fall through to the second-subscriber path instead of proceeding as first subscriber.

Adds regression test RelayUpstreamSubscribeRaceTest::ConcurrentSubscribesSameTrack that reproduces the crash without the fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/158)
<!-- Reviewable:end -->
