### PR TITLE
feat: Add TopNFilter component with unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(moqx_core STATIC
   src/stats/PicoQuicStatsCollector.cpp
   src/stats/QuicStatsCollector.cpp
   src/UpstreamProvider.cpp
+  src/relay/TopNFilter.cpp
 )
 
 target_include_directories(moqx_core

--- a/src/relay/TopNFilter.cpp
+++ b/src/relay/TopNFilter.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/TopNFilter.h"
+
+#include <folly/logging/xlog.h>
+
+namespace openmoq::moqx {
+
+TopNFilter::TopNFilter(
+    moxygen::FullTrackName ftn,
+    std::shared_ptr<moxygen::TrackConsumer> downstream
+)
+    : TrackConsumerFilter(downstream), ftn_(std::move(ftn)), downstream_(std::move(downstream)) {}
+
+void TopNFilter::registerObserver(uint64_t propertyType, PropertyObserver observer) {
+  XLOG(DBG4) << "[TopNFilter] Registering observer for propertyType=0x" << std::hex << propertyType
+             << std::dec << " on track " << ftn_;
+  observers_[propertyType] = ObserverEntry{
+      .lastSeenValue = std::nullopt,
+      .observer = std::move(observer),
+  };
+}
+
+void TopNFilter::removeObserver(uint64_t propertyType) {
+  observers_.erase(propertyType);
+}
+
+void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
+  // FAST PATH: No observers to notify
+  if (observers_.empty()) {
+    return;
+  }
+
+  // Check extensions for property values we're observing
+  for (auto& [propertyType, entry] : observers_) {
+    auto valueOpt = extensions.getIntExtension(propertyType);
+    if (!valueOpt) {
+      continue;
+    }
+
+    uint64_t value = *valueOpt;
+    if (!entry.lastSeenValue || *entry.lastSeenValue != value) {
+      XLOG(DBG4) << "[TopNFilter] Property changed on " << ftn_ << ": propertyType=0x" << std::hex
+                 << propertyType << std::dec << " oldValue=" << entry.lastSeenValue.value_or(0)
+                 << " newValue=" << value;
+      entry.lastSeenValue = value;
+      if (entry.observer.onValueChanged) {
+        entry.observer.onValueChanged(value);
+      }
+    }
+  }
+}
+
+void TopNFilter::notifyTrackEnded() {
+  XLOG(DBG4) << "[TopNFilter] Track ended: " << ftn_;
+  for (auto& [propertyType, entry] : observers_) {
+    if (entry.observer.onTrackEnded) {
+      entry.observer.onTrackEnded();
+    }
+  }
+}
+
+folly::Expected<std::shared_ptr<moxygen::SubgroupConsumer>, moxygen::MoQPublishError>
+TopNFilter::beginSubgroup(
+    uint64_t groupID,
+    uint64_t subgroupID,
+    moxygen::Priority priority,
+    bool containsLastInGroup
+) {
+  // Handle objects arriving after publishDone - this can happen due to
+  // out-of-order delivery. We still forward them but log a warning.
+  if (ended_) {
+    XLOG(WARN) << "[TopNFilter] beginSubgroup received after publishDone on " << ftn_;
+  }
+
+  auto result = downstream_->beginSubgroup(groupID, subgroupID, priority, containsLastInGroup);
+  if (!result) {
+    return result;
+  }
+
+  // Wrap the downstream SubgroupConsumer with our filter
+  return std::make_shared<TopNSubgroupConsumer>(shared_from_this(), std::move(result.value()));
+}
+
+folly::Expected<folly::Unit, moxygen::MoQPublishError> TopNFilter::objectStream(
+    const moxygen::ObjectHeader& header,
+    moxygen::Payload payload,
+    bool lastInGroup
+) {
+  if (ended_) {
+    XLOG(WARN) << "[TopNFilter] objectStream received after publishDone on " << ftn_;
+  }
+  // Check properties before forwarding
+  checkProperties(header.extensions);
+  return TrackConsumerFilter::objectStream(header, std::move(payload), lastInGroup);
+}
+
+folly::Expected<folly::Unit, moxygen::MoQPublishError> TopNFilter::datagram(
+    const moxygen::ObjectHeader& header,
+    moxygen::Payload payload,
+    bool lastInGroup
+) {
+  if (ended_) {
+    XLOG(WARN) << "[TopNFilter] datagram received after publishDone on " << ftn_;
+  }
+  // Check properties before forwarding
+  checkProperties(header.extensions);
+  return TrackConsumerFilter::datagram(header, std::move(payload), lastInGroup);
+}
+
+folly::Expected<folly::Unit, moxygen::MoQPublishError>
+TopNFilter::publishDone(moxygen::PublishDone pubDone) {
+  // Mark as ended before notifying observers
+  ended_ = true;
+  // Notify observers that the track has ended
+  notifyTrackEnded();
+  return TrackConsumerFilter::publishDone(std::move(pubDone));
+}
+
+// TopNSubgroupConsumer implementation
+
+TopNSubgroupConsumer::TopNSubgroupConsumer(
+    std::shared_ptr<TopNFilter> filter,
+    std::shared_ptr<moxygen::SubgroupConsumer> downstream
+)
+    : SubgroupConsumerFilter(std::move(downstream)), filter_(std::move(filter)) {}
+
+folly::Expected<folly::Unit, moxygen::MoQPublishError> TopNSubgroupConsumer::object(
+    uint64_t objectID,
+    moxygen::Payload payload,
+    moxygen::Extensions extensions,
+    bool finSubgroup
+) {
+  // Check properties before forwarding
+  filter_->checkProperties(extensions);
+  return SubgroupConsumerFilter::object(
+      objectID,
+      std::move(payload),
+      std::move(extensions),
+      finSubgroup
+  );
+}
+
+folly::Expected<folly::Unit, moxygen::MoQPublishError> TopNSubgroupConsumer::beginObject(
+    uint64_t objectID,
+    uint64_t length,
+    moxygen::Payload initialPayload,
+    moxygen::Extensions extensions
+) {
+  // Check properties before forwarding
+  filter_->checkProperties(extensions);
+  return SubgroupConsumerFilter::beginObject(
+      objectID,
+      length,
+      std::move(initialPayload),
+      std::move(extensions)
+  );
+}
+
+} // namespace openmoq::moqx

