### PR TITLE
feat: Add sweepIdle to PropertyRanking for idle track eviction

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1326,6 +1326,8 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
     ranking = std::make_shared<PropertyRanking>(
         propertyType,
         maxDeselected_,
+        std::chrono::milliseconds(0), // idle eviction wired in subsequent commit
+        nullptr,                      // getLastActivity wired in subsequent commit
         // Batch callback: called once per track-selected event with all sessions
         [this](
             const FullTrackName& ftn,

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -13,13 +13,15 @@ namespace openmoq::moqx {
 PropertyRanking::PropertyRanking(
     uint64_t propertyType,
     uint64_t maxDeselected,
+    std::chrono::milliseconds idleTimeout,
+    GetLastActivityFn getLastActivity,
     BatchSelectCallback onBatchSelected,
     SelectCallback onSelected,
     EvictCallback onEvicted
 )
-    : propertyType_(propertyType), maxDeselected_(maxDeselected),
-      onBatchSelected_(std::move(onBatchSelected)), onSelected_(std::move(onSelected)),
-      onEvicted_(std::move(onEvicted)) {}
+    : propertyType_(propertyType), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
+      getLastActivity_(std::move(getLastActivity)), onBatchSelected_(std::move(onBatchSelected)),
+      onSelected_(std::move(onSelected)), onEvicted_(std::move(onEvicted)) {}
 
 void PropertyRanking::registerTrack(
     const moxygen::FullTrackName& ftn,
@@ -96,6 +98,9 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
     return;
   }
 
+  // Opportunistic idle sweep: a value change is worth a quick idle check
+  sweepIdle();
+
   // SLOW PATH: value crossed a threshold, recompute TopNGroups
   XLOG(DBG4) << "updateSortValue slow path: " << ftn << " value=" << value << " rank " << oldRank
              << " -> " << newRank << " (threshold crossed)";
@@ -144,15 +149,7 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
         // Fallback: deselected queue empty — scan ranked list for first non-selected track.
         // This path is taken when no tracks have been through the deselected queue yet
         // (e.g., first removal after initial registration).
-        for (auto& [key, rankedEntry] : rankedTracks_) {
-          auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
-          if (stIt != topNGroup.trackStates.end() && stIt->second == TrackState::Selected) {
-            continue;
-          }
-          topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
-          notifyTrackSelected(rankedEntry.ftn, topNGroup);
-          break;
-        }
+        promoteNextAvailableTrack(topNGroup, ftn);
       }
     }
   }
@@ -330,9 +327,7 @@ void PropertyRanking::recomputeTopNGroups(
         topNGroup.trackStates[ftn] = TrackState::Selected;
         removeFromDeselectedQueue(topNGroup, ftn);
       } else {
-        topNGroup.trackStates[ftn] = TrackState::Deselected;
-        topNGroup.deselectedQueue.push_back(ftn);
-        trimDeselectedQueue(topNGroup);
+        demoteTrack(topNGroup, ftn);
       }
     }
 
@@ -421,6 +416,31 @@ void PropertyRanking::demoteTrackAtRank(uint64_t n, TopNGroup& group) {
   }
 }
 
+void PropertyRanking::demoteTrack(TopNGroup& group, const moxygen::FullTrackName& ftn) {
+  group.trackStates[ftn] = TrackState::Deselected;
+  group.deselectedQueue.push_back(ftn);
+  trimDeselectedQueue(group);
+}
+
+void PropertyRanking::promoteNextAvailableTrack(
+    TopNGroup& group,
+    const moxygen::FullTrackName& excludeFtn
+) {
+  for (const auto& [key, rankedEntry] : rankedTracks_) {
+    if (rankedEntry.ftn == excludeFtn) {
+      continue;
+    }
+    auto stIt = group.trackStates.find(rankedEntry.ftn);
+    if (stIt != group.trackStates.end() && stIt->second == TrackState::Selected) {
+      continue;
+    }
+    group.trackStates[rankedEntry.ftn] = TrackState::Selected;
+    removeFromDeselectedQueue(group, rankedEntry.ftn);
+    notifyTrackSelected(rankedEntry.ftn, group);
+    break;
+  }
+}
+
 // Batch callback rationale: all sessions in a TopNGroup share the same N, so
 // when a track enters their top-N the relay can handle them together — one
 // upstream subscribe decision, one forwarder lookup, one cache check. An
