### PR TITLE
feat: Wire idle eviction into MoqxRelay

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -527,6 +527,11 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   auto [filterConsumer, topNFilter] = buildFilterChain(pub.fullTrackName, forwarder);
   rsub.topNFilter = topNFilter;
 
+  // Wire activity tracking: TopNFilter writes lastObjectTime on every object,
+  // and fires onActivity callbacks (throttled) for idle sweep triggering.
+  topNFilter->setActivityTarget(&rsub.lastObjectTime);
+  topNFilter->setActivityThreshold(activityThreshold_);
+
   // Register track with all PropertyRankings along the path from root to this
   // node (inclusive). Rankings exist at nodes where TRACK_FILTER subscribers
   // subscribed. A subscriber at /conf should see tracks published under
@@ -541,7 +546,7 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
               .onValueChanged = [ranking, ftn = pub.fullTrackName](uint64_t value
                                 ) { ranking->updateSortValue(ftn, value); },
               .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); },
-              .onActivity = {}
+              .onActivity = [ranking]() { ranking->sweepIdle(); }
           }
       );
     }
@@ -1326,9 +1331,15 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
     ranking = std::make_shared<PropertyRanking>(
         propertyType,
         maxDeselected_,
-        std::chrono::milliseconds(0), // idle eviction wired in subsequent commit
+        idleTimeout_,
         std::chrono::milliseconds(0), // sweepThrottle wired in subsequent commit
-        nullptr,                      // getLastActivity wired in subsequent commit
+        [this](const FullTrackName& ftn) -> std::chrono::steady_clock::time_point {
+          auto it = subscriptions_.find(ftn);
+          if (it == subscriptions_.end()) {
+            return std::chrono::steady_clock::time_point{};
+          }
+          return it->second.lastObjectTime;
+        },
         // Batch callback: called once per track-selected event with all sessions
         [this](
             const FullTrackName& ftn,
@@ -1366,7 +1377,7 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
         auto subIt = subscriptions_.find(ftn);
         if (subIt != subscriptions_.end()) {
           initialValue = subIt->second.forwarder->extensions().getIntExtension(propertyType);
-          // Wire value-change and track-ended observers on the existing TopNFilter.
+          // Wire value-change, track-ended, and activity observers on the existing TopNFilter.
           if (subIt->second.topNFilter) {
             auto rankingPtr = ranking;
             subIt->second.topNFilter->registerObserver(
@@ -1375,7 +1386,7 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
                     .onValueChanged = [rankingPtr, ftn](uint64_t value
                                       ) { rankingPtr->updateSortValue(ftn, value); },
                     .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); },
-                    .onActivity = {}
+                    .onActivity = [rankingPtr]() { rankingPtr->sweepIdle(); }
                 }
             );
           }

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -17,6 +17,7 @@
 #include <moxygen/relay/MoQCache.h>
 #include <moxygen/relay/MoQForwarder.h>
 
+#include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #include <string>
 
@@ -35,9 +36,12 @@ public:
   explicit MoqxRelay(
       config::CacheConfig cache = {},
       std::string relayID = {},
-      uint64_t maxDeselected = kDefaultMaxDeselected
+      uint64_t maxDeselected = kDefaultMaxDeselected,
+      std::chrono::milliseconds idleTimeout = kDefaultIdleTimeout,
+      std::chrono::milliseconds activityThreshold = kDefaultActivityThreshold
   )
