### PR TITLE
feat: Add activityTarget and onActivity to TopNFilter

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -540,7 +540,8 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
           PropertyObserver{
               .onValueChanged = [ranking, ftn = pub.fullTrackName](uint64_t value
                                 ) { ranking->updateSortValue(ftn, value); },
-              .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); }
+              .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); },
+              .onActivity = {}
           }
       );
     }
@@ -1370,7 +1371,8 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
                 PropertyObserver{
                     .onValueChanged = [rankingPtr, ftn](uint64_t value
                                       ) { rankingPtr->updateSortValue(ftn, value); },
-                    .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); }
+                    .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); },
+                    .onActivity = {}
                 }
             );
           }

--- a/src/relay/TopNFilter.cpp
+++ b/src/relay/TopNFilter.cpp
@@ -29,11 +29,27 @@ void TopNFilter::removeObserver(uint64_t propertyType) {
   observers_.erase(propertyType);
 }
 
+void TopNFilter::setActivityTarget(std::chrono::steady_clock::time_point* target) {
+  activityTarget_ = target;
+}
+
+void TopNFilter::setActivityThreshold(std::chrono::milliseconds threshold) {
+  activityThreshold_ = threshold;
+}
+
 void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
-  // FAST PATH: No observers to notify
+  // FAST PATH: No observers — nothing to do
   if (observers_.empty()) {
     return;
   }
+
+  auto now = std::chrono::steady_clock::now();
+
+  // Throttle check for onActivity
+  bool activityThrottleAllows =
+      activityThreshold_.count() > 0 &&
+      (!lastActivityNotify_ || now - *lastActivityNotify_ >= activityThreshold_);
+  bool firedAnyActivity = false;
 
   // Check extensions for property values we're observing
   for (auto& [propertyType, entry] : observers_) {
@@ -42,8 +58,14 @@ void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
       continue;
     }
 
+    // Property matched — update activity timestamp
+    if (activityTarget_) {
+      *activityTarget_ = now;
+    }
+
     uint64_t value = *valueOpt;
     if (!entry.lastSeenValue || *entry.lastSeenValue != value) {
+      // Value changed: fire onValueChanged (not onActivity)
       XLOG(DBG4) << "[TopNFilter] Property changed on " << ftn_ << ": propertyType=0x" << std::hex
                  << propertyType << std::dec << " oldValue=" << entry.lastSeenValue.value_or(0)
                  << " newValue=" << value;
@@ -51,7 +73,15 @@ void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
       if (entry.observer.onValueChanged) {
         entry.observer.onValueChanged(value);
       }
+    } else if (activityThrottleAllows && entry.observer.onActivity) {
+      // Property seen but value unchanged: fire onActivity (throttled)
+      entry.observer.onActivity();
+      firedAnyActivity = true;
     }
+  }
+
+  if (firedAnyActivity) {
+    lastActivityNotify_ = now;
   }
 }
 

--- a/src/relay/TopNFilter.h
+++ b/src/relay/TopNFilter.h
@@ -10,6 +10,7 @@
 #include <moxygen/MoQFilters.h>
 #include <moxygen/MoQTypes.h>
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -24,6 +25,12 @@ struct PropertyObserver {
 
   // Called when the track ends (PUBLISH_DONE received).
   std::function<void()> onTrackEnded;
+
+  // Called when the observed property is present but value is unchanged.
+  // Throttled to at most once per activityThreshold_. Complements onValueChanged:
+  // either onValueChanged fires (value changed) or onActivity fires (value same),
+  // never both on the same object. Used to trigger idle sweeps in PropertyRanking.
+  std::function<void()> onActivity;
 };
 
 // Entry for tracking observer state per property type.
@@ -66,6 +73,13 @@ public:
 
   // Check if any observers are registered.
   bool hasObservers() const { return !observers_.empty(); }
+
+  // Set pointer to external timestamp; written when an observed property matches.
+  // Lifetime: caller guarantees the pointed-to time_point outlives this filter.
+  void setActivityTarget(std::chrono::steady_clock::time_point* target);
+
+  // Set minimum interval between onActivity callbacks. Zero = never fire onActivity.
+  void setActivityThreshold(std::chrono::milliseconds threshold);
 
   // Check extensions for property values and notify observers.
   // This is called for each object received.