@@ -436,6 +456,43 @@ void PropertyRanking::notifyTrackSelected(const moxygen::FullTrackName& ftn, Top
     XLOG(DBG4) << "notifyTrackSelected: " << ftn << " to " << batch.size()
                << " sessions in TopNGroup maxSelected=" << topNGroup.maxSelected;
     onBatchSelected_(ftn, batch);
+  }
+}
+
+void PropertyRanking::sweepIdle() {
+  if (idleTimeout_.count() == 0 || !getLastActivity_) {
+    return;
+  }
+
+  auto now = std::chrono::steady_clock::now();
+
+  for (auto& [n, topNGroup] : topNGroups_) {
+    // Snapshot selected FTNs: deselecting mutates trackStates
+    std::vector<moxygen::FullTrackName> selected;
+    for (const auto& [ftn, state] : topNGroup.trackStates) {
+      if (state == TrackState::Selected) {
+        selected.push_back(ftn);
+      }
+    }
+
+    for (const auto& ftn : selected) {
+      auto lastActivity = getLastActivity_(ftn);
+      // Epoch (default time_point) means the track never published an object.
+      // Treat this as infinitely idle — a track that never sends data should
+      // be evicted to make room for active tracks.
+      bool neverPublished = (lastActivity == std::chrono::steady_clock::time_point{});
+      if (!neverPublished && now - lastActivity <= idleTimeout_) {
+        continue;
+      }
+
+      XLOG(DBG4) << "[PropertyRanking] Idle eviction: " << ftn << " (group N=" << n << ")"
+                 << (neverPublished ? " [never published]" : "");
+
+      // Demote into deselected queue and promote the highest-ranked replacement.
+      demoteTrack(topNGroup, ftn);
+      IterationGuard guard(*this);
+      promoteNextAvailableTrack(topNGroup, ftn);
+    }
   }
 }
 

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -10,6 +10,7 @@
 #include <moxygen/MoQSession.h>
 #include <moxygen/MoQTypes.h>
 
+#include <chrono>
 #include <deque>
 #include <functional>
 #include <map>
@@ -131,22 +132,33 @@ public:
       const std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>>& sessions
   )>;
 