-      : relayID_(std::move(relayID)), maxDeselected_(maxDeselected) {
+      : relayID_(std::move(relayID)), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
+        activityThreshold_(activityThreshold) {
     if (cache.maxCachedTracks > 0) {
       cache_ =
           std::make_unique<moxygen::MoQCache>(cache.maxCachedTracks, cache.maxCachedGroupsPerTrack);
@@ -252,6 +256,10 @@ private:
 
     // TopNFilter installed in the publisher's filter chain for property observation
     std::shared_ptr<TopNFilter> topNFilter;
+
+    // Written by TopNFilter on every object arrival; read by PropertyRanking::sweepIdle
+    // via the getLastActivity_ callback. Default-constructed (epoch) = always-idle.
+    std::chrono::steady_clock::time_point lastObjectTime{};
   };
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
@@ -332,7 +340,7 @@ private:
       moxygen::MoQSession*,
       std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle>>
       peerSubNsHandles_;
-  folly::F14FastMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
+  folly::F14NodeMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
       subscriptions_;
 
   std::shared_ptr<moxygen::TrackConsumer> getSubscribeWriteback(
@@ -341,6 +349,11 @@ private:
   );
   std::unique_ptr<moxygen::MoQCache> cache_;
   uint64_t maxDeselected_{kDefaultMaxDeselected};
+
+  static constexpr std::chrono::milliseconds kDefaultIdleTimeout{10'000};
+  static constexpr std::chrono::milliseconds kDefaultActivityThreshold{2'000};
+  std::chrono::milliseconds idleTimeout_{kDefaultIdleTimeout};
+  std::chrono::milliseconds activityThreshold_{kDefaultActivityThreshold};
 };
 
 // Creates a NamespacePublishHandle that bridges NAMESPACE/NAMESPACE_DONE

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -771,6 +771,54 @@ TEST_F(MoqxTrackFilterTest, ForwardStateUpdatedWhenFilterSubscriberJoins) {
   consumerB->publishDone(makePublishDone());
 }
 
+// ---------------------------------------------------------------------------
+// Tests: idle eviction
+// ---------------------------------------------------------------------------
+
+// A selected track that stops sending objects is evicted once it has been
+// silent for longer than idleTimeout. An outsider that keeps sending objects
+// triggers the sweep (via the throttled onActivity callback) and is promoted.
+TEST_F(MoqxTrackFilterTest, IdleEviction_SilentTrackReplacedByActiveOutsider) {
+  relay_ = std::make_shared<MoqxRelay>(
+      config::CacheConfig{0, 0}, // no cache
+      /*relayID=*/"",
+      /*maxDeselected=*/5,
+      /*idleTimeout=*/std::chrono::milliseconds(10),
+      /*activityThreshold=*/std::chrono::milliseconds(1)
+  );
+  relay_->setAllowedNamespacePrefix(kPrefix);
+
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  // "a" (100) enters top-1; "b" (50) is outside.
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // Stamp "a"'s lastObjectTime so it is not treated as epoch-idle.
+  sendValue(consumerA, 100);
+  exec_->driveFor(5);
+
+  // Schedule an object on "b" after idleTimeout has elapsed. loop() blocks
+  // until the timer fires, the sendValue call triggers sweepIdle (which
+  // schedules the publishToSession coroutine), and all resulting callbacks
+  // drain — then loop() returns naturally with no pending work.
+  auto* evb = exec_->getBackingEventBase();
+  evb->runAfterDelay([&] { sendValue(consumerB, 50); }, 20 /* ms, > idleTimeout=10ms */);
+  evb->loop();
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+}
+
 // Verifies that TopNFilter is installed in the filter chain for both PUBLISH
 // and SUBSCRIBE paths. A direct subscriber joins first (triggering filter chain
 // creation), then a TRACK_FILTER subscriber joins later. Value changes on


### PR DESCRIPTION
- RelaySubscription gains lastObjectTime (steady_clock::time_point), written by TopNFilter on every object via setActivityTarget
- MoqxRelay gains idleTimeout_ (10s) and activityThreshold_ (1s) relay policy fields, exposed via constructor params
- publish(): wires setActivityTarget(&rsub.lastObjectTime) and setActivityThreshold(activityThreshold_) on each TopNFilter
- Both observer registration sites (publish and getOrCreateRanking) now include onActivity = sweepIdle() so throttled object arrivals trigger idle eviction across all selected tracks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/166)
<!-- Reviewable:end -->
