### PR TITLE
Apply upstream relay bug fixes

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -481,22 +481,29 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
     // multipublisher
     XLOG(DBG1) << "New publisher for existing subscription";
     nodePtr->publishes.erase(pub.fullTrackName.trackName);
+    // Move the forwarder out and erase the entry BEFORE calling publishDone.
+    // publishDone iterates subscribers via forEachSubscriber; if a subscriber
+    // has no open subgroups, drainSubscriber → onEmpty fires. If the entry
+    // still existed, onEmpty would erase it (destroying the forwarder) while
+    // forEachSubscriber is still iterating → use-after-free.
     // handle is null when the previous publisher already terminated (e.g.
     // reconnect after a dropped connection with subscribers still draining open
     // subgroups).  onPublishDone() already reset handle and drained the
     // forwarder, so skip both calls to avoid a null deref and a double
     // publishDone.
-    if (it->second.handle) {
-      it->second.handle->unsubscribe();
-      it->second.forwarder->publishDone(
+    auto oldHandle = std::move(it->second.handle);
+    auto oldForwarder = std::move(it->second.forwarder);
+    XLOG(DBG4) << "Erasing subscription to " << it->first;
+    subscriptions_.erase(it);
+    if (oldHandle) {
+      oldHandle->unsubscribe();
+      oldForwarder->publishDone(
           {RequestID(0),
            PublishDoneStatusCode::SUBSCRIPTION_ENDED,
            0, // filled in by session
            "upstream disconnect"}
       );
     }
-    XLOG(DBG4) << "Erasing subscription to " << it->first;
-    subscriptions_.erase(it);
   }
   auto res = nodePtr->publishes.emplace(pub.fullTrackName.trackName, session);
   XCHECK(res.second) << "Duplicate publish";
@@ -1159,10 +1166,10 @@ MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
     auto subscriptionIt = subscriptions_.find(fetch.fullTrackName);
     if (subscriptionIt != subscriptions_.end()) {
       upstreamSession = subscriptionIt->second.upstream;
-    } else {
-      // no such namespace has been published
+    }
+    if (!upstreamSession) {
       co_return folly::makeUnexpected(
-          FetchError({fetch.requestID, FetchErrorCode::TRACK_NOT_EXIST, "no such namespace"})
+          FetchError({fetch.requestID, FetchErrorCode::TRACK_NOT_EXIST, "no upstream for fetch"})
       );
     }
   }