+  // Returns the last activity time for a track. Called during sweepIdle().
+  // If the track is unknown, return a default-constructed time_point (treated
+  // as always-idle).
+  using GetLastActivityFn =
+      std::function<std::chrono::steady_clock::time_point(const moxygen::FullTrackName&)>;
+
   /**
-   * @param propertyType  The property type ID to rank by
-   * @param maxDeselected Maximum tracks in deselected queue before eviction.
+   * @param propertyType    The property type ID to rank by
+   * @param maxDeselected   Maximum tracks in deselected queue before eviction.
    *        NOTE: Currently only maxDeselected=0 is fully supported. With maxDeselected>0,
    *        tracks enter the deselected queue but the relay has no way to pause/resume
    *        forwarding since onDeselected/onReselected callbacks are not yet implemented.
    *        TODO: Add onDeselected callback (when track enters deselected queue) and
    *        onReselected callback (when track is promoted from queue back to selected)
    *        to enable the relay to manage forwarding state for maxDeselected>0.
+   * @param idleTimeout     How long a selected track may be silent before
+   *                        being deselected. Zero disables idle eviction.
+   * @param getLastActivity Relay callback to read per-track activity time
    * @param onBatchSelected Batch callback for viewer notifications (required)
-   * @param onSelected  Individual callback for per-session notifications
-   * @param onEvicted   Callback when track is evicted from deselected queue
+   * @param onSelected      Individual callback for per-session notifications
+   * @param onEvicted       Callback when track is evicted from deselected queue
    */
   PropertyRanking(
       uint64_t propertyType,
       uint64_t maxDeselected,
+      std::chrono::milliseconds idleTimeout,
+      GetLastActivityFn getLastActivity,
       BatchSelectCallback onBatchSelected,
       SelectCallback onSelected,
       EvictCallback onEvicted
@@ -220,8 +232,17 @@ public:
 
   bool empty() const { return topNGroups_.empty(); }
 
-  size_t numTracks() const { return trackIndexByName_.size(); }
+  /**
+   * Sweep all selected tracks for idleness. Any track whose last activity
+   * time is older than idleTimeout_ is deselected into the deselectedQueue
+   * (same path as ranking-based demotion — cheap reselection still works).
+   * No-op when idleTimeout_ is zero.
+   * Called from onActivity observer (already throttled by TopNFilter) and
+   * opportunistically from updateSortValue().
+   */
+  void sweepIdle();
 
+  size_t numTracks() const { return trackIndexByName_.size(); }
   size_t numTopNGroups() const { return topNGroups_.size(); }
 
   // Test accessors
@@ -266,10 +287,20 @@ private:
   // the previous occupant of rank N-1 down to rank N. O(N) traversal.
   void demoteTrackAtRank(uint64_t n, TopNGroup& group);
 
+  // Mark ftn as Deselected, append to deselected queue, and trim.
+  void demoteTrack(TopNGroup& group, const moxygen::FullTrackName& ftn);
+
+  // Scan rankedTracks_ from the top and promote the highest-ranked non-selected
+  // track into the group. Skips excludeFtn (typically the track just demoted).
+  // Must be called inside an IterationGuard.
+  void promoteNextAvailableTrack(TopNGroup& group, const moxygen::FullTrackName& excludeFtn);
+
   void invalidateRankCache() { rankCacheValid_ = false; }
 
   uint64_t propertyType_;
   uint64_t maxDeselected_;
+  std::chrono::milliseconds idleTimeout_;
+  GetLastActivityFn getLastActivity_;
   BatchSelectCallback onBatchSelected_;
   SelectCallback onSelected_;
   EvictCallback onEvicted_;

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -53,10 +53,21 @@ public:
     MoQSession* session;
   };
 
-  explicit RankingHarness(uint64_t maxDeselected = 5)
+  explicit RankingHarness(
+      uint64_t maxDeselected = 5,
+      std::chrono::milliseconds idleTimeout = std::chrono::milliseconds(0)
+  )
       : ranking_(std::make_unique<PropertyRanking>(
             kProp,
             maxDeselected,
+            idleTimeout,
+            [this](const FullTrackName& f) {
+              auto it = activityTimes_.find(f);
+              if (it == activityTimes_.end()) {
+                return std::chrono::steady_clock::time_point{};
+              }
+              return it->second;
+            },
             [this](
                 const FullTrackName& f,
                 const std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>& sessions
@@ -72,6 +83,11 @@ public:
               evicted_.push_back({f, s.get()});
             }
         )) {}
+
+  // Set a mock activity time for a track (used in idle tests)
+  void setActivityTime(const FullTrackName& f, std::chrono::steady_clock::time_point t) {
+    activityTimes_[f] = t;
+  }
 
   PropertyRanking& ranking() { return *ranking_; }
 
@@ -114,6 +130,8 @@ public:
 
   std::vector<SelectEvent> selected_;
   std::vector<EvictEvent> evicted_;
+  folly::F14FastMap<FullTrackName, std::chrono::steady_clock::time_point, FullTrackName::hash>
+      activityTimes_;
 
 private:
   std::unique_ptr<PropertyRanking> ranking_;
@@ -500,6 +518,118 @@ TEST_F(PropertyRankingBaseTest, RemoveSelected_FallbackPicksHighestNonSelected) 
   EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 1);
   EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
   EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 0); // b was already selected
