### PR TITLE
feat: Add PropertyRanking top-N selection with unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(moqx_core STATIC
   src/stats/QuicStatsCollector.cpp
   src/UpstreamProvider.cpp
   src/relay/TopNFilter.cpp
+  src/relay/PropertyRanking.cpp
 )
 
 target_include_directories(moqx_core

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/PropertyRanking.h"
+
+#include <folly/logging/xlog.h>
+
+namespace openmoq::moqx {
+
+PropertyRanking::PropertyRanking(
+    uint64_t propertyType,
+    uint64_t maxDeselected,
+    BatchSelectCallback onBatchSelected,
+    SelectCallback onSelected,
+    EvictCallback onEvicted
+)
+    : propertyType_(propertyType), maxDeselected_(maxDeselected),
+      onBatchSelected_(std::move(onBatchSelected)), onSelected_(std::move(onSelected)),
+      onEvicted_(std::move(onEvicted)) {}
+
+void PropertyRanking::registerTrack(
+    const moxygen::FullTrackName& ftn,
+    std::optional<uint64_t> initialValue,
+    std::weak_ptr<moxygen::MoQSession> publisher
+) {
+  if (trackIndexByName_.find(ftn) != trackIndexByName_.end()) {
+    XLOG(WARN) << "Track already registered: " << ftn;
+    return;
+  }
+
+  uint64_t value = initialValue.value_or(0);
+  RankKey key{value, nextSeq_++};
+
+  auto [iter, inserted] =
+      rankedTracks_.emplace(key, RankedEntry{.ftn = ftn, .publisher = std::move(publisher)});
+  trackIndexByName_[ftn] = RankIndex{.rankIter = iter, .cachedRank = UINT64_MAX};
+  invalidateRankCache();
+
+  uint64_t rank = getCachedRank(ftn);
+  XLOG(DBG4) << "Registered track " << ftn << " with value " << value << " at rank " << rank;
+
+  for (auto& [n, topNGroup] : topNGroups_) {
+    if (rank < n) {
+      topNGroup.trackStates[ftn] = TrackState::Selected;
+      IterationGuard guard(*this);
+      notifyTrackSelected(ftn, topNGroup);
+
+      // The new track pushed the previous occupant of rank N-1 to rank N.
+      // If that track was Selected, demote it into the deselected queue.
+      // Only fires when numTracks > N (otherwise no track to demote).
+      demoteTrackAtRank(n, topNGroup);
+    }
+    // Tracks outside top N are not added to the deselected queue on register;
+    // they only enter the queue when they fall out of an already-selected position.
+  }
+}
+
+void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_t value) {
+  auto it = trackIndexByName_.find(ftn);
+  if (it == trackIndexByName_.end()) {
+    XLOG(DBG4) << "updateSortValue: track not registered " << ftn;
+    return;
+  }
+
+  auto& entry = it->second;
+  RankKey oldKey = entry.rankIter->first;
+
+  // Early exit: no change in value
+  if (oldKey.value == value) {
+    return;
+  }
+
+  // Construct new key after the early-exit check
+  RankKey newKey{value, oldKey.arrivalSeq};
+
+  // Capture old rank before modifying the map (oldKey disappears after erase)
+  uint64_t oldRank = getCachedRank(ftn);
+
+  // Update the sorted map
+  auto rankedEntry = std::move(entry.rankIter->second);
+  rankedTracks_.erase(entry.rankIter);
+  auto [newIter, _] = rankedTracks_.emplace(newKey, std::move(rankedEntry));
+  entry.rankIter = newIter;
+  invalidateRankCache();
+
+  // Compute new rank now that the map reflects the new position
+  uint64_t newRank = getCachedRank(ftn);
+
+  // FAST PATH: value change doesn't cross any threshold
+  if (!crossesThreshold(oldRank, newRank)) {
+    XLOG(DBG5) << "updateSortValue fast path: " << ftn << " value=" << value << " rank " << oldRank
+               << " -> " << newRank << " (no threshold crossed)";
+    return;
+  }
+
+  // SLOW PATH: value crossed a threshold, recompute TopNGroups
+  XLOG(DBG4) << "updateSortValue slow path: " << ftn << " value=" << value << " rank " << oldRank
+             << " -> " << newRank << " (threshold crossed)";
+  recomputeTopNGroups(ftn, oldRank, newRank);
+}
+
+void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
+  auto it = trackIndexByName_.find(ftn);
+  if (it == trackIndexByName_.end()) {
+    return;
+  }
+
+  auto& entry = it->second;
+  uint64_t oldRank = getCachedRank(ftn);
+
+  rankedTracks_.erase(entry.rankIter);
+  trackIndexByName_.erase(it);
+  invalidateRankCache();
+
+  XLOG(DBG4) << "Removed track " << ftn << " from rank " << oldRank;
+
+  for (auto& [n, topNGroup] : topNGroups_) {
+    auto stateIt = topNGroup.trackStates.find(ftn);
+    if (stateIt == topNGroup.trackStates.end()) {
+      continue;
+    }
+
+    bool wasSelected = stateIt->second == TrackState::Selected;
+    topNGroup.trackStates.erase(stateIt);
+
+    // Always remove from deselected queue if present
+    removeFromDeselectedQueue(topNGroup, ftn);
+
+    if (wasSelected) {
+      IterationGuard guard(*this);
+
+      // Try deselected queue first for O(1) promotion
+      if (!topNGroup.deselectedQueue.empty()) {
+        auto promoted = topNGroup.deselectedQueue.front();
+        topNGroup.deselectedQueue.pop_front();
+        XLOG(DBG4) << "removeTrack: promoting " << promoted
+                   << " from deselected queue for TopNGroup maxSelected=" << n;
+        topNGroup.trackStates[promoted] = TrackState::Selected;
+        notifyTrackSelected(promoted, topNGroup);
+      } else {
+        // Fallback: deselected queue empty — scan ranked list for first non-selected track.
+        // This path is taken when no tracks have been through the deselected queue yet
+        // (e.g., first removal after initial registration).
+        for (auto& [key, rankedEntry] : rankedTracks_) {
+          auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
+          if (stIt != topNGroup.trackStates.end() && stIt->second == TrackState::Selected) {
+            continue;
+          }
+          topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
+          notifyTrackSelected(rankedEntry.ftn, topNGroup);
+          break;
+        }
+      }
+    }
+  }
+}
+
+TopNGroup& PropertyRanking::getOrCreateTopNGroup(uint64_t maxSelected) {
+  auto [it, inserted] = topNGroups_.try_emplace(maxSelected);
+  if (inserted) {
+    XLOG(DBG4) << "Created new TopNGroup with maxSelected=" << maxSelected;
+    it->second.maxSelected = maxSelected;
+    updateSelectionThreshold();
+
+    uint64_t rank = 0;
+    for (auto& [key, entry] : rankedTracks_) {
+      if (rank < maxSelected) {
+        it->second.trackStates[entry.ftn] = TrackState::Selected;
+      }
+      rank++;
+    }
+  }
+  return it->second;
+}
+
+void PropertyRanking::addSessionToTopNGroup(
+    uint64_t maxSelected,
+    std::shared_ptr<moxygen::MoQSession> session,
+    bool forward
+) {
+  XCHECK(!iteratingSessions_) << "Cannot add session while iterating";
+  XLOG(DBG4) << "addSessionToTopNGroup: maxSelected=" << maxSelected << " forward=" << forward;
+
+  auto& topNGroup = getOrCreateTopNGroup(maxSelected);
+  topNGroup.sessions[session] = SessionInfo{.forward = forward};
+
+  // Notify session of all currently-selected tracks
+  uint64_t rank = 0;
+  for (auto& [key, entry] : rankedTracks_) {
+    if (rank >= maxSelected) {
+      break;
+    }
+    if (onSelected_) {
+      onSelected_(entry.ftn, session, forward);
+    }
+    rank++;
+  }
+}
+
+void PropertyRanking::removeSessionFromTopNGroup(
+    uint64_t maxSelected,
+    const std::shared_ptr<moxygen::MoQSession>& session
+) {
+  XCHECK(!iteratingSessions_) << "Cannot remove session while iterating";
+
+  auto it = topNGroups_.find(maxSelected);
+  if (it == topNGroups_.end()) {
+    XLOG(WARN) << "removeSessionFromTopNGroup: TopNGroup not found for maxSelected=" << maxSelected;
+    return;
+  }
+
+  it->second.sessions.erase(session);
+
+  if (it->second.sessions.empty()) {
+    removeTopNGroup(maxSelected);
+  }
+}
+
+void PropertyRanking::updateSessionForward(
+    uint64_t maxSelected,
+    const std::shared_ptr<moxygen::MoQSession>& session,
+    bool forward
+) {
+  auto it = topNGroups_.find(maxSelected);
+  if (it == topNGroups_.end()) {
+    XLOG(WARN) << "updateSessionForward: TopNGroup not found for maxSelected=" << maxSelected;
+    return;
+  }
+
+  auto sessionIt = it->second.sessions.find(session);
+  if (sessionIt == it->second.sessions.end()) {
+    XLOG(WARN) << "updateSessionForward: session not found in TopNGroup maxSelected="
+               << maxSelected;
+    return;
+  }
+
+  XLOG(DBG4) << "updateSessionForward: maxSelected=" << maxSelected
+             << " forward=" << sessionIt->second.forward << " -> " << forward;
+  sessionIt->second.forward = forward;
+}
+
+void PropertyRanking::removeTopNGroup(uint64_t maxSelected) {
+  XLOG(DBG4) << "removeTopNGroup: maxSelected=" << maxSelected;
+  topNGroups_.erase(maxSelected);
+  updateSelectionThreshold();
+}
+
+uint64_t PropertyRanking::getRank(const RankKey& key) const {
+  auto it = rankedTracks_.find(key);
+  if (it == rankedTracks_.end()) {
+    return UINT64_MAX;
+  }
+  rebuildRankCacheIfNeeded();
+  return trackIndexByName_.find(it->second.ftn)->second.cachedRank;
+}
+
+void PropertyRanking::rebuildRankCacheIfNeeded() const {
+  if (rankCacheValid_) {
+    return;
+  }
+  uint64_t rank = 0;
+  for (const auto& [key, entry] : rankedTracks_) {
+    auto it = trackIndexByName_.find(entry.ftn);
+    if (it != trackIndexByName_.end()) {
+      const_cast<RankIndex&>(it->second).cachedRank = rank;
+    }
+    rank++;
+  }
+  rankCacheValid_ = true;
+}
+
+uint64_t PropertyRanking::getCachedRank(const moxygen::FullTrackName& ftn) const {
+  rebuildRankCacheIfNeeded();
+  auto it = trackIndexByName_.find(ftn);
+  if (it == trackIndexByName_.end()) {
+    return UINT64_MAX;
+  }
+  return it->second.cachedRank;
+}
+
+bool PropertyRanking::crossesThreshold(uint64_t oldRank, uint64_t newRank) const {
+  if (topNGroups_.empty()) {
+    return false;
+  }
+
+  if (oldRank >= selectionThreshold_ && newRank >= selectionThreshold_) {
+    return false;
+  }
+
+  uint64_t minRank = std::min(oldRank, newRank);
+  uint64_t maxRank = std::max(oldRank, newRank);
+
+  // If the track crossed the outer selection boundary, it must have crossed at
+  // least one group's N threshold too.
+  bool oldInAnyTopN = oldRank < selectionThreshold_;
+  bool newInAnyTopN = newRank < selectionThreshold_;
+  if (oldInAnyTopN != newInAnyTopN) {
+    return true;
+  }
+  // NOTE: We do NOT fast-exit when both ranks are below selectionThreshold_.
+  // Even if both are inside the selection region, a specific N boundary may
+  // still be crossed (e.g., rank 5→2 crosses N=3 but not N=7).
+
+  // O(log G) check: any threshold between minRank and maxRank?
+  auto it = std::upper_bound(sortedThresholds_.begin(), sortedThresholds_.end(), minRank);
+  if (it != sortedThresholds_.end() && *it <= maxRank) {
+    return true;
+  }
+
+  return false;
+}
+
+void PropertyRanking::recomputeTopNGroups(
+    const moxygen::FullTrackName& ftn,
+    uint64_t oldRank,
+    uint64_t newRank
+) {
+  XLOG(DBG4) << "recomputeTopNGroups: " << ftn << " moved from rank " << oldRank << " to "
+             << newRank;
+
+  for (auto& [n, topNGroup] : topNGroups_) {
+    bool wasInTopN = oldRank < n;
+    bool nowInTopN = newRank < n;
+
+    if (wasInTopN != nowInTopN) {
+      if (nowInTopN) {
+        topNGroup.trackStates[ftn] = TrackState::Selected;
+        removeFromDeselectedQueue(topNGroup, ftn);
+      } else {
+        topNGroup.trackStates[ftn] = TrackState::Deselected;
+        topNGroup.deselectedQueue.push_back(ftn);
+        trimDeselectedQueue(topNGroup);
+      }
+    }
+
+    // Batch-notify all sessions when track enters shared top-N
+    if (!wasInTopN && nowInTopN) {
+      IterationGuard guard(*this);
+      notifyTrackSelected(ftn, topNGroup);
+
+      // The track that just entered top-N displaced the one at position n;
+      // mark that track as deselected.
+      demoteTrackAtRank(n, topNGroup);
+    }
+
+    // When the track fell out of top-N, promote the one now at position n-1.
+    if (wasInTopN && !nowInTopN) {
+      IterationGuard guard(*this);
+      uint64_t count = 0;
+      for (auto& [key, rankedEntry] : rankedTracks_) {
+        if (count == n - 1) {
+          auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
+          if (stIt == topNGroup.trackStates.end() || stIt->second != TrackState::Selected) {
+            topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
+            removeFromDeselectedQueue(topNGroup, rankedEntry.ftn);
+            notifyTrackSelected(rankedEntry.ftn, topNGroup);
+          }
+          break;
+        }
+        count++;
+      }
+    }
+  }
+}
+
+void PropertyRanking::updateSelectionThreshold() {
+  uint64_t maxN = 0;
+  sortedThresholds_.clear();
+  sortedThresholds_.reserve(topNGroups_.size());
+  for (const auto& [n, topNGroup] : topNGroups_) {
+    maxN = std::max(maxN, n);
+    sortedThresholds_.push_back(n);
+  }
+  std::sort(sortedThresholds_.begin(), sortedThresholds_.end());
+  selectionThreshold_ = maxN + maxDeselected_;
+}
+
+void PropertyRanking::trimDeselectedQueue(TopNGroup& topNGroup) {
+  while (topNGroup.deselectedQueue.size() > maxDeselected_) {
+    auto evicted = topNGroup.deselectedQueue.front();
+    topNGroup.deselectedQueue.pop_front();
+    topNGroup.trackStates.erase(evicted);
+
+    XLOG(DBG4) << "[PropertyRanking] Evicting track " << evicted
+               << " from TopNGroup maxSelected=" << topNGroup.maxSelected
+               << " (deselectedQueue exceeded maxDeselected=" << maxDeselected_ << ")";
+
+    IterationGuard guard(*this);
+    for (const auto& [session, info] : topNGroup.sessions) {
+      if (session && onEvicted_) {
+        onEvicted_(evicted, session);
+      }
+    }
+  }
+}
+
+void PropertyRanking::removeFromDeselectedQueue(
+    TopNGroup& group,
+    const moxygen::FullTrackName& ftn
+) {
+  auto& dq = group.deselectedQueue;
+  dq.erase(std::remove(dq.begin(), dq.end(), ftn), dq.end());
+}
+
+void PropertyRanking::demoteTrackAtRank(uint64_t n, TopNGroup& group) {
+  uint64_t count = 0;
+  for (auto& [key, rankedEntry] : rankedTracks_) {
+    if (count == n) {
+      auto stIt = group.trackStates.find(rankedEntry.ftn);
+      if (stIt != group.trackStates.end() && stIt->second == TrackState::Selected) {
+        stIt->second = TrackState::Deselected;
+        group.deselectedQueue.push_back(rankedEntry.ftn);
+        trimDeselectedQueue(group);
+      }
+      break;
+    }
+    count++;
+  }
+}
+
+// Batch callback rationale: all sessions in a TopNGroup share the same N, so
+// when a track enters their top-N the relay can handle them together — one
+// upstream subscribe decision, one forwarder lookup, one cache check. An
+// alternative per-session callback (onSelected_) exists for cases needing
+// individual handling (e.g., a late-joining session).
+void PropertyRanking::notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup) {
+  std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> batch;
+  batch.reserve(topNGroup.sessions.size());
+  for (const auto& [session, info] : topNGroup.sessions) {
+    batch.emplace_back(session, info.forward);
+  }
+  if (!batch.empty() && onBatchSelected_) {
+    XLOG(DBG4) << "notifyTrackSelected: " << ftn << " to " << batch.size()
+               << " sessions in TopNGroup maxSelected=" << topNGroup.maxSelected;
+    onBatchSelected_(ftn, batch);
+  }
+}
+
+} // namespace openmoq::moqx

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <moxygen/MoQSession.h>
+#include <moxygen/MoQTypes.h>
+
+#include <deque>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace openmoq::moqx {
+
+/**
+ * Ranking key for deterministic ordering in std::map.
+ * Uses std::greater<> comparator for descending order (highest value first).
+ */
+struct RankKey {
+  uint64_t value;      // Property value (higher = better rank)
+  uint64_t arrivalSeq; // Tie-breaker (lower = earlier = wins)
+
+  bool operator<(const RankKey& other) const {
+    if (value != other.value) {
+      return value < other.value;
+    }
+    return arrivalSeq > other.arrivalSeq;
+  }
+
+  bool operator>(const RankKey& other) const {
+    if (value != other.value) {
+      return value > other.value;
+    }
+    return arrivalSeq < other.arrivalSeq;
+  }
+
+  bool operator==(const RankKey& other) const {
+    return value == other.value && arrivalSeq == other.arrivalSeq;
+  }
+
+  bool operator!=(const RankKey& other) const { return !(*this == other); }
+
+  bool operator<=(const RankKey& other) const { return *this < other || *this == other; }
+
+  bool operator>=(const RankKey& other) const { return *this > other || *this == other; }
+};
+
+/**
+ * Entry stored in the sorted container.
+ */
+struct RankedEntry {
+  moxygen::FullTrackName ftn;
+  std::weak_ptr<moxygen::MoQSession> publisher;
+};
+
+/**
+ * Fast lookup from track name to rank position.
+ * Includes cached rank to avoid O(n) std::distance() calls.
+ */
+struct RankIndex {
+  std::map<RankKey, RankedEntry, std::greater<RankKey>>::iterator rankIter;
+  uint64_t cachedRank{UINT64_MAX};
+};
+
+/**
+ * Track state within a TopNGroup.
+ */
+enum class TrackState { Selected, Deselected };
+
+/**
+ * Per-session state within a TopNGroup.
+ */
+struct SessionInfo {
+  bool forward{true};
+};
+
+/**
+ * TopNGroup - Group of subscribers with the same N value.
+ */
+struct TopNGroup {
+  uint64_t maxSelected{0}; // N
+
+  // Session -> state mapping. Not redundant with MoqxRelay's namespace tree:
+  // this groups sessions by N for O(1) batch notifications.
+  folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, SessionInfo> sessions;
+
+  // Track -> state (Selected or Deselected).
+  // Only contains tracks that are either in top-N or in the deselected queue
+  // (i.e., at most N + maxDeselected entries).
+  folly::F14FastMap<moxygen::FullTrackName, TrackState, moxygen::FullTrackName::hash> trackStates;
+
+  // FIFO queue for cheap reselection. Lives in TopNGroup, not PropertyRanking.
+  // Bounded by maxDeselected_ (a PropertyRanking-level property) before eviction.
+  std::deque<moxygen::FullTrackName> deselectedQueue;
+};
+
+/**
+ * PropertyRanking - Manages ranking of tracks by a property value.
+ *
+ * Maintains a sorted map of tracks by their property values and notifies
+ * subscribers when tracks enter or leave their top-N selection.
+ *
+ * Key design decisions:
+ * - std::map with std::greater<> for O(log T) sorted iteration (descending)
+ * - F14FastMap for O(1) track lookups
+ * - Fast path when value change doesn't cross any threshold
+ * - Deselected queue (per TopNGroup) for cheap reselection without PUBLISH_DONE
+ */
+class PropertyRanking {
+public:
+  using SelectCallback = std::function<void(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQSession> session,
+      bool forward
+  )>;
+
+  using EvictCallback = std::function<
+      void(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQSession> session)>;
+
+  // Batch notification callback for viewer sessions.
+  // Called once per track state change with all affected sessions.
+  using BatchSelectCallback = std::function<void(
+      const moxygen::FullTrackName& ftn,
+      const std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>>& sessions
+  )>;
+
+  /**
+   * @param propertyType  The property type ID to rank by
+   * @param maxDeselected Maximum tracks in deselected queue before eviction.
+   *        NOTE: Currently only maxDeselected=0 is fully supported. With maxDeselected>0,
+   *        tracks enter the deselected queue but the relay has no way to pause/resume
+   *        forwarding since onDeselected/onReselected callbacks are not yet implemented.
+   *        TODO: Add onDeselected callback (when track enters deselected queue) and
+   *        onReselected callback (when track is promoted from queue back to selected)
+   *        to enable the relay to manage forwarding state for maxDeselected>0.
+   * @param onBatchSelected Batch callback for viewer notifications (required)
+   * @param onSelected  Individual callback for per-session notifications
+   * @param onEvicted   Callback when track is evicted from deselected queue
+   */
+  PropertyRanking(
+      uint64_t propertyType,
+      uint64_t maxDeselected,
+      BatchSelectCallback onBatchSelected,
+      SelectCallback onSelected,
+      EvictCallback onEvicted
+  );
+
+  ~PropertyRanking() = default;
+
+  PropertyRanking(const PropertyRanking&) = delete;
+  PropertyRanking& operator=(const PropertyRanking&) = delete;
+  PropertyRanking(PropertyRanking&&) = delete;
+  PropertyRanking& operator=(PropertyRanking&&) = delete;
+
+  uint64_t propertyType() const { return propertyType_; }
+
+  /**
+   * Register a track. Called at publish() time.
+   */
+  void registerTrack(
+      const moxygen::FullTrackName& ftn,
+      std::optional<uint64_t> initialValue,
+      std::weak_ptr<moxygen::MoQSession> publisher
+  );
+
+  /**
+   * Update track's sort value. Main hot-path entry point.
+   * Returns quickly (fast path) if value doesn't cross threshold.
+   */
+  void updateSortValue(const moxygen::FullTrackName& ftn, uint64_t value);
+
+  /**
+   * Remove track (on PUBLISH_DONE).
+   */
+  void removeTrack(const moxygen::FullTrackName& ftn);
+
+  /**
+   * Get or create TopNGroup for given N.
+   */
+  TopNGroup& getOrCreateTopNGroup(uint64_t maxSelected);
+
+  /**
+   * Add a session to a TopNGroup.
+   */
+  void addSessionToTopNGroup(
+      uint64_t maxSelected,
+      std::shared_ptr<moxygen::MoQSession> session,
+      bool forward
+  );
+
+  /**
+   * Update the forward flag for a session in a TopNGroup.
+   * Use case: subscriber initially joins with forward=false, later wants to forward.
+   */
+  void updateSessionForward(
+      uint64_t maxSelected,
+      const std::shared_ptr<moxygen::MoQSession>& session,
+      bool forward
+  );
+
+  /**
+   * Remove a session from a TopNGroup.
+   */
+  void removeSessionFromTopNGroup(
+      uint64_t maxSelected,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  );
+
+  /**
+   * Remove TopNGroup (last subscriber with this N left).
+   */
+  void removeTopNGroup(uint64_t maxSelected);
+
+  bool empty() const { return topNGroups_.empty(); }
+
+  size_t numTracks() const { return trackIndexByName_.size(); }
+
+  size_t numTopNGroups() const { return topNGroups_.size(); }
+
+  // Test accessors
+  const std::map<RankKey, RankedEntry, std::greater<RankKey>>& rankedTracks() const {
+    return rankedTracks_;
+  }
+
+  const TopNGroup* getTopNGroup(uint64_t maxSelected) const {
+    auto it = topNGroups_.find(maxSelected);
+    return it != topNGroups_.end() ? &it->second : nullptr;
+  }
+
+private:
+  uint64_t getRank(const RankKey& key) const;
+
+  // Check whether a rank move from oldRank to newRank crosses any selection
+  // threshold. Both ranks must be computed against the same (post-update) map.
+  bool crossesThreshold(uint64_t oldRank, uint64_t newRank) const;
+
+  // Recompute TopNGroup state after a rank move. oldRank/newRank are the
+  // ranks captured before and after the map update respectively.
+  void recomputeTopNGroups(const moxygen::FullTrackName& ftn, uint64_t oldRank, uint64_t newRank);
+
+  void updateSelectionThreshold();
+
+  void trimDeselectedQueue(TopNGroup& topNGroup);
+
+  /**
+   * Notify all sessions in a TopNGroup about a newly selected track.
+   * Must be called with iteratingSessions_ guard active.
+   */
+  void notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup);
+
+  void rebuildRankCacheIfNeeded() const;
+  uint64_t getCachedRank(const moxygen::FullTrackName& ftn) const;
+
+  // Remove ftn from the deselected queue (if present). O(queue size).
+  void removeFromDeselectedQueue(TopNGroup& group, const moxygen::FullTrackName& ftn);
+
+  // If the track at rank n in rankedTracks_ is marked Selected, move it to the
+  // deselected queue and trim. Call this after a track enters top-N and pushes
+  // the previous occupant of rank N-1 down to rank N. O(N) traversal.
+  void demoteTrackAtRank(uint64_t n, TopNGroup& group);
+
+  void invalidateRankCache() { rankCacheValid_ = false; }
+
+  uint64_t propertyType_;
+  uint64_t maxDeselected_;
+  BatchSelectCallback onBatchSelected_;
+  SelectCallback onSelected_;
+  EvictCallback onEvicted_;
+
+  std::map<RankKey, RankedEntry, std::greater<RankKey>> rankedTracks_;
+  // Name → iterator/rank index into rankedTracks_. O(1) lookup by track name.
+  folly::F14FastMap<moxygen::FullTrackName, RankIndex, moxygen::FullTrackName::hash>
+      trackIndexByName_;
+  folly::F14FastMap<uint64_t, TopNGroup> topNGroups_;
+
+  uint64_t nextSeq_{0};
+  uint64_t selectionThreshold_{0};
+  std::vector<uint64_t> sortedThresholds_;
+
+  mutable bool rankCacheValid_{false};
+
+  bool iteratingSessions_{false};
+
+  class IterationGuard {
+  public:
+    explicit IterationGuard(PropertyRanking& pr) : pr_(pr) { pr_.iteratingSessions_ = true; }
+    ~IterationGuard() { pr_.iteratingSessions_ = false; }
+    IterationGuard(const IterationGuard&) = delete;
+    IterationGuard& operator=(const IterationGuard&) = delete;
+
+  private:
+    PropertyRanking& pr_;
+  };
+};
+
+} // namespace openmoq::moqx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,3 +165,14 @@ target_link_libraries(moqx_topn_filter_test PRIVATE
   GTest::gmock
 )
 gtest_discover_tests(moqx_topn_filter_test)
