### PR TITLE
feat: Wire TRACK_FILTER top-N selection into MoqxRelay (no self-exclusion)

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -116,6 +116,7 @@ std::shared_ptr<MoqxRelay::NamespaceNode> MoqxRelay::findNamespaceNode(
         sessions
 ) {
   std::shared_ptr<NamespaceNode> nodePtr(std::shared_ptr<void>(), &publishNamespaceRoot_);
+  TrackNamespace partialNs;
   for (auto i = 0ul; i < ns.size(); i++) {
     if (sessions) {
       // Extract session pointers with their subscriber info from the map
@@ -124,10 +125,12 @@ std::shared_ptr<MoqxRelay::NamespaceNode> MoqxRelay::findNamespaceNode(
       }
     }
     auto& name = ns[i];
+    partialNs.append(name);
     auto it = nodePtr->children.find(name);
     if (it == nodePtr->children.end()) {
       if (createMissingNodes) {
         auto node = std::make_shared<NamespaceNode>(*this, nodePtr.get());
+        node->trackNamespace_ = partialNs;
         nodePtr->children.emplace(name, node);
         // Don't increment yet - only when content is actually added
         nodePtr = std::move(node);
@@ -520,8 +523,38 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   rsub.handle = std::move(handle);
   rsub.isPublish = true;
 
+  // Build filter chain using shared helper (TopNFilter → TerminationFilter → Forwarder).
+  auto [filterConsumer, topNFilter] = buildFilterChain(pub.fullTrackName, forwarder);
+  rsub.topNFilter = topNFilter;
+
+  // Register track with all PropertyRankings along the path from root to this
+  // node (inclusive). Rankings exist at nodes where TRACK_FILTER subscribers
+  // subscribed. A subscriber at /conf should see tracks published under
+  // /conf/room1, so we must walk up the ancestor chain.
+  for (NamespaceNode* node = nodePtr.get(); node != nullptr; node = node->parent_) {
+    for (auto& [propertyType, ranking] : node->rankings) {
+      auto initialValue = pub.extensions.getIntExtension(propertyType);
+      ranking->registerTrack(pub.fullTrackName, initialValue, session);
+      topNFilter->registerObserver(
+          propertyType,
+          PropertyObserver{
+              .onValueChanged = [ranking, ftn = pub.fullTrackName](uint64_t value
+                                ) { ranking->updateSortValue(ftn, value); },
+              .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); }
+          }
+      );
+    }
+  }
+
   uint64_t nSubscribers = 0;
+  bool hasTrackFilterSub = false;
   for (auto& [outSession, info] : sessions) {
+    if (info.trackFilter) {
+      // TRACK_FILTER subscribers: PropertyRanking handles selection via
+      // onTrackSelected; don't publish directly here.
+      hasTrackFilterSub = true;
+      continue;
+    }
     if (outSession != session && (info.options == SubscribeNamespaceOptions::PUBLISH ||
                                   info.options == SubscribeNamespaceOptions::BOTH)) {
       nSubscribers++;
@@ -531,16 +564,16 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   }
   forwarder->setCallback(shared_from_this());
 
-  // Wrap forwarder in filter to intercept publishDone
-  auto filterImpl =
-      std::make_shared<TerminationFilter>(shared_from_this(), pub.fullTrackName, forwarder);
-  std::shared_ptr<TrackConsumer> filter = std::static_pointer_cast<TrackConsumer>(filterImpl);
+  // Forward if there are direct subscribers OR TRACK_FILTER subscribers
+  // (PropertyRanking needs objects to evaluate property values for ranking).
+  // When subscribers join later via subscribeNamespace, forwardChanged() sends REQUEST_UPDATE.
+  bool shouldForward = (nSubscribers > 0) || hasTrackFilterSub;
 
   return PublishConsumerAndReplyTask{
-      filter, // Return filter, not forwarder directly
+      filterConsumer,
       folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(PublishOk{
           pub.requestID,
-          /*forward=*/(nSubscribers > 0),
+          /*forward=*/shouldForward,
           kDefaultPriority,
           pub.groupOrder,
           LocationType::AbsoluteRange,
@@ -553,13 +586,21 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
 folly::coro::Task<void> MoqxRelay::publishToSession(
     std::shared_ptr<MoQSession> session,
     std::shared_ptr<MoQForwarder> forwarder,
-    bool forward
+    bool forward,
+    bool trackFilterSubscriber
 ) {
+  if (session->isClosed()) {
+    XLOG(WARN) << "publishToSession: session closed, skipping " << forwarder->fullTrackName();
+    co_return;
+  }
   auto subscriber = forwarder->addSubscriber(session, forward);
   if (!subscriber) {
     XLOG(ERR) << "Subscribe failed: addSubscriber returned null for " << forwarder->fullTrackName();
     co_return;
   }
+  // Direct subscribers are pinned (not evictable by PropertyRanking).
+  // TRACK_FILTER subscribers are unpinned so onTrackEvicted can remove them.
+  subscriber->pinned = !trackFilterSubscriber;
   XLOG(DBG4) << "added subscriber for ftn=" << forwarder->fullTrackName();
   auto guard = folly::makeGuard([subscriber] { subscriber->unsubscribe(); });
 
@@ -619,11 +660,14 @@ private:
   TrackNamespace trackNamespacePrefix_;
 };
 
-// Filter TrackConsumer that intercepts publishDone to clean up relay state
+// Filter TrackConsumer that intercepts publishDone to clean up relay state.
+// Holds a weak_ptr to avoid a reference cycle: relay owns RelaySubscription
+// which owns the filter chain (TopNFilter→TerminationFilter), so a strong
+// relay ref here would prevent the relay from ever being destroyed.
 class MoqxRelay::TerminationFilter : public TrackConsumerFilter {
 public:
   TerminationFilter(
-      std::shared_ptr<MoqxRelay> relay,
+      std::weak_ptr<MoqxRelay> relay,
       FullTrackName ftn,
       std::shared_ptr<TrackConsumer> downstream
   )
@@ -634,15 +678,15 @@ public:
     // Notify relay that publisher is done - this will:
     // 1. Remove from nodePtr->publishes
     // 2. Clear subscription.handle
-    if (relay_) {
-      relay_->onPublishDone(ftn_);
+    if (auto relay = relay_.lock()) {
+      relay->onPublishDone(ftn_);
     }
     // Change the downstream code to something like "upstream ended"?
     return TrackConsumerFilter::publishDone(std::move(pubDone));
   }
 
 private:
-  std::shared_ptr<MoqxRelay> relay_;
+  std::weak_ptr<MoqxRelay> relay_;
   FullTrackName ftn_;
 };
 
@@ -655,6 +699,23 @@ std::shared_ptr<TrackConsumer> MoqxRelay::getSubscribeWriteback(
   auto filterConsumer =
       std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(baseConsumer));
   return std::static_pointer_cast<TrackConsumer>(filterConsumer);
+}
+
+MoqxRelay::FilterChainResult
+MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForwarder> forwarder) {
+  // Build chain: TopNFilter → TerminationFilter → (cache?) → Forwarder
+  // This ensures property values are observed in both PUBLISH and SUBSCRIBE paths.
+  auto baseConsumer = cache_ ? cache_->getSubscribeWriteback(ftn, forwarder)
+                             : std::static_pointer_cast<TrackConsumer>(forwarder);
+  auto terminationFilter =
+      std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(baseConsumer));
+  auto topNFilter =
+      std::make_shared<TopNFilter>(ftn, std::static_pointer_cast<TrackConsumer>(terminationFilter));
+
+  return FilterChainResult{
+      .consumer = std::static_pointer_cast<TrackConsumer>(topNFilter),
+      .topNFilter = topNFilter
+  };
 }
 
 folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNamespace(
@@ -700,6 +761,15 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   SubscribeNamespaceOptions effectiveOptions;
   effectiveOptions = subNs.options;
 
+  // Parse TRACK_FILTER parameter if present (SUBSCRIBE_NAMESPACE only)
+  std::optional<TrackFilter> trackFilter;
+  for (const auto& param : subNs.params) {
+    if (param.key == folly::to_underlying(TrackRequestParamKey::TRACK_FILTER)) {
+      trackFilter = param.asTrackFilter;
+      break;
+    }
+  }
+
   // Check if this is the first session subscriber for this node
   bool wasEmpty = !nodePtr->hasLocalSessions();
   nodePtr->sessions.emplace(
@@ -708,9 +778,19 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
           subNs.forward,
           effectiveOptions,
           namespacePublishHandle,
-          subNs.trackNamespacePrefix
+          subNs.trackNamespacePrefix,
+          trackFilter
       }
   );
+
+  // If TRACK_FILTER is present, enroll session in PropertyRanking for top-N selection.
+  // NOTE: onSelected callbacks fire synchronously within addSessionToTopNGroup() for
+  // tracks already in top-N, triggering publishToSession() before this call returns.
+  if (trackFilter) {
+    auto ranking =
+        getOrCreateRanking(nodePtr, trackFilter->propertyType, subNs.trackNamespacePrefix);
+    ranking->addSessionToTopNGroup(trackFilter->maxSelected, session, subNs.forward);
+  }
 
   // If this is the first content added to this node, notify parent
   if (wasEmpty && nodePtr->hasLocalSessions() && nodePtr->parent_) {
@@ -754,13 +834,22 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
         continue;
       }
       auto& forwarder = subscriptionIt->second.forwarder;
+      auto& rsub = subscriptionIt->second;
       if (forwarder->empty()) {
-        // Use forward value from this namespace subscription
-        co_withExecutor(exec, doSubscribeUpdate(subscriptionIt->second.handle, subNs.forward))
-            .start();
+        // Forwarder has no downstream subscribers yet. Send REQUEST_UPDATE to
+        // notify the upstream (relay subscription or local publisher) of the
+        // new forwarding state before adding the subscriber.
+        co_withExecutor(exec, doSubscribeUpdate(rsub.handle, subNs.forward)).start();
       }
       auto maybeNegotiatedVersion = session->getNegotiatedVersion();
       CHECK(maybeNegotiatedVersion.has_value());
+
+      // TRACK_FILTER subscribers: PropertyRanking drives selection via
+      // onTrackSelected; skip direct publish here.
+      if (trackFilter) {
+        continue;
+      }
+
       if (getDraftMajorVersion(*maybeNegotiatedVersion) <= 15 ||
           (subNs.options == SubscribeNamespaceOptions::BOTH ||
            subNs.options == SubscribeNamespaceOptions::PUBLISH)) {
@@ -801,6 +890,14 @@ void MoqxRelay::unsubscribeNamespace(
 
   auto it = nodePtr->sessions.find(session);
   if (it != nodePtr->sessions.end()) {
+    // If session used TRACK_FILTER, remove it from the PropertyRanking group.
+    if (it->second.trackFilter) {
+      auto rankingIt = nodePtr->rankings.find(it->second.trackFilter->propertyType);
+      if (rankingIt != nodePtr->rankings.end()) {
+        rankingIt->second->removeSessionFromTopNGroup(it->second.trackFilter->maxSelected, session);
+      }
+    }
+
     nodePtr->sessions.erase(it);
 
     // Prune if node became empty and has a parent
@@ -889,11 +986,18 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
     subReq.locType = LocationType::LargestObject;
     auto forwarder = std::make_shared<MoQForwarder>(subReq.fullTrackName, std::nullopt);
     forwarder->setCallback(shared_from_this());
+
+    // Build filter chain using shared helper (TopNFilter → TerminationFilter → Forwarder).
+    // This ensures property values are observed even for SUBSCRIBE-path tracks,
+    // so TRACK_FILTER subscribers who join later see correct rankings.
+    auto [filterConsumer, topNFilter] = buildFilterChain(subReq.fullTrackName, forwarder);
+
     auto emplaceRes = subscriptions_.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(subReq.fullTrackName),
         std::forward_as_tuple(forwarder, upstreamSession)
     );
+    emplaceRes.first->second.topNFilter = topNFilter;
     // The iterator returned from emplace does not survive across coroutine
     // resumption, so both the guard and updating the RelaySubscription below
     // require another lookup in the subscriptions_ map.
@@ -923,10 +1027,7 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
     subReq.forward = forwarder->numForwardingSubscribers() > 0;
 
     emplaceRes.first->second.requestID = upstreamSession->peekNextRequestID();
-    auto subRes = co_await upstreamSession->subscribe(
-        subReq,
-        getSubscribeWriteback(subReq.fullTrackName, forwarder)
-    );
+    auto subRes = co_await upstreamSession->subscribe(subReq, filterConsumer);
     if (subRes.hasError()) {
       co_return folly::makeUnexpected(SubscribeError(
           {subReq.requestID,
@@ -1210,6 +1311,146 @@ void MoqxRelay::newGroupRequested(MoQForwarder* forwarder, uint64_t group) {
   auto exec = subscription.upstream->getExecutor();
   auto handle = subscription.handle;
   co_withExecutor(exec, doNewGroupRequestUpdate(std::move(handle), group)).start();
+}
+
+// TRACK_FILTER support
+
+std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
+    std::shared_ptr<NamespaceNode> node,
+    uint64_t propertyType,
+    const TrackNamespace& ns
+) {
+  auto& ranking = node->rankings[propertyType];
+  if (!ranking) {
+    ranking = std::make_shared<PropertyRanking>(
+        propertyType,
+        maxDeselected_,
+        // Batch callback: called once per track-selected event with all sessions
+        [this](
+            const FullTrackName& ftn,
+            const std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>& sessions
+        ) {
+          for (const auto& [session, forward] : sessions) {
+            onTrackSelected(ftn, session, forward);
+          }
+        },
+        // Individual callback: called by addSessionToTopNGroup to notify a newly
+        // joined session of tracks already in top-N at the time it subscribes.
+        [this](const FullTrackName& ftn, std::shared_ptr<MoQSession> session, bool forward) {
+          onTrackSelected(ftn, session, forward);
+        },
+        // Eviction callback
+        [this](const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {
+          onTrackEvicted(ftn, session);
+        }
+    );
+
+    // Retroactively register tracks already published under this node and all
+    // descendants. A subscriber at /conf should see tracks at /conf/room1/track1.
+    // Use BFS to traverse the subtree and register all published tracks.
+    std::deque<std::pair<TrackNamespace, NamespaceNode*>> queue;
+    queue.emplace_back(ns, node.get());
+
+    while (!queue.empty()) {
+      auto [prefix, current] = queue.front();
+      queue.pop_front();
+
+      // Register tracks at this level
+      for (auto& [trackName, publishSession] : current->publishes) {
+        FullTrackName ftn{prefix, trackName};
+        std::optional<uint64_t> initialValue;
+        auto subIt = subscriptions_.find(ftn);
+        if (subIt != subscriptions_.end()) {
+          initialValue = subIt->second.forwarder->extensions().getIntExtension(propertyType);
+          // Wire value-change and track-ended observers on the existing TopNFilter.
+          if (subIt->second.topNFilter) {
+            auto rankingPtr = ranking;
+            subIt->second.topNFilter->registerObserver(
+                propertyType,
+                PropertyObserver{
+                    .onValueChanged = [rankingPtr, ftn](uint64_t value
+                                      ) { rankingPtr->updateSortValue(ftn, value); },
+                    .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); }
+                }
+            );
+          }
+        }
+        ranking->registerTrack(ftn, initialValue, publishSession);
+        XLOG(DBG4) << "[getOrCreateRanking] Retroactively registered track " << ftn;
+      }
+
+      // Queue children for traversal
+      for (auto& [childKey, childNode] : current->children) {
+        TrackNamespace childPrefix(prefix);
+        childPrefix.append(childKey);
+        queue.emplace_back(childPrefix, childNode.get());
+      }
+    }
+  }
+  return ranking;
+}
+
+void MoqxRelay::onTrackSelected(
+    const FullTrackName& ftn,
+    std::shared_ptr<MoQSession> session,
+    bool forward
+) {
+  XLOG(DBG4) << "[MoqxRelay] Track selected: " << ftn << " session=" << session.get()
+             << " forward=" << forward;
+
+  if (!session || session->isClosed()) {
+    XLOG(ERR) << "onTrackSelected: session null or closed, skipping " << ftn;
+    return;
+  }
+
+  auto subIt = subscriptions_.find(ftn);
+  if (subIt == subscriptions_.end() || !subIt->second.forwarder) {
+    XLOG(DBG4) << "onTrackSelected: no subscription/forwarder for " << ftn;
+    return;
+  }
+
+  auto exec = session->getExecutor();
+  XCHECK(exec) << "onTrackSelected: null executor for session " << session.get();
+
+  // TODO: Consider batching multiple publishToSession calls on the same executor
+  // when multiple tracks are selected for the same session in a single ranking update.
+  co_withExecutor(
+      exec,
+      publishToSession(session, subIt->second.forwarder, forward, /*trackFilterSubscriber=*/true)
+  )
+      .start();
+}
+
+void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {
+  XLOG(DBG4) << "[MoqxRelay] Track evicted: " << ftn << " session=" << session.get();
+
+  if (!session || session->isClosed()) {
+    XLOG(WARN) << "onTrackEvicted: session null or closed, skipping " << ftn;
+    return;
+  }
+
+  auto subIt = subscriptions_.find(ftn);
+  if (subIt == subscriptions_.end()) {
+    return;
+  }
+
+  if (!subIt->second.forwarder) {
+    return;
+  }
+  auto& forwarder = subIt->second.forwarder;
+  auto sub = forwarder->getSubscriber(session.get());
+  if (!sub || sub->isPinned()) {
+    XLOG(DBG4) << "onTrackEvicted: pinned subscriber, skipping";
+    return;
+  }
+  // Pass PublishDone so removeSubscriber calls trackConsumer->publishDone() before
+  // removing the subscriber. Passing nullopt would silently drop the subscriber
+  // without notifying the downstream session that its subscription ended.
+  forwarder->removeSubscriber(
+      session,
+      PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "evicted"},
+      "onTrackEvicted"
+  );
 }
 
 } // namespace openmoq::moqx

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -10,6 +10,8 @@
 
 #include "UpstreamProvider.h"
 #include "config/Config.h"
+#include "relay/PropertyRanking.h"
+#include "relay/TopNFilter.h"
 #include <folly/coro/SharedPromise.h>
 #include <moxygen/MoQSession.h>
 #include <moxygen/relay/MoQCache.h>
@@ -25,8 +27,17 @@ class MoqxRelay : public moxygen::Publisher,
                   public std::enable_shared_from_this<MoqxRelay>,
                   public moxygen::MoQForwarder::Callback {
 public:
-  explicit MoqxRelay(config::CacheConfig cache = {}, std::string relayID = {})
-      : relayID_(std::move(relayID)) {
+  // Default for maxDeselected (tracks kept in deselected queue before eviction).
+  // Set to 0 until pause/resume forwarding callbacks are wired in PropertyRanking;
+  // a non-zero value without those callbacks is just topN+N with no benefit.
+  static constexpr uint64_t kDefaultMaxDeselected = 0;
+
+  explicit MoqxRelay(
+      config::CacheConfig cache = {},
+      std::string relayID = {},
+      uint64_t maxDeselected = kDefaultMaxDeselected
+  )
+      : relayID_(std::move(relayID)), maxDeselected_(maxDeselected) {
     if (cache.maxCachedTracks > 0) {
       cache_ =
           std::make_unique<moxygen::MoQCache>(cache.maxCachedTracks, cache.maxCachedGroupsPerTrack);
@@ -185,7 +196,12 @@ private:
       std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> namespacePublishHandle;
       // The namespace prefix this subscriber used for SUBSCRIBE_NAMESPACE
       moxygen::TrackNamespace trackNamespacePrefix;
+      // TRACK_FILTER parameters (non-null when subscriber uses top-N filtering)
+      std::optional<moxygen::TrackFilter> trackFilter;
     };
+
+    // PropertyRanking instances per property type for TRACK_FILTER subscribers
+    folly::F14FastMap<uint64_t, std::shared_ptr<PropertyRanking>> rankings;
 
     // Sessions with a SUBSCRIBE_NAMESPACE here, with their preferences
     folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, NamespaceSubscriberInfo> sessions;
@@ -233,6 +249,9 @@ private:
     std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle;
     folly::coro::SharedPromise<folly::Unit> promise;
     bool isPublish{false};
+
+    // TopNFilter installed in the publisher's filter chain for property observation
+    std::shared_ptr<TopNFilter> topNFilter;
   };
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
@@ -248,7 +267,8 @@ private:
   folly::coro::Task<void> publishToSession(
       std::shared_ptr<moxygen::MoQSession> session,
       std::shared_ptr<moxygen::MoQForwarder> forwarder,
-      bool forward
+      bool forward,
+      bool trackFilterSubscriber = false
   );
 
   folly::coro::Task<void>
@@ -260,6 +280,42 @@ private:
   );
 
   void publishNamespaceDone(const moxygen::TrackNamespace& trackNamespace, NamespaceNode* node);
+
+  // TRACK_FILTER support
+
+  // Result of buildFilterChain - contains both the consumer to pass upstream
+  // and the TopNFilter pointer to store for later observer wiring.
+  struct FilterChainResult {
+    std::shared_ptr<moxygen::TrackConsumer> consumer;
+    std::shared_ptr<TopNFilter> topNFilter;
+  };
+
+  // Build the filter chain for a track subscription: TopNFilter → TerminationFilter → (cache) →
+  // forwarder. Used by both publish() and subscribe() paths to ensure consistent filter chain.
+  FilterChainResult buildFilterChain(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQForwarder> forwarder
+  );
+
+  // Get or create PropertyRanking for the given property type on a namespace node.
+  // Retroactively registers any tracks already published under that node.
+  // ns must be the full namespace of `node` (used as BFS seed for track registration).
+  std::shared_ptr<PropertyRanking> getOrCreateRanking(
+      std::shared_ptr<NamespaceNode> node,
+      uint64_t propertyType,
+      const moxygen::TrackNamespace& ns
+  );
+
+  // Called by PropertyRanking when a track enters a session's top-N selection.
+  void onTrackSelected(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQSession> session,
+      bool forward
+  );
+
+  // Called by PropertyRanking when a track is evicted from a session's deselected queue.
+  void
+  onTrackEvicted(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQSession> session);
 
   moxygen::TrackNamespace allowedNamespacePrefix_;
   std::string relayID_;
@@ -284,6 +340,7 @@ private:
       std::shared_ptr<moxygen::TrackConsumer> consumer
   );
   std::unique_ptr<moxygen::MoQCache> cache_;
+  uint64_t maxDeselected_{kDefaultMaxDeselected};
 };
 
 // Creates a NamespacePublishHandle that bridges NAMESPACE/NAMESPACE_DONE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,3 +176,15 @@ target_link_libraries(moqx_property_ranking_base_test PRIVATE
   GTest::gmock
 )
 gtest_discover_tests(moqx_property_ranking_base_test)
+
+# TRACK_FILTER integration tests (in-process relay, no live server)
+add_executable(moqx_track_filter_test
+  MoqxTrackFilterTest.cpp
+)
+target_link_libraries(moqx_track_filter_test PRIVATE
+  moqx_core
+  moqx_test_main
+  GTest::gmock
+  moxygen::moxygen_events_moq_folly_executor_impl
+)
+gtest_discover_tests(moqx_track_filter_test)

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -1,0 +1,824 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * In-process integration tests for TRACK_FILTER (top-N track selection).
+ *
+ * All tests use NiceMock<MockMoQSession> driven by TestMoQExecutor::driveFor().
+ * Verification is done by counting session->publish() calls per FullTrackName.
+ */
+
+#include "MoqxRelay.h"
+#include <folly/coro/BlockingWait.h>
+#include <folly/io/async/EventBase.h>
+#include <folly/io/async/Request.h>
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/MoQTrackProperties.h>
+#include <moxygen/events/MoQFollyExecutorImpl.h>
+#include <moxygen/relay/MoQForwarder.h>
+#include <moxygen/test/MockMoQSession.h>
+#include <moxygen/test/Mocks.h>
+
+using namespace testing;
+using namespace moxygen;
+using namespace moxygen::test;
+using namespace openmoq::moqx;
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TrackNamespace kNs{{"conf", "room1"}};
+const TrackNamespace kPrefix{{"conf"}};
+constexpr uint64_t kPropType = 0x100; // audio level property type
+
+// ---------------------------------------------------------------------------
+// Test executor (same pattern as MoqxRelayTest)
+// TODO: Move TestMoQExecutor to a shared test helper (e.g., test/TestUtils.h)
+// ---------------------------------------------------------------------------
+
+class TestMoQExecutor : public MoQFollyExecutorImpl, public folly::DrivableExecutor {
+public:
+  explicit TestMoQExecutor() : MoQFollyExecutorImpl(&evb_) {}
+
+  void add(folly::Func func) override { MoQFollyExecutorImpl::add(std::move(func)); }
+
+  void drive() override {
+    if (auto* evb = getBackingEventBase()) {
+      evb->loopOnce();
+    }
+  }
+
+  // TODO: Audit driveFor() call sites to use minimum iterations needed rather
+  // than arbitrary values like 10/20. Consider adding a driveUntilIdle() helper.
+  void driveFor(int n) {
+    for (int i = 0; i < n; i++) {
+      drive();
+    }
+  }
+
+private:
+  folly::EventBase evb_;
+};
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+class MoqxTrackFilterTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    exec_ = std::make_shared<TestMoQExecutor>();
+    relay_ = std::make_shared<MoqxRelay>(
+        config::CacheConfig{0, 0}, // no cache
+        /*relayID=*/"",
+        /*maxDeselected=*/0
+    );
+    relay_->setAllowedNamespacePrefix(kPrefix);
+  }
+
+  void TearDown() override {
+    relay_.reset();
+    exec_->driveFor(10);
+  }
+
+  // Create a mock session wired to accept publish() calls.
+  // publish() calls are recorded in publishedTracks_[session.get()].
+  std::shared_ptr<MockMoQSession> makeSession() {
+    auto session = std::make_shared<NiceMock<MockMoQSession>>(exec_);
+    ON_CALL(*session, getNegotiatedVersion())
+        .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));
+
+    auto* raw = session.get();
+    ON_CALL(*session, publish(_, _))
+        .WillByDefault(Invoke([this, raw](PublishRequest pub, auto) -> Subscriber::PublishResult {
+          publishedTracks_[raw].push_back(pub.fullTrackName);
+          auto consumer = std::make_shared<NiceMock<MockTrackConsumer>>();
+          ON_CALL(*consumer, setTrackAlias(_))
+              .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+          ON_CALL(*consumer, objectStream(_, _, _))
+              .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+          ON_CALL(*consumer, publishDone(_))
+              .WillByDefault(Invoke([this, raw, ftn = pub.fullTrackName](PublishDone) mutable {
+                publishDoneCount_[raw][ftn]++;
+                return folly::makeExpected<MoQPublishError>(folly::unit);
+              }));
+          PublishOk ok{
+              pub.requestID,
+              true,
+              128,
+              GroupOrder::Default,
+              LocationType::LargestObject,
+              std::nullopt,
+              std::make_optional(uint64_t(0))
+          };
+          return Subscriber::PublishConsumerAndReplyTask{
+              std::static_pointer_cast<TrackConsumer>(consumer),
+              folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(std::move(ok))
+          };
+        }));
+    return session;
+  }
+
+  // How many times session received a publish() for ftn
+  int publishCount(MockMoQSession* s, const FullTrackName& ftn) const {
+    auto it = publishedTracks_.find(s);
+    if (it == publishedTracks_.end()) {
+      return 0;
+    }
+    return std::count(it->second.begin(), it->second.end(), ftn);
+  }
+
+  // How many times session received publishDone() for ftn
+  int publishDoneCount(MockMoQSession* s, const FullTrackName& ftn) const {
+    auto it = publishDoneCount_.find(s);
+    if (it == publishDoneCount_.end()) {
+      return 0;
+    }
+    auto it2 = it->second.find(ftn);
+    return it2 != it->second.end() ? it2->second : 0;
+  }
+
+  // All FTNs published to this session (in order)
+  std::vector<FullTrackName> published(MockMoQSession* s) const {
+    auto it = publishedTracks_.find(s);
+    return it != publishedTracks_.end() ? it->second : std::vector<FullTrackName>{};
+  }
+
+  // ---- Relay helpers -------------------------------------------------------
+
+  template <typename F> auto withSession(std::shared_ptr<MoQSession> session, F&& f) {
+    folly::RequestContextScopeGuard guard;
+    folly::RequestContext::get()->setContextData(
+        sessionToken_,
+        std::make_unique<MoQSession::MoQSessionRequestData>(std::move(session))
+    );
+    return f();
+  }
+
+  // Publish a track; returns the TrackConsumer so caller can send objects.
+  std::shared_ptr<TrackConsumer> doPublish(
+      std::shared_ptr<MoQSession> session,
+      const std::string& trackName,
+      uint64_t initialLevel = 0
+  ) {
+    PublishRequest pub;
+    pub.fullTrackName = FullTrackName{kNs, trackName};
+    pub.requestID = RequestID(nextId_++);
+    pub.groupOrder = GroupOrder::OldestFirst;
+    if (initialLevel > 0) {
+      pub.extensions.insertMutableExtension(Extension{kPropType, initialLevel});
+    }
+    auto handle = makeHandle();
+    std::shared_ptr<TrackConsumer> consumer;
+    withSession(session, [&] {
+      auto result = relay_->publish(std::move(pub), handle);
+      ASSERT_TRUE(result.hasValue());
+      consumer = result->consumer;
+    });
+    return consumer;
+  }
+
+  // Subscribe with TRACK_FILTER; returns the subNs handle.
+  std::shared_ptr<Publisher::SubscribeNamespaceHandle>
+  doSubscribeFilter(std::shared_ptr<MoQSession> session, uint64_t maxSelected) {
+    SubscribeNamespace subNs;
+    subNs.trackNamespacePrefix = kNs;
+    subNs.requestID = RequestID(nextId_++);
+    subNs.options = SubscribeNamespaceOptions::PUBLISH;
+    subNs.forward = true;
+
+    TrackRequestParameter p;
+    p.key = folly::to_underlying(TrackRequestParamKey::TRACK_FILTER);
+    p.asTrackFilter = TrackFilter{kPropType, maxSelected};
+    subNs.params.insertParam(p);
+
+    std::shared_ptr<Publisher::SubscribeNamespaceHandle> handle;
+    withSession(session, [&] {
+      auto result = folly::coro::blockingWait(
+          relay_->subscribeNamespace(std::move(subNs), nullptr),
+          exec_.get()
+      );
+      ASSERT_TRUE(result.hasValue());
+      handle = *result;
+    });
+    return handle;
+  }
+
+  // Send an object carrying a new property value
+  void sendValue(std::shared_ptr<TrackConsumer> consumer, uint64_t value) {
+    ObjectHeader hdr;
+    hdr.group = 0;
+    hdr.id = nextObjId_++;
+    hdr.extensions.insertMutableExtension(Extension{kPropType, value});
+    consumer->objectStream(hdr, nullptr, false); // errors OK (no subscribers yet)
+  }
+
+  std::shared_ptr<Publisher::SubscriptionHandle> makeHandle() {
+    SubscribeOk ok;
+    ok.requestID = RequestID(0);
+    ok.trackAlias = TrackAlias(0);
+    ok.expires = std::chrono::milliseconds(0);
+    ok.groupOrder = GroupOrder::Default;
+    return std::make_shared<NiceMock<MockSubscriptionHandle>>(std::move(ok));
+  }
+
+  FullTrackName ftn(const std::string& name) const { return FullTrackName{kNs, name}; }
+
+  // Subscribe without TRACK_FILTER (plain namespace subscription)
+  void doSubscribeDirect(std::shared_ptr<MoQSession> session) {
+    SubscribeNamespace subNs;
+    subNs.trackNamespacePrefix = kNs;
+    subNs.requestID = RequestID(nextId_++);
+    subNs.options = SubscribeNamespaceOptions::PUBLISH;
+    subNs.forward = true;
+    withSession(session, [&] {
+      auto result = folly::coro::blockingWait(
+          relay_->subscribeNamespace(std::move(subNs), nullptr),
+          exec_.get()
+      );
+      ASSERT_TRUE(result.hasValue());
+    });
+  }
+
+  PublishDone makePublishDone() {
+    PublishDone done;
+    done.requestID = RequestID(0);
+    done.statusCode = PublishDoneStatusCode::TRACK_ENDED;
+    return done;
+  }
+
+  // ---- Members -------------------------------------------------------------
+
+  std::shared_ptr<TestMoQExecutor> exec_;
+  std::shared_ptr<MoqxRelay> relay_;
+  uint64_t nextId_{1};
+  uint64_t nextObjId_{0};
+  folly::RequestToken sessionToken_{"moq_session"};
+
+  // per-session record of which FTNs were pushed via publish()
+  std::map<MoQSession*, std::vector<FullTrackName>> publishedTracks_;
+  // per-session, per-FTN count of publishDone() calls received
+  std::map<MoQSession*, std::map<FullTrackName, int>> publishDoneCount_;
+};
+
+// ---------------------------------------------------------------------------
+// Tests: subscriber joins before publishers
+// ---------------------------------------------------------------------------
+
+// Subscriber joins first; only top-N publishers should be forwarded.
+TEST_F(MoqxTrackFilterTest, SubscribeFirst_Top2Of3_CorrectTracksForwarded) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  auto subHandle = doSubscribeFilter(viewer, /*maxSelected=*/2);
+  ASSERT_NE(subHandle, nullptr);
+
+  // Publish 3 tracks with different levels; top-2 are "a" (100) and "b" (80)
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 80);
+  auto cC = doPublish(pubSess, "c", 40);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("c")), 0); // outside top-2
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// Top-1: only the single highest track reaches the subscriber.
+TEST_F(MoqxTrackFilterTest, SubscribeFirst_Top1_OnlyHighestForwarded) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  auto cLoud = doPublish(pubSess, "loud", 100);
+  auto cQuiet = doPublish(pubSess, "quiet", 30);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("loud")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("quiet")), 0);
+
+  cLoud->publishDone(makePublishDone());
+  cQuiet->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: publisher joins before subscriber (late subscriber)
+// ---------------------------------------------------------------------------
+
+// Late subscriber should receive top-N from already-published tracks via
+// getOrCreateRanking retroactive registration + addSessionToTopNGroup.
+TEST_F(MoqxTrackFilterTest, PublishFirst_LateSubscriber_GetsTopN) {
+  auto pubSess = makeSession();
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 80);
+  auto cC = doPublish(pubSess, "c", 40);
+  exec_->driveFor(10);
+
+  // Late subscriber joins; expects to immediately receive top-2
+  auto viewer = makeSession();
+  auto subHandle = doSubscribeFilter(viewer, /*maxSelected=*/2);
+  ASSERT_NE(subHandle, nullptr);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("c")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: dynamic value changes
+// ---------------------------------------------------------------------------
+
+// A track outside top-N rises above the threshold and displaces the occupant.
+TEST_F(MoqxTrackFilterTest, ValueChange_OutsiderEntersTopN) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  // "a" starts loudest, "b" starts quiet
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 20);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // "b" jumps above "a"
+  sendValue(consumerB, 110);
+  exec_->driveFor(20);
+
+  // viewer should now receive "b" (entered top-1), and "a" evicted with publishDone
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishDoneCount(viewer.get(), ftn("a")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+}
+
+// Two subscribers with different N values see independent top-N sets.
+TEST_F(MoqxTrackFilterTest, TwoSubscribers_DifferentN_IndependentSets) {
+  auto pubSess = makeSession();
+
+  auto viewerTop1 = makeSession();
+  auto viewerTop3 = makeSession();
+  doSubscribeFilter(viewerTop1, 1);
+  doSubscribeFilter(viewerTop3, 3);
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 80);
+  auto cC = doPublish(pubSess, "c", 60);
+  auto cD = doPublish(pubSess, "d", 20);
+  exec_->driveFor(20);
+
+  // top-1 viewer: only "a"
+  EXPECT_EQ(publishCount(viewerTop1.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewerTop1.get(), ftn("b")), 0);
+  EXPECT_EQ(publishCount(viewerTop1.get(), ftn("c")), 0);
+
+  // top-3 viewer: "a", "b", "c"
+  EXPECT_EQ(publishCount(viewerTop3.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewerTop3.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewerTop3.get(), ftn("c")), 1);
+  EXPECT_EQ(publishCount(viewerTop3.get(), ftn("d")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+  cD->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: forward flag
+// ---------------------------------------------------------------------------
+
+// forward=false propagates through to publishToSession without affecting selection.
+// The subscriber should still receive publishes for selected tracks, but with
+// forward=false passed to the forwarder (controls whether the relay requests
+// forwarding from upstream).
+TEST_F(MoqxTrackFilterTest, ForwardFalse_TracksStillSelected) {
+  auto pubSess = makeSession();
+
+  SubscribeNamespace subNs;
+  subNs.trackNamespacePrefix = kNs;
+  subNs.requestID = RequestID(nextId_++);
+  subNs.options = SubscribeNamespaceOptions::PUBLISH;
+  subNs.forward = false; // subscriber does not want forwarding
+
+  TrackRequestParameter p;
+  p.key = folly::to_underlying(TrackRequestParamKey::TRACK_FILTER);
+  p.asTrackFilter = TrackFilter{kPropType, 2};
+  subNs.params.insertParam(p);
+
+  auto viewer = makeSession();
+  withSession(viewer, [&] {
+    auto result = folly::coro::blockingWait(
+        relay_->subscribeNamespace(std::move(subNs), nullptr),
+        exec_.get()
+    );
+    EXPECT_TRUE(result.hasValue());
+  });
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 80);
+  auto cC = doPublish(pubSess, "c", 40);
+  exec_->driveFor(20);
+
+  // forward=false should not affect track selection: top-2 still receive publish
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("c")), 0); // outside top-2
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: unsubscribe cleans up ranking
+// ---------------------------------------------------------------------------
+
+TEST_F(MoqxTrackFilterTest, Unsubscribe_RemovesFromRanking) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  auto subHandle = doSubscribeFilter(viewer, /*maxSelected=*/2);
+  ASSERT_NE(subHandle, nullptr);
+
+  auto cA = doPublish(pubSess, "a", 100);
+  exec_->driveFor(10);
+
+  // Unsubscribe removes session from ranking
+  subHandle->unsubscribeNamespace();
+  exec_->driveFor(10);
+
+  // New track can still be published after subscriber leaves
+  auto cB = doPublish(pubSess, "b", 80);
+  exec_->driveFor(10);
+
+  // Verify track "a" was received before unsubscribe, "b" was not
+  // (no subscriber to receive it after unsubscribe)
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+}
+
+// Late subscriber joins, then a previously-quiet track sends a value update
+// that pushes it into top-N. Verifies that getOrCreateRanking wires the
+// TopNFilter observer correctly so subsequent value changes are tracked.
+TEST_F(MoqxTrackFilterTest, PublishFirst_LateSubscriber_ValueChangeUpdatesRanking) {
+  auto pubSess = makeSession();
+
+  // "loud" (100) and "quiet" (20) published before subscriber joins
+  auto consumerLoud = doPublish(pubSess, "loud", 100);
+  auto consumerQuiet = doPublish(pubSess, "quiet", 20);
+  exec_->driveFor(10);
+
+  // Late subscriber: top-1 only
+  auto viewer = makeSession();
+  auto subHandle = doSubscribeFilter(viewer, /*maxSelected=*/1);
+  ASSERT_NE(subHandle, nullptr);
+  exec_->driveFor(20);
+
+  // Initial selection: "loud" should be the top-1
+  ASSERT_EQ(publishCount(viewer.get(), ftn("loud")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("quiet")), 0);
+
+  // "quiet" jumps above "loud" — observer wired by getOrCreateRanking must fire
+  sendValue(consumerQuiet, 200);
+  exec_->driveFor(20);
+
+  // "quiet" should now enter top-1, "loud" evicted with publishDone
+  EXPECT_EQ(publishCount(viewer.get(), ftn("quiet")), 1);
+  EXPECT_EQ(publishDoneCount(viewer.get(), ftn("loud")), 1);
+
+  consumerLoud->publishDone(makePublishDone());
+  consumerQuiet->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: track ending (PUBLISH_DONE) while selected
+// ---------------------------------------------------------------------------
+
+// When the top-N track sends PUBLISH_DONE, the ranking should remove it and
+// promote the next candidate. This exercises the notifyTrackEnded→removeTrack
+// path without the redundant direct-loop in onPublishDone.
+TEST_F(MoqxTrackFilterTest, PublishDone_SelectedTrack_PromotesReplacement) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // "a" ends: ranking must clean up and promote "b" into top-1.
+  consumerA->publishDone(makePublishDone());
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+
+  consumerB->publishDone(makePublishDone());
+}
+
+// PUBLISH_DONE on a non-selected track should not cause spurious selection.
+TEST_F(MoqxTrackFilterTest, PublishDone_NonSelectedTrack_NoSpuriousSelection) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+
+  // "b" ends while outside top-1; no new selection should occur.
+  consumerB->publishDone(makePublishDone());
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1); // unchanged
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  consumerA->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: value decrease causes track to drop out of top-N
+// ---------------------------------------------------------------------------
+
+// A selected track's value drops below an unselected track's value; the
+// unselected one should be promoted and the old top-track should be evicted.
+TEST_F(MoqxTrackFilterTest, ValueDecrease_TopTrackDropsOutOfTopN) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // "a" drops below "b": "b" should enter top-1, "a" evicted with publishDone.
+  sendValue(consumerA, 20);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishDoneCount(viewer.get(), ftn("a")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: direct subscriber and TRACK_FILTER subscriber on the same namespace
+// ---------------------------------------------------------------------------
+
+// A direct (non-filtered) subscriber must receive all published tracks while
+// the TRACK_FILTER subscriber receives only the top-N subset.
+TEST_F(MoqxTrackFilterTest, DirectAndFilterSubscriberCoexist) {
+  auto pubSess = makeSession();
+
+  auto directViewer = makeSession();
+  doSubscribeDirect(directViewer);
+
+  auto filteredViewer = makeSession();
+  doSubscribeFilter(filteredViewer, /*maxSelected=*/1);
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 50);
+  auto cC = doPublish(pubSess, "c", 20);
+  exec_->driveFor(20);
+
+  // Direct subscriber sees all three tracks.
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("c")), 1);
+
+  // TRACK_FILTER subscriber sees only the top-1.
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("b")), 0);
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("c")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: trackFilterSubscribers_ cleanup on unsubscribe
+// ---------------------------------------------------------------------------
+
+// After a TRACK_FILTER subscriber unsubscribes, a subsequent subscriber with
+// the same N should receive the correct top-N independently. Stale entries
+// left over by the first subscriber must not interfere with selection or
+// eviction for the second subscriber.
+TEST_F(MoqxTrackFilterTest, Unsubscribe_StaleEntriesDoNotAffectResubscribe) {
+  auto pubSess = makeSession();
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(10);
+
+  // First subscriber joins, "a" is selected, then unsubscribes.
+  // Without the fix, {a, viewer1*} lingers in trackFilterSubscribers_.
+  auto viewer1 = makeSession();
+  auto subHandle = doSubscribeFilter(viewer1, /*maxSelected=*/1);
+  ASSERT_NE(subHandle, nullptr);
+  exec_->driveFor(10);
+  ASSERT_EQ(publishCount(viewer1.get(), ftn("a")), 1);
+
+  subHandle->unsubscribeNamespace();
+  exec_->driveFor(10);
+
+  // Second subscriber should get the correct top-1 with no interference.
+  auto viewer2 = makeSession();
+  doSubscribeFilter(viewer2, /*maxSelected=*/1);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer2.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer2.get(), ftn("b")), 0);
+
+  // A new higher-value track should be selected for viewer2 only.
+  auto cC = doPublish(pubSess, "c", 200);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer2.get(), ftn("c")), 1);
+
+  // viewer1 was unsubscribed and must not receive anything new.
+  EXPECT_EQ(publishCount(viewer1.get(), ftn("b")), 0);
+  EXPECT_EQ(publishCount(viewer1.get(), ftn("c")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: deselected queue eviction
+// ---------------------------------------------------------------------------
+
+// When the deselected queue overflows maxDeselected, the oldest entry is
+// evicted (subscriber removed from forwarder). This test uses maxDeselected=2
+// to keep the setup minimal: three displaced tracks fills the queue to 3.
+TEST_F(MoqxTrackFilterTest, DeselectedQueueEviction_EvictsOldestEntry) {
+  // Override relay_ with a tighter maxDeselected so eviction triggers quickly.
+  relay_ = std::make_shared<MoqxRelay>(
+      config::CacheConfig{0, 0}, // no cache
+      /*relayID=*/"",
+      /*maxDeselected=*/2
+  );
+  relay_->setAllowedNamespacePrefix(kPrefix);
+
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  // "base" enters top-1 first.
+  auto cBase = doPublish(pubSess, "base", 10);
+  exec_->driveFor(10);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("base")), 1);
+
+  // Each successive track displaces the previous top-1 into the deselected queue.
+  // After "t3" arrives the queue is {"base","t1","t2"} (size 3 > maxDeselected=2),
+  // which evicts "base".
+  auto cT1 = doPublish(pubSess, "t1", 20); // deselected: {base}
+  auto cT2 = doPublish(pubSess, "t2", 30); // deselected: {base, t1}
+  auto cT3 = doPublish(pubSess, "t3", 40); // deselected overflows → "base" evicted
+  exec_->driveFor(20);
+
+  // All four tracks entered top-1 in sequence as higher-value tracks arrived.
+  EXPECT_EQ(publishCount(viewer.get(), ftn("base")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("t1")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("t2")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("t3")), 1);
+
+  // Verify total number of selections: all 4 tracks should have been selected
+  // exactly once as they successively entered top-1.
+  auto allPublished = published(viewer.get());
+  EXPECT_EQ(allPublished.size(), 4);
+
+  // "base" overflowed the deselected queue and was evicted with publishDone
+  EXPECT_EQ(publishDoneCount(viewer.get(), ftn("base")), 1);
+
+  cBase->publishDone(makePublishDone());
+  cT1->publishDone(makePublishDone());
+  cT2->publishDone(makePublishDone());
+  cT3->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: filter chain installation in both publish and subscribe paths
+// ---------------------------------------------------------------------------
+
+// Verifies that when a TRACK_FILTER subscriber joins after PUBLISH, the relay
+// correctly handles forwarding. The forwardChanged() callback mechanism sends
+// REQUEST_UPDATE when forwarding state changes.
+TEST_F(MoqxTrackFilterTest, ForwardStateUpdatedWhenFilterSubscriberJoins) {
+  auto pubSess = makeSession();
+
+  // Publish tracks with no subscribers initially (forward would be false/true
+  // depending on whether TRACK_FILTER subscribers exist at publish time)
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(10);
+
+  // TRACK_FILTER subscriber joins - should trigger forwardChanged() callback
+  // which sends REQUEST_UPDATE with forward=true to the publisher
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+  exec_->driveFor(20);
+
+  // Verify subscriber receives the top-1 track
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // Value changes should still work (verifies forwarder is receiving objects)
+  sendValue(consumerB, 200);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+}
+
+// Verifies that TopNFilter is installed in the filter chain for both PUBLISH
+// and SUBSCRIBE paths. A direct subscriber joins first (triggering filter chain
+// creation), then a TRACK_FILTER subscriber joins later. Value changes on
+// existing tracks must be observed and reflected in the TRACK_FILTER ranking.
+TEST_F(MoqxTrackFilterTest, FilterChainInstalledForBothPaths) {
+  auto pubSess = makeSession();
+
+  // Direct subscriber joins first — establishes the relay subscription path
+  auto directViewer = makeSession();
+  doSubscribeDirect(directViewer);
+
+  // Publisher publishes tracks (direct subscriber receives all)
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  auto consumerC = doPublish(pubSess, "c", 20);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(directViewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(directViewer.get(), ftn("b")), 1);
+  ASSERT_EQ(publishCount(directViewer.get(), ftn("c")), 1);
+
+  // TRACK_FILTER subscriber joins later — must see correct top-1 based on
+  // current values at the time of join
+  auto filteredViewer = makeSession();
+  doSubscribeFilter(filteredViewer, /*maxSelected=*/1);
+  exec_->driveFor(20);
+
+  // "a" (100) is top-1
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("b")), 0);
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("c")), 0);
+
+  // Value change: "c" jumps to top — filter chain must observe this change
+  // even though tracks were published before TRACK_FILTER subscriber joined
+  sendValue(consumerC, 200);
+  exec_->driveFor(20);
+
+  // "c" (200) should now be selected for filteredViewer
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("c")), 1);
+
+  // Direct viewer is unaffected by ranking changes
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("c")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+  consumerC->publishDone(makePublishDone());
+}
+
+} // namespace