--- a/src/relay/TopNFilter.h
+++ b/src/relay/TopNFilter.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <moxygen/MoQFilters.h>
+#include <moxygen/MoQTypes.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+
+namespace openmoq::moqx {
+
+// Observer interface for property value changes on a track.
+// Used by PropertyRanking to receive notifications when track values change.
+struct PropertyObserver {
+  // Called when the property value changes for this track.
+  std::function<void(uint64_t value)> onValueChanged;
+
+  // Called when the track ends (PUBLISH_DONE received).
+  std::function<void()> onTrackEnded;
+};
+
+// Entry for tracking observer state per property type.
+struct ObserverEntry {
+  std::optional<uint64_t> lastSeenValue;
+  PropertyObserver observer;
+};
+
+/**
+ * TopNFilter - A TrackConsumer filter that:
+ * 1. Observes property value changes in object extensions
+ * 2. Notifies registered observers of value changes
+ * 3. Handles PUBLISH_DONE to notify observers that the track ended
+ *
+ * This is part of the TRACK_FILTER implementation for selecting top N tracks
+ * based on property values (e.g., audio level).
+ *
+ * The filter sits in the chain: Publisher -> TopNFilter -> downstream consumer
+ */
+class TopNFilter : public moxygen::TrackConsumerFilter,
+                   public std::enable_shared_from_this<TopNFilter> {
+public:
+  explicit TopNFilter(
+      moxygen::FullTrackName ftn,
+      std::shared_ptr<moxygen::TrackConsumer> downstream
+  );
+
+  ~TopNFilter() override = default;
+
+  // Get the full track name this filter is associated with
+  const moxygen::FullTrackName& fullTrackName() const { return ftn_; }
+
+  // Register an observer for a specific property type.
+  // Only one observer per property type is supported; registering a second
+  // observer for the same type silently overwrites the first.
+  void registerObserver(uint64_t propertyType, PropertyObserver observer);
+
+  // Remove an observer for a property type.
+  void removeObserver(uint64_t propertyType);
+
+  // Check if any observers are registered.
+  bool hasObservers() const { return !observers_.empty(); }
+
+  // Check extensions for property values and notify observers.
+  // This is called for each object received.
+  void checkProperties(const moxygen::Extensions& extensions);
+
+  // Notify observers that the track has ended.
+  void notifyTrackEnded();
+
+  // Check if publishDone has been received
+  bool isEnded() const { return ended_; }
+
+  // Override beginSubgroup to wrap the returned SubgroupConsumer
+  folly::Expected<std::shared_ptr<moxygen::SubgroupConsumer>, moxygen::MoQPublishError>
+  beginSubgroup(
+      uint64_t groupID,
+      uint64_t subgroupID,
+      moxygen::Priority priority,
+      bool containsLastInGroup = false
+  ) override;
+
+  // Override objectStream to check properties
+  folly::Expected<folly::Unit, moxygen::MoQPublishError> objectStream(
+      const moxygen::ObjectHeader& header,
+      moxygen::Payload payload,
+      bool lastInGroup = false
+  ) override;
+
+  // Override datagram to check properties
+  folly::Expected<folly::Unit, moxygen::MoQPublishError>
+  datagram(const moxygen::ObjectHeader& header, moxygen::Payload payload, bool lastInGroup = false)
+      override;
+
+  // Override publishDone to notify observers
+  folly::Expected<folly::Unit, moxygen::MoQPublishError> publishDone(moxygen::PublishDone pubDone
+  ) override;
+
+private:
+  moxygen::FullTrackName ftn_;
+
+  // Map of property type -> observer entry
+  folly::F14FastMap<uint64_t, ObserverEntry> observers_;
+
+  // Reference to downstream (stored in base class, but we need it for
+  // creating TopNSubgroupConsumer)
+  std::shared_ptr<moxygen::TrackConsumer> downstream_;
+
+  // Track whether publishDone has been received
+  bool ended_{false};
+};
+
+/**
+ * TopNSubgroupConsumer - Wraps a SubgroupConsumer to intercept objects
+ * and check their extensions for property values.
+ */
+class TopNSubgroupConsumer : public moxygen::SubgroupConsumerFilter {
+public:
+  TopNSubgroupConsumer(
+      std::shared_ptr<TopNFilter> filter,
+      std::shared_ptr<moxygen::SubgroupConsumer> downstream
+  );
+
+  // Override object to check extensions
+  folly::Expected<folly::Unit, moxygen::MoQPublishError> object(
+      uint64_t objectID,
+      moxygen::Payload payload,
+      moxygen::Extensions extensions = moxygen::noExtensions(),
+      bool finSubgroup = false
+  ) override;
+
+  // Override beginObject to check extensions
+  folly::Expected<folly::Unit, moxygen::MoQPublishError> beginObject(
+      uint64_t objectID,
+      uint64_t length,
+      moxygen::Payload initialPayload,
+      moxygen::Extensions extensions = moxygen::noExtensions()
+  ) override;
+
+private:
+  std::shared_ptr<TopNFilter> filter_;
+};
+
+} // namespace openmoq::moqx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -154,3 +154,14 @@ target_link_libraries(moqx_upstream_provider_test PRIVATE
   GTest::gmock
 )
 gtest_discover_tests(moqx_upstream_provider_test)