@@ -1288,6 +1295,12 @@ void MoqxRelay::forwardChanged(MoQForwarder* forwarder) {
   auto& subscription = subscriptionIt->second;
   if (!subscription.promise.isFulfilled()) {
     // Ignore: it's the first subscriber, forward update not needed
+    return;
+  }
+  if (!subscription.handle) {
+    // Publisher terminated (onPublishDone cleared handle/upstream)
+    XLOG(DBG4) << "Ignoring forward change for " << subscriptionIt->first
+               << " - publisher terminated";
     return;
   }
   XLOG(INFO) << "Updating forward for " << subscriptionIt->first

--- a/test/MoqxRelayTest.cpp
+++ b/test/MoqxRelayTest.cpp
@@ -2827,4 +2827,230 @@ TEST_F(MoQRelayTest, DuplicateSubgroupSkipsTombstonedSubscriber) {
   removeSession(subB);
 }
 
+// ============================================================
+// Publish Replaces Subscribe Tests
+// ============================================================
+
+// Regression test: When a PUBLISH replaces a subscribe-path subscription, the
+// old forwarder's subscribers must receive publishDone, and the new
+// publish-path subscription must be fully functional (accepting data from the
+// new publisher).
+TEST_F(MoQRelayTest, PublishReplacesSubscribeDrainsOldAndServesNew) {
+  auto publisherSession = createMockSession();
+  auto subscriberSession = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Set up upstream subscribe that succeeds
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(1);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce([upstreamOk](const auto& /*req*/, auto /*consumer*/) {
+        auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+        return folly::coro::makeTask<Publisher::SubscribeResult>(
+            folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(handle)
+        );
+      });
+
+  // Subscribe to the track (creates subscribe-path subscription)
+  auto oldConsumer = createMockConsumer();
+  bool publishDoneReceived = false;
+  EXPECT_CALL(*oldConsumer, publishDone(_)).WillOnce([&publishDoneReceived](const PublishDone&) {
+    publishDoneReceived = true;
+    return folly::makeExpected<MoQPublishError>(folly::unit);
+  });
+  auto handle = subscribeToTrack(
+      subscriberSession,
+      kTestTrackName,
+      oldConsumer,
+      RequestID(1),
+      /*addToState=*/false
+  );
+  ASSERT_NE(handle, nullptr);
+
+  // PUBLISH arrives for the same track — replaces subscribe-path subscription
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  ASSERT_NE(publishConsumer, nullptr);
+
+  // Old subscriber must have been drained
+  EXPECT_TRUE(publishDoneReceived) << "Old subscribe-path subscriber should receive publishDone";
+
+  // New publish-path subscription should be functional: subscribe a new
+  // downstream consumer and verify it receives data from the publisher
+  auto newConsumer = createMockConsumer();
+  auto sg = createMockSubgroupConsumer();
+  EXPECT_CALL(*newConsumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&sg](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+  EXPECT_CALL(*sg, endOfSubgroup()).WillOnce(Return(folly::unit));
+
+  subscribeToTrack(subscriberSession, kTestTrackName, newConsumer, RequestID(2));
+
+  auto sgRes = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(sgRes.hasValue());
+  EXPECT_TRUE(sgRes.value()->endOfSubgroup().hasValue());
+
+  removeSession(publisherSession);
+  removeSession(subscriberSession);
+}
+
+// Test: publishDone on a forwarder with a forward-only subscriber (null
+// trackConsumer) should not crash. Forward-only subscribers are created by
+// addSubscriber(session, forward) which sets trackConsumer to nullptr.
+// drainSubscriber unconditionally calls subscriber.trackConsumer->publishDone()
+// which crashes on null.
+TEST_F(MoQRelayTest, PublishDoneWithForwardOnlySubscriber) {
+  auto session = createMockSession();
+
+  auto forwarder = std::make_shared<MoQForwarder>(kTestTrackName, AbsoluteLocation{0, 0});
+
+  // Add a forward-only subscriber (null trackConsumer)
+  auto subscriber = forwarder->addSubscriber(session, /*forward=*/true);
+  ASSERT_NE(subscriber, nullptr);
+  EXPECT_EQ(subscriber->trackConsumer, nullptr);
+
+  // publishDone should not crash despite null trackConsumer
+  auto res = forwarder->publishDone(
+      PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher ended"}
+  );
+  EXPECT_TRUE(res.hasValue());
+
+  // The subscriber should have been removed
+  EXPECT_TRUE(forwarder->empty());
+}
+
+// Test: removeSubscriber with a PublishDone value on a forward-only subscriber
+// (null trackConsumer) should not crash.
+TEST_F(MoQRelayTest, RemoveForwardOnlySubscriberWithPublishDone) {
+  auto session = createMockSession();
+
+  auto forwarder = std::make_shared<MoQForwarder>(kTestTrackName, AbsoluteLocation{0, 0});
+
+  // Add a forward-only subscriber (null trackConsumer)
+  auto subscriber = forwarder->addSubscriber(session, /*forward=*/true);
+  ASSERT_NE(subscriber, nullptr);
+  EXPECT_EQ(subscriber->trackConsumer, nullptr);
+
+  // removeSubscriber with pubDone should not crash
+  forwarder->removeSubscriber(
+      session,
+      PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "session disconnect"},
+      "test"
+  );
+  EXPECT_TRUE(forwarder->empty());
+}
+
+// Test: forwardChanged must not crash when called after the publisher has
+// terminated (onPublishDone clears handle/upstream). We trigger forwardChanged
+// via Subscriber::requestUpdate changing forward from true→false (1→0
+// transition). The subscriber survives drain because it has an open subgroup.
+TEST_F(MoQRelayTest, ForwardChangedAfterPublisherTermination) {
+  auto publisherSession = createMockSession();
+  auto subSession = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+
+  // Subscriber with forward=true (default)
+  auto consumer = createMockConsumer();
+  auto handle = subscribeToTrack(subSession, kTestTrackName, consumer, RequestID(0));
+  ASSERT_NE(handle, nullptr);
+
+  // Begin a subgroup so the subscriber has open subgroups and survives drain
+  auto sg = createMockSubgroupConsumer();
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&sg](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+  auto subgroupRes = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(subgroupRes.hasValue());
+
+  // Publisher terminates — onPublishDone clears handle/upstream.
+  // forwarder->publishDone sets draining and calls drainSubscriber, but the
+  // subscriber has an open subgroup so it stays (receivedPublishDone_=true).
+  EXPECT_CALL(*consumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  publishConsumer->publishDone(
+      {RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher ended"}
+  );
+
+  // Subscriber sends requestUpdate changing forward from true→false.
+  // This calls removeForwardingSubscriber → forwardingSubscribers_ 1→0 →
+  // forwardChanged on relay callback. forwardChanged accesses
+  // subscription.upstream which was nulled by onPublishDone → crash.
+  RequestUpdate update;
+  update.requestID = RequestID(0);
+  update.forward = false;
+  auto task = handle->requestUpdate(std::move(update));
+  auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+  EXPECT_TRUE(res.hasValue());
+
+  // Clean up: reset the subgroup so subscriber can be fully removed
+  EXPECT_CALL(*sg, reset(_)).Times(1);
+  subgroupRes.value()->reset(ResetStreamErrorCode::CANCELLED);
+
+  removeSession(publisherSession);
+  removeSession(subSession);
+}
+
+// Test: fetch fallback to subscriptions_ after publisher termination must not
+// crash. When findPublishNamespaceSession returns null (no publishNamespace),
+// fetch falls back to subscriptions_. After onPublishDone, upstream is null
+// but the subscription entry remains if the forwarder has subscribers.
+TEST_F(MoQRelayTest, FetchAfterPublisherTermination) {
+  auto publisherSession = createMockSession();
+  auto subSession = createMockSession();
+  auto fetchSession = createMockSession();
+
+  // Publish WITHOUT publishNamespace so findPublishNamespaceSession returns null
+  // and fetch falls back to subscriptions_
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName, /*addToState=*/false);
+
+  // Subscriber with open subgroup so subscription survives publisher drain
+  auto consumer = createMockConsumer();
+  auto sg = createMockSubgroupConsumer();
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&sg](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+  auto handle = subscribeToTrack(subSession, kTestTrackName, consumer, RequestID(0));
+  ASSERT_NE(handle, nullptr);
+
+  // Begin subgroup to keep subscriber alive
+  auto subgroupRes = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(subgroupRes.hasValue());
+
+  // Publisher terminates — clears upstream but subscription stays
+  EXPECT_CALL(*consumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  publishConsumer->publishDone(
+      {RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher ended"}
+  );
+
+  // Fetch from a different session — falls back to subscriptions_, gets null
+  // upstream, then crashes at line 1011 dereferencing null upstreamSession
+  Fetch fetch(RequestID(0), kTestTrackName, AbsoluteLocation{0, 0}, AbsoluteLocation{1, 0});
+  auto fetchConsumer = std::make_shared<NiceMock<MockFetchConsumer>>();
+  withSessionContext(fetchSession, [&]() {
+    auto task = relay_->fetch(std::move(fetch), fetchConsumer);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    // Should return an error, not crash
+    EXPECT_FALSE(res.hasValue());
+    EXPECT_EQ(res.error().errorCode, FetchErrorCode::TRACK_NOT_EXIST);
+  });
+
+  // Clean up
+  EXPECT_CALL(*sg, reset(_)).Times(1);
+  subgroupRes.value()->reset(ResetStreamErrorCode::CANCELLED);
+  handle->unsubscribe();
+  removeSession(publisherSession);
+  removeSession(subSession);
+  removeSession(fetchSession);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
Three use-after-free / null-deref fixes ported from moxygen MoQRelay.cpp:
- publish(): move forwarder out and erase subscription entry before calling publishDone, preventing UAF when drainSubscriber fires onEmpty mid-iteration
- fetch(): check !upstreamSession after subscription lookup so a null upstream (publisher terminated, entry still live) returns TRACK_NOT_EXIST instead of crashing
- forwardChanged(): guard against null handle after publisher termination so a requestUpdate(forward=false) arriving after onPublishDone doesn't deref null upstream

Five regression tests added to MoqxRelayTest.cpp covering all three fixes.

Bumps moxygen submodule to openmoq/moxygen sync/pr-141-fixes (5232364b), which contains the MoQForwarder null-trackConsumer fix the new tests depend on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/159)
<!-- Reviewable:end -->