+
+# PropertyRanking base unit tests (no self-exclusion)
+add_executable(moqx_property_ranking_base_test
+  PropertyRankingBaseTest.cpp
+)
+target_link_libraries(moqx_property_ranking_base_test PRIVATE
+  moqx_core
+  GTest::gtest_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_property_ranking_base_test)

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -1,0 +1,505 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Unit tests for PropertyRanking top-N base logic (no self-exclusion).
+ *
+ * Covers:
+ * - registerTrack + addSessionToTopNGroup → correct sessions notified at top-N boundary
+ * - updateSortValue fast path: no notification when threshold not crossed
+ * - updateSortValue slow path: correct promotions/evictions across multiple
+ *   TopNGroups with different N
+ * - removeTrack of a selected track → next eligible track promoted via
+ *   deselected queue, then ranked list
+ * - Multiple TopNGroups (N=1, N=3) on same ranking instance
+ * - deselectedQueue bounded by maxDeselected_; eviction callback fires when
+ *   queue overflows
+ * - Session removal cleans up TopNGroup; last session removes the group
+ */
+
+#include "relay/PropertyRanking.h"
+
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/test/MockMoQSession.h>
+#include <moxygen/test/Mocks.h>
+
+using namespace testing;
+using namespace moxygen;
+using namespace openmoq::moqx;
+
+namespace {
+
+const TrackNamespace kNs{{"test"}};
+constexpr uint64_t kProp = 0x100;
+
+FullTrackName ftn(const std::string& name) {
+  return FullTrackName{kNs, name};
+}
+
+// Thin wrapper: creates a PropertyRanking, records callbacks in vectors.
+class RankingHarness {
+public:
+  struct SelectEvent {
+    FullTrackName ftn;
+    MoQSession* session;
+    bool forward;
+  };
+  struct EvictEvent {
+    FullTrackName ftn;
+    MoQSession* session;
+  };
+
+  explicit RankingHarness(uint64_t maxDeselected = 5)
+      : ranking_(std::make_unique<PropertyRanking>(
+            kProp,
+            maxDeselected,
+            [this](
+                const FullTrackName& f,
+                const std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>& sessions
+            ) {
+              for (auto& [s, fwd] : sessions) {
+                selected_.push_back({f, s.get(), fwd});
+              }
+            },
+            [this](const FullTrackName& f, std::shared_ptr<MoQSession> s, bool fwd) {
+              selected_.push_back({f, s.get(), fwd});
+            },
+            [this](const FullTrackName& f, std::shared_ptr<MoQSession> s) {
+              evicted_.push_back({f, s.get()});
+            }
+        )) {}
+
+  PropertyRanking& ranking() { return *ranking_; }
+
+  // Count how many select events were fired for a given track
+  int selectCount(const FullTrackName& f) const {
+    int n = 0;
+    for (auto& e : selected_) {
+      if (e.ftn == f) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  // Count select events for a (track, session) pair
+  int selectCount(const FullTrackName& f, MoQSession* s) const {
+    int n = 0;
+    for (auto& e : selected_) {
+      if (e.ftn == f && e.session == s) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  int evictCount(const FullTrackName& f) const {
+    int n = 0;
+    for (auto& e : evicted_) {
+      if (e.ftn == f) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  void clearEvents() {
+    selected_.clear();
+    evicted_.clear();
+  }
+
+  std::vector<SelectEvent> selected_;
+  std::vector<EvictEvent> evicted_;
+
+private:
+  std::unique_ptr<PropertyRanking> ranking_;
+};
+
+// Minimal stub session (not a real MoQSession, just needs a unique address)
+// We use NiceMock<MockMoQSession> from moxygen mocks but that requires an
+// executor. Instead, we make shared_ptrs to distinct mock objects so that
+// the F14FastMap keys are unique pointers.
+//
+// PropertyRanking only stores shared_ptr<MoQSession> as map keys and passes
+// them back through callbacks — it never calls any MoQSession methods itself.
+// So we can cast a shared_ptr<MockMoQSession> (which IS a MoQSession) safely.
+
+class PropertyRankingBaseTest : public ::testing::Test {
+protected:
+  // PropertyRanking only stores shared_ptr<MoQSession> as map keys and passes
+  // them back through callbacks — it never calls any MoQSession methods.
+  // MockMoQSession has a default constructor for exactly this use case.
+  std::shared_ptr<MoQSession> makeSession() {
+    auto s = std::make_shared<NiceMock<moxygen::test::MockMoQSession>>();
+    sessions_.push_back(s);
+    return std::static_pointer_cast<MoQSession>(s);
+  }
+
+  std::vector<std::shared_ptr<NiceMock<moxygen::test::MockMoQSession>>> sessions_;
+};
+
+// ---------------------------------------------------------------------------
+// registerTrack + addSessionToTopNGroup
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, RegisterThenSubscribe_TopNBoundary) {
+  RankingHarness h;
+
+  // 3 tracks registered before any subscriber
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 70, {});
+  h.ranking().registerTrack(ftn("d"), 20, {});
+
+  // Subscriber joins wanting top-2
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, /*forward=*/true);
+
+  // Should have received exactly ftn("a") and ftn("b")
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 0);
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, SubscribeThenRegister_TopNBoundary) {
+  RankingHarness h;
+
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, /*forward=*/true);
+
+  // Tracks arrive after subscriber
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 70, {}); // rank 2 — not in top-2
+
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, ForwardFlagPassedThrough_False) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, /*forward=*/false);
+  h.ranking().registerTrack(ftn("a"), 10, {});
+
+  ASSERT_EQ(h.selected_.size(), 1u);
+  EXPECT_FALSE(h.selected_[0].forward);
+}
+
+TEST_F(PropertyRankingBaseTest, ForwardFlagPassedThrough_True) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, /*forward=*/true);
+  h.ranking().registerTrack(ftn("a"), 10, {});
+
+  ASSERT_EQ(h.selected_.size(), 1u);
+  EXPECT_TRUE(h.selected_[0].forward);
+}
+
+// ---------------------------------------------------------------------------
+// updateSortValue fast path
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, FastPath_NoNotificationWhenThresholdNotCrossed) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  // 4 tracks: top-2 = {a=90, b=80}; {c=70, d=50} are outside
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 70, {}); // rank 2 — just outside top-2
+  h.ranking().registerTrack(ftn("d"), 50, {}); // rank 3
+  h.clearEvents();
+
+  // Move "d" from rank 3 to rank 2 — still outside top-2, no notification
+  h.ranking().updateSortValue(ftn("d"), 75); // d=75 < c=70? no: 75>70 → d is rank 2, c rank 3
+  EXPECT_EQ(h.selected_.size(), 0u);
+
+  // Swap "a" and "b" within the selected zone — both stay in top-2
+  h.ranking().updateSortValue(ftn("a"), 79); // a=79 < b=80 → a is rank 1, still in top-2
+  EXPECT_EQ(h.selected_.size(), 0u);
+}
+
+TEST_F(PropertyRankingBaseTest, FastPath_SameValueNoNotification) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+  h.ranking().registerTrack(ftn("a"), 50, {});
+  h.clearEvents();
+
+  h.ranking().updateSortValue(ftn("a"), 50); // no change
+  EXPECT_EQ(h.selected_.size(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// updateSortValue slow path — promotions and evictions
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, SlowPath_TrackPromotedWhenCrossesThreshold) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 80, {});
+  h.ranking().registerTrack(ftn("b"), 60, {}); // rank 1 — not in top-1
+  h.clearEvents();
+
+  // "b" jumps to rank 0 — should be selected, "a" deselected
+  h.ranking().updateSortValue(ftn("b"), 90);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, SlowPath_MultipleTopNGroups) {
+  RankingHarness h;
+  auto sub1 = makeSession(); // wants top-1
+  auto sub3 = makeSession(); // wants top-3
+
+  h.ranking().addSessionToTopNGroup(1, sub1, true);
+  h.ranking().addSessionToTopNGroup(3, sub3, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 60, {});
+  h.ranking().registerTrack(ftn("d"), 40, {}); // rank 3 — NOT in top-3, not in top-1
+  h.clearEvents();
+
+  // "d" surpasses "a" — crosses threshold for both groups
+  h.ranking().updateSortValue(ftn("d"), 110);
+
+  // sub1 (top-1) should now receive "d"
+  EXPECT_GE(h.selectCount(ftn("d"), sub1.get()), 1);
+  // sub3 (top-3) should also receive "d" — it was NOT in top-3 before (rank 3 is not < 3),
+  // now it's rank 0 so sub3 should be notified
+  EXPECT_GE(h.selectCount(ftn("d"), sub3.get()), 1);
+}
+
+// ---------------------------------------------------------------------------
+// removeTrack of a selected track — promotion via deselected queue / ranked list
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, RemoveSelected_PromotesFromDeselectedQueue) {
+  // To test deselected-queue promotion, we need a track to have been selected,
+  // then fall out of selection (entering the queue), then be promoted on removeTrack.
+  //
+  // Setup: top-1, tracks a=90(selected), b=80
+  // Step 1: c registers at 95 — c→rank0(selected), a→rank1(deselected, enters queue)
+  // Step 2: remove c — a should be promoted from deselected queue
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 90, {}); // selected
+  h.ranking().registerTrack(ftn("b"), 80, {}); // rank 1, unselected
+  h.clearEvents();
+
+  // c arrives louder than a → a falls to deselected queue
+  h.ranking().registerTrack(ftn("c"), 95, {}); // c→rank0(selected), a→rank1(deselected queue)
+  h.clearEvents();
+
+  // Remove c (selected): a should be promoted from deselected queue
+  h.ranking().removeTrack(ftn("c"));
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveSelected_PromotesFromRankedList) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 70, {}); // rank 1
+  h.clearEvents();
+
+  h.ranking().removeTrack(ftn("a"));
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveDeselected_NoPromotionNeeded) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 70, {}); // rank 1 — deselected
+  h.clearEvents();
+
+  // Removing a deselected track should not trigger any selection notification
+  h.ranking().removeTrack(ftn("b"));
+  EXPECT_EQ(h.selected_.size(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple TopNGroups with different N
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, TwoGroupsDifferentN_IndependentSelection) {
+  RankingHarness h;
+  auto sub1 = makeSession(); // top-1
+  auto sub3 = makeSession(); // top-3
+
+  h.ranking().addSessionToTopNGroup(1, sub1, true);
+  h.ranking().addSessionToTopNGroup(3, sub3, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 60, {});
+  h.ranking().registerTrack(ftn("d"), 40, {});
+
+  // sub1 should have received only "a"
+  EXPECT_EQ(h.selectCount(ftn("a"), sub1.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub1.get()), 0);
+
+  // sub3 should have received "a", "b", "c"
+  EXPECT_EQ(h.selectCount(ftn("a"), sub3.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub3.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("c"), sub3.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("d"), sub3.get()), 0);
+}
+
+// ---------------------------------------------------------------------------
+// deselectedQueue bounded by maxDeselected_
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, DeselectedQueueBounded_EvictionFires) {
+  // Only tracks that were previously *selected* enter the deselected queue.
+  // To overflow a queue with maxDeselected=2, we need 3 different tracks to
+  // have been selected at some point and then fall out.
+  //
+  // Strategy: top-1, rotate the "winner" 3 times so each loser enters the queue.
+  //   round 1: a=90 selected. Register b=95 → b selected, a enters queue (size 1).
+  //   round 2: c=100 registered → c selected, b enters queue (size 2, at limit).
+  //   round 3: d=110 registered → d selected, c enters queue (size 3 > max=2 → eviction).
+  RankingHarness h(/*maxDeselected=*/2);
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 90, {});  // selected
+  h.ranking().registerTrack(ftn("b"), 95, {});  // b→selected, a→deselected queue (size 1)
+  h.ranking().registerTrack(ftn("c"), 100, {}); // c→selected, b→deselected queue (size 2)
+  EXPECT_EQ(h.evicted_.size(), 0u);             // not yet
+
+  h.ranking().registerTrack(ftn("d"), 110, {}); // d→selected, c→deselected queue (size 3 > 2)
+  EXPECT_GE(h.evicted_.size(), 1u);             // oldest entry evicted
+}
+
+// ---------------------------------------------------------------------------
+// Session removal
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, RemoveSession_GroupRemainsIfOtherSessionsExist) {
+  RankingHarness h;
+  auto sub1 = makeSession();
+  auto sub2 = makeSession();
+
+  h.ranking().addSessionToTopNGroup(2, sub1, true);
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+
+  h.ranking().removeSessionFromTopNGroup(2, sub1);
+
+  const auto* grp = h.ranking().getTopNGroup(2);
+  ASSERT_NE(grp, nullptr);
+  EXPECT_EQ(grp->sessions.size(), 1u);
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveLastSession_GroupRemoved) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true);
+
+  h.ranking().removeSessionFromTopNGroup(3, sub);
+
+  EXPECT_EQ(h.ranking().getTopNGroup(3), nullptr);
+  EXPECT_TRUE(h.ranking().empty());
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveLastSession_ThresholdUpdated) {
+  RankingHarness h;
+  auto sub1 = makeSession();
+  auto sub2 = makeSession();
+
+  h.ranking().addSessionToTopNGroup(1, sub1, true);
+  h.ranking().addSessionToTopNGroup(3, sub2, true);
+
+  h.ranking().removeSessionFromTopNGroup(3, sub2); // group N=3 gone
+
+  // Only N=1 group remains; threshold should reflect that
+  EXPECT_NE(h.ranking().getTopNGroup(1), nullptr);
+  EXPECT_EQ(h.ranking().getTopNGroup(3), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// recomputeTopNGroups: track crosses one group threshold but not another
+// ---------------------------------------------------------------------------
+
+// TODO: Add tests for deselection/reselection notifications once onDeselected
+// and onReselected callbacks are implemented (see PropertyRanking.h TODO).
+// Tests needed:
+// - DeselectionNotification_WhenTrackFallsOutOfTopN
+// - ReselectionNotification_WhenPromotedFromQueue
+
+// This test validates that TopNGroups are evaluated independently: crossing
+// one N boundary doesn't affect groups where the track was already selected.
+TEST_F(PropertyRankingBaseTest, SlowPath_CrossesLowerThreshold_HigherGroupUnchanged) {
+  // N=2 group and N=4 group. A track moves from rank 3 (inside N=4, outside
+  // N=2) to rank 1 (inside both). Only the N=2 group should fire a selection
+  // notification; the N=4 group's state is unchanged (track was already
+  // selected there).
+  RankingHarness h;
+  auto sub2 = makeSession(); // top-2
+  auto sub4 = makeSession(); // top-4
+
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+  h.ranking().addSessionToTopNGroup(4, sub4, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 — in top-4, not top-2
+  h.clearEvents();
+
+  // d jumps to rank 1: crosses the N=2 boundary (3→1), stays inside N=4
+  h.ranking().updateSortValue(ftn("d"), 90); // order: a=100, d=90, b=80, c=60
+
+  // sub2 should be notified about d entering top-2
+  EXPECT_EQ(h.selectCount(ftn("d"), sub2.get()), 1);
+  // sub4 should NOT be notified — d was already in its top-4
+  EXPECT_EQ(h.selectCount(ftn("d"), sub4.get()), 0);
+  // b was at rank 1 (selected for both), falls to rank 2: leaves top-2
+  // sub2 gets no additional select events (b was demoted, not selected)
+  EXPECT_EQ(h.selectCount(ftn("b"), sub2.get()), 0);
+}
+
+// ---------------------------------------------------------------------------
+// removeTrack fallback: ranked list scan promotes highest non-selected track
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, RemoveSelected_FallbackPicksHighestNonSelected) {
+  // top-2, tracks a=100(sel), b=80(sel), c=60, d=40
+  // Remove a: fallback scan should promote c (rank 2, highest non-selected),
+  // not d (rank 3).
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 60, {});
+  h.ranking().registerTrack(ftn("d"), 40, {});
+  h.clearEvents();
+
+  h.ranking().removeTrack(ftn("a"));
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 0); // b was already selected
+}
+
+} // namespace


### PR DESCRIPTION
PropertyRanking maintains a sorted map of tracks by property value and notifies subscribers when tracks enter or leave their top-N selection.

Key design: std::map<RankKey, _, std::greater<>> for O(log T) descending iteration, F14FastMap for O(1) lookups, fast path when a value change doesn't cross any selection threshold, and a bounded deselected queue for cheap reselection without waiting for PUBLISH_DONE.

Bug fixes vs PR draft:
- crossesThreshold / recomputeTopNGroups now receive pre/post-update ranks directly rather than re-deriving them from keys that are no longer in the map, fixing spurious slow-path notifications.
- registerTrack now demotes the track displaced from rank N-1→N when a higher-value track arrives, correctly populating the deselected queue.

Self-exclusion (publisher-subscriber waterline) is deferred to a later commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/161)
<!-- Reviewable:end -->