### PR DESCRIPTION
- publish(): create TopNFilter in the filter chain; seed initial property value from pub.extensions.getIntExtension() so late subscribers see correct starting ranks; store topNFilter in RelaySubscription
- subscribeNamespace(): parse TrackFilter param; call getOrCreateRanking() + addSessionToTopNGroup(); skip direct publish for TRACK_FILTER subscribers (relay waits for onTrackSelected callbacks instead)
- getOrCreateRanking(): creates PropertyRanking for the node's property type; retroactively registers existing tracks with correct initial values from stored forwarder extensions; wires TopNFilter observers for future updates
- onTrackSelected(): called by PropertyRanking when a track enters a session's top-N; drives publishToSession with trackFilterSubscriber=true
- onTrackEvicted(): removes unpinned (TRACK_FILTER) subscribers from the forwarder; direct subscribers are pinned and immune to eviction
- publishToSession(): set subscriber->pinned = !trackFilterSubscriber so direct subscribers are protected while TRACK_FILTER subscribers can be removed on eviction
- unsubscribeNamespace(): call ranking->removeSessionFromTopNGroup() on exit
- onPublishDone(): notify ranking->removeTrack() and topNFilter->notifyTrackEnded()
- Bump deps/moxygen to 7d21c4a (Add pinned flag and getSubscriber to MoQForwarder) — needed for isPinned()/getSubscriber() in onTrackEvicted
- Add MoqxTrackFilterTest.cpp: 8 integration tests covering subscribe-first, publish-first, value changes, two subscribers with different N, forward=false, unsubscribe cleanup, and late-subscriber value-change ranking

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/162)
<!-- Reviewable:end -->