+}
+
+// ---------------------------------------------------------------------------
+// sweepIdle tests
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, SweepIdle_IdleTrackEvictedAndReplacementPromoted) {
+  // Setup: 3 tracks, N=2 group, idleTimeout=100ms
+  RankingHarness h(5, std::chrono::milliseconds(100));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 90, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 80, {});  // rank 2
+
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+  h.clearEvents();
+
+  // Set activity times: a and c are active (recent), b is idle (old)
+  auto now = std::chrono::steady_clock::now();
+  h.setActivityTime(ftn("a"), now);
+  h.setActivityTime(ftn("b"), now - std::chrono::milliseconds(200)); // idle
+  h.setActivityTime(ftn("c"), now);
+
+  // Sweep should evict b (idle) and promote c (next best)
+  h.ranking().sweepIdle();
+
+  // c should be promoted to replace b
+  EXPECT_EQ(h.selectCount(ftn("c")), 1);
+
+  // Check states: a and c selected, b deselected
+  auto* group = h.ranking().getTopNGroup(2);
+  ASSERT_NE(group, nullptr);
+  EXPECT_EQ(group->trackStates.at(ftn("a")), TrackState::Selected);
+  EXPECT_EQ(group->trackStates.at(ftn("b")), TrackState::Deselected);
+  EXPECT_EQ(group->trackStates.at(ftn("c")), TrackState::Selected);
+}
+
+TEST_F(PropertyRankingBaseTest, SweepIdle_TrackThatNeverPublishedIsTreatedAsIdle) {
+  // A track with epoch timestamp (never published) should be evicted
+  RankingHarness h(5, std::chrono::milliseconds(100));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 90, {});  // rank 1 - never sets activity time
+  h.ranking().registerTrack(ftn("c"), 80, {});  // rank 2
+
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+  h.clearEvents();
+
+  // Only set activity for a and c; b has epoch (never published)
+  auto now = std::chrono::steady_clock::now();
+  h.setActivityTime(ftn("a"), now);
+  h.setActivityTime(ftn("c"), now);
+  // b has no activity time set -> epoch -> treated as idle
+
+  h.ranking().sweepIdle();
+
+  // b should be evicted, c promoted
+  EXPECT_EQ(h.selectCount(ftn("c")), 1);
+
+  auto* group = h.ranking().getTopNGroup(2);
+  ASSERT_NE(group, nullptr);
+  EXPECT_EQ(group->trackStates.at(ftn("b")), TrackState::Deselected);
+  EXPECT_EQ(group->trackStates.at(ftn("c")), TrackState::Selected);
+}
+
+TEST_F(PropertyRankingBaseTest, SweepIdle_NoEvictionWhenIdleTimeoutIsZero) {
+  // idleTimeout=0 disables idle eviction
+  RankingHarness h(5, std::chrono::milliseconds(0));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 90, {});
+
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+  h.clearEvents();
+
+  // Even with old activity time, should not evict when timeout is 0
+  auto now = std::chrono::steady_clock::now();
+  h.setActivityTime(ftn("a"), now - std::chrono::hours(1));
+  h.setActivityTime(ftn("b"), now - std::chrono::hours(1));
+
+  h.ranking().sweepIdle();
+
+  // No promotions should occur
+  EXPECT_EQ(h.selectCount(ftn("a")), 0);
+  EXPECT_EQ(h.selectCount(ftn("b")), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, SweepIdle_ActiveTracksNotEvicted) {
+  RankingHarness h(5, std::chrono::milliseconds(100));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 90, {});
+
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+  h.clearEvents();
+
+  // Both tracks are active (recent activity)
+  auto now = std::chrono::steady_clock::now();
+  h.setActivityTime(ftn("a"), now);
+  h.setActivityTime(ftn("b"), now);
+
+  h.ranking().sweepIdle();
+
+  // No evictions
+  auto* group = h.ranking().getTopNGroup(2);
+  ASSERT_NE(group, nullptr);
+  EXPECT_EQ(group->trackStates.at(ftn("a")), TrackState::Selected);
+  EXPECT_EQ(group->trackStates.at(ftn("b")), TrackState::Selected);
 }
 
 } // namespace


### PR DESCRIPTION
PropertyRanking gains idle eviction capability:

- New constructor params: idleTimeout (zero = disabled) and getLastActivity callback (relay provides per-track lastObjectTime)
- sweepIdle(): iterates selected tracks per group, deselects any whose last activity exceeds idleTimeout into deselectedQueue (same path as ranking-based demotion — cheap reselection still works on resume). Promotes the highest-ranked non-idle non-selected track into the opened slot. Called opportunistically from updateSortValue().
- MoqxRelay passes zero timeout stub; real wiring comes in the next commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/165)
<!-- Reviewable:end -->