@@ -114,6 +128,14 @@ private:
 
   // Track whether publishDone has been received
   bool ended_{false};
+
+  // Activity tracking: raw pointer written on every object (cheap); null = disabled.
+  std::chrono::steady_clock::time_point* activityTarget_{nullptr};
+
+  // Throttle for onActivity callbacks: minimum interval between fires.
+  // Zero means onActivity is never fired.
+  std::chrono::milliseconds activityThreshold_{};
+  std::optional<std::chrono::steady_clock::time_point> lastActivityNotify_;
 };
 
 /**

--- a/test/TopNFilterTest.cpp
+++ b/test/TopNFilterTest.cpp
@@ -10,6 +10,8 @@
 #include <folly/portability/GTest.h>
 #include <moxygen/test/Mocks.h>
 
+#include <thread>
+
 using namespace testing;
 using namespace moxygen;
 using namespace openmoq::moqx;
@@ -271,6 +273,69 @@ TEST_F(TopNFilterTest, DatagramTriggersCheckProperties) {
   hdr.extensions = makeExt(kPropA, 99);
   filter_->datagram(hdr, nullptr, false);
   EXPECT_EQ(called, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Activity tracking: activityTarget_ and onActivity callback
+// ---------------------------------------------------------------------------
+
+TEST_F(TopNFilterTest, ActivityTargetOnlyUpdatedOnPropertyMatch) {
+  std::chrono::steady_clock::time_point ts{};
+  filter_->setActivityTarget(&ts);
+  filter_->registerObserver(kPropA, PropertyObserver{});
+
+  // No match: timestamp not written
+  filter_->checkProperties(makeExt(kPropB, 99));
+  EXPECT_EQ(ts, std::chrono::steady_clock::time_point{});
+
+  // Match: timestamp written
+  filter_->checkProperties(makeExt(kPropA, 1));
+  auto ts1 = ts;
+  EXPECT_NE(ts1, std::chrono::steady_clock::time_point{});
+
+  // Sleep then match again: timestamp updated
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  filter_->checkProperties(makeExt(kPropA, 2));
+  EXPECT_GT(ts, ts1);
+}
+
+TEST_F(TopNFilterTest, OnActivityCallbackBehavior) {
+  int activityCount = 0;
+  int valueChangedCount = 0;
+  filter_->registerObserver(
+      kPropA,
+      PropertyObserver{
+          .onValueChanged = [&](uint64_t) { valueChangedCount++; },
+          .onActivity = [&]() { activityCount++; },
+      }
+  );
+
+  // Threshold=0 (default): onActivity never fires
+  filter_->checkProperties(makeExt(kPropA, 1));
+  filter_->checkProperties(makeExt(kPropA, 1));
+  EXPECT_EQ(activityCount, 0);
+
+  // Enable threshold
+  filter_->setActivityThreshold(std::chrono::hours(1));
+
+  // Value changes: onValueChanged fires, NOT onActivity
+  filter_->checkProperties(makeExt(kPropA, 42));
+  EXPECT_EQ(valueChangedCount, 2); // includes earlier call
+  EXPECT_EQ(activityCount, 0);
+
+  // Same value: onActivity fires
+  filter_->checkProperties(makeExt(kPropA, 42));
+  EXPECT_EQ(valueChangedCount, 2);
+  EXPECT_EQ(activityCount, 1);
+
+  // Same value immediately: throttled
+  filter_->checkProperties(makeExt(kPropA, 42));
+  EXPECT_EQ(activityCount, 1);
+
+  // No property match: neither callback fires
+  filter_->checkProperties(makeExt(kPropB, 99));
+  EXPECT_EQ(valueChangedCount, 2);
+  EXPECT_EQ(activityCount, 1);
 }
 
 } // namespace


### PR DESCRIPTION
TopNFilter now supports two new capabilities needed for idle eviction:

- setActivityTarget(time_point*): raw pointer written on every object arrival (cheap single store); callers pass &RelaySubscription::lastObjectTime
- setActivityThreshold(milliseconds): throttle for onActivity callbacks; zero means never fire
- PropertyObserver gains optional onActivity callback, fired at most once per activityThreshold_ across all observers on the filter — even when the property value is absent or unchanged
- Fast path updated: early-exit only when observers_.empty() && !activityTarget_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/164)
<!-- Reviewable:end -->