+
+# TopNFilter unit tests
+add_executable(moqx_topn_filter_test
+  TopNFilterTest.cpp
+)
+target_link_libraries(moqx_topn_filter_test PRIVATE
+  moqx_core
+  GTest::gtest_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_topn_filter_test)

--- a/test/TopNFilterTest.cpp
+++ b/test/TopNFilterTest.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/TopNFilter.h"
+
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/test/Mocks.h>
+
+using namespace testing;
+using namespace moxygen;
+using namespace openmoq::moqx;
+
+namespace {
+
+const TrackNamespace kNs{{"test"}};
+const FullTrackName kFtn{kNs, "track1"};
+constexpr uint64_t kPropA = 0x100;
+constexpr uint64_t kPropB = 0x200;
+
+// Build an Extensions object with a single integer extension
+Extensions makeExt(uint64_t type, uint64_t value) {
+  Extensions ext;
+  ext.insertMutableExtension(Extension{type, value});
+  return ext;
+}
+
+// A TopNFilter wired to a NiceMock downstream for isolation
+class TopNFilterTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    downstream_ = std::make_shared<NiceMock<MockTrackConsumer>>();
+    // downstream objectStream / publishDone always succeed
+    ON_CALL(*downstream_, objectStream(_, _, _))
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+    ON_CALL(*downstream_, datagram(_, _, _))
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+    ON_CALL(*downstream_, publishDone(_))
+        .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+
+    filter_ = std::make_shared<TopNFilter>(kFtn, downstream_);
+  }
+
+  std::shared_ptr<NiceMock<MockTrackConsumer>> downstream_;
+  std::shared_ptr<TopNFilter> filter_;
+};
+
+// ---------------------------------------------------------------------------
+// registerObserver / removeObserver
+// ---------------------------------------------------------------------------
+
+TEST_F(TopNFilterTest, NoObserversInitially) {
+  EXPECT_FALSE(filter_->hasObservers());
+}
+
+TEST_F(TopNFilterTest, RegisterObserverSetsHasObservers) {
+  filter_->registerObserver(kPropA, PropertyObserver{});
+  EXPECT_TRUE(filter_->hasObservers());
+}
+
+TEST_F(TopNFilterTest, RemoveObserverClearsHasObservers) {
+  filter_->registerObserver(kPropA, PropertyObserver{});
+  filter_->removeObserver(kPropA);
+  EXPECT_FALSE(filter_->hasObservers());
+}
+
+TEST_F(TopNFilterTest, RemoveNonExistentObserverIsNoop) {
+  // Should not crash
+  filter_->removeObserver(kPropA);
+  EXPECT_FALSE(filter_->hasObservers());
+}
+
+// Only one observer per property type; second registration silently overwrites first.
+TEST_F(TopNFilterTest, SecondRegisterOverwritesFirst) {
+  int calls1 = 0;
+  int calls2 = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t) {
+                              calls1++;
+                            }});
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t) {
+                              calls2++;
+                            }});
+
+  filter_->checkProperties(makeExt(kPropA, 42));
+  EXPECT_EQ(calls1, 0); // first observer was overwritten
+  EXPECT_EQ(calls2, 1); // second observer fires
+}
+
+// ---------------------------------------------------------------------------
+// checkProperties: value-change firing semantics
+// ---------------------------------------------------------------------------
+
+TEST_F(TopNFilterTest, CheckPropertiesFiresOnFirstSighting) {
+  int called = 0;
+  uint64_t seen = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t v) {
+                              called++;
+                              seen = v;
+                            }});
+
+  filter_->checkProperties(makeExt(kPropA, 77));
+  EXPECT_EQ(called, 1);
+  EXPECT_EQ(seen, 77u);
+}
+
+TEST_F(TopNFilterTest, CheckPropertiesDoesNotFireOnSameValue) {
+  int called = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t) {
+                              called++;
+                            }});
+
+  filter_->checkProperties(makeExt(kPropA, 50));
+  filter_->checkProperties(makeExt(kPropA, 50)); // same value – no fire
+  EXPECT_EQ(called, 1);
+}
+
+TEST_F(TopNFilterTest, CheckPropertiesFiresOnValueChange) {
+  std::vector<uint64_t> values;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t v) {
+                              values.push_back(v);
+                            }});
+
+  filter_->checkProperties(makeExt(kPropA, 10));
+  filter_->checkProperties(makeExt(kPropA, 10)); // same, no fire
+  filter_->checkProperties(makeExt(kPropA, 20)); // change
+  filter_->checkProperties(makeExt(kPropA, 10)); // change back
+
+  EXPECT_THAT(values, ElementsAre(10u, 20u, 10u));
+}
+
+TEST_F(TopNFilterTest, CheckPropertiesIgnoresUnobservedType) {
+  int called = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t) {
+                              called++;
+                            }});
+
+  // Only kPropB in the extensions – should not fire kPropA observer
+  filter_->checkProperties(makeExt(kPropB, 99));
+  EXPECT_EQ(called, 0);
+}
+
+TEST_F(TopNFilterTest, CheckPropertiesNoObserversIsNoop) {
+  // Must not crash with empty observers
+  filter_->checkProperties(makeExt(kPropA, 42));
+}
+
+// ---------------------------------------------------------------------------
+// Multiple property types observed independently
+// ---------------------------------------------------------------------------
+
+TEST_F(TopNFilterTest, TwoPropertyTypesObservedIndependently) {
+  std::vector<uint64_t> aValues, bValues;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t v) {
+                              aValues.push_back(v);
+                            }});
+  filter_->registerObserver(kPropB, PropertyObserver{.onValueChanged = [&](uint64_t v) {
+                              bValues.push_back(v);
+                            }});
+
+  Extensions ext;
+  ext.insertMutableExtension(Extension{kPropA, 10});
+  ext.insertMutableExtension(Extension{kPropB, 20});
+  filter_->checkProperties(ext); // both fire once
+
+  filter_->checkProperties(makeExt(kPropA, 11)); // only A changes
+  filter_->checkProperties(makeExt(kPropB, 21)); // only B changes
+
+  EXPECT_THAT(aValues, ElementsAre(10u, 11u));
+  EXPECT_THAT(bValues, ElementsAre(20u, 21u));
+}
+
+// ---------------------------------------------------------------------------
+// publishDone → notifyTrackEnded
+// ---------------------------------------------------------------------------
+
+TEST_F(TopNFilterTest, PublishDoneCallsOnTrackEndedOnAllObservers) {
+  int endedA = 0, endedB = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onTrackEnded = [&]() { endedA++; }});
+  filter_->registerObserver(kPropB, PropertyObserver{.onTrackEnded = [&]() { endedB++; }});
+
+  EXPECT_FALSE(filter_->isEnded());
+
+  PublishDone done;
+  done.statusCode = PublishDoneStatusCode::SUBSCRIPTION_ENDED;
+  filter_->publishDone(std::move(done));
+
+  EXPECT_TRUE(filter_->isEnded());
+  EXPECT_EQ(endedA, 1);
+  EXPECT_EQ(endedB, 1);
+}
+
+TEST_F(TopNFilterTest, NotifyTrackEndedDirectlyFiresObservers) {
+  int ended = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onTrackEnded = [&]() { ended++; }});
+  filter_->notifyTrackEnded();
+  EXPECT_EQ(ended, 1);
+}
+
+TEST_F(TopNFilterTest, PublishDoneDoesNotFireOnValueChanged) {
+  int valueChanged = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t) {
+                              valueChanged++;
+                            }});
+
+  PublishDone done;
+  done.statusCode = PublishDoneStatusCode::SUBSCRIPTION_ENDED;
+  filter_->publishDone(std::move(done));
+
+  EXPECT_EQ(valueChanged, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Objects arriving after publishDone must not crash
+// ---------------------------------------------------------------------------
+
+TEST_F(TopNFilterTest, ObjectStreamAfterPublishDoneDoesNotCrash) {
+  PublishDone done;
+  done.statusCode = PublishDoneStatusCode::SUBSCRIPTION_ENDED;
+  filter_->publishDone(std::move(done));
+
+  // Should log a warning but not crash
+  ObjectHeader hdr;
+  hdr.group = 1;
+  hdr.id = 0;
+  hdr.extensions = makeExt(kPropA, 5);
+  filter_->objectStream(hdr, nullptr, false);
+}
+
+TEST_F(TopNFilterTest, DatagramAfterPublishDoneDoesNotCrash) {
+  PublishDone done;
+  done.statusCode = PublishDoneStatusCode::SUBSCRIPTION_ENDED;
+  filter_->publishDone(std::move(done));
+
+  ObjectHeader hdr;
+  hdr.group = 1;
+  hdr.id = 0;
+  hdr.extensions = makeExt(kPropA, 5);
+  filter_->datagram(hdr, nullptr, false);
+}
+
+// ---------------------------------------------------------------------------
+// objectStream / datagram trigger checkProperties
+// ---------------------------------------------------------------------------
+
+TEST_F(TopNFilterTest, ObjectStreamTriggersCheckProperties) {
+  int called = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t) {
+                              called++;
+                            }});
+
+  ObjectHeader hdr;
+  hdr.group = 1;
+  hdr.id = 0;
+  hdr.extensions = makeExt(kPropA, 42);
+  filter_->objectStream(hdr, nullptr, false);
+  EXPECT_EQ(called, 1);
+}
+
+TEST_F(TopNFilterTest, DatagramTriggersCheckProperties) {
+  int called = 0;
+  filter_->registerObserver(kPropA, PropertyObserver{.onValueChanged = [&](uint64_t) {
+                              called++;
+                            }});
+
+  ObjectHeader hdr;
+  hdr.group = 1;
+  hdr.id = 0;
+  hdr.extensions = makeExt(kPropA, 99);
+  filter_->datagram(hdr, nullptr, false);
+  EXPECT_EQ(called, 1);
+}
+
+} // namespace


### PR DESCRIPTION
TopNFilter is a TrackConsumer filter that observes property value changes in object extensions and notifies registered observers. It sits in the publisher chain (Publisher → TopNFilter → downstream) and is the property observation layer for the TRACK_FILTER top-N selection feature.

Covers: registerObserver/removeObserver, value-change firing semantics, multi-property independence, publishDone → onTrackEnded notification, and safety of objects arriving after publishDone.

Note: only one observer per property type is supported; a second registration silently overwrites the first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/160)
<!-- Reviewable:end -->
