### PR TITLE
feat: Wire MoqxRelay self-exclusion for publisher-subscribers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(moqx_core STATIC
   src/stats/QuicStatsCollector.cpp
   src/UpstreamProvider.cpp
   src/relay/TopNFilter.cpp
+  src/relay/PropertyRanking.cpp
 )
 
 target_include_directories(moqx_core

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -412,21 +412,9 @@ void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
       // Remove from publishes map
       auto nodePtr = findNamespaceNode(ftn.trackNamespace);
       if (nodePtr) {
-        // If the publisher also had a TRACK_FILTER subscription, remove the
-        // self-track from their exclusion set before erasing from publishes.
-        auto publishIt = nodePtr->publishes.find(ftn.trackName);
-        if (publishIt != nodePtr->publishes.end()) {
-          auto& publisherSession = publishIt->second;
-          auto sessIt = nodePtr->sessions.find(publisherSession);
-          if (sessIt != nodePtr->sessions.end() && sessIt->second.trackFilter) {
-            auto& tf = *sessIt->second.trackFilter;
-            auto rankingIt = nodePtr->rankings.find(tf.propertyType);
-            if (rankingIt != nodePtr->rankings.end()) {
-              rankingIt->second
-                  ->removePublishedTrackFromSession(tf.maxSelected, publisherSession, ftn);
-            }
-          }
-        }
+        // Note: Self-exclusion cleanup happens automatically when removeTrack()
+        // is called (via TopNFilter's onTrackEnded observer). The publisher's
+        // personal selection is reconciled inside PropertyRanking.
         bool hadLocalContent = nodePtr->hasLocalSessions();
         nodePtr->publishes.erase(ftn.trackName);
 
@@ -806,22 +794,11 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   // If TRACK_FILTER is present, enroll session in PropertyRanking for top-N selection.
   // NOTE: onSelected callbacks fire synchronously within addSessionToTopNGroup() for
   // tracks already in top-N, triggering publishToSession() before this call returns.
+  // Self-exclusion is automatic: if this session already published tracks, they are
+  // excluded from its personal top-N (handled inside addSessionToTopNGroup).
   if (trackFilter) {
     auto ranking = getOrCreateRanking(nodePtr, trackFilter->propertyType);
-    // Collect tracks already published by this session so the ranking can set
-    // up self-exclusion from the start (publisher-subscriber case).
-    std::vector<FullTrackName> publishedBySession;
-    for (const auto& [trackName, publishSession] : nodePtr->publishes) {
-      if (publishSession == session) {
-        publishedBySession.emplace_back(FullTrackName{nodePtr->trackNamespace_, trackName});
-      }
-    }
-    ranking->addSessionToTopNGroup(
-        trackFilter->maxSelected,
-        session,
-        subNs.forward,
-        std::move(publishedBySession)
-    );
+    ranking->addSessionToTopNGroup(trackFilter->maxSelected, session, subNs.forward);
   }
 
   // If this is the first content added to this node, notify parent

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1346,7 +1346,11 @@ MoqxRelay::getOrCreateRanking(std::shared_ptr<NamespaceNode> node, uint64_t prop
         [this](const FullTrackName& ftn, std::shared_ptr<MoQSession> session, bool forward) {
           onTrackSelected(ftn, session, forward);
         },
-        // Eviction callback
+        // Deselection callback: pause forwarding locally (no control message)
+        [this](const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {
+          onTrackDeselected(ftn, session);
+        },
+        // Eviction callback: send SUBSCRIBE_DONE when track leaves deselected queue
         [this](const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {
           onTrackEvicted(ftn, session);
         }
@@ -1418,6 +1422,24 @@ void MoqxRelay::onTrackSelected(
     return;
   }
 
+  auto& forwarder = subIt->second.forwarder;
+
+  // Check if this is a reselection (subscriber exists but was paused).
+  auto sub = forwarder->getSubscriber(session.get());
+  if (sub && !sub->isPinned()) {
+    if (!sub->shouldForward) {
+      // Reselection: resume forwarding locally — no control message sent.
+      sub->shouldForward = true;
+      forwarder->addForwardingSubscriber();
+      XLOG(DBG4) << "onTrackSelected: resumed forwarding for " << ftn;
+      return;
+    }
+    // Already forwarding — nothing to do.
+    XLOG(DBG4) << "onTrackSelected: already forwarding " << ftn;
+    return;
+  }
+
+  // New selection: publish the track to the session.
   auto exec = session->getExecutor();
   XCHECK(exec) << "onTrackSelected: null executor for session " << session.get();
 
@@ -1425,9 +1447,40 @@ void MoqxRelay::onTrackSelected(
   // when multiple tracks are selected for the same session in a single ranking update.
   co_withExecutor(
       exec,
-      publishToSession(session, subIt->second.forwarder, forward, /*trackFilterSubscriber=*/true)
+      publishToSession(session, forwarder, forward, /*trackFilterSubscriber=*/true)
   )
       .start();
+}
+
+void MoqxRelay::onTrackDeselected(const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {
+  XLOG(DBG4) << "[MoqxRelay] Track deselected: " << ftn << " session=" << session.get();
+
+  if (!session || session->isClosed()) {
+    return;
+  }
+
+  auto subIt = subscriptions_.find(ftn);
+  if (subIt == subscriptions_.end() || !subIt->second.forwarder) {
+    return;
+  }
+
+  auto& forwarder = subIt->second.forwarder;
+  auto sub = forwarder->getSubscriber(session.get());
+  if (!sub || sub->isPinned()) {
+    // Pinned subscribers are not affected by TRACK_FILTER deselection.
+    XLOG(DBG4) << "onTrackDeselected: pinned or no subscriber, skipping";
+    return;
+  }
+
+  if (!sub->shouldForward) {
+    // Already paused (e.g., from a previous deselection).
+    return;
+  }
+
+  // Pause forwarding locally — no control message sent.
+  sub->shouldForward = false;
+  forwarder->removeForwardingSubscriber();
+  XLOG(DBG4) << "onTrackDeselected: paused forwarding for " << ftn;
 }
 
 void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1318,6 +1318,8 @@ MoqxRelay::getOrCreateRanking(std::shared_ptr<NamespaceNode> node, uint64_t prop
     ranking = std::make_shared<PropertyRanking>(
         propertyType,
         maxDeselected_,
+        std::chrono::milliseconds(0), // idle eviction wired in subsequent commit
+        nullptr,                      // getLastActivity wired in subsequent commit
         // Batch callback: called once per track-selected event with all sessions
         [this](
             const FullTrackName& ftn,

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -524,6 +524,11 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   auto [filterConsumer, topNFilter] = buildFilterChain(pub.fullTrackName, forwarder);
   rsub.topNFilter = topNFilter;
 
+  // Wire activity tracking: TopNFilter writes lastObjectTime on every object,
+  // and fires onActivity callbacks (throttled) for idle sweep triggering.
+  topNFilter->setActivityTarget(&rsub.lastObjectTime);
+  topNFilter->setActivityThreshold(activityThreshold_);
+
   // Register track with all PropertyRankings along the path from root to this
   // node (inclusive). Rankings exist at nodes where TRACK_FILTER subscribers
   // subscribed. A subscriber at /conf should see tracks published under
@@ -537,7 +542,8 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
           PropertyObserver{
               .onValueChanged = [ranking, ftn = pub.fullTrackName](uint64_t value
                                 ) { ranking->updateSortValue(ftn, value); },
-              .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); }
+              .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); },
+              .onActivity = [ranking]() { ranking->sweepIdle(); }
           }
       );
     }
@@ -1318,8 +1324,14 @@ MoqxRelay::getOrCreateRanking(std::shared_ptr<NamespaceNode> node, uint64_t prop
     ranking = std::make_shared<PropertyRanking>(
         propertyType,
         maxDeselected_,
-        std::chrono::milliseconds(0), // idle eviction wired in subsequent commit
-        nullptr,                      // getLastActivity wired in subsequent commit
+        idleTimeout_,
+        [this](const FullTrackName& ftn) -> std::chrono::steady_clock::time_point {
+          auto it = subscriptions_.find(ftn);
+          if (it == subscriptions_.end()) {
+            return std::chrono::steady_clock::time_point{};
+          }
+          return it->second.lastObjectTime;
+        },
         // Batch callback: called once per track-selected event with all sessions
         [this](
             const FullTrackName& ftn,
@@ -1365,7 +1377,8 @@ MoqxRelay::getOrCreateRanking(std::shared_ptr<NamespaceNode> node, uint64_t prop
                 PropertyObserver{
                     .onValueChanged = [rankingPtr, ftn](uint64_t value
                                       ) { rankingPtr->updateSortValue(ftn, value); },
-                    .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); }
+                    .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); },
+                    .onActivity = [rankingPtr]() { rankingPtr->sweepIdle(); }
                 }
             );
           }

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -412,6 +412,21 @@ void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
       // Remove from publishes map
       auto nodePtr = findNamespaceNode(ftn.trackNamespace);
       if (nodePtr) {
+        // If the publisher also had a TRACK_FILTER subscription, remove the
+        // self-track from their exclusion set before erasing from publishes.
+        auto publishIt = nodePtr->publishes.find(ftn.trackName);
+        if (publishIt != nodePtr->publishes.end()) {
+          auto& publisherSession = publishIt->second;
+          auto sessIt = nodePtr->sessions.find(publisherSession);
+          if (sessIt != nodePtr->sessions.end() && sessIt->second.trackFilter) {
+            auto& tf = *sessIt->second.trackFilter;
+            auto rankingIt = nodePtr->rankings.find(tf.propertyType);
+            if (rankingIt != nodePtr->rankings.end()) {
+              rankingIt->second
+                  ->removePublishedTrackFromSession(tf.maxSelected, publisherSession, ftn);
+            }
+          }
+        }
         bool hadLocalContent = nodePtr->hasLocalSessions();
         nodePtr->publishes.erase(ftn.trackName);
 
@@ -533,6 +548,8 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   // node (inclusive). Rankings exist at nodes where TRACK_FILTER subscribers
   // subscribed. A subscriber at /conf should see tracks published under
   // /conf/room1, so we must walk up the ancestor chain.
+  // Self-exclusion is handled automatically inside registerTrack via
+  // reconcilePublisherInAllGroups when the publishing session is also subscribed.
   for (NamespaceNode* node = nodePtr.get(); node != nullptr; node = node->parent_) {
     for (auto& [propertyType, ranking] : node->rankings) {
       auto initialValue = pub.extensions.getIntExtension(propertyType);
@@ -791,7 +808,20 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   // tracks already in top-N, triggering publishToSession() before this call returns.
   if (trackFilter) {
     auto ranking = getOrCreateRanking(nodePtr, trackFilter->propertyType);
-    ranking->addSessionToTopNGroup(trackFilter->maxSelected, session, subNs.forward);
+    // Collect tracks already published by this session so the ranking can set
+    // up self-exclusion from the start (publisher-subscriber case).
+    std::vector<FullTrackName> publishedBySession;
+    for (const auto& [trackName, publishSession] : nodePtr->publishes) {
+      if (publishSession == session) {
+        publishedBySession.emplace_back(FullTrackName{nodePtr->trackNamespace_, trackName});
+      }
+    }
+    ranking->addSessionToTopNGroup(
+        trackFilter->maxSelected,
+        session,
+        subNs.forward,
+        std::move(publishedBySession)
+    );
   }
 
   // If this is the first content added to this node, notify parent

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -520,8 +520,38 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   rsub.handle = std::move(handle);
   rsub.isPublish = true;
 
+  // Build filter chain using shared helper (TopNFilter → TerminationFilter → Forwarder).
+  auto [filterConsumer, topNFilter] = buildFilterChain(pub.fullTrackName, forwarder);
+  rsub.topNFilter = topNFilter;
+
+  // Register track with all PropertyRankings along the path from root to this
+  // node (inclusive). Rankings exist at nodes where TRACK_FILTER subscribers
+  // subscribed. A subscriber at /conf should see tracks published under
+  // /conf/room1, so we must walk up the ancestor chain.
+  for (NamespaceNode* node = nodePtr.get(); node != nullptr; node = node->parent_) {
+    for (auto& [propertyType, ranking] : node->rankings) {
+      auto initialValue = pub.extensions.getIntExtension(propertyType);
+      ranking->registerTrack(pub.fullTrackName, initialValue, session);
+      topNFilter->registerObserver(
+          propertyType,
+          PropertyObserver{
+              .onValueChanged = [ranking, ftn = pub.fullTrackName](uint64_t value
+                                ) { ranking->updateSortValue(ftn, value); },
+              .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); }
+          }
+      );
+    }
+  }
+
   uint64_t nSubscribers = 0;
+  bool hasTrackFilterSub = false;
   for (auto& [outSession, info] : sessions) {
+    if (info.trackFilter) {
+      // TRACK_FILTER subscribers: PropertyRanking handles selection via
+      // onTrackSelected; don't publish directly here.
+      hasTrackFilterSub = true;
+      continue;
+    }
     if (outSession != session && (info.options == SubscribeNamespaceOptions::PUBLISH ||
                                   info.options == SubscribeNamespaceOptions::BOTH)) {
       nSubscribers++;
@@ -531,16 +561,16 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   }
   forwarder->setCallback(shared_from_this());
 
-  // Wrap forwarder in filter to intercept publishDone
-  auto filterImpl =
-      std::make_shared<TerminationFilter>(shared_from_this(), pub.fullTrackName, forwarder);
-  std::shared_ptr<TrackConsumer> filter = std::static_pointer_cast<TrackConsumer>(filterImpl);
+  // Forward if there are direct subscribers OR TRACK_FILTER subscribers
+  // (PropertyRanking needs objects to evaluate property values for ranking).
+  // When subscribers join later via subscribeNamespace, forwardChanged() sends REQUEST_UPDATE.
+  bool shouldForward = (nSubscribers > 0) || hasTrackFilterSub;
 
   return PublishConsumerAndReplyTask{
-      filter, // Return filter, not forwarder directly
+      filterConsumer,
       folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(PublishOk{
           pub.requestID,
-          /*forward=*/(nSubscribers > 0),
+          /*forward=*/shouldForward,
           kDefaultPriority,
           pub.groupOrder,
           LocationType::AbsoluteRange,
@@ -553,13 +583,21 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
 folly::coro::Task<void> MoqxRelay::publishToSession(
     std::shared_ptr<MoQSession> session,
     std::shared_ptr<MoQForwarder> forwarder,
-    bool forward
+    bool forward,
+    bool trackFilterSubscriber
 ) {
+  if (session->isClosed()) {
+    XLOG(DBG4) << "publishToSession: session closed, skipping " << forwarder->fullTrackName();
+    co_return;
+  }
   auto subscriber = forwarder->addSubscriber(session, forward);
   if (!subscriber) {
     XLOG(ERR) << "Subscribe failed: addSubscriber returned null for " << forwarder->fullTrackName();
     co_return;
   }
+  // Direct subscribers are pinned (not evictable by PropertyRanking).
+  // TRACK_FILTER subscribers are unpinned so onTrackEvicted can remove them.
+  subscriber->pinned = !trackFilterSubscriber;
   XLOG(DBG4) << "added subscriber for ftn=" << forwarder->fullTrackName();
   auto guard = folly::makeGuard([subscriber] { subscriber->unsubscribe(); });
 
@@ -619,11 +657,14 @@ private:
   TrackNamespace trackNamespacePrefix_;
 };
 
-// Filter TrackConsumer that intercepts publishDone to clean up relay state
+// Filter TrackConsumer that intercepts publishDone to clean up relay state.
+// Holds a weak_ptr to avoid a reference cycle: relay owns RelaySubscription
+// which owns the filter chain (TopNFilter→TerminationFilter), so a strong
+// relay ref here would prevent the relay from ever being destroyed.
 class MoqxRelay::TerminationFilter : public TrackConsumerFilter {
 public:
   TerminationFilter(
-      std::shared_ptr<MoqxRelay> relay,
+      std::weak_ptr<MoqxRelay> relay,
       FullTrackName ftn,
       std::shared_ptr<TrackConsumer> downstream
   )
@@ -634,15 +675,15 @@ public:
     // Notify relay that publisher is done - this will:
     // 1. Remove from nodePtr->publishes
     // 2. Clear subscription.handle
-    if (relay_) {
-      relay_->onPublishDone(ftn_);
+    if (auto relay = relay_.lock()) {
+      relay->onPublishDone(ftn_);
     }
     // Change the downstream code to something like "upstream ended"?
     return TrackConsumerFilter::publishDone(std::move(pubDone));
   }
 
 private:
-  std::shared_ptr<MoqxRelay> relay_;
+  std::weak_ptr<MoqxRelay> relay_;
   FullTrackName ftn_;
 };
 
@@ -655,6 +696,23 @@ std::shared_ptr<TrackConsumer> MoqxRelay::getSubscribeWriteback(
   auto filterConsumer =
       std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(baseConsumer));
   return std::static_pointer_cast<TrackConsumer>(filterConsumer);
+}
+
+MoqxRelay::FilterChainResult
+MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForwarder> forwarder) {
+  // Build chain: TopNFilter → TerminationFilter → (cache?) → Forwarder
+  // This ensures property values are observed in both PUBLISH and SUBSCRIBE paths.
+  auto baseConsumer = cache_ ? cache_->getSubscribeWriteback(ftn, forwarder)
+                             : std::static_pointer_cast<TrackConsumer>(forwarder);
+  auto terminationFilter =
+      std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(baseConsumer));
+  auto topNFilter =
+      std::make_shared<TopNFilter>(ftn, std::static_pointer_cast<TrackConsumer>(terminationFilter));
+
+  return FilterChainResult{
+      .consumer = std::static_pointer_cast<TrackConsumer>(topNFilter),
+      .topNFilter = topNFilter
+  };
 }
 
 folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNamespace(
@@ -700,6 +758,15 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   SubscribeNamespaceOptions effectiveOptions;
   effectiveOptions = subNs.options;
 
+  // Parse TRACK_FILTER parameter if present (SUBSCRIBE_NAMESPACE only)
+  std::optional<TrackFilter> trackFilter;
+  for (const auto& param : subNs.params) {
+    if (param.key == folly::to_underlying(TrackRequestParamKey::TRACK_FILTER)) {
+      trackFilter = param.asTrackFilter;
+      break;
+    }
+  }
+
   // Check if this is the first session subscriber for this node
   bool wasEmpty = !nodePtr->hasLocalSessions();
   nodePtr->sessions.emplace(
@@ -708,9 +775,18 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
           subNs.forward,
           effectiveOptions,
           namespacePublishHandle,
-          subNs.trackNamespacePrefix
+          subNs.trackNamespacePrefix,
+          trackFilter
       }
   );
+
+  // If TRACK_FILTER is present, enroll session in PropertyRanking for top-N selection.
+  // NOTE: onSelected callbacks fire synchronously within addSessionToTopNGroup() for
+  // tracks already in top-N, triggering publishToSession() before this call returns.
+  if (trackFilter) {
+    auto ranking = getOrCreateRanking(nodePtr, trackFilter->propertyType);
+    ranking->addSessionToTopNGroup(trackFilter->maxSelected, session, subNs.forward);
+  }
 
   // If this is the first content added to this node, notify parent
   if (wasEmpty && nodePtr->hasLocalSessions() && nodePtr->parent_) {
@@ -754,13 +830,22 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
         continue;
       }
       auto& forwarder = subscriptionIt->second.forwarder;
+      auto& rsub = subscriptionIt->second;
       if (forwarder->empty()) {
-        // Use forward value from this namespace subscription
-        co_withExecutor(exec, doSubscribeUpdate(subscriptionIt->second.handle, subNs.forward))
-            .start();
+        // Forwarder has no downstream subscribers yet. Send REQUEST_UPDATE to
+        // notify the upstream (relay subscription or local publisher) of the
+        // new forwarding state before adding the subscriber.
+        co_withExecutor(exec, doSubscribeUpdate(rsub.handle, subNs.forward)).start();
       }
       auto maybeNegotiatedVersion = session->getNegotiatedVersion();
       CHECK(maybeNegotiatedVersion.has_value());
+
+      // TRACK_FILTER subscribers: PropertyRanking drives selection via
+      // onTrackSelected; skip direct publish here.
+      if (trackFilter) {
+        continue;
+      }
+
       if (getDraftMajorVersion(*maybeNegotiatedVersion) <= 15 ||
           (subNs.options == SubscribeNamespaceOptions::BOTH ||
            subNs.options == SubscribeNamespaceOptions::PUBLISH)) {
@@ -801,6 +886,14 @@ void MoqxRelay::unsubscribeNamespace(
 
   auto it = nodePtr->sessions.find(session);
   if (it != nodePtr->sessions.end()) {
+    // If session used TRACK_FILTER, remove it from the PropertyRanking group.
+    if (it->second.trackFilter) {
+      auto rankingIt = nodePtr->rankings.find(it->second.trackFilter->propertyType);
+      if (rankingIt != nodePtr->rankings.end()) {
+        rankingIt->second->removeSessionFromTopNGroup(it->second.trackFilter->maxSelected, session);
+      }
+    }
+
     nodePtr->sessions.erase(it);
 
     // Prune if node became empty and has a parent
@@ -889,11 +982,18 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
     subReq.locType = LocationType::LargestObject;
     auto forwarder = std::make_shared<MoQForwarder>(subReq.fullTrackName, std::nullopt);
     forwarder->setCallback(shared_from_this());
+
+    // Build filter chain using shared helper (TopNFilter → TerminationFilter → Forwarder).
+    // This ensures property values are observed even for SUBSCRIBE-path tracks,
+    // so TRACK_FILTER subscribers who join later see correct rankings.
+    auto [filterConsumer, topNFilter] = buildFilterChain(subReq.fullTrackName, forwarder);
+
     auto emplaceRes = subscriptions_.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(subReq.fullTrackName),
         std::forward_as_tuple(forwarder, upstreamSession)
     );
+    emplaceRes.first->second.topNFilter = topNFilter;
     // The iterator returned from emplace does not survive across coroutine
     // resumption, so both the guard and updating the RelaySubscription below
     // require another lookup in the subscriptions_ map.
@@ -923,10 +1023,7 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
     subReq.forward = forwarder->numForwardingSubscribers() > 0;
 
     emplaceRes.first->second.requestID = upstreamSession->peekNextRequestID();
-    auto subRes = co_await upstreamSession->subscribe(
-        subReq,
-        getSubscribeWriteback(subReq.fullTrackName, forwarder)
-    );
+    auto subRes = co_await upstreamSession->subscribe(subReq, filterConsumer);
     if (subRes.hasError()) {
       co_return folly::makeUnexpected(SubscribeError(
           {subReq.requestID,
@@ -1210,6 +1307,136 @@ void MoqxRelay::newGroupRequested(MoQForwarder* forwarder, uint64_t group) {
   auto exec = subscription.upstream->getExecutor();
   auto handle = subscription.handle;
   co_withExecutor(exec, doNewGroupRequestUpdate(std::move(handle), group)).start();
+}
+
+// TRACK_FILTER support
+
+std::shared_ptr<PropertyRanking>
+MoqxRelay::getOrCreateRanking(std::shared_ptr<NamespaceNode> node, uint64_t propertyType) {
+  auto& ranking = node->rankings[propertyType];
+  if (!ranking) {
+    ranking = std::make_shared<PropertyRanking>(
+        propertyType,
+        maxDeselected_,
+        // Batch callback: called once per track-selected event with all sessions
+        [this](
+            const FullTrackName& ftn,
+            const std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>& sessions
+        ) {
+          for (const auto& [session, forward] : sessions) {
+            onTrackSelected(ftn, session, forward);
+          }
+        },
+        // Individual callback: called by addSessionToTopNGroup to notify a newly
+        // joined session of tracks already in top-N at the time it subscribes.
+        [this](const FullTrackName& ftn, std::shared_ptr<MoQSession> session, bool forward) {
+          onTrackSelected(ftn, session, forward);
+        },
+        // Eviction callback
+        [this](const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {
+          onTrackEvicted(ftn, session);
+        }
+    );
+
+    // Retroactively register tracks already published under this node and all
+    // descendants. A subscriber at /conf should see tracks at /conf/room1/track1.
+    // Use BFS to traverse the subtree and register all published tracks.
+    std::deque<std::pair<TrackNamespace, NamespaceNode*>> queue;
+    queue.emplace_back(node->trackNamespace_, node.get());
+
+    while (!queue.empty()) {
+      auto [prefix, current] = queue.front();
+      queue.pop_front();
+
+      // Register tracks at this level
+      for (auto& [trackName, publishSession] : current->publishes) {
+        FullTrackName ftn{prefix, trackName};
+        std::optional<uint64_t> initialValue;
+        auto subIt = subscriptions_.find(ftn);
+        if (subIt != subscriptions_.end()) {
+          initialValue = subIt->second.forwarder->extensions().getIntExtension(propertyType);
+          // Wire value-change and track-ended observers on the existing TopNFilter.
+          if (subIt->second.topNFilter) {
+            auto rankingPtr = ranking;
+            subIt->second.topNFilter->registerObserver(
+                propertyType,
+                PropertyObserver{
+                    .onValueChanged = [rankingPtr, ftn](uint64_t value
+                                      ) { rankingPtr->updateSortValue(ftn, value); },
+                    .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); }
+                }
+            );
+          }
+        }
+        ranking->registerTrack(ftn, initialValue, publishSession);
+        XLOG(DBG4) << "[getOrCreateRanking] Retroactively registered track " << ftn;
+      }
+
+      // Queue children for traversal
+      for (auto& [childKey, childNode] : current->children) {
+        TrackNamespace childPrefix(prefix);
+        childPrefix.append(childKey);
+        queue.emplace_back(childPrefix, childNode.get());
+      }
+    }
+  }
+  return ranking;
+}
+
+void MoqxRelay::onTrackSelected(
+    const FullTrackName& ftn,
+    std::shared_ptr<MoQSession> session,
+    bool forward
+) {
+  XLOG(DBG4) << "[MoqxRelay] Track selected: " << ftn << " session=" << session.get()
+             << " forward=" << forward;
+
+  if (!session || session->isClosed()) {
+    // Defensive check - session may have closed between ranking update and callback
+    XLOG(WARN) << "onTrackSelected: session null or closed, skipping " << ftn;
+    return;
+  }
+
+  auto subIt = subscriptions_.find(ftn);
+  if (subIt == subscriptions_.end() || !subIt->second.forwarder) {
+    XLOG(DBG4) << "onTrackSelected: no subscription/forwarder for " << ftn;
+    return;
+  }
+
+  auto exec = session->getExecutor();
+  XCHECK(exec) << "onTrackSelected: null executor for session " << session.get();
+
+  // TODO: Consider batching multiple publishToSession calls on the same executor
+  // when multiple tracks are selected for the same session in a single ranking update.
+  co_withExecutor(
+      exec,
+      publishToSession(session, subIt->second.forwarder, forward, /*trackFilterSubscriber=*/true)
+  )
+      .start();
+}
+
+void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {
+  XLOG(DBG4) << "[MoqxRelay] Track evicted: " << ftn << " session=" << session.get();
+
+  if (!session || session->isClosed()) {
+    return;
+  }
+
+  auto subIt = subscriptions_.find(ftn);
+  if (subIt == subscriptions_.end()) {
+    return;
+  }
+
+  if (!subIt->second.forwarder) {
+    return;
+  }
+  auto& forwarder = subIt->second.forwarder;
+  auto sub = forwarder->getSubscriber(session.get());
+  if (!sub || sub->isPinned()) {
+    XLOG(DBG4) << "onTrackEvicted: pinned subscriber, skipping";
+    return;
+  }
+  forwarder->removeSubscriber(session, std::nullopt, "onTrackEvicted");
 }
 
 } // namespace openmoq::moqx

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -17,6 +17,7 @@
 #include <moxygen/relay/MoQCache.h>
 #include <moxygen/relay/MoQForwarder.h>
 
+#include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #include <string>
 
@@ -37,9 +38,12 @@ public:
   explicit MoqxRelay(
       config::CacheConfig cache = {},
       std::string relayID = {},
-      uint64_t maxDeselected = kDefaultMaxDeselected
+      uint64_t maxDeselected = kDefaultMaxDeselected,
+      std::chrono::milliseconds idleTimeout = kDefaultIdleTimeout,
+      std::chrono::milliseconds activityThreshold = kDefaultActivityThreshold
   )
-      : relayID_(std::move(relayID)), maxDeselected_(maxDeselected) {
+      : relayID_(std::move(relayID)), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
+        activityThreshold_(activityThreshold) {
     if (cache.maxCachedTracks > 0) {
       cache_ =
           std::make_unique<moxygen::MoQCache>(cache.maxCachedTracks, cache.maxCachedGroupsPerTrack);
@@ -254,6 +258,10 @@ private:
 
     // TopNFilter installed in the publisher's filter chain for property observation
     std::shared_ptr<TopNFilter> topNFilter;
+
+    // Written by TopNFilter on every object arrival; read by PropertyRanking::sweepIdle
+    // via the getLastActivity_ callback. Default-constructed (epoch) = always-idle.
+    std::chrono::steady_clock::time_point lastObjectTime{};
   };
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
@@ -330,7 +338,7 @@ private:
       moxygen::MoQSession*,
       std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle>>
       peerSubNsHandles_;
-  folly::F14FastMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
+  folly::F14NodeMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
       subscriptions_;
 
   std::shared_ptr<moxygen::TrackConsumer> getSubscribeWriteback(
@@ -339,6 +347,11 @@ private:
   );
   std::unique_ptr<moxygen::MoQCache> cache_;
   uint64_t maxDeselected_{kDefaultMaxDeselected};
+
+  static constexpr std::chrono::milliseconds kDefaultIdleTimeout{10'000};
+  static constexpr std::chrono::milliseconds kDefaultActivityThreshold{2'000};
+  std::chrono::milliseconds idleTimeout_{kDefaultIdleTimeout};
+  std::chrono::milliseconds activityThreshold_{kDefaultActivityThreshold};
 };
 
 // Creates a NamespacePublishHandle that bridges NAMESPACE/NAMESPACE_DONE

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -10,6 +10,8 @@
 
 #include "UpstreamProvider.h"
 #include "config/Config.h"
+#include "relay/PropertyRanking.h"
+#include "relay/TopNFilter.h"
 #include <folly/coro/SharedPromise.h>
 #include <moxygen/MoQSession.h>
 #include <moxygen/relay/MoQCache.h>
@@ -25,8 +27,19 @@ class MoqxRelay : public moxygen::Publisher,
                   public std::enable_shared_from_this<MoqxRelay>,
                   public moxygen::MoQForwarder::Callback {
 public:
-  explicit MoqxRelay(config::CacheConfig cache = {}, std::string relayID = {})
-      : relayID_(std::move(relayID)) {
+  // Default for maxDeselected (tracks kept in deselected queue before eviction).
+  // A modest value reduces PUBLISH churn when tracks briefly drop out of top-N.
+  // NOTE: With maxDeselected>0, tracks enter the queue but PropertyRanking
+  // doesn't yet have callbacks for pause/resume forwarding. See PropertyRanking.h
+  // for the TODO on onDeselected/onReselected callbacks.
+  static constexpr uint64_t kDefaultMaxDeselected = 15;
+
+  explicit MoqxRelay(
+      config::CacheConfig cache = {},
+      std::string relayID = {},
+      uint64_t maxDeselected = kDefaultMaxDeselected
+  )
+      : relayID_(std::move(relayID)), maxDeselected_(maxDeselected) {
     if (cache.maxCachedTracks > 0) {
       cache_ =
           std::make_unique<moxygen::MoQCache>(cache.maxCachedTracks, cache.maxCachedGroupsPerTrack);
@@ -185,7 +198,12 @@ private:
       std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> namespacePublishHandle;
       // The namespace prefix this subscriber used for SUBSCRIBE_NAMESPACE
       moxygen::TrackNamespace trackNamespacePrefix;
+      // TRACK_FILTER parameters (non-null when subscriber uses top-N filtering)
+      std::optional<moxygen::TrackFilter> trackFilter;
     };
+
+    // PropertyRanking instances per property type for TRACK_FILTER subscribers
+    folly::F14FastMap<uint64_t, std::shared_ptr<PropertyRanking>> rankings;
 
     // Sessions with a SUBSCRIBE_NAMESPACE here, with their preferences
     folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, NamespaceSubscriberInfo> sessions;
@@ -233,6 +251,9 @@ private:
     std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle;
     folly::coro::SharedPromise<folly::Unit> promise;
     bool isPublish{false};
+
+    // TopNFilter installed in the publisher's filter chain for property observation
+    std::shared_ptr<TopNFilter> topNFilter;
   };
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
@@ -248,7 +269,8 @@ private:
   folly::coro::Task<void> publishToSession(
       std::shared_ptr<moxygen::MoQSession> session,
       std::shared_ptr<moxygen::MoQForwarder> forwarder,
-      bool forward
+      bool forward,
+      bool trackFilterSubscriber = false
   );
 
   folly::coro::Task<void>
@@ -260,6 +282,38 @@ private:
   );
 
   void publishNamespaceDone(const moxygen::TrackNamespace& trackNamespace, NamespaceNode* node);
+
+  // TRACK_FILTER support
+
+  // Result of buildFilterChain - contains both the consumer to pass upstream
+  // and the TopNFilter pointer to store for later observer wiring.
+  struct FilterChainResult {
+    std::shared_ptr<moxygen::TrackConsumer> consumer;
+    std::shared_ptr<TopNFilter> topNFilter;
+  };
+
+  // Build the filter chain for a track subscription: TopNFilter → TerminationFilter → (cache) →
+  // forwarder. Used by both publish() and subscribe() paths to ensure consistent filter chain.
+  FilterChainResult buildFilterChain(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQForwarder> forwarder
+  );
+
+  // Get or create PropertyRanking for the given property type on a namespace node.
+  // Retroactively registers any tracks already published under that node.
+  std::shared_ptr<PropertyRanking>
+  getOrCreateRanking(std::shared_ptr<NamespaceNode> node, uint64_t propertyType);
+
+  // Called by PropertyRanking when a track enters a session's top-N selection.
+  void onTrackSelected(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQSession> session,
+      bool forward
+  );
+
+  // Called by PropertyRanking when a track is evicted from a session's deselected queue.
+  void
+  onTrackEvicted(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQSession> session);
 
   moxygen::TrackNamespace allowedNamespacePrefix_;
   std::string relayID_;
@@ -284,6 +338,7 @@ private:
       std::shared_ptr<moxygen::TrackConsumer> consumer
   );
   std::unique_ptr<moxygen::MoQCache> cache_;
+  uint64_t maxDeselected_{kDefaultMaxDeselected};
 };
 
 // Creates a NamespacePublishHandle that bridges NAMESPACE/NAMESPACE_DONE

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -319,6 +319,13 @@ private:
       bool forward
   );
 
+  // Called by PropertyRanking when a track enters a session's deselected queue.
+  // Pauses forwarding locally by setting shouldForward=false (no control message).
+  void onTrackDeselected(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQSession> session
+  );
+
   // Called by PropertyRanking when a track is evicted from a session's deselected queue.
   void
   onTrackEvicted(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQSession> session);

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -66,10 +66,10 @@ void PropertyRanking::registerTrack(
     auto prevIndexIt = trackIndexByName_.find(prevIt->second.ftn);
     XCHECK(prevIndexIt != trackIndexByName_.end()) << "Previous track must exist in index";
 
-    // Handle sentinel: if previous track has UINT64_MAX (lazy partial cache),
-    // fall back to O(rank) distance computation for accurate rank.
+    // If previous track has sentinel (beyond threshold), new track is too.
+    // No need to compute exact rank for tracks outside selection region.
     if (prevIndexIt->second.cachedRank == UINT64_MAX) {
-      rank = static_cast<uint64_t>(std::distance(rankedTracks_.begin(), iter));
+      rank = UINT64_MAX;
     } else {
       rank = prevIndexIt->second.cachedRank + 1;
     }
@@ -179,50 +179,30 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
   entry.rankIter = newIter;
 
   // --- Step 3: Compute new rank ---
-  // O(newRank) for bidirectional iterator. Acceptable because top-ranked tracks
-  // (where we care most about performance) have small newRank values.
+  // Must use distance() for accurate rank since cached ranks of other tracks
+  // may be stale until Step 4 updates them. Could optimize for tracks beyond
+  // threshold by checking if previous element has sentinel, but that's rare.
   uint64_t newRank = static_cast<uint64_t>(std::distance(rankedTracks_.begin(), newIter));
   entry.cachedRank = newRank;
 
   // --- Step 4: Incrementally update cached ranks for affected tracks ---
   // Only tracks between old and new positions are affected: O(|oldRank - newRank|).
-  //
-  // Special case: if oldRank == UINT64_MAX (sentinel from lazy partial cache),
-  // the track was outside the selection threshold. We only need to update
-  // tracks up to selectionThreshold_ since tracks beyond don't affect selection.
-  uint64_t effectiveOldRank =
-      (oldRank == UINT64_MAX)
-          ? std::min(static_cast<uint64_t>(rankedTracks_.size()), selectionThreshold_)
-          : oldRank;
+  // Skip entirely if either rank is sentinel (beyond threshold).
+  if (oldRank != UINT64_MAX && newRank != UINT64_MAX && oldRank != newRank) {
+    uint64_t minRank = std::min(oldRank, newRank);
+    uint64_t maxRank = std::max(oldRank, newRank);
 
-  if (newRank < effectiveOldRank) {
-    // Track moved UP (higher value → lower rank number).
-    // Tracks in range (newRank, effectiveOldRank] shift DOWN by 1 (their rank increases).
-    // Example: track moves from rank 5 to rank 2
-    //   Before: [0, 1, 2, 3, 4, T, 6, ...]  (T was at rank 5)
-    //   After:  [0, 1, T, 2, 3, 4, 6, ...]  (tracks 2,3,4 shift to 3,4,5)
-    auto rankedIt = newIter;
-    ++rankedIt; // Start after the moved track
-    for (uint64_t r = newRank + 1; r <= effectiveOldRank && rankedIt != rankedTracks_.end();
-         ++r, ++rankedIt) {
-      auto indexIt = trackIndexByName_.find(rankedIt->second.ftn);
-      if (indexIt != trackIndexByName_.end()) {
-        indexIt->second.cachedRank = r;
+    // Iterate forward through affected range, assigning sequential ranks.
+    // After the move, the map has correct order - we just update cachedRank values.
+    auto rankedIt = rankedTracks_.begin();
+    std::advance(rankedIt, minRank);
+
+    for (uint64_t r = minRank; r <= maxRank && rankedIt != rankedTracks_.end(); ++rankedIt, ++r) {
+      if (rankedIt == newIter) {
+        continue; // Skip the track we just moved (already has correct cachedRank)
       }
-    }
-  } else if (newRank > effectiveOldRank && oldRank != UINT64_MAX) {
-    // Track moved DOWN (lower value → higher rank number).
-    // Tracks in range [oldRank, newRank) shift UP by 1 (their rank decreases).
-    // Note: Skip if oldRank was sentinel - no accurate prior position to update from.
-    // Example: track moves from rank 2 to rank 5
-    //   Before: [0, 1, T, 3, 4, 5, 6, ...]  (T was at rank 2)
-    //   After:  [0, 1, 2, 3, 4, T, 6, ...]  (tracks 3,4,5 shift to 2,3,4)
-    auto rankedIt = newIter;
-    for (uint64_t r = newRank; r > oldRank && rankedIt != rankedTracks_.begin();) {
-      --rankedIt;
-      --r;
       auto indexIt = trackIndexByName_.find(rankedIt->second.ftn);
-      if (indexIt != trackIndexByName_.end()) {
+      if (indexIt != trackIndexByName_.end() && indexIt->second.cachedRank != UINT64_MAX) {
         indexIt->second.cachedRank = r;
       }
     }

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -313,13 +313,24 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
       } else {
         // Fallback: deselected queue empty (e.g., first removal after registration
         // when no tracks have been demoted yet). Scan for first non-selected track.
+        uint64_t rank = 0;
         for (auto& [key, rankedEntry] : rankedTracks_) {
           auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
           if (stIt != topNGroup.trackStates.end() && stIt->second == TrackState::Selected) {
+            rank++;
             continue; // Already selected, skip
           }
           // Found first non-selected track - promote it
           topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
+
+          // Fix cachedRank if it was a sentinel (track was beyond threshold before removal).
+          // This is critical: a Selected track must have accurate cachedRank for
+          // subsequent updateSortValue calls to compute correct wasInTopN.
+          auto indexIt = trackIndexByName_.find(rankedEntry.ftn);
+          if (indexIt != trackIndexByName_.end() && indexIt->second.cachedRank == UINT64_MAX) {
+            indexIt->second.cachedRank = rank;
+          }
+
           notifyTrackSelected(rankedEntry.ftn, topNGroup);
           break;
         }
@@ -708,6 +719,14 @@ void PropertyRanking::promoteTrackInGroup(
     XLOG(DBG4) << "promoteTrackInGroup: promoting " << ftn << " at rank " << rank << " into top-N";
     group.trackStates[ftn] = TrackState::Selected;
     removeFromDeselectedQueue(group, ftn);
+
+    // Fix cachedRank if it was a sentinel (track was beyond threshold before promotion).
+    // This ensures a Selected track has accurate cachedRank for subsequent updateSortValue.
+    auto indexIt = trackIndexByName_.find(ftn);
+    if (indexIt != trackIndexByName_.end() && indexIt->second.cachedRank == UINT64_MAX) {
+      indexIt->second.cachedRank = rank;
+    }
+
     notifyTrackSelected(ftn, group);
   }
 }

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -51,9 +51,16 @@ void PropertyRanking::registerTrack(
   // --- Step 1: Ensure cache validity for O(1) rank computation ---
   rebuildRankCacheIfNeeded();
 
-  // --- Step 2: Insert into sorted map ---
+  // --- Step 2: Insert into sorted map and update publisher track count ---
   uint64_t value = initialValue.value_or(0);
   RankKey key{value, nextSeq_++};
+
+  // Increment publisher track count for O(1) isPublisher() lookup
+  if (auto pubSession = publisher.lock()) {
+    auto& entry = publisherTrackCount_[pubSession.get()];
+    entry.session = pubSession; // Store weak_ptr for ABA validation
+    entry.trackCount++;
+  }
 
   auto [iter, inserted] =
       rankedTracks_.emplace(key, RankedEntry{.ftn = ftn, .publisher = std::move(publisher)});
@@ -263,6 +270,16 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
   auto nextIt = entry.rankIter;
   ++nextIt;
 
+  // Decrement publisher track count before erasing
+  if (auto pubSession = entry.rankIter->second.publisher.lock()) {
+    auto countIt = publisherTrackCount_.find(pubSession.get());
+    if (countIt != publisherTrackCount_.end()) {
+      if (--countIt->second.trackCount == 0) {
+        publisherTrackCount_.erase(countIt);
+      }
+    }
+  }
+
   // --- Step 2: Remove from data structures ---
   rankedTracks_.erase(entry.rankIter);
   trackIndexByName_.erase(it);
@@ -383,16 +400,14 @@ void PropertyRanking::addSessionToTopNGroup(
     // it fires onSelected_ for each track in the personal top-N and
     // populates selectedTracks for future delta computation.
     reconcilePublisherSelection(sessionInfo, maxSelected, session);
-  } else {
+  } else if (onSelected_) {
     // Notify viewer of all currently-selected tracks.
     uint64_t rank = 0;
     for (auto& [key, entry] : rankedTracks_) {
       if (rank >= maxSelected) {
         break;
       }
-      if (onSelected_) {
-        onSelected_(entry.ftn, session, sessionInfo.forward);
-      }
+      onSelected_(entry.ftn, session, sessionInfo.forward);
       rank++;
     }
   }
@@ -708,8 +723,8 @@ void PropertyRanking::trimDeselectedQueue(TopNGroup& topNGroup) {
                << " from TopNGroup maxSelected=" << topNGroup.maxSelected
                << " (deselectedQueue exceeded maxDeselected=" << maxDeselected_ << ")";
 
-    for (const auto& [session, info] : topNGroup.sessions) {
-      if (session && onEvicted_) {
+    if (onEvicted_) {
+      for (const auto& [session, info] : topNGroup.sessions) {
         onEvicted_(evicted, session);
       }
     }
@@ -827,17 +842,16 @@ bool PropertyRanking::isSelfTrack(
 }
 
 bool PropertyRanking::isPublisher(const std::shared_ptr<moxygen::MoQSession>& session) const {
-  // Check if this session owns any track in rankedTracks_.
-  for (const auto& [key, entry] : rankedTracks_) {
-    if (entry.publisher.lock() == session) {
-      return true;
-    }
+  // O(1) lookup using cached publisher track count
+  auto it = publisherTrackCount_.find(session.get());
+  if (it == publisherTrackCount_.end()) {
+    return false;
   }
-  return false;
+  // Validate weak_ptr to guard against ABA problem (new session at same address)
+  return it->second.session.lock() == session;
 }
 
-std::optional<RankKey>
-PropertyRanking::computeWaterlineKey(
+std::optional<RankKey> PropertyRanking::computeWaterlineKey(
     const std::shared_ptr<moxygen::MoQSession>& session,
     uint64_t maxSelected
 ) const {
@@ -846,7 +860,8 @@ PropertyRanking::computeWaterlineKey(
   // (RankKey uses std::greater<>, so higher key = lower rank = better.)
   uint64_t nonSelfCount = 0;
   for (const auto& [key, entry] : rankedTracks_) {
-    if (!isSelfTrack(entry.ftn, session)) {
+    // Inline self-track check: compare publisher directly (avoids redundant lookup)
+    if (entry.publisher.lock() != session) {
       nonSelfCount++;
       if (nonSelfCount == maxSelected) {
         return key;
@@ -870,23 +885,27 @@ void PropertyRanking::reconcilePublisherSelection(
   // A track is selected iff it's non-self AND at-or-above the waterline.
   folly::F14FastSet<moxygen::FullTrackName, moxygen::FullTrackName::hash> nowSelected;
   for (const auto& [key, entry] : rankedTracks_) {
-    if (!isSelfTrack(entry.ftn, session) &&
-        (!info.waterlineKey || key >= *info.waterlineKey)) {
+    // Inline self-track check: compare publisher directly (avoids redundant lookup)
+    if (entry.publisher.lock() != session && (!info.waterlineKey || key >= *info.waterlineKey)) {
       nowSelected.insert(entry.ftn);
     }
   }
 
   // Evict tracks that left the publisher's personal top-N.
-  for (const auto& ftn : info.selectedTracks) {
-    if (nowSelected.count(ftn) == 0 && onEvicted_) {
-      onEvicted_(ftn, session);
+  if (onEvicted_) {
+    for (const auto& ftn : info.selectedTracks) {
+      if (nowSelected.count(ftn) == 0) {
+        onEvicted_(ftn, session);
+      }
     }
   }
 
   // Notify tracks that entered the publisher's personal top-N.
-  for (const auto& ftn : nowSelected) {
-    if (info.selectedTracks.count(ftn) == 0 && onSelected_) {
-      onSelected_(ftn, session, info.forward);
+  if (onSelected_) {
+    for (const auto& ftn : nowSelected) {
+      if (info.selectedTracks.count(ftn) == 0) {
+        onSelected_(ftn, session, info.forward);
+      }
     }
   }
 

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -21,6 +21,19 @@ PropertyRanking::PropertyRanking(
       onBatchSelected_(std::move(onBatchSelected)), onSelected_(std::move(onSelected)),
       onEvicted_(std::move(onEvicted)) {}
 
+/**
+ * Register a new track with an optional initial property value.
+ *
+ * Algorithm overview:
+ * 1. Insert into sorted map (O(log T))
+ * 2. Compute rank using previous track's cached rank (O(1))
+ * 3. Incrementally update ranks for tracks shifted down (O(T - rank))
+ * 4. Two-phase TopNGroup update:
+ *    - Phase 1: Mark selected in applicable groups, collect demotion positions
+ *    - Phase 2: Single traversal to demote tracks pushed out of top-N
+ *
+ * Total complexity: O(log T + T - rank + G log G + N) where T=tracks, G=groups, N=max(N)
+ */
 void PropertyRanking::registerTrack(
     const moxygen::FullTrackName& ftn,
     std::optional<uint64_t> initialValue,
@@ -31,34 +44,48 @@ void PropertyRanking::registerTrack(
     return;
   }
 
-  // Ensure cache is valid before insertion so we can use iterator-- for O(1) rank lookup
+  // --- Step 1: Ensure cache validity for O(1) rank computation ---
   rebuildRankCacheIfNeeded();
 
+  // --- Step 2: Insert into sorted map ---
   uint64_t value = initialValue.value_or(0);
   RankKey key{value, nextSeq_++};
 
   auto [iter, inserted] =
       rankedTracks_.emplace(key, RankedEntry{.ftn = ftn, .publisher = std::move(publisher)});
 
-  // Compute rank in O(1) using previous track's cached rank
+  // --- Step 3: Compute rank in O(1) using previous track's cached rank ---
+  // Since map is sorted descending, the previous iterator has the next-lower rank.
   uint64_t rank;
   if (iter == rankedTracks_.begin()) {
+    // Highest value track gets rank 0
     rank = 0;
   } else {
     auto prevIt = iter;
     --prevIt;
     auto prevIndexIt = trackIndexByName_.find(prevIt->second.ftn);
-    rank = (prevIndexIt != trackIndexByName_.end()) ? prevIndexIt->second.cachedRank + 1 : 0;
+    XCHECK(prevIndexIt != trackIndexByName_.end())
+        << "Previous track must exist in index";
+
+    // Handle sentinel: if previous track has UINT64_MAX (lazy partial cache),
+    // fall back to O(rank) distance computation for accurate rank.
+    if (prevIndexIt->second.cachedRank == UINT64_MAX) {
+      rank = static_cast<uint64_t>(std::distance(rankedTracks_.begin(), iter));
+    } else {
+      rank = prevIndexIt->second.cachedRank + 1;
+    }
   }
 
   trackIndexByName_[ftn] = RankIndex{.rankIter = iter, .cachedRank = rank};
 
-  // Increment cached ranks for all tracks after insertion point: O(numTracks - rank)
+  // --- Step 4: Increment cached ranks for all tracks shifted down ---
+  // Tracks after insertion point had their rank increase by 1.
+  // Skip tracks with sentinel value (UINT64_MAX from lazy partial cache).
   auto nextIt = iter;
   ++nextIt;
   for (; nextIt != rankedTracks_.end(); ++nextIt) {
     auto indexIt = trackIndexByName_.find(nextIt->second.ftn);
-    if (indexIt != trackIndexByName_.end()) {
+    if (indexIt != trackIndexByName_.end() && indexIt->second.cachedRank != UINT64_MAX) {
       indexIt->second.cachedRank++;
     }
   }
@@ -66,8 +93,10 @@ void PropertyRanking::registerTrack(
 
   XLOG(DBG4) << "Registered track " << ftn << " with value " << value << " at rank " << rank;
 
-  // Two-phase algorithm: O(G log G + N) instead of O(G * N)
-  // Phase 1: Mark track selected in applicable groups, collect demotion positions
+  // --- Step 5: Two-phase TopNGroup update ---
+  // Phase 1: Mark track selected in applicable groups, collect demotion positions.
+  // For each group where rank < N, the new track enters top-N and pushes
+  // the track at rank N-1 down to rank N (out of top-N).
   std::vector<std::pair<uint64_t, TopNGroup*>> demotions;  // (position n, group)
 
   for (auto& [n, topNGroup] : topNGroups_) {
@@ -75,36 +104,53 @@ void PropertyRanking::registerTrack(
       topNGroup.trackStates[ftn] = TrackState::Selected;
       notifyTrackSelected(ftn, topNGroup);
 
-      // The new track pushed the previous occupant of rank N-1 to rank N.
-      // Queue demotion (only fires when numTracks > N).
+      // Queue demotion at position N (the first rank outside top-N).
+      // Only fires when numTracks > N (otherwise no track to demote).
       demotions.emplace_back(n, &topNGroup);
     }
-    // Tracks outside top N are not added to the deselected queue on register;
-    // they only enter the queue when they fall out of an already-selected position.
+    // Tracks outside top-N are not added to deselected queue on registration;
+    // they only enter the queue when falling out of an already-selected position.
   }
 
-  // Phase 2: Single traversal to demote tracks at collected positions
+  // Phase 2: Single traversal to demote tracks at collected positions.
+  // By sorting demotion positions, we process all demotions in one pass.
   if (!demotions.empty()) {
     IterationGuard guard(*this);
 
+    // Sort by position for single-pass processing
     std::sort(demotions.begin(), demotions.end(),
               [](const auto& a, const auto& b) { return a.first < b.first; });
 
     size_t demIdx = 0;
     uint64_t count = 0;
     for (auto& [key, rankedEntry] : rankedTracks_) {
+      // Process all demotions at current position
       while (demIdx < demotions.size() && count == demotions[demIdx].first) {
         demoteTrackInGroup(*demotions[demIdx].second, rankedEntry.ftn, count);
         demIdx++;
       }
       if (demIdx >= demotions.size()) {
-        break;
+        break;  // All demotions processed
       }
       count++;
     }
   }
 }
 
+/**
+ * Update a track's sort value. Main hot-path entry point.
+ *
+ * Algorithm overview:
+ * 1. Early exit if value unchanged
+ * 2. Re-insert into sorted map at new position (O(log T))
+ * 3. Compute new rank via std::distance (O(newRank))
+ * 4. Incrementally update cached ranks for affected range (O(|movement|))
+ * 5. Fast path exit if no threshold crossed
+ * 6. Slow path: recompute TopNGroup states
+ *
+ * The fast path (step 5) avoids expensive group updates when rank changes
+ * don't affect any subscriber's top-N selection.
+ */
 void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_t value) {
   auto it = trackIndexByName_.find(ftn);
   if (it == trackIndexByName_.end()) {
@@ -115,45 +161,62 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
   auto& entry = it->second;
   RankKey oldKey = entry.rankIter->first;
 
-  // Early exit: no change in value
+  // --- Step 1: Early exit if no change ---
   if (oldKey.value == value) {
     return;
   }
 
-  // Construct new key after the early-exit check
-  RankKey newKey{value, oldKey.arrivalSeq};
+  // --- Step 2: Re-insert at new position in sorted map ---
+  RankKey newKey{value, oldKey.arrivalSeq};  // Preserve arrival sequence for tie-breaking
 
-  // Ensure cache is valid and capture old rank before modifying the map
   rebuildRankCacheIfNeeded();
   uint64_t oldRank = entry.cachedRank;
 
-  // Update the sorted map: O(log N) erase + insert
+  // Erase and re-insert: O(log T) each
   auto rankedEntry = std::move(entry.rankIter->second);
   rankedTracks_.erase(entry.rankIter);
   auto [newIter, _] = rankedTracks_.emplace(newKey, std::move(rankedEntry));
   entry.rankIter = newIter;
 
-  // Compute new rank using std::distance: O(newRank) for bidirectional iterator.
-  // For top-ranked tracks (where we care most), this is fast.
+  // --- Step 3: Compute new rank ---
+  // O(newRank) for bidirectional iterator. Acceptable because top-ranked tracks
+  // (where we care most about performance) have small newRank values.
   uint64_t newRank = static_cast<uint64_t>(
       std::distance(rankedTracks_.begin(), newIter));
   entry.cachedRank = newRank;
 
-  // Incrementally update cached ranks for affected tracks only: O(|oldRank - newRank|).
-  // Tracks between old and new positions had their ranks shift by ±1.
-  if (newRank < oldRank) {
-    // Track moved up (higher value → lower rank). Tracks in (newRank, oldRank] shift down.
+  // --- Step 4: Incrementally update cached ranks for affected tracks ---
+  // Only tracks between old and new positions are affected: O(|oldRank - newRank|).
+  //
+  // Special case: if oldRank == UINT64_MAX (sentinel from lazy partial cache),
+  // the track was outside the selection threshold. We only need to update
+  // tracks up to selectionThreshold_ since tracks beyond don't affect selection.
+  uint64_t effectiveOldRank = (oldRank == UINT64_MAX)
+      ? std::min(static_cast<uint64_t>(rankedTracks_.size()), selectionThreshold_)
+      : oldRank;
+
+  if (newRank < effectiveOldRank) {
+    // Track moved UP (higher value → lower rank number).
+    // Tracks in range (newRank, effectiveOldRank] shift DOWN by 1 (their rank increases).
+    // Example: track moves from rank 5 to rank 2
+    //   Before: [0, 1, 2, 3, 4, T, 6, ...]  (T was at rank 5)
+    //   After:  [0, 1, T, 2, 3, 4, 6, ...]  (tracks 2,3,4 shift to 3,4,5)
     auto rankedIt = newIter;
-    ++rankedIt;  // Skip the moved track
-    for (uint64_t r = newRank + 1; r <= oldRank && rankedIt != rankedTracks_.end();
+    ++rankedIt;  // Start after the moved track
+    for (uint64_t r = newRank + 1; r <= effectiveOldRank && rankedIt != rankedTracks_.end();
          ++r, ++rankedIt) {
       auto indexIt = trackIndexByName_.find(rankedIt->second.ftn);
       if (indexIt != trackIndexByName_.end()) {
         indexIt->second.cachedRank = r;
       }
     }
-  } else if (newRank > oldRank) {
-    // Track moved down (lower value → higher rank). Tracks in [oldRank, newRank) shift up.
+  } else if (newRank > effectiveOldRank && oldRank != UINT64_MAX) {
+    // Track moved DOWN (lower value → higher rank number).
+    // Tracks in range [oldRank, newRank) shift UP by 1 (their rank decreases).
+    // Note: Skip if oldRank was sentinel - no accurate prior position to update from.
+    // Example: track moves from rank 2 to rank 5
+    //   Before: [0, 1, T, 3, 4, 5, 6, ...]  (T was at rank 2)
+    //   After:  [0, 1, 2, 3, 4, T, 6, ...]  (tracks 3,4,5 shift to 2,3,4)
     auto rankedIt = newIter;
     for (uint64_t r = newRank; r > oldRank && rankedIt != rankedTracks_.begin();) {
       --rankedIt;
@@ -166,42 +229,55 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
   }
   // Cache remains valid - no full rebuild needed
 
-  // FAST PATH: value change doesn't cross any threshold
+  // --- Step 5: Fast path - no threshold crossed ---
   if (!crossesThreshold(oldRank, newRank)) {
     XLOG(DBG5) << "updateSortValue fast path: " << ftn << " value=" << value
                << " rank " << oldRank << " -> " << newRank << " (no threshold crossed)";
     return;
   }
 
-  // SLOW PATH: value crossed a threshold, recompute TopNGroups
+  // --- Step 6: Slow path - threshold crossed, update TopNGroups ---
   XLOG(DBG4) << "updateSortValue slow path: " << ftn << " value=" << value
              << " rank " << oldRank << " -> " << newRank << " (threshold crossed)";
   recomputeTopNGroups(ftn, oldRank, newRank);
 }
 
+/**
+ * Remove a track (typically on PUBLISH_DONE).
+ *
+ * Algorithm overview:
+ * 1. Remove from sorted map and index (O(log T))
+ * 2. Decrement cached ranks for tracks shifted up (O(T - oldRank))
+ * 3. For each TopNGroup where track was selected, promote a replacement:
+ *    - Try deselected queue first (O(1))
+ *    - Fallback: scan ranked list for first non-selected track (O(N))
+ */
 void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
   auto it = trackIndexByName_.find(ftn);
   if (it == trackIndexByName_.end()) {
     return;
   }
 
-  // Ensure cache is valid before removal
+  // --- Step 1: Ensure cache is valid and capture position ---
   rebuildRankCacheIfNeeded();
 
   auto& entry = it->second;
   uint64_t oldRank = entry.cachedRank;
 
-  // Save iterator to next track before erasing (remains valid after erase per std::map guarantees)
+  // Save iterator to next track before erasing (remains valid per std::map guarantees)
   auto nextIt = entry.rankIter;
   ++nextIt;
 
+  // --- Step 2: Remove from data structures ---
   rankedTracks_.erase(entry.rankIter);
   trackIndexByName_.erase(it);
 
-  // Decrement cached ranks for all tracks after removal point: O(numTracks - oldRank)
+  // --- Step 3: Decrement cached ranks for tracks shifted up ---
+  // Tracks after removal point move up by 1 (their rank decreases).
+  // Skip tracks with sentinel value (UINT64_MAX from lazy partial cache).
   for (; nextIt != rankedTracks_.end(); ++nextIt) {
     auto indexIt = trackIndexByName_.find(nextIt->second.ftn);
-    if (indexIt != trackIndexByName_.end()) {
+    if (indexIt != trackIndexByName_.end() && indexIt->second.cachedRank != UINT64_MAX) {
       indexIt->second.cachedRank--;
     }
   }
@@ -209,6 +285,7 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
 
   XLOG(DBG4) << "Removed track " << ftn << " from rank " << oldRank;
 
+  // --- Step 4: Update TopNGroups and promote replacements ---
   for (auto& [n, topNGroup] : topNGroups_) {
     auto stateIt = topNGroup.trackStates.find(ftn);
     if (stateIt == topNGroup.trackStates.end()) {
@@ -222,9 +299,10 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
     removeFromDeselectedQueue(topNGroup, ftn);
 
     if (wasSelected) {
+      // Need to promote a replacement into top-N
       IterationGuard guard(*this);
 
-      // Try deselected queue first for cheap promotion
+      // Try deselected queue first for O(1) promotion
       if (!topNGroup.deselectedQueue.empty()) {
         auto promoted = topNGroup.deselectedQueue.front();
         topNGroup.deselectedQueue.pop_front();
@@ -233,17 +311,14 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
         topNGroup.trackStates[promoted] = TrackState::Selected;
         notifyTrackSelected(promoted, topNGroup);
       } else {
-        // Fallback: deselected queue is empty (e.g., first removal after registration
-        // when no tracks have yet been demoted). Scan ranked list for the first
-        // non-selected track to promote into the vacated slot.
+        // Fallback: deselected queue empty (e.g., first removal after registration
+        // when no tracks have been demoted yet). Scan for first non-selected track.
         for (auto& [key, rankedEntry] : rankedTracks_) {
           auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
           if (stIt != topNGroup.trackStates.end() && stIt->second == TrackState::Selected) {
-            continue;
+            continue;  // Already selected, skip
           }
-          // Deselected queue is empty — scan ranked list for the first non-selected
-          // track. Since we just removed one selected track, there's guaranteed room
-          // in top-N for exactly one promotion.
+          // Found first non-selected track - promote it
           topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
           notifyTrackSelected(rankedEntry.ftn, topNGroup);
           break;
@@ -258,7 +333,16 @@ TopNGroup& PropertyRanking::getOrCreateTopNGroup(uint64_t maxSelected) {
   if (inserted) {
     XLOG(DBG4) << "Created new TopNGroup with maxSelected=" << maxSelected;
     it->second.maxSelected = maxSelected;
+
+    // Capture old threshold before updating
+    uint64_t oldThreshold = selectionThreshold_;
     updateSelectionThreshold();
+
+    // If threshold increased, tracks that had UINT64_MAX sentinel may now need
+    // accurate ranks. Invalidate cache to force rebuild on next access.
+    if (selectionThreshold_ > oldThreshold) {
+      rankCacheValid_ = false;
+    }
 
     uint64_t rank = 0;
     for (auto& [key, entry] : rankedTracks_) {
@@ -352,36 +436,80 @@ uint64_t PropertyRanking::getRank(const RankKey& key) const {
   return trackIndexByName_.find(it->second.ftn)->second.cachedRank;
 }
 
-// O(numTracks) full cache rebuild. Only called when cache is invalid (e.g., after
-// direct map manipulation in tests). Normal operations use incremental updates:
-// - registerTrack: O(1) rank lookup via iterator--, O(numTracks - rank) updates
-// - removeTrack: O(numTracks - oldRank) updates
-// - updateSortValue: O(newRank) + O(|movement|) updates
-//
-// Future optimization opportunity:
-// Lazy partial cache: don't compute ranks for tracks past max(N) + maxDeselected.
-// Their rank only matters on track removal or increasing N (not yet supported).
+/**
+ * Rebuild rank cache if invalid.
+ *
+ * Complexity: O(min(numTracks, selectionThreshold_)) with lazy partial caching.
+ *
+ * Only called when cache is invalid (e.g., after direct map manipulation in tests).
+ * Normal operations use incremental updates:
+ * - registerTrack: O(1) rank lookup via iterator--, O(numTracks - rank) updates
+ * - removeTrack: O(numTracks - oldRank) updates
+ * - updateSortValue: O(newRank) + O(|movement|) updates
+ *
+ * Lazy partial cache optimization:
+ * Only computes ranks up to selectionThreshold_ (max(N) + maxDeselected).
+ * Tracks beyond this threshold get cachedRank = UINT64_MAX (sentinel).
+ * Rationale: tracks past the threshold don't affect any top-N selection or
+ * deselected queue, so their exact rank doesn't matter for correctness.
+ *
+ * When selectionThreshold_ increases (new TopNGroup with larger N), the cache
+ * is invalidated in getOrCreateTopNGroup() to ensure tracks in the expanded
+ * range get accurate ranks on next rebuild.
+ */
 void PropertyRanking::rebuildRankCacheIfNeeded() const {
   if (rankCacheValid_) {
     return;
   }
+
+  // Traverse sorted map and assign sequential ranks (0 = highest value).
+  // trackIndexByName_ is mutable to allow this lazy cache update in const context.
   uint64_t rank = 0;
   for (const auto& [key, entry] : rankedTracks_) {
     auto it = trackIndexByName_.find(entry.ftn);
     if (it != trackIndexByName_.end()) {
-      const_cast<RankIndex&>(it->second).cachedRank = rank;
+      // Lazy partial cache: stop computing exact ranks past selectionThreshold_.
+      // These tracks are outside all top-N groups and deselected queues.
+      if (rank < selectionThreshold_ || selectionThreshold_ == 0) {
+        it->second.cachedRank = rank;
+      } else {
+        // Sentinel value indicates "rank >= selectionThreshold_"
+        it->second.cachedRank = UINT64_MAX;
+      }
     }
     rank++;
   }
   rankCacheValid_ = true;
 }
 
+/**
+ * Check if a rank change crosses any TopNGroup threshold.
+ *
+ * A threshold is crossed when the track enters or exits some group's top-N.
+ * For group with N=5, threshold is at rank 5 (ranks 0-4 are in, 5+ are out).
+ *
+ * Algorithm: O(log G) using sorted thresholds
+ * 1. Fast exit if both ranks outside all selection regions
+ * 2. Check if track crossed into/out of selection region entirely
+ * 3. Binary search for any threshold between old and new rank
+ *
+ * Example: groups with N=3 and N=7, track moves from rank 5 to rank 2
+ *   - sortedThresholds_ = [3, 7]
+ *   - minRank=2, maxRank=5
+ *   - upper_bound(2) finds 3, and 3 <= 5, so threshold crossed (N=3)
+ *
+ * Sentinel handling: if oldRank == UINT64_MAX (lazy partial cache sentinel),
+ * it correctly represents "outside all selection regions" since
+ * UINT64_MAX >= selectionThreshold_ is always true.
+ */
 bool PropertyRanking::crossesThreshold(uint64_t oldRank, uint64_t newRank) const {
   if (topNGroups_.empty()) {
     return false;
   }
 
-  // Fast exit: both ranks outside selection region - no threshold can be crossed.
+  // --- Fast exit: both ranks outside all selection regions ---
+  // selectionThreshold_ = max(N) + maxDeselected_, so ranks >= threshold
+  // are outside all groups and their deselected queues.
   if (oldRank >= selectionThreshold_ && newRank >= selectionThreshold_) {
     return false;
   }
@@ -392,14 +520,15 @@ bool PropertyRanking::crossesThreshold(uint64_t oldRank, uint64_t newRank) const
   uint64_t minRank = std::min(oldRank, newRank);
   uint64_t maxRank = std::max(oldRank, newRank);
 
-  // Check if track crossed into/out of the selection region entirely.
+  // --- Check if track crossed into/out of selection region entirely ---
   bool oldInAnyTopN = oldRank < selectionThreshold_;
   bool newInAnyTopN = newRank < selectionThreshold_;
   if (oldInAnyTopN != newInAnyTopN) {
     return true;
   }
 
-  // O(log G) check: any threshold between minRank and maxRank?
+  // --- O(log G) binary search for threshold in (minRank, maxRank] ---
+  // upper_bound gives first threshold > minRank; check if it's <= maxRank.
   auto it = std::upper_bound(sortedThresholds_.begin(), sortedThresholds_.end(), minRank);
   if (it != sortedThresholds_.end() && *it <= maxRank) {
     return true;
@@ -408,6 +537,28 @@ bool PropertyRanking::crossesThreshold(uint64_t oldRank, uint64_t newRank) const
   return false;
 }
 
+/**
+ * Recompute TopNGroup states after a track crosses selection thresholds.
+ *
+ * Two-phase algorithm achieving O(G log G + N) instead of naive O(G * N):
+ *
+ * Phase 1: Iterate groups O(G)
+ *   - Update moved track's state (Selected ↔ Deselected)
+ *   - Collect boundary operations (positions where other tracks need demotion/promotion)
+ *
+ * Phase 2: Single traversal of rankedTracks_ O(N)
+ *   - Sort operations by position O(G log G)
+ *   - Process all demotions/promotions in one pass
+ *
+ * Why two phases? When a track enters top-N, it pushes another track out.
+ * We need to find the track at position N (the boundary). Rather than
+ * traversing rankedTracks_ once per group, we collect all boundary positions
+ * and handle them in a single traversal.
+ *
+ * Example: track moves from rank 8 to rank 2, groups N=3, N=5, N=7
+ *   - Track enters N=3, N=5, N=7 → demote tracks at positions 3, 5, 7
+ *   - Phase 2: traverse once, demote at positions 3, 5, 7
+ */
 void PropertyRanking::recomputeTopNGroups(
     const moxygen::FullTrackName& ftn,
     uint64_t oldRank,
@@ -418,8 +569,7 @@ void PropertyRanking::recomputeTopNGroups(
 
   IterationGuard guard(*this);
 
-  // Two-phase algorithm: O(G log G + N) instead of O(G * N)
-  // Phase 1: Update state and collect boundary positions needing demotion/promotion
+  // --- Phase 1: Update state and collect boundary operations ---
   enum class Action { Demote, Promote };
   std::vector<std::tuple<uint64_t, TopNGroup*, Action>> boundaryOps;
 
@@ -427,42 +577,46 @@ void PropertyRanking::recomputeTopNGroups(
     bool wasInTopN = oldRank < n;
     bool nowInTopN = newRank < n;
 
+    // Update moved track's state if it crossed this group's threshold
     if (wasInTopN != nowInTopN) {
       if (nowInTopN) {
+        // Track entered top-N: mark selected, remove from deselected queue if present
         topNGroup.trackStates[ftn] = TrackState::Selected;
         removeFromDeselectedQueue(topNGroup, ftn);
       } else {
+        // Track fell out of top-N: mark deselected, add to queue
         topNGroup.trackStates[ftn] = TrackState::Deselected;
         topNGroup.deselectedQueue.push_back(ftn);
         trimDeselectedQueue(topNGroup);
       }
     }
 
-    // Track entered top-N: notify and queue demotion at position n
+    // Queue boundary operations for other tracks affected by this move
     if (!wasInTopN && nowInTopN) {
+      // Track entered top-N → demote track at position N (pushed out of top-N)
       notifyTrackSelected(ftn, topNGroup);
       boundaryOps.emplace_back(n, &topNGroup, Action::Demote);
     }
 
-    // Track fell out of top-N: queue promotion at position n-1
     if (wasInTopN && !nowInTopN) {
+      // Track fell out of top-N → promote track at position N-1 (now enters top-N)
       boundaryOps.emplace_back(n - 1, &topNGroup, Action::Promote);
     }
   }
 
-  // Phase 2: Single traversal of rankedTracks_ to handle all boundary operations
+  // --- Phase 2: Single traversal to handle all boundary operations ---
   if (boundaryOps.empty()) {
     return;
   }
 
-  // Sort by position so we can process in one pass
+  // Sort by position for single-pass processing
   std::sort(boundaryOps.begin(), boundaryOps.end(),
             [](const auto& a, const auto& b) { return std::get<0>(a) < std::get<0>(b); });
 
   size_t opIdx = 0;
   uint64_t count = 0;
   for (auto& [key, rankedEntry] : rankedTracks_) {
-    // Process all operations at this position
+    // Process all operations at current position
     while (opIdx < boundaryOps.size() && count == std::get<0>(boundaryOps[opIdx])) {
       auto* group = std::get<1>(boundaryOps[opIdx]);
       Action action = std::get<2>(boundaryOps[opIdx]);
@@ -495,6 +649,13 @@ void PropertyRanking::updateSelectionThreshold() {
 }
 
 void PropertyRanking::trimDeselectedQueue(TopNGroup& topNGroup) {
+  if (topNGroup.deselectedQueue.size() <= maxDeselected_) {
+    return;
+  }
+
+  // Guard once for all evictions rather than per-iteration
+  IterationGuard guard(*this);
+
   while (topNGroup.deselectedQueue.size() > maxDeselected_) {
     auto evicted = topNGroup.deselectedQueue.front();
     topNGroup.deselectedQueue.pop_front();
@@ -504,7 +665,6 @@ void PropertyRanking::trimDeselectedQueue(TopNGroup& topNGroup) {
                << " from TopNGroup maxSelected=" << topNGroup.maxSelected
                << " (deselectedQueue exceeded maxDeselected=" << maxDeselected_ << ")";
 
-    IterationGuard guard(*this);
     for (const auto& [session, info] : topNGroup.sessions) {
       if (session && onEvicted_) {
         onEvicted_(evicted, session);
@@ -560,6 +720,7 @@ void PropertyRanking::promoteTrackInGroup(
 // An alternative per-session callback exists (onSelected_) for cases needing individual handling.
 void PropertyRanking::notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup) {
   std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> batch;
+  batch.reserve(topNGroup.sessions.size());
   for (const auto& [session, info] : topNGroup.sessions) {
     batch.emplace_back(session, info.forward);
   }

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -13,13 +13,15 @@ namespace openmoq::moqx {
 PropertyRanking::PropertyRanking(
     uint64_t propertyType,
     uint64_t maxDeselected,
+    std::chrono::milliseconds idleTimeout,
+    GetLastActivityFn getLastActivity,
     BatchSelectCallback onBatchSelected,
     SelectCallback onSelected,
     EvictCallback onEvicted
 )
-    : propertyType_(propertyType), maxDeselected_(maxDeselected),
-      onBatchSelected_(std::move(onBatchSelected)), onSelected_(std::move(onSelected)),
-      onEvicted_(std::move(onEvicted)) {}
+    : propertyType_(propertyType), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
+      getLastActivity_(std::move(getLastActivity)), onBatchSelected_(std::move(onBatchSelected)),
+      onSelected_(std::move(onSelected)), onEvicted_(std::move(onEvicted)) {}
 
 /**
  * Register a new track with an optional initial property value.
@@ -215,6 +217,9 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
                << " -> " << newRank << " (no threshold crossed)";
     return;
   }
+
+  // Opportunistic idle sweep: a value change is worth a quick idle check
+  sweepIdle();
 
   // --- Step 6: Slow path - threshold crossed, update TopNGroups ---
   XLOG(DBG4) << "updateSortValue slow path: " << ftn << " value=" << value << " rank " << oldRank
@@ -716,6 +721,29 @@ void PropertyRanking::promoteTrackInGroup(
   }
 }
 
+void PropertyRanking::promoteNextAvailableTrack(
+    TopNGroup& group,
+    const moxygen::FullTrackName& excludeFtn
+) {
+  // Find the highest-ranked non-selected track and promote it.
+  // Scan rankedTracks_ from the top; skip Selected tracks and excludeFtn.
+  IterationGuard guard(*this);
+  for (const auto& [key, rankedEntry] : rankedTracks_) {
+    if (rankedEntry.ftn == excludeFtn) {
+      continue;
+    }
+    auto stIt = group.trackStates.find(rankedEntry.ftn);
+    bool isSelected =
+        stIt != group.trackStates.end() && stIt->second == TrackState::Selected;
+    if (!isSelected) {
+      group.trackStates[rankedEntry.ftn] = TrackState::Selected;
+      removeFromDeselectedQueue(group, rankedEntry.ftn);
+      notifyTrackSelected(rankedEntry.ftn, group);
+      return;
+    }
+  }
+}
+
 // Batch callback rationale: All sessions in a TopNGroup share the same N, so when a
 // track enters their top-N, the relay can handle them together. Benefits:
 // 1. Single upstream subscribe decision covers all sessions wanting this track
@@ -732,6 +760,42 @@ void PropertyRanking::notifyTrackSelected(const moxygen::FullTrackName& ftn, Top
     XLOG(DBG4) << "notifyTrackSelected: " << ftn << " to " << batch.size()
                << " sessions in TopNGroup maxSelected=" << topNGroup.maxSelected;
     onBatchSelected_(ftn, batch);
+  }
+}
+
+void PropertyRanking::sweepIdle() {
+  if (idleTimeout_.count() == 0 || !getLastActivity_) {
+    return;
+  }
+
+  auto now = std::chrono::steady_clock::now();
+
+  for (auto& [n, topNGroup] : topNGroups_) {
+    // Snapshot selected FTNs: deselecting mutates trackStates
+    std::vector<moxygen::FullTrackName> selected;
+    for (const auto& [ftn, state] : topNGroup.trackStates) {
+      if (state == TrackState::Selected) {
+        selected.push_back(ftn);
+      }
+    }
+
+    for (const auto& ftn : selected) {
+      auto lastActivity = getLastActivity_(ftn);
+      // Epoch (default time_point) means the track never published an object.
+      // Treat this as infinitely idle — a track that never sends data should
+      // be evicted to make room for active tracks.
+      bool neverPublished = (lastActivity == std::chrono::steady_clock::time_point{});
+      if (!neverPublished && now - lastActivity <= idleTimeout_) {
+        continue;
+      }
+
+      XLOG(DBG4) << "[PropertyRanking] Idle eviction: " << ftn << " (group N=" << n << ")"
+                 << (neverPublished ? " [never published]" : "");
+
+      // Demote into deselected queue and promote a replacement
+      demoteTrackInGroup(topNGroup, ftn, 0 /* rank unknown */);
+      promoteNextAvailableTrack(topNGroup, ftn);
+    }
   }
 }
 

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -17,11 +17,13 @@ PropertyRanking::PropertyRanking(
     GetLastActivityFn getLastActivity,
     BatchSelectCallback onBatchSelected,
     SelectCallback onSelected,
+    DeselectedCallback onDeselected,
     EvictCallback onEvicted
 )
     : propertyType_(propertyType), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
       getLastActivity_(std::move(getLastActivity)), onBatchSelected_(std::move(onBatchSelected)),
-      onSelected_(std::move(onSelected)), onEvicted_(std::move(onEvicted)) {}
+      onSelected_(std::move(onSelected)), onDeselected_(std::move(onDeselected)),
+      onEvicted_(std::move(onEvicted)) {}
 
 /**
  * Register a new track with an optional initial property value.
@@ -695,6 +697,16 @@ void PropertyRanking::demoteTrackInGroup(
                << " to deselected queue";
     stIt->second = TrackState::Deselected;
     group.deselectedQueue.push_back(ftn);
+
+    // Notify relay to pause forwarding for each session in this group.
+    // The relay will check if the subscriber exists and is not pinned.
+    if (onDeselected_) {
+      IterationGuard guard(*this);
+      for (const auto& [session, info] : group.sessions) {
+        onDeselected_(ftn, session);
+      }
+    }
+
     trimDeselectedQueue(group);
   }
 }

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -139,6 +139,14 @@ void PropertyRanking::registerTrack(
       count++;
     }
   }
+
+  // --- Step 6: Handle self-exclusion for publisher-subscribers ---
+  // If the track publisher is already subscribed in some TopNGroup, this new
+  // track becomes a self-track for that session. Reconcile to exclude it.
+  auto pubSession = publisher.lock();
+  if (pubSession) {
+    reconcilePublisherInAllGroups(pubSession);
+  }
 }
 
 /**
@@ -362,18 +370,31 @@ void PropertyRanking::addSessionToTopNGroup(
   XLOG(DBG4) << "addSessionToTopNGroup: maxSelected=" << maxSelected << " forward=" << forward;
 
   auto& topNGroup = getOrCreateTopNGroup(maxSelected);
-  topNGroup.sessions[session] = SessionInfo{.forward = forward};
+  SessionInfo info;
+  info.forward = forward;
 
-  // Notify session of all currently-selected tracks
-  uint64_t rank = 0;
-  for (auto& [key, entry] : rankedTracks_) {
-    if (rank >= maxSelected) {
-      break;
+  topNGroup.sessions[session] = std::move(info);
+  auto& sessionInfo = topNGroup.sessions[session];
+
+  // Check if this session is a publisher (owns any tracks in rankedTracks_).
+  // Self-exclusion is automatic based on RankedEntry::publisher.
+  if (isPublisher(session)) {
+    // reconcilePublisherSelection handles initial delivery for publishers:
+    // it fires onSelected_ for each track in the personal top-N and
+    // populates selectedTracks for future delta computation.
+    reconcilePublisherSelection(sessionInfo, maxSelected, session);
+  } else {
+    // Notify viewer of all currently-selected tracks.
+    uint64_t rank = 0;
+    for (auto& [key, entry] : rankedTracks_) {
+      if (rank >= maxSelected) {
+        break;
+      }
+      if (onSelected_) {
+        onSelected_(entry.ftn, session, sessionInfo.forward);
+      }
+      rank++;
     }
-    if (onSelected_) {
-      onSelected_(entry.ftn, session, forward);
-    }
-    rank++;
   }
 }
 
@@ -567,7 +588,7 @@ void PropertyRanking::recomputeTopNGroups(
 
   IterationGuard guard(*this);
 
-  // --- Phase 1: Update state and collect boundary operations ---
+  // --- Phase 1: Update state, notify sessions, collect boundary operations ---
   enum class Action { Demote, Promote };
   std::vector<std::tuple<uint64_t, TopNGroup*, Action>> boundaryOps;
 
@@ -575,7 +596,8 @@ void PropertyRanking::recomputeTopNGroups(
     bool wasInTopN = oldRank < n;
     bool nowInTopN = newRank < n;
 
-    // Update moved track's state if it crossed this group's threshold
+    // Update shared track state (governs viewer selection and the
+    // deselected queue for cheap reselection).
     if (wasInTopN != nowInTopN) {
       if (nowInTopN) {
         // Track entered top-N: mark selected, remove from deselected queue if present
@@ -589,10 +611,27 @@ void PropertyRanking::recomputeTopNGroups(
       }
     }
 
+    // Viewers get a batch notification when ftn enters the shared top-N.
+    // Publishers are reconciled individually: the waterline is key-based and
+    // invariant to self-track rank changes, so we only reconcile when ftn is
+    // non-self (a non-self move is the only thing that can shift the waterline).
+    std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> viewerBatch;
+    for (auto& [session, info] : topNGroup.sessions) {
+      if (isPublisher(session)) {
+        if (!isSelfTrack(ftn, session)) {
+          reconcilePublisherSelection(info, n, session);
+        }
+      } else if (!wasInTopN && nowInTopN) {
+        viewerBatch.emplace_back(session, info.forward);
+      }
+    }
+    if (!viewerBatch.empty() && onBatchSelected_) {
+      onBatchSelected_(ftn, viewerBatch);
+    }
+
     // Queue boundary operations for other tracks affected by this move
     if (!wasInTopN && nowInTopN) {
       // Track entered top-N → demote track at position N (pushed out of top-N)
-      notifyTrackSelected(ftn, topNGroup);
       boundaryOps.emplace_back(n, &topNGroup, Action::Demote);
     }
 
@@ -762,15 +801,128 @@ void PropertyRanking::promoteNextAvailableTrack(
 // 3. Reduces per-session callback overhead when many sessions share the same N
 // An alternative per-session callback exists (onSelected_) for cases needing individual handling.
 void PropertyRanking::notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup) {
-  std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> batch;
-  batch.reserve(topNGroup.sessions.size());
-  for (const auto& [session, info] : topNGroup.sessions) {
-    batch.emplace_back(session, info.forward);
+  std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> viewerBatch;
+  for (auto& [session, info] : topNGroup.sessions) {
+    if (isPublisher(session)) {
+      reconcilePublisherSelection(info, topNGroup.maxSelected, session);
+    } else {
+      viewerBatch.emplace_back(session, info.forward);
+    }
   }
-  if (!batch.empty() && onBatchSelected_) {
-    XLOG(DBG4) << "notifyTrackSelected: " << ftn << " to " << batch.size()
-               << " sessions in TopNGroup maxSelected=" << topNGroup.maxSelected;
-    onBatchSelected_(ftn, batch);
+  if (!viewerBatch.empty() && onBatchSelected_) {
+    onBatchSelected_(ftn, viewerBatch);
+  }
+}
+
+bool PropertyRanking::isSelfTrack(
+    const moxygen::FullTrackName& ftn,
+    const std::shared_ptr<moxygen::MoQSession>& session
+) const {
+  auto it = trackIndexByName_.find(ftn);
+  if (it == trackIndexByName_.end()) {
+    return false;
+  }
+  auto publisher = it->second.rankIter->second.publisher.lock();
+  return publisher == session;
+}
+
+bool PropertyRanking::isPublisher(const std::shared_ptr<moxygen::MoQSession>& session) const {
+  // Check if this session owns any track in rankedTracks_.
+  for (const auto& [key, entry] : rankedTracks_) {
+    if (entry.publisher.lock() == session) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::optional<RankKey>
+PropertyRanking::computeWaterlineKey(
+    const std::shared_ptr<moxygen::MoQSession>& session,
+    uint64_t maxSelected
+) const {
+  // Find the Nth non-self track. Its RankKey is the waterline: all non-self
+  // tracks with key >= waterline should be selected for this session.
+  // (RankKey uses std::greater<>, so higher key = lower rank = better.)
+  uint64_t nonSelfCount = 0;
+  for (const auto& [key, entry] : rankedTracks_) {
+    if (!isSelfTrack(entry.ftn, session)) {
+      nonSelfCount++;
+      if (nonSelfCount == maxSelected) {
+        return key;
+      }
+    }
+  }
+
+  // Fewer than N non-self tracks exist — select all of them.
+  return std::nullopt;
+}
+
+void PropertyRanking::reconcilePublisherSelection(
+    SessionInfo& info,
+    uint64_t maxSelected,
+    const std::shared_ptr<moxygen::MoQSession>& session
+) {
+  // Recompute the publisher's personal waterline using dynamic self-exclusion.
+  info.waterlineKey = computeWaterlineKey(session, maxSelected);
+
+  // Determine what should currently be delivered to this publisher session.
+  // A track is selected iff it's non-self AND at-or-above the waterline.
+  folly::F14FastSet<moxygen::FullTrackName, moxygen::FullTrackName::hash> nowSelected;
+  for (const auto& [key, entry] : rankedTracks_) {
+    if (!isSelfTrack(entry.ftn, session) &&
+        (!info.waterlineKey || key >= *info.waterlineKey)) {
+      nowSelected.insert(entry.ftn);
+    }
+  }
+
+  // Evict tracks that left the publisher's personal top-N.
+  for (const auto& ftn : info.selectedTracks) {
+    if (nowSelected.count(ftn) == 0 && onEvicted_) {
+      onEvicted_(ftn, session);
+    }
+  }
+
+  // Notify tracks that entered the publisher's personal top-N.
+  for (const auto& ftn : nowSelected) {
+    if (info.selectedTracks.count(ftn) == 0 && onSelected_) {
+      onSelected_(ftn, session, info.forward);
+    }
+  }
+
+  info.selectedTracks = std::move(nowSelected);
+}
+
+void PropertyRanking::reconcilePublisherInAllGroups(
+    const std::shared_ptr<moxygen::MoQSession>& session
+) {
+  // When a track is registered by a session that is already subscribed,
+  // that track becomes a self-track for this session. Reconcile all groups
+  // where this session appears to update their selection accordingly.
+  for (auto& [n, topNGroup] : topNGroups_) {
+    auto sessionIt = topNGroup.sessions.find(session);
+    if (sessionIt == topNGroup.sessions.end()) {
+      continue;
+    }
+
+    auto& info = sessionIt->second;
+    bool wasPublisher = !info.selectedTracks.empty() || info.waterlineKey.has_value();
+
+    // If upgrading from viewer to publisher-subscriber, seed selectedTracks from
+    // the shared top-N so reconcile can compute the correct delta (i.e. evict the
+    // newly-self track rather than re-notifying every viewer-delivered track).
+    if (!wasPublisher) {
+      uint64_t rank = 0;
+      for (const auto& [key, entry] : rankedTracks_) {
+        if (rank >= n) {
+          break;
+        }
+        info.selectedTracks.insert(entry.ftn);
+        rank++;
+      }
+    }
+
+    reconcilePublisherSelection(info, n, session);
   }
 }
 

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -64,8 +64,7 @@ void PropertyRanking::registerTrack(
     auto prevIt = iter;
     --prevIt;
     auto prevIndexIt = trackIndexByName_.find(prevIt->second.ftn);
-    XCHECK(prevIndexIt != trackIndexByName_.end())
-        << "Previous track must exist in index";
+    XCHECK(prevIndexIt != trackIndexByName_.end()) << "Previous track must exist in index";
 
     // Handle sentinel: if previous track has UINT64_MAX (lazy partial cache),
     // fall back to O(rank) distance computation for accurate rank.
@@ -97,7 +96,7 @@ void PropertyRanking::registerTrack(
   // Phase 1: Mark track selected in applicable groups, collect demotion positions.
   // For each group where rank < N, the new track enters top-N and pushes
   // the track at rank N-1 down to rank N (out of top-N).
-  std::vector<std::pair<uint64_t, TopNGroup*>> demotions;  // (position n, group)
+  std::vector<std::pair<uint64_t, TopNGroup*>> demotions; // (position n, group)
 
   for (auto& [n, topNGroup] : topNGroups_) {
     if (rank < n) {
@@ -118,8 +117,9 @@ void PropertyRanking::registerTrack(
     IterationGuard guard(*this);
 
     // Sort by position for single-pass processing
-    std::sort(demotions.begin(), demotions.end(),
-              [](const auto& a, const auto& b) { return a.first < b.first; });
+    std::sort(demotions.begin(), demotions.end(), [](const auto& a, const auto& b) {
+      return a.first < b.first;
+    });
 
     size_t demIdx = 0;
     uint64_t count = 0;
@@ -130,7 +130,7 @@ void PropertyRanking::registerTrack(
         demIdx++;
       }
       if (demIdx >= demotions.size()) {
-        break;  // All demotions processed
+        break; // All demotions processed
       }
       count++;
     }
@@ -167,7 +167,7 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
   }
 
   // --- Step 2: Re-insert at new position in sorted map ---
-  RankKey newKey{value, oldKey.arrivalSeq};  // Preserve arrival sequence for tie-breaking
+  RankKey newKey{value, oldKey.arrivalSeq}; // Preserve arrival sequence for tie-breaking
 
   rebuildRankCacheIfNeeded();
   uint64_t oldRank = entry.cachedRank;
@@ -181,8 +181,7 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
   // --- Step 3: Compute new rank ---
   // O(newRank) for bidirectional iterator. Acceptable because top-ranked tracks
   // (where we care most about performance) have small newRank values.
-  uint64_t newRank = static_cast<uint64_t>(
-      std::distance(rankedTracks_.begin(), newIter));
+  uint64_t newRank = static_cast<uint64_t>(std::distance(rankedTracks_.begin(), newIter));
   entry.cachedRank = newRank;
 
   // --- Step 4: Incrementally update cached ranks for affected tracks ---
@@ -191,9 +190,10 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
   // Special case: if oldRank == UINT64_MAX (sentinel from lazy partial cache),
   // the track was outside the selection threshold. We only need to update
   // tracks up to selectionThreshold_ since tracks beyond don't affect selection.
-  uint64_t effectiveOldRank = (oldRank == UINT64_MAX)
-      ? std::min(static_cast<uint64_t>(rankedTracks_.size()), selectionThreshold_)
-      : oldRank;
+  uint64_t effectiveOldRank =
+      (oldRank == UINT64_MAX)
+          ? std::min(static_cast<uint64_t>(rankedTracks_.size()), selectionThreshold_)
+          : oldRank;
 
   if (newRank < effectiveOldRank) {
     // Track moved UP (higher value → lower rank number).
@@ -202,7 +202,7 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
     //   Before: [0, 1, 2, 3, 4, T, 6, ...]  (T was at rank 5)
     //   After:  [0, 1, T, 2, 3, 4, 6, ...]  (tracks 2,3,4 shift to 3,4,5)
     auto rankedIt = newIter;
-    ++rankedIt;  // Start after the moved track
+    ++rankedIt; // Start after the moved track
     for (uint64_t r = newRank + 1; r <= effectiveOldRank && rankedIt != rankedTracks_.end();
          ++r, ++rankedIt) {
       auto indexIt = trackIndexByName_.find(rankedIt->second.ftn);
@@ -231,14 +231,14 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
 
   // --- Step 5: Fast path - no threshold crossed ---
   if (!crossesThreshold(oldRank, newRank)) {
-    XLOG(DBG5) << "updateSortValue fast path: " << ftn << " value=" << value
-               << " rank " << oldRank << " -> " << newRank << " (no threshold crossed)";
+    XLOG(DBG5) << "updateSortValue fast path: " << ftn << " value=" << value << " rank " << oldRank
+               << " -> " << newRank << " (no threshold crossed)";
     return;
   }
 
   // --- Step 6: Slow path - threshold crossed, update TopNGroups ---
-  XLOG(DBG4) << "updateSortValue slow path: " << ftn << " value=" << value
-             << " rank " << oldRank << " -> " << newRank << " (threshold crossed)";
+  XLOG(DBG4) << "updateSortValue slow path: " << ftn << " value=" << value << " rank " << oldRank
+             << " -> " << newRank << " (threshold crossed)";
   recomputeTopNGroups(ftn, oldRank, newRank);
 }
 
@@ -316,7 +316,7 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
         for (auto& [key, rankedEntry] : rankedTracks_) {
           auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
           if (stIt != topNGroup.trackStates.end() && stIt->second == TrackState::Selected) {
-            continue;  // Already selected, skip
+            continue; // Already selected, skip
           }
           // Found first non-selected track - promote it
           topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
@@ -361,8 +361,7 @@ void PropertyRanking::addSessionToTopNGroup(
     bool forward
 ) {
   XCHECK(!iteratingSessions_) << "Cannot add session while iterating";
-  XLOG(DBG4) << "addSessionToTopNGroup: maxSelected=" << maxSelected
-             << " forward=" << forward;
+  XLOG(DBG4) << "addSessionToTopNGroup: maxSelected=" << maxSelected << " forward=" << forward;
 
   auto& topNGroup = getOrCreateTopNGroup(maxSelected);
   topNGroup.sessions[session] = SessionInfo{.forward = forward};
@@ -393,7 +392,8 @@ void PropertyRanking::updateSessionForward(
 
   auto sessionIt = it->second.sessions.find(session);
   if (sessionIt == it->second.sessions.end()) {
-    XLOG(WARN) << "updateSessionForward: session not found in TopNGroup maxSelected=" << maxSelected;
+    XLOG(WARN) << "updateSessionForward: session not found in TopNGroup maxSelected="
+               << maxSelected;
     return;
   }
 
@@ -610,8 +610,9 @@ void PropertyRanking::recomputeTopNGroups(
   }
 
   // Sort by position for single-pass processing
-  std::sort(boundaryOps.begin(), boundaryOps.end(),
-            [](const auto& a, const auto& b) { return std::get<0>(a) < std::get<0>(b); });
+  std::sort(boundaryOps.begin(), boundaryOps.end(), [](const auto& a, const auto& b) {
+    return std::get<0>(a) < std::get<0>(b);
+  });
 
   size_t opIdx = 0;
   uint64_t count = 0;
@@ -630,7 +631,7 @@ void PropertyRanking::recomputeTopNGroups(
     }
 
     if (opIdx >= boundaryOps.size()) {
-      break;  // All operations processed
+      break; // All operations processed
     }
     count++;
   }
@@ -689,8 +690,8 @@ void PropertyRanking::demoteTrackInGroup(
 ) {
   auto stIt = group.trackStates.find(ftn);
   if (stIt != group.trackStates.end() && stIt->second == TrackState::Selected) {
-    XLOG(DBG4) << "demoteTrackInGroup: demoting " << ftn
-               << " at rank " << rank << " to deselected queue";
+    XLOG(DBG4) << "demoteTrackInGroup: demoting " << ftn << " at rank " << rank
+               << " to deselected queue";
     stIt->second = TrackState::Deselected;
     group.deselectedQueue.push_back(ftn);
     trimDeselectedQueue(group);
@@ -704,8 +705,7 @@ void PropertyRanking::promoteTrackInGroup(
 ) {
   auto stIt = group.trackStates.find(ftn);
   if (stIt == group.trackStates.end() || stIt->second != TrackState::Selected) {
-    XLOG(DBG4) << "promoteTrackInGroup: promoting " << ftn
-               << " at rank " << rank << " into top-N";
+    XLOG(DBG4) << "promoteTrackInGroup: promoting " << ftn << " at rank " << rank << " into top-N";
     group.trackStates[ftn] = TrackState::Selected;
     removeFromDeselectedQueue(group, ftn);
     notifyTrackSelected(ftn, group);

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/PropertyRanking.h"
+
+#include <folly/logging/xlog.h>
+
+namespace openmoq::moqx {
+
+PropertyRanking::PropertyRanking(
+    uint64_t propertyType,
+    uint64_t maxDeselected,
+    BatchSelectCallback onBatchSelected,
+    SelectCallback onSelected,
+    EvictCallback onEvicted
+)
+    : propertyType_(propertyType), maxDeselected_(maxDeselected),
+      onBatchSelected_(std::move(onBatchSelected)), onSelected_(std::move(onSelected)),
+      onEvicted_(std::move(onEvicted)) {}
+
+void PropertyRanking::registerTrack(
+    const moxygen::FullTrackName& ftn,
+    std::optional<uint64_t> initialValue,
+    std::weak_ptr<moxygen::MoQSession> publisher
+) {
+  if (trackIndexByName_.find(ftn) != trackIndexByName_.end()) {
+    XLOG(WARN) << "Track already registered: " << ftn;
+    return;
+  }
+
+  uint64_t value = initialValue.value_or(0);
+  RankKey key{value, nextSeq_++};
+
+  auto [iter, inserted] =
+      rankedTracks_.emplace(key, RankedEntry{.ftn = ftn, .publisher = std::move(publisher)});
+  trackIndexByName_[ftn] = RankIndex{.rankIter = iter, .cachedRank = UINT64_MAX};
+  invalidateRankCache();
+
+  uint64_t rank = getCachedRank(ftn);
+  XLOG(DBG4) << "Registered track " << ftn << " with value " << value << " at rank " << rank;
+
+  for (auto& [n, topNGroup] : topNGroups_) {
+    if (rank < n) {
+      topNGroup.trackStates[ftn] = TrackState::Selected;
+      IterationGuard guard(*this);
+      notifyTrackSelected(ftn, topNGroup);
+
+      // The new track pushed the previous occupant of rank N-1 to rank N.
+      // If that track was Selected, demote it into the deselected queue.
+      // (Only fires when numTracks > N, otherwise there's no track at rank N.)
+      demoteTrackAtRank(n, topNGroup);
+    }
+    // Tracks outside top N are not added to the deselected queue on register;
+    // they only enter the queue when they fall out of an already-selected position.
+  }
+}
+
+void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_t value) {
+  auto it = trackIndexByName_.find(ftn);
+  if (it == trackIndexByName_.end()) {
+    XLOG(DBG4) << "updateSortValue: track not registered " << ftn;
+    return;
+  }
+
+  auto& entry = it->second;
+  RankKey oldKey = entry.rankIter->first;
+
+  // Early exit: no change in value
+  if (oldKey.value == value) {
+    return;
+  }
+
+  // Construct new key after the early-exit check
+  RankKey newKey{value, oldKey.arrivalSeq};
+
+  // Capture old rank before modifying the map (oldKey disappears after erase)
+  uint64_t oldRank = getCachedRank(ftn);
+
+  // Update the sorted map
+  auto rankedEntry = std::move(entry.rankIter->second);
+  rankedTracks_.erase(entry.rankIter);
+  auto [newIter, _] = rankedTracks_.emplace(newKey, std::move(rankedEntry));
+  entry.rankIter = newIter;
+  invalidateRankCache();
+
+  // Compute new rank now that the map reflects the new position
+  uint64_t newRank = getCachedRank(ftn);
+
+  // FAST PATH: value change doesn't cross any threshold
+  if (!crossesThreshold(oldRank, newRank)) {
+    XLOG(DBG5) << "updateSortValue fast path: " << ftn << " value=" << value
+               << " rank " << oldRank << " -> " << newRank << " (no threshold crossed)";
+    return;
+  }
+
+  // SLOW PATH: value crossed a threshold, recompute TopNGroups
+  XLOG(DBG4) << "updateSortValue slow path: " << ftn << " value=" << value
+             << " rank " << oldRank << " -> " << newRank << " (threshold crossed)";
+  recomputeTopNGroups(ftn, oldRank, newRank);
+}
+
+void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
+  auto it = trackIndexByName_.find(ftn);
+  if (it == trackIndexByName_.end()) {
+    return;
+  }
+
+  auto& entry = it->second;
+  uint64_t oldRank = getCachedRank(ftn);
+
+  rankedTracks_.erase(entry.rankIter);
+  trackIndexByName_.erase(it);
+  invalidateRankCache();
+
+  XLOG(DBG4) << "Removed track " << ftn << " from rank " << oldRank;
+
+  for (auto& [n, topNGroup] : topNGroups_) {
+    auto stateIt = topNGroup.trackStates.find(ftn);
+    if (stateIt == topNGroup.trackStates.end()) {
+      continue;
+    }
+
+    bool wasSelected = stateIt->second == TrackState::Selected;
+    topNGroup.trackStates.erase(stateIt);
+
+    // Always remove from deselected queue if present
+    removeFromDeselectedQueue(topNGroup, ftn);
+
+    if (wasSelected) {
+      IterationGuard guard(*this);
+
+      // Try deselected queue first for cheap promotion
+      if (!topNGroup.deselectedQueue.empty()) {
+        auto promoted = topNGroup.deselectedQueue.front();
+        topNGroup.deselectedQueue.pop_front();
+        XLOG(DBG4) << "removeTrack: promoting " << promoted
+                   << " from deselected queue for TopNGroup maxSelected=" << n;
+        topNGroup.trackStates[promoted] = TrackState::Selected;
+        notifyTrackSelected(promoted, topNGroup);
+      } else {
+        // Fallback: deselected queue is empty (e.g., first removal after registration
+        // when no tracks have yet been demoted). Scan ranked list for the first
+        // non-selected track to promote into the vacated slot.
+        for (auto& [key, rankedEntry] : rankedTracks_) {
+          auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
+          if (stIt != topNGroup.trackStates.end() && stIt->second == TrackState::Selected) {
+            continue;
+          }
+          // Deselected queue is empty — scan ranked list for the first non-selected
+          // track. Since we just removed one selected track, there's guaranteed room
+          // in top-N for exactly one promotion.
+          topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
+          notifyTrackSelected(rankedEntry.ftn, topNGroup);
+          break;
+        }
+      }
+    }
+  }
+}
+
+TopNGroup& PropertyRanking::getOrCreateTopNGroup(uint64_t maxSelected) {
+  auto [it, inserted] = topNGroups_.try_emplace(maxSelected);
+  if (inserted) {
+    XLOG(DBG4) << "Created new TopNGroup with maxSelected=" << maxSelected;
+    it->second.maxSelected = maxSelected;
+    updateSelectionThreshold();
+
+    uint64_t rank = 0;
+    for (auto& [key, entry] : rankedTracks_) {
+      if (rank < maxSelected) {
+        it->second.trackStates[entry.ftn] = TrackState::Selected;
+      }
+      rank++;
+    }
+  }
+  return it->second;
+}
+
+void PropertyRanking::addSessionToTopNGroup(
+    uint64_t maxSelected,
+    std::shared_ptr<moxygen::MoQSession> session,
+    bool forward
+) {
+  XCHECK(!iteratingSessions_) << "Cannot add session while iterating";
+  XLOG(DBG4) << "addSessionToTopNGroup: maxSelected=" << maxSelected
+             << " forward=" << forward;
+
+  auto& topNGroup = getOrCreateTopNGroup(maxSelected);
+  topNGroup.sessions[session] = SessionInfo{.forward = forward};
+
+  // Notify session of all currently-selected tracks
+  uint64_t rank = 0;
+  for (auto& [key, entry] : rankedTracks_) {
+    if (rank >= maxSelected) {
+      break;
+    }
+    if (onSelected_) {
+      onSelected_(entry.ftn, session, forward);
+    }
+    rank++;
+  }
+}
+
+void PropertyRanking::updateSessionForward(
+    uint64_t maxSelected,
+    const std::shared_ptr<moxygen::MoQSession>& session,
+    bool forward
+) {
+  auto it = topNGroups_.find(maxSelected);
+  if (it == topNGroups_.end()) {
+    XLOG(WARN) << "updateSessionForward: TopNGroup not found for maxSelected=" << maxSelected;
+    return;
+  }
+
+  auto sessionIt = it->second.sessions.find(session);
+  if (sessionIt == it->second.sessions.end()) {
+    XLOG(WARN) << "updateSessionForward: session not found in TopNGroup maxSelected=" << maxSelected;
+    return;
+  }
+
+  XLOG(DBG4) << "updateSessionForward: maxSelected=" << maxSelected
+             << " forward=" << sessionIt->second.forward << " -> " << forward;
+  sessionIt->second.forward = forward;
+}
+
+void PropertyRanking::removeSessionFromTopNGroup(
+    uint64_t maxSelected,
+    const std::shared_ptr<moxygen::MoQSession>& session
+) {
+  XCHECK(!iteratingSessions_) << "Cannot remove session while iterating";
+
+  auto it = topNGroups_.find(maxSelected);
+  if (it == topNGroups_.end()) {
+    XLOG(WARN) << "removeSessionFromTopNGroup: TopNGroup not found for maxSelected=" << maxSelected;
+    return;
+  }
+
+  it->second.sessions.erase(session);
+
+  if (it->second.sessions.empty()) {
+    removeTopNGroup(maxSelected);
+  }
+}
+
+void PropertyRanking::removeTopNGroup(uint64_t maxSelected) {
+  XLOG(DBG4) << "removeTopNGroup: maxSelected=" << maxSelected;
+  topNGroups_.erase(maxSelected);
+  updateSelectionThreshold();
+}
+
+uint64_t PropertyRanking::getRank(const RankKey& key) const {
+  auto it = rankedTracks_.find(key);
+  if (it == rankedTracks_.end()) {
+    return UINT64_MAX;
+  }
+  rebuildRankCacheIfNeeded();
+  return trackIndexByName_.find(it->second.ftn)->second.cachedRank;
+}
+
+void PropertyRanking::rebuildRankCacheIfNeeded() const {
+  if (rankCacheValid_) {
+    return;
+  }
+  uint64_t rank = 0;
+  for (const auto& [key, entry] : rankedTracks_) {
+    auto it = trackIndexByName_.find(entry.ftn);
+    if (it != trackIndexByName_.end()) {
+      const_cast<RankIndex&>(it->second).cachedRank = rank;
+    }
+    rank++;
+  }
+  rankCacheValid_ = true;
+}
+
+uint64_t PropertyRanking::getCachedRank(const moxygen::FullTrackName& ftn) const {
+  rebuildRankCacheIfNeeded();
+  auto it = trackIndexByName_.find(ftn);
+  if (it == trackIndexByName_.end()) {
+    return UINT64_MAX;
+  }
+  return it->second.cachedRank;
+}
+
+bool PropertyRanking::crossesThreshold(uint64_t oldRank, uint64_t newRank) const {
+  if (topNGroups_.empty()) {
+    return false;
+  }
+
+  if (oldRank >= selectionThreshold_ && newRank >= selectionThreshold_) {
+    return false;
+  }
+
+  uint64_t minRank = std::min(oldRank, newRank);
+  uint64_t maxRank = std::max(oldRank, newRank);
+
+  // Both ranks within selection region; check if they cross a specific N boundary.
+  bool oldInAnyTopN = oldRank < selectionThreshold_;
+  bool newInAnyTopN = newRank < selectionThreshold_;
+  if (oldInAnyTopN != newInAnyTopN) {
+    return true;
+  }
+
+  // O(log G) check: any threshold between minRank and maxRank?
+  auto it = std::upper_bound(sortedThresholds_.begin(), sortedThresholds_.end(), minRank);
+  if (it != sortedThresholds_.end() && *it <= maxRank) {
+    return true;
+  }
+
+  return false;
+}
+
+void PropertyRanking::recomputeTopNGroups(
+    const moxygen::FullTrackName& ftn,
+    uint64_t oldRank,
+    uint64_t newRank
+) {
+  XLOG(DBG4) << "recomputeTopNGroups: " << ftn << " moved from rank " << oldRank << " to "
+             << newRank;
+
+  // O(G * N) where G = number of TopNGroups. For each group, we may iterate
+  // rankedTracks_ to find tracks at boundary positions.
+  // TODO: For large numbers of TopNGroups (G > ~5), optimize with single-pass
+  // algorithm: collect all crossed thresholds, sort them, then single iteration
+  // over rankedTracks_ to find all needed boundary positions.
+  IterationGuard guard(*this);
+  for (auto& [n, topNGroup] : topNGroups_) {
+    bool wasInTopN = oldRank < n;
+    bool nowInTopN = newRank < n;
+
+    if (wasInTopN != nowInTopN) {
+      if (nowInTopN) {
+        topNGroup.trackStates[ftn] = TrackState::Selected;
+        removeFromDeselectedQueue(topNGroup, ftn);
+      } else {
+        topNGroup.trackStates[ftn] = TrackState::Deselected;
+        topNGroup.deselectedQueue.push_back(ftn);
+        trimDeselectedQueue(topNGroup);
+      }
+    }
+
+    // Batch-notify all sessions when track enters shared top-N
+    if (!wasInTopN && nowInTopN) {
+      notifyTrackSelected(ftn, topNGroup);
+
+      // The track that just entered top-N displaced the one at position n;
+      // mark that track as deselected.
+      demoteTrackAtRank(n, topNGroup);
+    }
+
+    // When a track falls out of top-N, the track that was at position n (just
+    // outside) shifts into position n-1 (now inside). Promote it if not already
+    // selected.
+    if (wasInTopN && !nowInTopN) {
+      uint64_t count = 0;
+      for (auto& [key, rankedEntry] : rankedTracks_) {
+        if (count == n - 1) {
+          auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
+          if (stIt == topNGroup.trackStates.end() || stIt->second != TrackState::Selected) {
+            topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
+            removeFromDeselectedQueue(topNGroup, rankedEntry.ftn);
+            notifyTrackSelected(rankedEntry.ftn, topNGroup);
+          }
+          break;
+        }
+        count++;
+      }
+    }
+  }
+}
+
+void PropertyRanking::updateSelectionThreshold() {
+  uint64_t maxN = 0;
+  sortedThresholds_.clear();
+  sortedThresholds_.reserve(topNGroups_.size());
+  for (const auto& [n, topNGroup] : topNGroups_) {
+    maxN = std::max(maxN, n);
+    sortedThresholds_.push_back(n);
+  }
+  std::sort(sortedThresholds_.begin(), sortedThresholds_.end());
+  selectionThreshold_ = maxN + maxDeselected_;
+}
+
+void PropertyRanking::trimDeselectedQueue(TopNGroup& topNGroup) {
+  while (topNGroup.deselectedQueue.size() > maxDeselected_) {
+    auto evicted = topNGroup.deselectedQueue.front();
+    topNGroup.deselectedQueue.pop_front();
+    topNGroup.trackStates.erase(evicted);
+
+    XLOG(DBG4) << "[PropertyRanking] Evicting track " << evicted
+               << " from TopNGroup maxSelected=" << topNGroup.maxSelected
+               << " (deselectedQueue exceeded maxDeselected=" << maxDeselected_ << ")";
+
+    IterationGuard guard(*this);
+    for (const auto& [session, info] : topNGroup.sessions) {
+      if (session && onEvicted_) {
+        onEvicted_(evicted, session);
+      }
+    }
+  }
+}
+
+// O(maxDeselected_) linear scan to remove ftn from the deselected queue.
+void PropertyRanking::removeFromDeselectedQueue(
+    TopNGroup& group,
+    const moxygen::FullTrackName& ftn
+) {
+  auto& dq = group.deselectedQueue;
+  dq.erase(std::remove(dq.begin(), dq.end(), ftn), dq.end());
+}
+
+void PropertyRanking::demoteTrackAtRank(uint64_t n, TopNGroup& group) {
+  uint64_t count = 0;
+  for (auto& [key, rankedEntry] : rankedTracks_) {
+    if (count == n) {
+      auto stIt = group.trackStates.find(rankedEntry.ftn);
+      if (stIt != group.trackStates.end() && stIt->second == TrackState::Selected) {
+        XLOG(DBG4) << "demoteTrackAtRank: demoting " << rankedEntry.ftn
+                   << " at rank " << n << " to deselected queue";
+        stIt->second = TrackState::Deselected;
+        group.deselectedQueue.push_back(rankedEntry.ftn);
+        trimDeselectedQueue(group);
+      }
+      break;
+    }
+    count++;
+  }
+}
+
+void PropertyRanking::notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup) {
+  std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> batch;
+  for (const auto& [session, info] : topNGroup.sessions) {
+    batch.emplace_back(session, info.forward);
+  }
+  if (!batch.empty() && onBatchSelected_) {
+    XLOG(DBG4) << "notifyTrackSelected: " << ftn << " to " << batch.size()
+               << " sessions in TopNGroup maxSelected=" << topNGroup.maxSelected;
+    onBatchSelected_(ftn, batch);
+  }
+}
+
+} // namespace openmoq::moqx

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -648,6 +648,11 @@ void PropertyRanking::trimDeselectedQueue(TopNGroup& topNGroup) {
   // Guard once for all evictions rather than per-iteration
   IterationGuard guard(*this);
 
+  // Log warning once when queue overflows - indicates high track churn
+  XLOG(WARN) << "[PropertyRanking] Deselected queue overflow: " << topNGroup.deselectedQueue.size()
+             << " tracks queued, maxDeselected=" << maxDeselected_
+             << ". Consider increasing maxDeselected if this persists.";
+
   while (topNGroup.deselectedQueue.size() > maxDeselected_) {
     auto evicted = topNGroup.deselectedQueue.front();
     topNGroup.deselectedQueue.pop_front();

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -733,8 +733,7 @@ void PropertyRanking::promoteNextAvailableTrack(
       continue;
     }
     auto stIt = group.trackStates.find(rankedEntry.ftn);
-    bool isSelected =
-        stIt != group.trackStates.end() && stIt->second == TrackState::Selected;
+    bool isSelected = stIt != group.trackStates.end() && stIt->second == TrackState::Selected;
     if (!isSelected) {
       group.trackStates[rankedEntry.ftn] = TrackState::Selected;
       removeFromDeselectedQueue(group, rankedEntry.ftn);

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -31,30 +31,77 @@ void PropertyRanking::registerTrack(
     return;
   }
 
+  // Ensure cache is valid before insertion so we can use iterator-- for O(1) rank lookup
+  rebuildRankCacheIfNeeded();
+
   uint64_t value = initialValue.value_or(0);
   RankKey key{value, nextSeq_++};
 
   auto [iter, inserted] =
       rankedTracks_.emplace(key, RankedEntry{.ftn = ftn, .publisher = std::move(publisher)});
-  trackIndexByName_[ftn] = RankIndex{.rankIter = iter, .cachedRank = UINT64_MAX};
-  invalidateRankCache();
 
-  uint64_t rank = getCachedRank(ftn);
+  // Compute rank in O(1) using previous track's cached rank
+  uint64_t rank;
+  if (iter == rankedTracks_.begin()) {
+    rank = 0;
+  } else {
+    auto prevIt = iter;
+    --prevIt;
+    auto prevIndexIt = trackIndexByName_.find(prevIt->second.ftn);
+    rank = (prevIndexIt != trackIndexByName_.end()) ? prevIndexIt->second.cachedRank + 1 : 0;
+  }
+
+  trackIndexByName_[ftn] = RankIndex{.rankIter = iter, .cachedRank = rank};
+
+  // Increment cached ranks for all tracks after insertion point: O(numTracks - rank)
+  auto nextIt = iter;
+  ++nextIt;
+  for (; nextIt != rankedTracks_.end(); ++nextIt) {
+    auto indexIt = trackIndexByName_.find(nextIt->second.ftn);
+    if (indexIt != trackIndexByName_.end()) {
+      indexIt->second.cachedRank++;
+    }
+  }
+  // Cache remains valid - no full rebuild needed
+
   XLOG(DBG4) << "Registered track " << ftn << " with value " << value << " at rank " << rank;
+
+  // Two-phase algorithm: O(G log G + N) instead of O(G * N)
+  // Phase 1: Mark track selected in applicable groups, collect demotion positions
+  std::vector<std::pair<uint64_t, TopNGroup*>> demotions;  // (position n, group)
 
   for (auto& [n, topNGroup] : topNGroups_) {
     if (rank < n) {
       topNGroup.trackStates[ftn] = TrackState::Selected;
-      IterationGuard guard(*this);
       notifyTrackSelected(ftn, topNGroup);
 
       // The new track pushed the previous occupant of rank N-1 to rank N.
-      // If that track was Selected, demote it into the deselected queue.
-      // (Only fires when numTracks > N, otherwise there's no track at rank N.)
-      demoteTrackAtRank(n, topNGroup);
+      // Queue demotion (only fires when numTracks > N).
+      demotions.emplace_back(n, &topNGroup);
     }
     // Tracks outside top N are not added to the deselected queue on register;
     // they only enter the queue when they fall out of an already-selected position.
+  }
+
+  // Phase 2: Single traversal to demote tracks at collected positions
+  if (!demotions.empty()) {
+    IterationGuard guard(*this);
+
+    std::sort(demotions.begin(), demotions.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    size_t demIdx = 0;
+    uint64_t count = 0;
+    for (auto& [key, rankedEntry] : rankedTracks_) {
+      while (demIdx < demotions.size() && count == demotions[demIdx].first) {
+        demoteTrackInGroup(*demotions[demIdx].second, rankedEntry.ftn, count);
+        demIdx++;
+      }
+      if (demIdx >= demotions.size()) {
+        break;
+      }
+      count++;
+    }
   }
 }
 
@@ -76,18 +123,48 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
   // Construct new key after the early-exit check
   RankKey newKey{value, oldKey.arrivalSeq};
 
-  // Capture old rank before modifying the map (oldKey disappears after erase)
-  uint64_t oldRank = getCachedRank(ftn);
+  // Ensure cache is valid and capture old rank before modifying the map
+  rebuildRankCacheIfNeeded();
+  uint64_t oldRank = entry.cachedRank;
 
-  // Update the sorted map
+  // Update the sorted map: O(log N) erase + insert
   auto rankedEntry = std::move(entry.rankIter->second);
   rankedTracks_.erase(entry.rankIter);
   auto [newIter, _] = rankedTracks_.emplace(newKey, std::move(rankedEntry));
   entry.rankIter = newIter;
-  invalidateRankCache();
 
-  // Compute new rank now that the map reflects the new position
-  uint64_t newRank = getCachedRank(ftn);
+  // Compute new rank using std::distance: O(newRank) for bidirectional iterator.
+  // For top-ranked tracks (where we care most), this is fast.
+  uint64_t newRank = static_cast<uint64_t>(
+      std::distance(rankedTracks_.begin(), newIter));
+  entry.cachedRank = newRank;
+
+  // Incrementally update cached ranks for affected tracks only: O(|oldRank - newRank|).
+  // Tracks between old and new positions had their ranks shift by ±1.
+  if (newRank < oldRank) {
+    // Track moved up (higher value → lower rank). Tracks in (newRank, oldRank] shift down.
+    auto rankedIt = newIter;
+    ++rankedIt;  // Skip the moved track
+    for (uint64_t r = newRank + 1; r <= oldRank && rankedIt != rankedTracks_.end();
+         ++r, ++rankedIt) {
+      auto indexIt = trackIndexByName_.find(rankedIt->second.ftn);
+      if (indexIt != trackIndexByName_.end()) {
+        indexIt->second.cachedRank = r;
+      }
+    }
+  } else if (newRank > oldRank) {
+    // Track moved down (lower value → higher rank). Tracks in [oldRank, newRank) shift up.
+    auto rankedIt = newIter;
+    for (uint64_t r = newRank; r > oldRank && rankedIt != rankedTracks_.begin();) {
+      --rankedIt;
+      --r;
+      auto indexIt = trackIndexByName_.find(rankedIt->second.ftn);
+      if (indexIt != trackIndexByName_.end()) {
+        indexIt->second.cachedRank = r;
+      }
+    }
+  }
+  // Cache remains valid - no full rebuild needed
 
   // FAST PATH: value change doesn't cross any threshold
   if (!crossesThreshold(oldRank, newRank)) {
@@ -108,12 +185,27 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
     return;
   }
 
+  // Ensure cache is valid before removal
+  rebuildRankCacheIfNeeded();
+
   auto& entry = it->second;
-  uint64_t oldRank = getCachedRank(ftn);
+  uint64_t oldRank = entry.cachedRank;
+
+  // Save iterator to next track before erasing (remains valid after erase per std::map guarantees)
+  auto nextIt = entry.rankIter;
+  ++nextIt;
 
   rankedTracks_.erase(entry.rankIter);
   trackIndexByName_.erase(it);
-  invalidateRankCache();
+
+  // Decrement cached ranks for all tracks after removal point: O(numTracks - oldRank)
+  for (; nextIt != rankedTracks_.end(); ++nextIt) {
+    auto indexIt = trackIndexByName_.find(nextIt->second.ftn);
+    if (indexIt != trackIndexByName_.end()) {
+      indexIt->second.cachedRank--;
+    }
+  }
+  // Cache remains valid - no full rebuild needed
 
   XLOG(DBG4) << "Removed track " << ftn << " from rank " << oldRank;
 
@@ -260,6 +352,15 @@ uint64_t PropertyRanking::getRank(const RankKey& key) const {
   return trackIndexByName_.find(it->second.ftn)->second.cachedRank;
 }
 
+// O(numTracks) full cache rebuild. Only called when cache is invalid (e.g., after
+// direct map manipulation in tests). Normal operations use incremental updates:
+// - registerTrack: O(1) rank lookup via iterator--, O(numTracks - rank) updates
+// - removeTrack: O(numTracks - oldRank) updates
+// - updateSortValue: O(newRank) + O(|movement|) updates
+//
+// Future optimization opportunity:
+// Lazy partial cache: don't compute ranks for tracks past max(N) + maxDeselected.
+// Their rank only matters on track removal or increasing N (not yet supported).
 void PropertyRanking::rebuildRankCacheIfNeeded() const {
   if (rankCacheValid_) {
     return;
@@ -275,28 +376,23 @@ void PropertyRanking::rebuildRankCacheIfNeeded() const {
   rankCacheValid_ = true;
 }
 
-uint64_t PropertyRanking::getCachedRank(const moxygen::FullTrackName& ftn) const {
-  rebuildRankCacheIfNeeded();
-  auto it = trackIndexByName_.find(ftn);
-  if (it == trackIndexByName_.end()) {
-    return UINT64_MAX;
-  }
-  return it->second.cachedRank;
-}
-
 bool PropertyRanking::crossesThreshold(uint64_t oldRank, uint64_t newRank) const {
   if (topNGroups_.empty()) {
     return false;
   }
 
+  // Fast exit: both ranks outside selection region - no threshold can be crossed.
   if (oldRank >= selectionThreshold_ && newRank >= selectionThreshold_) {
     return false;
   }
+  // NOTE: We intentionally do NOT fast-exit when both ranks are below selectionThreshold_.
+  // Even though both are within the selection region, a specific N boundary might still
+  // be crossed (e.g., moving from rank 5 to rank 2 crosses N=3 but not N=7).
 
   uint64_t minRank = std::min(oldRank, newRank);
   uint64_t maxRank = std::max(oldRank, newRank);
 
-  // Both ranks within selection region; check if they cross a specific N boundary.
+  // Check if track crossed into/out of the selection region entirely.
   bool oldInAnyTopN = oldRank < selectionThreshold_;
   bool newInAnyTopN = newRank < selectionThreshold_;
   if (oldInAnyTopN != newInAnyTopN) {
@@ -320,12 +416,13 @@ void PropertyRanking::recomputeTopNGroups(
   XLOG(DBG4) << "recomputeTopNGroups: " << ftn << " moved from rank " << oldRank << " to "
              << newRank;
 
-  // O(G * N) where G = number of TopNGroups. For each group, we may iterate
-  // rankedTracks_ to find tracks at boundary positions.
-  // TODO: For large numbers of TopNGroups (G > ~5), optimize with single-pass
-  // algorithm: collect all crossed thresholds, sort them, then single iteration
-  // over rankedTracks_ to find all needed boundary positions.
   IterationGuard guard(*this);
+
+  // Two-phase algorithm: O(G log G + N) instead of O(G * N)
+  // Phase 1: Update state and collect boundary positions needing demotion/promotion
+  enum class Action { Demote, Promote };
+  std::vector<std::tuple<uint64_t, TopNGroup*, Action>> boundaryOps;
+
   for (auto& [n, topNGroup] : topNGroups_) {
     bool wasInTopN = oldRank < n;
     bool nowInTopN = newRank < n;
@@ -341,33 +438,47 @@ void PropertyRanking::recomputeTopNGroups(
       }
     }
 
-    // Batch-notify all sessions when track enters shared top-N
+    // Track entered top-N: notify and queue demotion at position n
     if (!wasInTopN && nowInTopN) {
       notifyTrackSelected(ftn, topNGroup);
-
-      // The track that just entered top-N displaced the one at position n;
-      // mark that track as deselected.
-      demoteTrackAtRank(n, topNGroup);
+      boundaryOps.emplace_back(n, &topNGroup, Action::Demote);
     }
 
-    // When a track falls out of top-N, the track that was at position n (just
-    // outside) shifts into position n-1 (now inside). Promote it if not already
-    // selected.
+    // Track fell out of top-N: queue promotion at position n-1
     if (wasInTopN && !nowInTopN) {
-      uint64_t count = 0;
-      for (auto& [key, rankedEntry] : rankedTracks_) {
-        if (count == n - 1) {
-          auto stIt = topNGroup.trackStates.find(rankedEntry.ftn);
-          if (stIt == topNGroup.trackStates.end() || stIt->second != TrackState::Selected) {
-            topNGroup.trackStates[rankedEntry.ftn] = TrackState::Selected;
-            removeFromDeselectedQueue(topNGroup, rankedEntry.ftn);
-            notifyTrackSelected(rankedEntry.ftn, topNGroup);
-          }
-          break;
-        }
-        count++;
-      }
+      boundaryOps.emplace_back(n - 1, &topNGroup, Action::Promote);
     }
+  }
+
+  // Phase 2: Single traversal of rankedTracks_ to handle all boundary operations
+  if (boundaryOps.empty()) {
+    return;
+  }
+
+  // Sort by position so we can process in one pass
+  std::sort(boundaryOps.begin(), boundaryOps.end(),
+            [](const auto& a, const auto& b) { return std::get<0>(a) < std::get<0>(b); });
+
+  size_t opIdx = 0;
+  uint64_t count = 0;
+  for (auto& [key, rankedEntry] : rankedTracks_) {
+    // Process all operations at this position
+    while (opIdx < boundaryOps.size() && count == std::get<0>(boundaryOps[opIdx])) {
+      auto* group = std::get<1>(boundaryOps[opIdx]);
+      Action action = std::get<2>(boundaryOps[opIdx]);
+
+      if (action == Action::Demote) {
+        demoteTrackInGroup(*group, rankedEntry.ftn, count);
+      } else {
+        promoteTrackInGroup(*group, rankedEntry.ftn, count);
+      }
+      opIdx++;
+    }
+
+    if (opIdx >= boundaryOps.size()) {
+      break;  // All operations processed
+    }
+    count++;
   }
 }
 
@@ -411,24 +522,42 @@ void PropertyRanking::removeFromDeselectedQueue(
   dq.erase(std::remove(dq.begin(), dq.end(), ftn), dq.end());
 }
 
-void PropertyRanking::demoteTrackAtRank(uint64_t n, TopNGroup& group) {
-  uint64_t count = 0;
-  for (auto& [key, rankedEntry] : rankedTracks_) {
-    if (count == n) {
-      auto stIt = group.trackStates.find(rankedEntry.ftn);
-      if (stIt != group.trackStates.end() && stIt->second == TrackState::Selected) {
-        XLOG(DBG4) << "demoteTrackAtRank: demoting " << rankedEntry.ftn
-                   << " at rank " << n << " to deselected queue";
-        stIt->second = TrackState::Deselected;
-        group.deselectedQueue.push_back(rankedEntry.ftn);
-        trimDeselectedQueue(group);
-      }
-      break;
-    }
-    count++;
+void PropertyRanking::demoteTrackInGroup(
+    TopNGroup& group,
+    const moxygen::FullTrackName& ftn,
+    uint64_t rank
+) {
+  auto stIt = group.trackStates.find(ftn);
+  if (stIt != group.trackStates.end() && stIt->second == TrackState::Selected) {
+    XLOG(DBG4) << "demoteTrackInGroup: demoting " << ftn
+               << " at rank " << rank << " to deselected queue";
+    stIt->second = TrackState::Deselected;
+    group.deselectedQueue.push_back(ftn);
+    trimDeselectedQueue(group);
   }
 }
 
+void PropertyRanking::promoteTrackInGroup(
+    TopNGroup& group,
+    const moxygen::FullTrackName& ftn,
+    uint64_t rank
+) {
+  auto stIt = group.trackStates.find(ftn);
+  if (stIt == group.trackStates.end() || stIt->second != TrackState::Selected) {
+    XLOG(DBG4) << "promoteTrackInGroup: promoting " << ftn
+               << " at rank " << rank << " into top-N";
+    group.trackStates[ftn] = TrackState::Selected;
+    removeFromDeselectedQueue(group, ftn);
+    notifyTrackSelected(ftn, group);
+  }
+}
+
+// Batch callback rationale: All sessions in a TopNGroup share the same N, so when a
+// track enters their top-N, the relay can handle them together. Benefits:
+// 1. Single upstream subscribe decision covers all sessions wanting this track
+// 2. Relay can batch state updates (e.g., one forwarder lookup, one cache check)
+// 3. Reduces per-session callback overhead when many sessions share the same N
+// An alternative per-session callback exists (onSelected_) for cases needing individual handling.
 void PropertyRanking::notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup) {
   std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> batch;
   for (const auto& [session, info] : topNGroup.sessions) {

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -287,9 +287,7 @@ private:
   // Helper: find and promote the highest-ranked non-selected track in a group.
   // Used by sweepIdle when evicting an idle track and needing a replacement.
   // excludeFtn is skipped (typically the track we just demoted).
-  void promoteNextAvailableTrack(
-      TopNGroup& group,
-      const moxygen::FullTrackName& excludeFtn);
+  void promoteNextAvailableTrack(TopNGroup& group, const moxygen::FullTrackName& excludeFtn);
 
   void invalidateRankCache() { rankCacheValid_ = false; }
 

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <moxygen/MoQSession.h>
+#include <moxygen/MoQTypes.h>
+
+#include <deque>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace openmoq::moqx {
+
+/**
+ * Ranking key for deterministic ordering in std::map.
+ * Uses std::greater<> comparator for descending order (highest value first).
+ */
+struct RankKey {
+  uint64_t value;      // Property value (higher = better rank)
+  uint64_t arrivalSeq; // Tie-breaker (lower = earlier = wins)
+
+  bool operator<(const RankKey& other) const {
+    if (value != other.value) {
+      return value < other.value;
+    }
+    return arrivalSeq > other.arrivalSeq;
+  }
+
+  bool operator>(const RankKey& other) const {
+    if (value != other.value) {
+      return value > other.value;
+    }
+    return arrivalSeq < other.arrivalSeq;
+  }
+
+  bool operator==(const RankKey& other) const {
+    return value == other.value && arrivalSeq == other.arrivalSeq;
+  }
+
+  bool operator!=(const RankKey& other) const { return !(*this == other); }
+
+  bool operator<=(const RankKey& other) const { return *this < other || *this == other; }
+
+  bool operator>=(const RankKey& other) const { return *this > other || *this == other; }
+};
+
+/**
+ * Entry stored in the sorted container.
+ */
+struct RankedEntry {
+  moxygen::FullTrackName ftn;
+  std::weak_ptr<moxygen::MoQSession> publisher;
+};
+
+/**
+ * Fast lookup from track name to rank position.
+ * Includes cached rank to avoid O(n) std::distance() calls.
+ */
+struct RankIndex {
+  std::map<RankKey, RankedEntry, std::greater<RankKey>>::iterator rankIter;
+  uint64_t cachedRank{UINT64_MAX};
+};
+
+/**
+ * Track state within a TopNGroup.
+ */
+enum class TrackState { Selected, Deselected };
+
+/**
+ * Per-session state within a TopNGroup.
+ */
+struct SessionInfo {
+  bool forward{true};
+};
+
+/**
+ * TopNGroup - Group of subscribers with the same N value.
+ */
+struct TopNGroup {
+  uint64_t maxSelected{0}; // N
+
+  // Session -> state mapping. Not redundant with MoqxRelay's namespace tree:
+  // this groups sessions by N for O(1) batch notifications.
+  folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, SessionInfo> sessions;
+
+  // Track -> state (Selected or Deselected).
+  // Only contains tracks that are either in top-N or in the deselected queue
+  // (i.e., at most N + maxDeselected entries).
+  folly::F14FastMap<moxygen::FullTrackName, TrackState, moxygen::FullTrackName::hash> trackStates;
+
+  // FIFO queue for cheap reselection. Lives in TopNGroup, not PropertyRanking.
+  // Bounded by maxDeselected_ (a PropertyRanking-level property) before eviction.
+  std::deque<moxygen::FullTrackName> deselectedQueue;
+};
+
+/**
+ * PropertyRanking - Manages ranking of tracks by a property value.
+ *
+ * Maintains a sorted map of tracks by their property values and notifies
+ * subscribers when tracks enter or leave their top-N selection.
+ *
+ * Key design decisions:
+ * - std::map with std::greater<> for O(log T) sorted iteration (descending)
+ * - F14FastMap for O(1) track lookups
+ * - Fast path when value change doesn't cross any threshold
+ * - Deselected queue for cheap reselection without PUBLISH_DONE
+ */
+class PropertyRanking {
+public:
+  using SelectCallback = std::function<void(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQSession> session,
+      bool forward
+  )>;
+
+  using EvictCallback = std::function<
+      void(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQSession> session)>;
+
+  // Batch notification callback for viewer sessions.
+  // Called once per track state change with all affected sessions.
+  using BatchSelectCallback = std::function<void(
+      const moxygen::FullTrackName& ftn,
+      const std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>>& sessions
+  )>;
+
+  /**
+   * @param propertyType  The property type ID to rank by
+   * @param maxDeselected Maximum tracks in deselected queue before eviction.
+   *        NOTE: Currently only maxDeselected=0 is fully supported. With maxDeselected>0,
+   *        tracks enter the deselected queue but the relay has no way to pause/resume
+   *        forwarding since onDeselected/onReselected callbacks are not yet implemented.
+   *        TODO: Add onDeselected callback (when track enters deselected queue) and
+   *        onReselected callback (when track is promoted from queue back to selected)
+   *        to enable the relay to manage forwarding state for maxDeselected>0.
+   * @param onBatchSelected Batch callback for viewer notifications (required)
+   * @param onSelected  Individual callback for per-session notifications
+   * @param onEvicted   Callback when track is evicted from deselected queue
+   */
+  PropertyRanking(
+      uint64_t propertyType,
+      uint64_t maxDeselected,
+      BatchSelectCallback onBatchSelected,
+      SelectCallback onSelected,
+      EvictCallback onEvicted
+  );
+
+  ~PropertyRanking() = default;
+
+  PropertyRanking(const PropertyRanking&) = delete;
+  PropertyRanking& operator=(const PropertyRanking&) = delete;
+  PropertyRanking(PropertyRanking&&) = delete;
+  PropertyRanking& operator=(PropertyRanking&&) = delete;
+
+  uint64_t propertyType() const { return propertyType_; }
+
+  /**
+   * Register a track. Called at publish() time.
+   */
+  void registerTrack(
+      const moxygen::FullTrackName& ftn,
+      std::optional<uint64_t> initialValue,
+      std::weak_ptr<moxygen::MoQSession> publisher
+  );
+
+  /**
+   * Update track's sort value. Main hot-path entry point.
+   * Returns quickly (fast path) if value doesn't cross threshold.
+   */
+  void updateSortValue(const moxygen::FullTrackName& ftn, uint64_t value);
+
+  /**
+   * Remove track (on PUBLISH_DONE).
+   */
+  void removeTrack(const moxygen::FullTrackName& ftn);
+
+  /**
+   * Get or create TopNGroup for given N.
+   */
+  TopNGroup& getOrCreateTopNGroup(uint64_t maxSelected);
+
+  /**
+   * Add a session to a TopNGroup.
+   */
+  void addSessionToTopNGroup(
+      uint64_t maxSelected,
+      std::shared_ptr<moxygen::MoQSession> session,
+      bool forward
+  );
+
+  /**
+   * Update the forward flag for a session in a TopNGroup.
+   * Use case: subscriber initially joins with forward=false, later wants to forward.
+   */
+  void updateSessionForward(
+      uint64_t maxSelected,
+      const std::shared_ptr<moxygen::MoQSession>& session,
+      bool forward
+  );
+
+  /**
+   * Remove a session from a TopNGroup.
+   */
+  void removeSessionFromTopNGroup(
+      uint64_t maxSelected,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  );
+
+  /**
+   * Remove TopNGroup (last subscriber with this N left).
+   */
+  void removeTopNGroup(uint64_t maxSelected);
+
+  bool empty() const { return topNGroups_.empty(); }
+
+  size_t numTracks() const { return trackIndexByName_.size(); }
+
+  size_t numTopNGroups() const { return topNGroups_.size(); }
+
+  // Test accessors
+  const std::map<RankKey, RankedEntry, std::greater<RankKey>>& rankedTracks() const {
+    return rankedTracks_;
+  }
+
+  const TopNGroup* getTopNGroup(uint64_t maxSelected) const {
+    auto it = topNGroups_.find(maxSelected);
+    return it != topNGroups_.end() ? &it->second : nullptr;
+  }
+
+private:
+  uint64_t getRank(const RankKey& key) const;
+
+  // Check whether a rank move from oldRank to newRank crosses any selection
+  // threshold. Both ranks must be computed against the same (post-update) map.
+  bool crossesThreshold(uint64_t oldRank, uint64_t newRank) const;
+
+  // Recompute TopNGroup state after a rank move. oldRank/newRank are the
+  // ranks captured before and after the map update respectively.
+  void recomputeTopNGroups(const moxygen::FullTrackName& ftn, uint64_t oldRank, uint64_t newRank);
+
+  void updateSelectionThreshold();
+
+  void trimDeselectedQueue(TopNGroup& topNGroup);
+
+  /**
+   * Notify all sessions in a TopNGroup about a newly selected track.
+   * Must be called with iteratingSessions_ guard active.
+   */
+  void notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup);
+
+  void rebuildRankCacheIfNeeded() const;
+  uint64_t getCachedRank(const moxygen::FullTrackName& ftn) const;
+
+  // Remove ftn from the deselected queue (if present). O(queue size).
+  void removeFromDeselectedQueue(TopNGroup& group, const moxygen::FullTrackName& ftn);
+
+  // If the track at rank n in rankedTracks_ is marked Selected, move it to the
+  // deselected queue and trim. Call this after a track enters top-N and pushes
+  // the previous occupant of rank N-1 down to rank N.
+  void demoteTrackAtRank(uint64_t n, TopNGroup& group);
+
+  void invalidateRankCache() { rankCacheValid_ = false; }
+
+  uint64_t propertyType_;
+  uint64_t maxDeselected_;
+  BatchSelectCallback onBatchSelected_;
+  SelectCallback onSelected_;
+  EvictCallback onEvicted_;
+
+  std::map<RankKey, RankedEntry, std::greater<RankKey>> rankedTracks_;
+  // Name → iterator/rank index into rankedTracks_. O(1) lookup by track name.
+  folly::F14FastMap<moxygen::FullTrackName, RankIndex, moxygen::FullTrackName::hash>
+      trackIndexByName_;
+  folly::F14FastMap<uint64_t, TopNGroup> topNGroups_;
+
+  uint64_t nextSeq_{0};
+  uint64_t selectionThreshold_{0};
+  std::vector<uint64_t> sortedThresholds_;
+
+  mutable bool rankCacheValid_{false};
+
+  bool iteratingSessions_{false};
+
+  class IterationGuard {
+  public:
+    explicit IterationGuard(PropertyRanking& pr) : pr_(pr) { pr_.iteratingSessions_ = true; }
+    ~IterationGuard() { pr_.iteratingSessions_ = false; }
+    IterationGuard(const IterationGuard&) = delete;
+    IterationGuard& operator=(const IterationGuard&) = delete;
+
+  private:
+    PropertyRanking& pr_;
+  };
+};
+
+} // namespace openmoq::moqx

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -10,6 +10,7 @@
 #include <moxygen/MoQSession.h>
 #include <moxygen/MoQTypes.h>
 
+#include <chrono>
 #include <deque>
 #include <functional>
 #include <map>
@@ -131,22 +132,30 @@ public:
       const std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>>& sessions
   )>;
 
+  // Returns the last activity time for a track. Called during sweepIdle().
+  // If the track is unknown, return a default-constructed time_point (treated
+  // as always-idle).
+  using GetLastActivityFn =
+      std::function<std::chrono::steady_clock::time_point(const moxygen::FullTrackName&)>;
+
   /**
-   * @param propertyType  The property type ID to rank by
-   * @param maxDeselected Maximum tracks in deselected queue before eviction.
+   * @param propertyType    The property type ID to rank by
+   * @param maxDeselected   Maximum tracks in deselected queue before eviction.
    *        NOTE: Currently only maxDeselected=0 is fully supported. With maxDeselected>0,
    *        tracks enter the deselected queue but the relay has no way to pause/resume
    *        forwarding since onDeselected/onReselected callbacks are not yet implemented.
-   *        TODO: Add onDeselected callback (when track enters deselected queue) and
-   *        onReselected callback (when track is promoted from queue back to selected)
-   *        to enable the relay to manage forwarding state for maxDeselected>0.
+   * @param idleTimeout     How long a selected track may be silent before
+   *                        being deselected. Zero disables idle eviction.
+   * @param getLastActivity Relay callback to read per-track activity time
    * @param onBatchSelected Batch callback for viewer notifications (required)
-   * @param onSelected  Individual callback for per-session notifications
-   * @param onEvicted   Callback when track is evicted from deselected queue
+   * @param onSelected      Individual callback for per-session notifications
+   * @param onEvicted       Callback when track is evicted from deselected queue
    */
   PropertyRanking(
       uint64_t propertyType,
       uint64_t maxDeselected,
+      std::chrono::milliseconds idleTimeout,
+      GetLastActivityFn getLastActivity,
       BatchSelectCallback onBatchSelected,
       SelectCallback onSelected,
       EvictCallback onEvicted
@@ -220,8 +229,17 @@ public:
 
   bool empty() const { return topNGroups_.empty(); }
 
-  size_t numTracks() const { return trackIndexByName_.size(); }
+  /**
+   * Sweep all selected tracks for idleness. Any track whose last activity
+   * time is older than idleTimeout_ is deselected into the deselectedQueue
+   * (same path as ranking-based demotion — cheap reselection still works).
+   * No-op when idleTimeout_ is zero.
+   * Called from onActivity observer (already throttled by TopNFilter) and
+   * opportunistically from updateSortValue().
+   */
+  void sweepIdle();
 
+  size_t numTracks() const { return trackIndexByName_.size(); }
   size_t numTopNGroups() const { return topNGroups_.size(); }
 
   // Test accessors
@@ -266,10 +284,19 @@ private:
   // Helper: promote track at given position in a group (-> Selected, notify)
   void promoteTrackInGroup(TopNGroup& group, const moxygen::FullTrackName& ftn, uint64_t rank);
 
+  // Helper: find and promote the highest-ranked non-selected track in a group.
+  // Used by sweepIdle when evicting an idle track and needing a replacement.
+  // excludeFtn is skipped (typically the track we just demoted).
+  void promoteNextAvailableTrack(
+      TopNGroup& group,
+      const moxygen::FullTrackName& excludeFtn);
+
   void invalidateRankCache() { rankCacheValid_ = false; }
 
   uint64_t propertyType_;
   uint64_t maxDeselected_;
+  std::chrono::milliseconds idleTimeout_;
+  GetLastActivityFn getLastActivity_;
   BatchSelectCallback onBatchSelected_;
   SelectCallback onSelected_;
   EvictCallback onEvicted_;

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -256,15 +256,21 @@ private:
   void notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup);
 
   void rebuildRankCacheIfNeeded() const;
-  uint64_t getCachedRank(const moxygen::FullTrackName& ftn) const;
 
   // Remove ftn from the deselected queue (if present). O(queue size).
   void removeFromDeselectedQueue(TopNGroup& group, const moxygen::FullTrackName& ftn);
 
-  // If the track at rank n in rankedTracks_ is marked Selected, move it to the
-  // deselected queue and trim. Call this after a track enters top-N and pushes
-  // the previous occupant of rank N-1 down to rank N.
-  void demoteTrackAtRank(uint64_t n, TopNGroup& group);
+  // Helper: demote track at given position in a group (Selected -> Deselected + queue)
+  void demoteTrackInGroup(
+      TopNGroup& group,
+      const moxygen::FullTrackName& ftn,
+      uint64_t rank);
+
+  // Helper: promote track at given position in a group (-> Selected, notify)
+  void promoteTrackInGroup(
+      TopNGroup& group,
+      const moxygen::FullTrackName& ftn,
+      uint64_t rank);
 
   void invalidateRankCache() { rankCacheValid_ = false; }
 

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -282,7 +282,8 @@ private:
 
   std::map<RankKey, RankedEntry, std::greater<RankKey>> rankedTracks_;
   // Name → iterator/rank index into rankedTracks_. O(1) lookup by track name.
-  folly::F14FastMap<moxygen::FullTrackName, RankIndex, moxygen::FullTrackName::hash>
+  // Mutable because cachedRank is a derived value updated lazily in const methods.
+  mutable folly::F14FastMap<moxygen::FullTrackName, RankIndex, moxygen::FullTrackName::hash>
       trackIndexByName_;
   folly::F14FastMap<uint64_t, TopNGroup> topNGroups_;
 

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -261,16 +261,10 @@ private:
   void removeFromDeselectedQueue(TopNGroup& group, const moxygen::FullTrackName& ftn);
 
   // Helper: demote track at given position in a group (Selected -> Deselected + queue)
-  void demoteTrackInGroup(
-      TopNGroup& group,
-      const moxygen::FullTrackName& ftn,
-      uint64_t rank);
+  void demoteTrackInGroup(TopNGroup& group, const moxygen::FullTrackName& ftn, uint64_t rank);
 
   // Helper: promote track at given position in a group (-> Selected, notify)
-  void promoteTrackInGroup(
-      TopNGroup& group,
-      const moxygen::FullTrackName& ftn,
-      uint64_t rank);
+  void promoteTrackInGroup(TopNGroup& group, const moxygen::FullTrackName& ftn, uint64_t rank);
 
   void invalidateRankCache() { rankCacheValid_ = false; }
 

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 #include <moxygen/MoQSession.h>
 #include <moxygen/MoQTypes.h>
 
@@ -77,9 +78,23 @@ enum class TrackState { Selected, Deselected };
 
 /**
  * Per-session state within a TopNGroup.
+ *
+ * Self-exclusion is determined dynamically by comparing RankedEntry::publisher
+ * with the session pointer. There's no separate "publishedTracks" set - a track
+ * is a self-track iff its publisher == this session.
  */
 struct SessionInfo {
   bool forward{true};
+
+  // Waterline for self-exclusion (publisher-subscribers only).
+  // Recomputed by reconcilePublisherSelection when any non-self track's rank changes.
+  // nullopt = fewer than N non-self tracks exist — select all non-self tracks.
+  std::optional<RankKey> waterlineKey;
+
+  // Tracks currently being delivered to this session.
+  // For publisher-subscribers: used to compute the select/evict delta.
+  // For viewers: cleared (viewer selection is handled via batch notifications).
+  folly::F14FastSet<moxygen::FullTrackName, moxygen::FullTrackName::hash> selectedTracks;
 };
 
 /**
@@ -201,6 +216,8 @@ public:
 
   /**
    * Add a session to a TopNGroup.
+   * Self-exclusion is automatic: if this session is the publisher of any
+   * registered track, those tracks will be excluded from its top-N selection.
    */
   void addSessionToTopNGroup(
       uint64_t maxSelected,
@@ -292,6 +309,41 @@ private:
   // Used by sweepIdle when evicting an idle track and needing a replacement.
   // excludeFtn is skipped (typically the track we just demoted).
   void promoteNextAvailableTrack(TopNGroup& group, const moxygen::FullTrackName& excludeFtn);
+
+  // Check if a track is owned by this session (self-track).
+  // Looks up the track in rankedTracks_ and compares publisher.
+  bool isSelfTrack(
+      const moxygen::FullTrackName& ftn,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  ) const;
+
+  // Check if session owns any tracks in rankedTracks_ (is a publisher).
+  bool isPublisher(const std::shared_ptr<moxygen::MoQSession>& session) const;
+
+  // Compute the waterline key for a publisher-subscriber session.
+  // Returns the RankKey of the Nth non-self track (the lowest-ranked track
+  // that should still be selected for this session). Returns nullopt if
+  // fewer than N non-self tracks exist (meaning all non-self tracks are selected).
+  // Uses isSelfTrack() to determine which tracks belong to the session.
+  std::optional<RankKey> computeWaterlineKey(
+      const std::shared_ptr<moxygen::MoQSession>& session,
+      uint64_t maxSelected
+  ) const;
+
+  // Recompute the publisher's personal top-N and fire callbacks for the delta.
+  // Evicts tracks that left the selection; selects tracks that entered it.
+  // Updates info.waterlineKey and info.selectedTracks to reflect the new state.
+  // Uses isSelfTrack() to determine which tracks to exclude.
+  void reconcilePublisherSelection(
+      SessionInfo& info,
+      uint64_t maxSelected,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  );
+
+  // Reconcile all publisher-subscribers in all TopNGroups that match this session.
+  // Called by registerTrack when a new track is registered by a session that
+  // is already subscribed - the new track becomes a self-track for that session.
+  void reconcilePublisherInAllGroups(const std::shared_ptr<moxygen::MoQSession>& session);
 
   void invalidateRankCache() { rankCacheValid_ = false; }
 

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -125,6 +125,11 @@ public:
   using EvictCallback = std::function<
       void(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQSession> session)>;
 
+  // Callback when a track is deselected (enters deselected queue).
+  // Used by the relay to pause forwarding without sending SUBSCRIBE_DONE.
+  using DeselectedCallback = std::function<
+      void(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQSession> session)>;
+
   // Batch notification callback for viewer sessions.
   // Called once per track state change with all affected sessions.
   using BatchSelectCallback = std::function<void(
@@ -141,14 +146,12 @@ public:
   /**
    * @param propertyType    The property type ID to rank by
    * @param maxDeselected   Maximum tracks in deselected queue before eviction.
-   *        NOTE: Currently only maxDeselected=0 is fully supported. With maxDeselected>0,
-   *        tracks enter the deselected queue but the relay has no way to pause/resume
-   *        forwarding since onDeselected/onReselected callbacks are not yet implemented.
    * @param idleTimeout     How long a selected track may be silent before
    *                        being deselected. Zero disables idle eviction.
    * @param getLastActivity Relay callback to read per-track activity time
    * @param onBatchSelected Batch callback for viewer notifications (required)
    * @param onSelected      Individual callback for per-session notifications
+   * @param onDeselected    Callback when track enters deselected queue (pause forwarding)
    * @param onEvicted       Callback when track is evicted from deselected queue
    */
   PropertyRanking(
@@ -158,6 +161,7 @@ public:
       GetLastActivityFn getLastActivity,
       BatchSelectCallback onBatchSelected,
       SelectCallback onSelected,
+      DeselectedCallback onDeselected,
       EvictCallback onEvicted
   );
 
@@ -297,6 +301,7 @@ private:
   GetLastActivityFn getLastActivity_;
   BatchSelectCallback onBatchSelected_;
   SelectCallback onSelected_;
+  DeselectedCallback onDeselected_;
   EvictCallback onEvicted_;
 
   std::map<RankKey, RankedEntry, std::greater<RankKey>> rankedTracks_;

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -363,6 +363,17 @@ private:
       trackIndexByName_;
   folly::F14FastMap<uint64_t, TopNGroup> topNGroups_;
 
+  // Track count per publisher session for O(1) isPublisher() lookup.
+  // Key is raw pointer; value is weak_ptr (for validation) + count.
+  // Updated by registerTrack (increment) and removeTrack (decrement/erase).
+  // The weak_ptr guards against ABA problem: if session is destroyed and a new
+  // session gets the same address, the stale entry's weak_ptr won't match.
+  struct PublisherEntry {
+    std::weak_ptr<moxygen::MoQSession> session;
+    size_t trackCount{0};
+  };
+  folly::F14FastMap<moxygen::MoQSession*, PublisherEntry> publisherTrackCount_;
+
   uint64_t nextSeq_{0};
   uint64_t selectionThreshold_{0};
   std::vector<uint64_t> sortedThresholds_;

--- a/src/relay/TopNFilter.cpp
+++ b/src/relay/TopNFilter.cpp
@@ -29,11 +29,26 @@ void TopNFilter::removeObserver(uint64_t propertyType) {
   observers_.erase(propertyType);
 }
 
+void TopNFilter::setActivityTarget(std::chrono::steady_clock::time_point* target) {
+  activityTarget_ = target;
+}
+
+void TopNFilter::setActivityThreshold(std::chrono::milliseconds threshold) {
+  activityThreshold_ = threshold;
+}
+
 void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
-  // FAST PATH: No observers to notify
+  // FAST PATH: No observers — nothing to do
   if (observers_.empty()) {
     return;
   }
+
+  auto now = std::chrono::steady_clock::now();
+
+  // Throttle check for onActivity
+  bool activityThrottleAllows =
+      activityThreshold_.count() > 0 && now - lastActivityNotify_ >= activityThreshold_;
+  bool firedAnyActivity = false;
 
   // Check extensions for property values we're observing
   for (auto& [propertyType, entry] : observers_) {
@@ -42,8 +57,14 @@ void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
       continue;
     }
 
+    // Property matched — update activity timestamp
+    if (activityTarget_) {
+      *activityTarget_ = now;
+    }
+
     uint64_t value = *valueOpt;
     if (!entry.lastSeenValue || *entry.lastSeenValue != value) {
+      // Value changed: fire onValueChanged (not onActivity)
       XLOG(DBG4) << "[TopNFilter] Property changed on " << ftn_ << ": propertyType=0x" << std::hex
                  << propertyType << std::dec << " oldValue=" << entry.lastSeenValue.value_or(0)
                  << " newValue=" << value;
@@ -51,7 +72,15 @@ void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
       if (entry.observer.onValueChanged) {
         entry.observer.onValueChanged(value);
       }
+    } else if (activityThrottleAllows && entry.observer.onActivity) {
+      // Property seen but value unchanged: fire onActivity (throttled)
+      entry.observer.onActivity();
+      firedAnyActivity = true;
     }
+  }
+
+  if (firedAnyActivity) {
+    lastActivityNotify_ = now;
   }
 }
 

--- a/src/relay/TopNFilter.h
+++ b/src/relay/TopNFilter.h
@@ -10,6 +10,7 @@
 #include <moxygen/MoQFilters.h>
 #include <moxygen/MoQTypes.h>
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -24,6 +25,12 @@ struct PropertyObserver {
 
   // Called when the track ends (PUBLISH_DONE received).
   std::function<void()> onTrackEnded;
+
+  // Called when the observed property is present but value is unchanged.
+  // Throttled to at most once per activityThreshold_. Complements onValueChanged:
+  // either onValueChanged fires (value changed) or onActivity fires (value same),
+  // never both on the same object. Used to trigger idle sweeps in PropertyRanking.
+  std::function<void()> onActivity;
 };
 
 // Entry for tracking observer state per property type.
@@ -66,6 +73,13 @@ public:
 
   // Check if any observers are registered.
   bool hasObservers() const { return !observers_.empty(); }
+
+  // Set pointer to external timestamp; written when an observed property matches.
+  // Lifetime: caller guarantees the pointed-to time_point outlives this filter.
+  void setActivityTarget(std::chrono::steady_clock::time_point* target);
+
+  // Set minimum interval between onActivity callbacks. Zero = never fire onActivity.
+  void setActivityThreshold(std::chrono::milliseconds threshold);
 
   // Check extensions for property values and notify observers.
   // This is called for each object received.
@@ -114,6 +128,14 @@ private:
 
   // Track whether publishDone has been received
   bool ended_{false};
+
+  // Activity tracking: raw pointer written on every object (cheap); null = disabled.
+  std::chrono::steady_clock::time_point* activityTarget_{nullptr};
+
+  // Throttle for onActivity callbacks: minimum interval between fires.
+  // Zero means onActivity is never fired.
+  std::chrono::milliseconds activityThreshold_{};
+  std::chrono::steady_clock::time_point lastActivityNotify_{};
 };
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,3 +176,15 @@ target_link_libraries(moqx_property_ranking_base_test PRIVATE
   GTest::gmock
 )
 gtest_discover_tests(moqx_property_ranking_base_test)
+
+# TRACK_FILTER integration tests (in-process relay, no live server)
+add_executable(moqx_track_filter_test
+  MoqxTrackFilterTest.cpp
+)
+target_link_libraries(moqx_track_filter_test PRIVATE
+  moqx_core
+  moqx_test_main
+  GTest::gmock
+  moxygen::moxygen_events_moq_folly_executor_impl
+)
+gtest_discover_tests(moqx_track_filter_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,3 +165,14 @@ target_link_libraries(moqx_topn_filter_test PRIVATE
   GTest::gmock
 )
 gtest_discover_tests(moqx_topn_filter_test)
+
+# PropertyRanking base unit tests (no self-exclusion)
+add_executable(moqx_property_ranking_base_test
+  PropertyRankingBaseTest.cpp
+)
+target_link_libraries(moqx_property_ranking_base_test PRIVATE
+  moqx_core
+  GTest::gtest_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_property_ranking_base_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -177,6 +177,17 @@ target_link_libraries(moqx_property_ranking_base_test PRIVATE
 )
 gtest_discover_tests(moqx_property_ranking_base_test)
 
+# PropertyRanking self-exclusion / waterline unit tests
+add_executable(moqx_property_ranking_self_exclusion_test
+  PropertyRankingSelfExclusionTest.cpp
+)
+target_link_libraries(moqx_property_ranking_self_exclusion_test PRIVATE
+  moqx_core
+  GTest::gtest_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_property_ranking_self_exclusion_test)
+
 # TRACK_FILTER integration tests (in-process relay, no live server)
 add_executable(moqx_track_filter_test
   MoqxTrackFilterTest.cpp

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -855,28 +855,35 @@ TEST_F(MoqxTrackFilterTest, IdleEviction_SilentTrackReplacedByActiveOutsider) {
 // A session that subscribes with TRACK_FILTER before it starts publishing
 // must not receive its own track in the top-N selection.
 //
-// Setup: pub subscribes N=2, then publishes "self" (100).  Two other
-// sessions publish "a" (80) and "b" (60).  Non-self top-2 for pub are
-// "a" and "b"; pub must not receive its own "self" track.
-// Note: "b" is at shared rank 2 (outside shared top-2 of N=2) because
-// "self" occupies a slot, so this also exercises the out-of-shared-top-N
-// reconcile path for publisher-subscribers.
+// Setup: pub and viewer both subscribe N=2.  pub publishes "self" (100),
+// others publish "a" (80) and "b" (60).  Shared top-2 = {self, a}.
+// Viewer receives {self, a} — proving "self" IS in shared top-2.
+// Publisher receives {a, b} — proving self-exclusion works, and "b"
+// (outside shared top-2) enters the publisher's personal top-2.
 TEST_F(MoqxTrackFilterTest, PublisherSubscriber_SubscribeBeforePublish_DoesNotReceiveOwnTrack) {
   auto pub = makeSession();
+  auto viewer = makeSession();
   auto other = makeSession();
   doPublishNamespace(pub);
 
-  // Subscribe before publishing.
+  // Both subscribe before tracks are published.
   doSubscribeFilter(pub, /*maxSelected=*/2);
+  doSubscribeFilter(viewer, /*maxSelected=*/2);
 
-  auto cSelf = doPublish(pub, "self", 100); // pub's own track
-  auto cA = doPublish(other, "a", 80);      // other participant
-  auto cB = doPublish(other, "b", 60);      // other participant
+  auto cSelf = doPublish(pub, "self", 100); // pub's own track — rank 0
+  auto cA = doPublish(other, "a", 80);      // other participant — rank 1
+  auto cB = doPublish(other, "b", 60);      // other participant — rank 2
   exec_->driveFor(20);
 
+  // Viewer sees shared top-2: {self, a}. This proves "self" IS selected globally.
+  EXPECT_EQ(publishCount(viewer.get(), ftn("self")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0); // outside shared top-2
+
+  // Publisher sees personal top-2: {a, b}. "self" excluded, "b" promoted.
   EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0); // own track excluded
   EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
-  EXPECT_EQ(publishCount(pub.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(pub.get(), ftn("b")), 1); // promoted into personal top-2
 
   cSelf->publishDone(makePublishDone());
   cA->publishDone(makePublishDone());
@@ -886,10 +893,12 @@ TEST_F(MoqxTrackFilterTest, PublisherSubscriber_SubscribeBeforePublish_DoesNotRe
 // A session that publishes before subscribing with TRACK_FILTER must still
 // have its already-published track excluded from its personal top-N.
 //
-// Setup: pub publishes "self" (100); another session publishes "a" (80) and
-// "b" (60).  pub subscribes N=2 — must see "a" and "b" but not "self".
+// Setup: pub publishes "self" (100); others publish "a" (80) and "b" (60).
+// Viewer subscribes first — gets {self, a}, proving "self" is top-ranked.
+// Then pub subscribes N=2 — must see {a, b} not {self, a}.
 TEST_F(MoqxTrackFilterTest, PublisherSubscriber_PublishBeforeSubscribe_StillExcluded) {
   auto pub = makeSession();
+  auto viewer = makeSession();
   auto other = makeSession();
   doPublishNamespace(pub);
 
@@ -899,24 +908,33 @@ TEST_F(MoqxTrackFilterTest, PublisherSubscriber_PublishBeforeSubscribe_StillExcl
   auto cB = doPublish(other, "b", 60);
   exec_->driveFor(10);
 
-  // Late TRACK_FILTER subscription — self-track must be excluded.
+  // Viewer subscribes first to establish baseline: "self" IS in shared top-2.
+  doSubscribeFilter(viewer, /*maxSelected=*/2);
+  exec_->driveFor(10);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("self")), 1); // "self" is rank 0
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);    // "a" is rank 1
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0);    // "b" outside top-2
+
+  // Now pub subscribes — despite "self" being rank 0, it must be excluded.
   doSubscribeFilter(pub, /*maxSelected=*/2);
   exec_->driveFor(20);
 
-  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0);
+  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0); // excluded (own track)
   EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
-  EXPECT_EQ(publishCount(pub.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(pub.get(), ftn("b")), 1); // promoted into personal top-2
 
   cSelf->publishDone(makePublishDone());
   cA->publishDone(makePublishDone());
   cB->publishDone(makePublishDone());
 }
 
-// A viewer receives all top-N tracks including the publisher-subscriber's
-// own track; the publisher-subscriber itself never receives its own stream.
+// Self-exclusion is per-session: a viewer sees all top-N tracks including
+// another session's self-track; only the publisher itself is excluded.
 //
 // Setup: pub publishes "self" (100); another session publishes "a" (60).
-// viewer subscribes N=2 — gets both.  pub subscribes N=2 — gets "a" only.
+// Both viewer and pub subscribe N=2 simultaneously. Same tracks, same N,
+// but different views: viewer sees {self, a}, pub sees {a} only.
 TEST_F(MoqxTrackFilterTest, PublisherSubscriber_ViewerReceivesSelfTrack) {
   auto pub = makeSession();
   auto other = makeSession();
@@ -927,16 +945,17 @@ TEST_F(MoqxTrackFilterTest, PublisherSubscriber_ViewerReceivesSelfTrack) {
   auto cA = doPublish(other, "a", 60);
   exec_->driveFor(10);
 
+  // Both subscribe with identical parameters.
   doSubscribeFilter(viewer, /*maxSelected=*/2);
   doSubscribeFilter(pub, /*maxSelected=*/2);
   exec_->driveFor(20);
 
-  // Viewer sees both tracks (including pub's self-track).
+  // Viewer sees both tracks — "self" is just another track to them.
   EXPECT_EQ(publishCount(viewer.get(), ftn("self")), 1);
   EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
 
-  // Publisher-subscriber never receives its own track.
-  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0);
+  // Publisher sees only non-self tracks — same N, different view.
+  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0); // excluded
   EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
 
   cSelf->publishDone(makePublishDone());

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -800,4 +800,52 @@ TEST_F(MoqxTrackFilterTest, FilterChainInstalledForBothPaths) {
   consumerC->publishDone(makePublishDone());
 }
 
+// ---------------------------------------------------------------------------
+// Tests: idle eviction
+// ---------------------------------------------------------------------------
+
+// A selected track that stops sending objects is evicted once it has been
+// silent for longer than idleTimeout. An outsider that keeps sending objects
+// triggers the sweep (via the throttled onActivity callback) and is promoted.
+TEST_F(MoqxTrackFilterTest, IdleEviction_SilentTrackReplacedByActiveOutsider) {
+  relay_ = std::make_shared<MoqxRelay>(
+      config::CacheConfig{},
+      /*relayID=*/"",
+      /*maxDeselected=*/5,
+      /*idleTimeout=*/std::chrono::milliseconds(10),
+      /*activityThreshold=*/std::chrono::milliseconds(1)
+  );
+  relay_->setAllowedNamespacePrefix(kPrefix);
+
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  // "a" (100) enters top-1; "b" (50) is outside.
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // Stamp "a"'s lastObjectTime so it is not treated as epoch-idle.
+  sendValue(consumerA, 100);
+  exec_->driveFor(5);
+
+  // Schedule an object on "b" after idleTimeout has elapsed. loop() blocks
+  // until the timer fires, the sendValue call triggers sweepIdle (which
+  // schedules the publishToSession coroutine), and all resulting callbacks
+  // drain — then loop() returns naturally with no pending work.
+  auto* evb = exec_->getBackingEventBase();
+  evb->runAfterDelay([&] { sendValue(consumerB, 50); }, 20 /* ms, > idleTimeout=10ms */);
+  evb->loop();
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+}
+
 } // namespace

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -864,7 +864,6 @@ TEST_F(MoqxTrackFilterTest, PublisherSubscriber_SubscribeBeforePublish_DoesNotRe
   auto pub = makeSession();
   auto viewer = makeSession();
   auto other = makeSession();
-  doPublishNamespace(pub);
 
   // Both subscribe before tracks are published.
   doSubscribeFilter(pub, /*maxSelected=*/2);
@@ -900,7 +899,6 @@ TEST_F(MoqxTrackFilterTest, PublisherSubscriber_PublishBeforeSubscribe_StillExcl
   auto pub = makeSession();
   auto viewer = makeSession();
   auto other = makeSession();
-  doPublishNamespace(pub);
 
   // Publish before subscribing.
   auto cSelf = doPublish(pub, "self", 100);
@@ -939,7 +937,6 @@ TEST_F(MoqxTrackFilterTest, PublisherSubscriber_ViewerReceivesSelfTrack) {
   auto pub = makeSession();
   auto other = makeSession();
   auto viewer = makeSession();
-  doPublishNamespace(pub);
 
   auto cSelf = doPublish(pub, "self", 100);
   auto cA = doPublish(other, "a", 60);

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -1,0 +1,803 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * In-process integration tests for TRACK_FILTER (top-N track selection).
+ *
+ * All tests use NiceMock<MockMoQSession> driven by TestMoQExecutor::driveFor().
+ * Verification is done by counting session->publish() calls per FullTrackName.
+ */
+
+#include "MoqxRelay.h"
+#include <folly/coro/BlockingWait.h>
+#include <folly/io/async/EventBase.h>
+#include <folly/io/async/Request.h>
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/MoQTrackProperties.h>
+#include <moxygen/events/MoQFollyExecutorImpl.h>
+#include <moxygen/relay/MoQForwarder.h>
+#include <moxygen/test/MockMoQSession.h>
+#include <moxygen/test/Mocks.h>
+
+using namespace testing;
+using namespace moxygen;
+using namespace moxygen::test;
+using namespace openmoq::moqx;
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TrackNamespace kNs{{"conf", "room1"}};
+const TrackNamespace kPrefix{{"conf"}};
+constexpr uint64_t kPropType = 0x100; // audio level property type
+
+// ---------------------------------------------------------------------------
+// Test executor (same pattern as MoqxRelayTest)
+// TODO: Move TestMoQExecutor to a shared test helper (e.g., test/TestUtils.h)
+// ---------------------------------------------------------------------------
+
+class TestMoQExecutor : public MoQFollyExecutorImpl, public folly::DrivableExecutor {
+public:
+  explicit TestMoQExecutor() : MoQFollyExecutorImpl(&evb_) {}
+
+  void add(folly::Func func) override { MoQFollyExecutorImpl::add(std::move(func)); }
+
+  void drive() override {
+    if (auto* evb = getBackingEventBase()) {
+      evb->loopOnce();
+    }
+  }
+
+  // TODO: Audit driveFor() call sites to use minimum iterations needed rather
+  // than arbitrary values like 10/20. Consider adding a driveUntilIdle() helper.
+  void driveFor(int n) {
+    for (int i = 0; i < n; i++) {
+      drive();
+    }
+  }
+
+private:
+  folly::EventBase evb_;
+};
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+class MoqxTrackFilterTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    exec_ = std::make_shared<TestMoQExecutor>();
+    relay_ = std::make_shared<MoqxRelay>(
+        config::CacheConfig{0, 0}, // no cache
+        /*relayID=*/"",
+        /*maxDeselected=*/5
+    );
+    relay_->setAllowedNamespacePrefix(kPrefix);
+  }
+
+  void TearDown() override {
+    relay_.reset();
+    exec_->driveFor(10);
+  }
+
+  // Create a mock session wired to accept publish() calls.
+  // publish() calls are recorded in publishedTracks_[session.get()].
+  std::shared_ptr<MockMoQSession> makeSession() {
+    auto session = std::make_shared<NiceMock<MockMoQSession>>(exec_);
+    ON_CALL(*session, getNegotiatedVersion())
+        .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));
+
+    auto* raw = session.get();
+    ON_CALL(*session, publish(_, _))
+        .WillByDefault(Invoke([this, raw](PublishRequest pub, auto) -> Subscriber::PublishResult {
+          publishedTracks_[raw].push_back(pub.fullTrackName);
+          auto consumer = std::make_shared<NiceMock<MockTrackConsumer>>();
+          ON_CALL(*consumer, setTrackAlias(_))
+              .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+          ON_CALL(*consumer, objectStream(_, _, _))
+              .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+          ON_CALL(*consumer, publishDone(_))
+              .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+          PublishOk ok{
+              pub.requestID,
+              true,
+              128,
+              GroupOrder::Default,
+              LocationType::LargestObject,
+              std::nullopt,
+              std::make_optional(uint64_t(0))
+          };
+          return Subscriber::PublishConsumerAndReplyTask{
+              std::static_pointer_cast<TrackConsumer>(consumer),
+              folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(std::move(ok))
+          };
+        }));
+    return session;
+  }
+
+  // How many times session received a publish() for ftn
+  int publishCount(MockMoQSession* s, const FullTrackName& ftn) const {
+    auto it = publishedTracks_.find(s);
+    if (it == publishedTracks_.end()) {
+      return 0;
+    }
+    return std::count(it->second.begin(), it->second.end(), ftn);
+  }
+
+  // All FTNs published to this session (in order)
+  std::vector<FullTrackName> published(MockMoQSession* s) const {
+    auto it = publishedTracks_.find(s);
+    return it != publishedTracks_.end() ? it->second : std::vector<FullTrackName>{};
+  }
+
+  // ---- Relay helpers -------------------------------------------------------
+
+  template <typename F> auto withSession(std::shared_ptr<MoQSession> session, F&& f) {
+    folly::RequestContextScopeGuard guard;
+    folly::RequestContext::get()->setContextData(
+        sessionToken_,
+        std::make_unique<MoQSession::MoQSessionRequestData>(std::move(session))
+    );
+    return f();
+  }
+
+  // Publish a track; returns the TrackConsumer so caller can send objects.
+  std::shared_ptr<TrackConsumer> doPublish(
+      std::shared_ptr<MoQSession> session,
+      const std::string& trackName,
+      uint64_t initialLevel = 0
+  ) {
+    PublishRequest pub;
+    pub.fullTrackName = FullTrackName{kNs, trackName};
+    pub.requestID = RequestID(nextId_++);
+    pub.groupOrder = GroupOrder::OldestFirst;
+    if (initialLevel > 0) {
+      pub.extensions.insertMutableExtension(Extension{kPropType, initialLevel});
+    }
+    auto handle = makeHandle();
+    std::shared_ptr<TrackConsumer> consumer;
+    withSession(session, [&] {
+      auto result = relay_->publish(std::move(pub), handle);
+      ASSERT_TRUE(result.hasValue());
+      consumer = result->consumer;
+    });
+    return consumer;
+  }
+
+  // Subscribe with TRACK_FILTER; returns the subNs handle.
+  std::shared_ptr<Publisher::SubscribeNamespaceHandle>
+  doSubscribeFilter(std::shared_ptr<MoQSession> session, uint64_t maxSelected) {
+    SubscribeNamespace subNs;
+    subNs.trackNamespacePrefix = kNs;
+    subNs.requestID = RequestID(nextId_++);
+    subNs.options = SubscribeNamespaceOptions::PUBLISH;
+    subNs.forward = true;
+
+    TrackRequestParameter p;
+    p.key = folly::to_underlying(TrackRequestParamKey::TRACK_FILTER);
+    p.asTrackFilter = TrackFilter{kPropType, maxSelected};
+    subNs.params.insertParam(p);
+
+    std::shared_ptr<Publisher::SubscribeNamespaceHandle> handle;
+    withSession(session, [&] {
+      auto result = folly::coro::blockingWait(
+          relay_->subscribeNamespace(std::move(subNs), nullptr),
+          exec_.get()
+      );
+      ASSERT_TRUE(result.hasValue());
+      handle = *result;
+    });
+    return handle;
+  }
+
+  // Send an object carrying a new property value
+  void sendValue(std::shared_ptr<TrackConsumer> consumer, uint64_t value) {
+    ObjectHeader hdr;
+    hdr.group = 0;
+    hdr.id = nextObjId_++;
+    hdr.extensions.insertMutableExtension(Extension{kPropType, value});
+    consumer->objectStream(hdr, nullptr, false); // errors OK (no subscribers yet)
+  }
+
+  std::shared_ptr<Publisher::SubscriptionHandle> makeHandle() {
+    SubscribeOk ok;
+    ok.requestID = RequestID(0);
+    ok.trackAlias = TrackAlias(0);
+    ok.expires = std::chrono::milliseconds(0);
+    ok.groupOrder = GroupOrder::Default;
+    return std::make_shared<NiceMock<MockSubscriptionHandle>>(std::move(ok));
+  }
+
+  FullTrackName ftn(const std::string& name) const { return FullTrackName{kNs, name}; }
+
+  // Subscribe without TRACK_FILTER (plain namespace subscription)
+  void doSubscribeDirect(std::shared_ptr<MoQSession> session) {
+    SubscribeNamespace subNs;
+    subNs.trackNamespacePrefix = kNs;
+    subNs.requestID = RequestID(nextId_++);
+    subNs.options = SubscribeNamespaceOptions::PUBLISH;
+    subNs.forward = true;
+    withSession(session, [&] {
+      auto result = folly::coro::blockingWait(
+          relay_->subscribeNamespace(std::move(subNs), nullptr),
+          exec_.get()
+      );
+      ASSERT_TRUE(result.hasValue());
+    });
+  }
+
+  PublishDone makePublishDone() {
+    PublishDone done;
+    done.requestID = RequestID(0);
+    done.statusCode = PublishDoneStatusCode::TRACK_ENDED;
+    return done;
+  }
+
+  // ---- Members -------------------------------------------------------------
+
+  std::shared_ptr<TestMoQExecutor> exec_;
+  std::shared_ptr<MoqxRelay> relay_;
+  uint64_t nextId_{1};
+  uint64_t nextObjId_{0};
+  folly::RequestToken sessionToken_{"moq_session"};
+
+  // per-session record of which FTNs were pushed via publish()
+  std::map<MoQSession*, std::vector<FullTrackName>> publishedTracks_;
+};
+
+// ---------------------------------------------------------------------------
+// Tests: subscriber joins before publishers
+// ---------------------------------------------------------------------------
+
+// Subscriber joins first; only top-N publishers should be forwarded.
+TEST_F(MoqxTrackFilterTest, SubscribeFirst_Top2Of3_CorrectTracksForwarded) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  auto subHandle = doSubscribeFilter(viewer, /*maxSelected=*/2);
+  ASSERT_NE(subHandle, nullptr);
+
+  // Publish 3 tracks with different levels; top-2 are "a" (100) and "b" (80)
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 80);
+  auto cC = doPublish(pubSess, "c", 40);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("c")), 0); // outside top-2
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// Top-1: only the single highest track reaches the subscriber.
+TEST_F(MoqxTrackFilterTest, SubscribeFirst_Top1_OnlyHighestForwarded) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  auto cLoud = doPublish(pubSess, "loud", 100);
+  auto cQuiet = doPublish(pubSess, "quiet", 30);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("loud")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("quiet")), 0);
+
+  cLoud->publishDone(makePublishDone());
+  cQuiet->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: publisher joins before subscriber (late subscriber)
+// ---------------------------------------------------------------------------
+
+// Late subscriber should receive top-N from already-published tracks via
+// getOrCreateRanking retroactive registration + addSessionToTopNGroup.
+TEST_F(MoqxTrackFilterTest, PublishFirst_LateSubscriber_GetsTopN) {
+  auto pubSess = makeSession();
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 80);
+  auto cC = doPublish(pubSess, "c", 40);
+  exec_->driveFor(10);
+
+  // Late subscriber joins; expects to immediately receive top-2
+  auto viewer = makeSession();
+  auto subHandle = doSubscribeFilter(viewer, /*maxSelected=*/2);
+  ASSERT_NE(subHandle, nullptr);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("c")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: dynamic value changes
+// ---------------------------------------------------------------------------
+
+// A track outside top-N rises above the threshold and displaces the occupant.
+TEST_F(MoqxTrackFilterTest, ValueChange_OutsiderEntersTopN) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  // "a" starts loudest, "b" starts quiet
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 20);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // "b" jumps above "a"
+  sendValue(consumerB, 110);
+  exec_->driveFor(20);
+
+  // viewer should now receive "b" (entered top-1)
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+}
+
+// Two subscribers with different N values see independent top-N sets.
+TEST_F(MoqxTrackFilterTest, TwoSubscribers_DifferentN_IndependentSets) {
+  auto pubSess = makeSession();
+
+  auto viewerTop1 = makeSession();
+  auto viewerTop3 = makeSession();
+  doSubscribeFilter(viewerTop1, 1);
+  doSubscribeFilter(viewerTop3, 3);
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 80);
+  auto cC = doPublish(pubSess, "c", 60);
+  auto cD = doPublish(pubSess, "d", 20);
+  exec_->driveFor(20);
+
+  // top-1 viewer: only "a"
+  EXPECT_EQ(publishCount(viewerTop1.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewerTop1.get(), ftn("b")), 0);
+  EXPECT_EQ(publishCount(viewerTop1.get(), ftn("c")), 0);
+
+  // top-3 viewer: "a", "b", "c"
+  EXPECT_EQ(publishCount(viewerTop3.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewerTop3.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewerTop3.get(), ftn("c")), 1);
+  EXPECT_EQ(publishCount(viewerTop3.get(), ftn("d")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+  cD->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: forward flag
+// ---------------------------------------------------------------------------
+
+// forward=false propagates through to publishToSession without affecting selection.
+// The subscriber should still receive publishes for selected tracks, but with
+// forward=false passed to the forwarder (controls whether the relay requests
+// forwarding from upstream).
+TEST_F(MoqxTrackFilterTest, ForwardFalse_TracksStillSelected) {
+  auto pubSess = makeSession();
+
+  SubscribeNamespace subNs;
+  subNs.trackNamespacePrefix = kNs;
+  subNs.requestID = RequestID(nextId_++);
+  subNs.options = SubscribeNamespaceOptions::PUBLISH;
+  subNs.forward = false; // subscriber does not want forwarding
+
+  TrackRequestParameter p;
+  p.key = folly::to_underlying(TrackRequestParamKey::TRACK_FILTER);
+  p.asTrackFilter = TrackFilter{kPropType, 2};
+  subNs.params.insertParam(p);
+
+  auto viewer = makeSession();
+  withSession(viewer, [&] {
+    auto result = folly::coro::blockingWait(
+        relay_->subscribeNamespace(std::move(subNs), nullptr),
+        exec_.get()
+    );
+    EXPECT_TRUE(result.hasValue());
+  });
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 80);
+  auto cC = doPublish(pubSess, "c", 40);
+  exec_->driveFor(20);
+
+  // forward=false should not affect track selection: top-2 still receive publish
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("c")), 0); // outside top-2
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: unsubscribe cleans up ranking
+// ---------------------------------------------------------------------------
+
+TEST_F(MoqxTrackFilterTest, Unsubscribe_RemovesFromRanking) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  auto subHandle = doSubscribeFilter(viewer, /*maxSelected=*/2);
+  ASSERT_NE(subHandle, nullptr);
+
+  auto cA = doPublish(pubSess, "a", 100);
+  exec_->driveFor(10);
+
+  // Unsubscribe removes session from ranking
+  subHandle->unsubscribeNamespace();
+  exec_->driveFor(10);
+
+  // New track can still be published after subscriber leaves
+  auto cB = doPublish(pubSess, "b", 80);
+  exec_->driveFor(10);
+
+  // Verify track "a" was received before unsubscribe, "b" was not
+  // (no subscriber to receive it after unsubscribe)
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+}
+
+// Late subscriber joins, then a previously-quiet track sends a value update
+// that pushes it into top-N. Verifies that getOrCreateRanking wires the
+// TopNFilter observer correctly so subsequent value changes are tracked.
+TEST_F(MoqxTrackFilterTest, PublishFirst_LateSubscriber_ValueChangeUpdatesRanking) {
+  auto pubSess = makeSession();
+
+  // "loud" (100) and "quiet" (20) published before subscriber joins
+  auto consumerLoud = doPublish(pubSess, "loud", 100);
+  auto consumerQuiet = doPublish(pubSess, "quiet", 20);
+  exec_->driveFor(10);
+
+  // Late subscriber: top-1 only
+  auto viewer = makeSession();
+  auto subHandle = doSubscribeFilter(viewer, /*maxSelected=*/1);
+  ASSERT_NE(subHandle, nullptr);
+  exec_->driveFor(20);
+
+  // Initial selection: "loud" should be the top-1
+  ASSERT_EQ(publishCount(viewer.get(), ftn("loud")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("quiet")), 0);
+
+  // "quiet" jumps above "loud" — observer wired by getOrCreateRanking must fire
+  sendValue(consumerQuiet, 200);
+  exec_->driveFor(20);
+
+  // "quiet" should now enter top-1
+  EXPECT_EQ(publishCount(viewer.get(), ftn("quiet")), 1);
+
+  consumerLoud->publishDone(makePublishDone());
+  consumerQuiet->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: track ending (PUBLISH_DONE) while selected
+// ---------------------------------------------------------------------------
+
+// When the top-N track sends PUBLISH_DONE, the ranking should remove it and
+// promote the next candidate. This exercises the notifyTrackEnded→removeTrack
+// path without the redundant direct-loop in onPublishDone.
+TEST_F(MoqxTrackFilterTest, PublishDone_SelectedTrack_PromotesReplacement) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // "a" ends: ranking must clean up and promote "b" into top-1.
+  consumerA->publishDone(makePublishDone());
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+
+  consumerB->publishDone(makePublishDone());
+}
+
+// PUBLISH_DONE on a non-selected track should not cause spurious selection.
+TEST_F(MoqxTrackFilterTest, PublishDone_NonSelectedTrack_NoSpuriousSelection) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+
+  // "b" ends while outside top-1; no new selection should occur.
+  consumerB->publishDone(makePublishDone());
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1); // unchanged
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  consumerA->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: value decrease causes track to drop out of top-N
+// ---------------------------------------------------------------------------
+
+// A selected track's value drops below an unselected track's value; the
+// unselected one should be promoted and the old top-track should be evicted.
+TEST_F(MoqxTrackFilterTest, ValueDecrease_TopTrackDropsOutOfTopN) {
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // "a" drops below "b": "b" should enter top-1.
+  sendValue(consumerA, 20);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: direct subscriber and TRACK_FILTER subscriber on the same namespace
+// ---------------------------------------------------------------------------
+
+// A direct (non-filtered) subscriber must receive all published tracks while
+// the TRACK_FILTER subscriber receives only the top-N subset.
+TEST_F(MoqxTrackFilterTest, DirectAndFilterSubscriberCoexist) {
+  auto pubSess = makeSession();
+
+  auto directViewer = makeSession();
+  doSubscribeDirect(directViewer);
+
+  auto filteredViewer = makeSession();
+  doSubscribeFilter(filteredViewer, /*maxSelected=*/1);
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 50);
+  auto cC = doPublish(pubSess, "c", 20);
+  exec_->driveFor(20);
+
+  // Direct subscriber sees all three tracks.
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("c")), 1);
+
+  // TRACK_FILTER subscriber sees only the top-1.
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("b")), 0);
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("c")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: trackFilterSubscribers_ cleanup on unsubscribe
+// ---------------------------------------------------------------------------
+
+// After a TRACK_FILTER subscriber unsubscribes, a subsequent subscriber with
+// the same N should receive the correct top-N independently. Stale entries
+// left over by the first subscriber must not interfere with selection or
+// eviction for the second subscriber.
+TEST_F(MoqxTrackFilterTest, Unsubscribe_StaleEntriesDoNotAffectResubscribe) {
+  auto pubSess = makeSession();
+
+  auto cA = doPublish(pubSess, "a", 100);
+  auto cB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(10);
+
+  // First subscriber joins, "a" is selected, then unsubscribes.
+  // Without the fix, {a, viewer1*} lingers in trackFilterSubscribers_.
+  auto viewer1 = makeSession();
+  auto subHandle = doSubscribeFilter(viewer1, /*maxSelected=*/1);
+  ASSERT_NE(subHandle, nullptr);
+  exec_->driveFor(10);
+  ASSERT_EQ(publishCount(viewer1.get(), ftn("a")), 1);
+
+  subHandle->unsubscribeNamespace();
+  exec_->driveFor(10);
+
+  // Second subscriber should get the correct top-1 with no interference.
+  auto viewer2 = makeSession();
+  doSubscribeFilter(viewer2, /*maxSelected=*/1);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer2.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer2.get(), ftn("b")), 0);
+
+  // A new higher-value track should be selected for viewer2 only.
+  auto cC = doPublish(pubSess, "c", 200);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer2.get(), ftn("c")), 1);
+
+  // viewer1 was unsubscribed and must not receive anything new.
+  EXPECT_EQ(publishCount(viewer1.get(), ftn("b")), 0);
+  EXPECT_EQ(publishCount(viewer1.get(), ftn("c")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: deselected queue eviction
+// ---------------------------------------------------------------------------
+
+// When the deselected queue overflows maxDeselected, the oldest entry is
+// evicted (subscriber removed from forwarder). This test uses maxDeselected=2
+// to keep the setup minimal: three displaced tracks fills the queue to 3.
+TEST_F(MoqxTrackFilterTest, DeselectedQueueEviction_EvictsOldestEntry) {
+  // Override relay_ with a tighter maxDeselected so eviction triggers quickly.
+  relay_ = std::make_shared<MoqxRelay>(
+      config::CacheConfig{0, 0}, // no cache
+      /*relayID=*/"",
+      /*maxDeselected=*/2
+  );
+  relay_->setAllowedNamespacePrefix(kPrefix);
+
+  auto pubSess = makeSession();
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+
+  // "base" enters top-1 first.
+  auto cBase = doPublish(pubSess, "base", 10);
+  exec_->driveFor(10);
+  ASSERT_EQ(publishCount(viewer.get(), ftn("base")), 1);
+
+  // Each successive track displaces the previous top-1 into the deselected queue.
+  // After "t3" arrives the queue is {"base","t1","t2"} (size 3 > maxDeselected=2),
+  // which evicts "base".
+  auto cT1 = doPublish(pubSess, "t1", 20); // deselected: {base}
+  auto cT2 = doPublish(pubSess, "t2", 30); // deselected: {base, t1}
+  auto cT3 = doPublish(pubSess, "t3", 40); // deselected overflows → "base" evicted
+  exec_->driveFor(20);
+
+  // All four tracks entered top-1 in sequence as higher-value tracks arrived.
+  EXPECT_EQ(publishCount(viewer.get(), ftn("base")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("t1")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("t2")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("t3")), 1);
+
+  // Verify total number of selections: all 4 tracks should have been selected
+  // exactly once as they successively entered top-1.
+  auto allPublished = published(viewer.get());
+  EXPECT_EQ(allPublished.size(), 4);
+
+  cBase->publishDone(makePublishDone());
+  cT1->publishDone(makePublishDone());
+  cT2->publishDone(makePublishDone());
+  cT3->publishDone(makePublishDone());
+}
+
+// ---------------------------------------------------------------------------
+// Tests: filter chain installation in both publish and subscribe paths
+// ---------------------------------------------------------------------------
+
+// Verifies that when a TRACK_FILTER subscriber joins after PUBLISH, the relay
+// correctly handles forwarding. The forwardChanged() callback mechanism sends
+// REQUEST_UPDATE when forwarding state changes.
+TEST_F(MoqxTrackFilterTest, ForwardStateUpdatedWhenFilterSubscriberJoins) {
+  auto pubSess = makeSession();
+
+  // Publish tracks with no subscribers initially (forward would be false/true
+  // depending on whether TRACK_FILTER subscribers exist at publish time)
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  exec_->driveFor(10);
+
+  // TRACK_FILTER subscriber joins - should trigger forwardChanged() callback
+  // which sends REQUEST_UPDATE with forward=true to the publisher
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/1);
+  exec_->driveFor(20);
+
+  // Verify subscriber receives the top-1 track
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  // Value changes should still work (verifies forwarder is receiving objects)
+  sendValue(consumerB, 200);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+}
+
+// Verifies that TopNFilter is installed in the filter chain for both PUBLISH
+// and SUBSCRIBE paths. A direct subscriber joins first (triggering filter chain
+// creation), then a TRACK_FILTER subscriber joins later. Value changes on
+// existing tracks must be observed and reflected in the TRACK_FILTER ranking.
+TEST_F(MoqxTrackFilterTest, FilterChainInstalledForBothPaths) {
+  auto pubSess = makeSession();
+
+  // Direct subscriber joins first — establishes the relay subscription path
+  auto directViewer = makeSession();
+  doSubscribeDirect(directViewer);
+
+  // Publisher publishes tracks (direct subscriber receives all)
+  auto consumerA = doPublish(pubSess, "a", 100);
+  auto consumerB = doPublish(pubSess, "b", 50);
+  auto consumerC = doPublish(pubSess, "c", 20);
+  exec_->driveFor(20);
+
+  ASSERT_EQ(publishCount(directViewer.get(), ftn("a")), 1);
+  ASSERT_EQ(publishCount(directViewer.get(), ftn("b")), 1);
+  ASSERT_EQ(publishCount(directViewer.get(), ftn("c")), 1);
+
+  // TRACK_FILTER subscriber joins later — must see correct top-1 based on
+  // current values at the time of join
+  auto filteredViewer = makeSession();
+  doSubscribeFilter(filteredViewer, /*maxSelected=*/1);
+  exec_->driveFor(20);
+
+  // "a" (100) is top-1
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("b")), 0);
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("c")), 0);
+
+  // Value change: "c" jumps to top — filter chain must observe this change
+  // even though tracks were published before TRACK_FILTER subscriber joined
+  sendValue(consumerC, 200);
+  exec_->driveFor(20);
+
+  // "c" (200) should now be selected for filteredViewer
+  EXPECT_EQ(publishCount(filteredViewer.get(), ftn("c")), 1);
+
+  // Direct viewer is unaffected by ranking changes
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(directViewer.get(), ftn("c")), 1);
+
+  consumerA->publishDone(makePublishDone());
+  consumerB->publishDone(makePublishDone());
+  consumerC->publishDone(makePublishDone());
+}
+
+} // namespace

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -848,4 +848,99 @@ TEST_F(MoqxTrackFilterTest, IdleEviction_SilentTrackReplacedByActiveOutsider) {
   consumerB->publishDone(makePublishDone());
 }
 
+// ---------------------------------------------------------------------------
+// Tests: publisher-subscriber self-exclusion
+// ---------------------------------------------------------------------------
+
+// A session that subscribes with TRACK_FILTER before it starts publishing
+// must not receive its own track in the top-N selection.
+//
+// Setup: pub subscribes N=2, then publishes "self" (100).  Two other
+// sessions publish "a" (80) and "b" (60).  Non-self top-2 for pub are
+// "a" and "b"; pub must not receive its own "self" track.
+// Note: "b" is at shared rank 2 (outside shared top-2 of N=2) because
+// "self" occupies a slot, so this also exercises the out-of-shared-top-N
+// reconcile path for publisher-subscribers.
+TEST_F(MoqxTrackFilterTest, PublisherSubscriber_SubscribeBeforePublish_DoesNotReceiveOwnTrack) {
+  auto pub = makeSession();
+  auto other = makeSession();
+  doPublishNamespace(pub);
+
+  // Subscribe before publishing.
+  doSubscribeFilter(pub, /*maxSelected=*/2);
+
+  auto cSelf = doPublish(pub, "self", 100); // pub's own track
+  auto cA = doPublish(other, "a", 80);      // other participant
+  auto cB = doPublish(other, "b", 60);      // other participant
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0); // own track excluded
+  EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(pub.get(), ftn("b")), 1);
+
+  cSelf->publishDone(makePublishDone());
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+}
+
+// A session that publishes before subscribing with TRACK_FILTER must still
+// have its already-published track excluded from its personal top-N.
+//
+// Setup: pub publishes "self" (100); another session publishes "a" (80) and
+// "b" (60).  pub subscribes N=2 — must see "a" and "b" but not "self".
+TEST_F(MoqxTrackFilterTest, PublisherSubscriber_PublishBeforeSubscribe_StillExcluded) {
+  auto pub = makeSession();
+  auto other = makeSession();
+  doPublishNamespace(pub);
+
+  // Publish before subscribing.
+  auto cSelf = doPublish(pub, "self", 100);
+  auto cA = doPublish(other, "a", 80);
+  auto cB = doPublish(other, "b", 60);
+  exec_->driveFor(10);
+
+  // Late TRACK_FILTER subscription — self-track must be excluded.
+  doSubscribeFilter(pub, /*maxSelected=*/2);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0);
+  EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(pub.get(), ftn("b")), 1);
+
+  cSelf->publishDone(makePublishDone());
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+}
+
+// A viewer receives all top-N tracks including the publisher-subscriber's
+// own track; the publisher-subscriber itself never receives its own stream.
+//
+// Setup: pub publishes "self" (100); another session publishes "a" (60).
+// viewer subscribes N=2 — gets both.  pub subscribes N=2 — gets "a" only.
+TEST_F(MoqxTrackFilterTest, PublisherSubscriber_ViewerReceivesSelfTrack) {
+  auto pub = makeSession();
+  auto other = makeSession();
+  auto viewer = makeSession();
+  doPublishNamespace(pub);
+
+  auto cSelf = doPublish(pub, "self", 100);
+  auto cA = doPublish(other, "a", 60);
+  exec_->driveFor(10);
+
+  doSubscribeFilter(viewer, /*maxSelected=*/2);
+  doSubscribeFilter(pub, /*maxSelected=*/2);
+  exec_->driveFor(20);
+
+  // Viewer sees both tracks (including pub's self-track).
+  EXPECT_EQ(publishCount(viewer.get(), ftn("self")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+
+  // Publisher-subscriber never receives its own track.
+  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0);
+  EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
+
+  cSelf->publishDone(makePublishDone());
+  cA->publishDone(makePublishDone());
+}
+
 } // namespace

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -1263,7 +1263,7 @@ TEST_F(PropertyRankingBaseTest, EdgeCase_UpdateToExactlyPreviousValue) {
 // sweepIdle tests
 // ---------------------------------------------------------------------------
 
-TEST(PropertyRankingSweepIdle, IdleTrackEvictedAndReplacementPromoted) {
+TEST_F(PropertyRankingBaseTest, SweepIdle_IdleTrackEvictedAndReplacementPromoted) {
   // Setup: 3 tracks, N=2 group, idleTimeout=100ms
   RankingHarness h(5, std::chrono::milliseconds(100));
   auto sub = makeSession();
@@ -1295,7 +1295,7 @@ TEST(PropertyRankingSweepIdle, IdleTrackEvictedAndReplacementPromoted) {
   EXPECT_EQ(group->trackStates.at(ftn("c")), TrackState::Selected);
 }
 
-TEST(PropertyRankingSweepIdle, TrackThatNeverPublishedIsTreatedAsIdle) {
+TEST_F(PropertyRankingBaseTest, SweepIdle_TrackThatNeverPublishedIsTreatedAsIdle) {
   // A track with epoch timestamp (never published) should be evicted
   RankingHarness h(5, std::chrono::milliseconds(100));
   auto sub = makeSession();
@@ -1324,7 +1324,7 @@ TEST(PropertyRankingSweepIdle, TrackThatNeverPublishedIsTreatedAsIdle) {
   EXPECT_EQ(group->trackStates.at(ftn("c")), TrackState::Selected);
 }
 
-TEST(PropertyRankingSweepIdle, NoEvictionWhenIdleTimeoutIsZero) {
+TEST_F(PropertyRankingBaseTest, SweepIdle_NoEvictionWhenIdleTimeoutIsZero) {
   // idleTimeout=0 disables idle eviction
   RankingHarness h(5, std::chrono::milliseconds(0));
   auto sub = makeSession();
@@ -1347,7 +1347,7 @@ TEST(PropertyRankingSweepIdle, NoEvictionWhenIdleTimeoutIsZero) {
   EXPECT_EQ(h.selectCount(ftn("b")), 0);
 }
 
-TEST(PropertyRankingSweepIdle, ActiveTracksNotEvicted) {
+TEST_F(PropertyRankingBaseTest, SweepIdle_ActiveTracksNotEvicted) {
   RankingHarness h(5, std::chrono::milliseconds(100));
   auto sub = makeSession();
 

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -576,4 +576,110 @@ TEST_F(PropertyRankingBaseTest, MultipleAdjacentGroups_SingleTraversalPromotion)
   EXPECT_GE(h.selectCount(ftn("e"), sub4.get()), 1); // e promoted into top-4
 }
 
+// ---------------------------------------------------------------------------
+// selectionThreshold changes: cache invalidation on increase, stability on decrease
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, ThresholdIncrease_CacheInvalidatedForNewRange) {
+  // Tests that when a larger N group is added, tracks that previously had
+  // sentinel ranks (UINT64_MAX) get accurate ranks after cache rebuild.
+  //
+  // Scenario: Start with N=2, add tracks, then add N=5 group. A track at
+  // position 3 (which had sentinel rank) should correctly detect threshold
+  // crossing when its value changes.
+  RankingHarness h;
+  auto sub2 = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+
+  // Register 5 tracks: positions 0-4
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0 - selected for N=2
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1 - selected for N=2
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2 - outside N=2, has sentinel
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 - outside N=2, has sentinel
+  h.ranking().registerTrack(ftn("e"), 20, {});  // rank 4 - outside N=2, has sentinel
+  h.clearEvents();
+
+  // Add a larger N group - this should invalidate cache
+  auto sub5 = makeSession();
+  h.ranking().addSessionToTopNGroup(5, sub5, true);
+  h.clearEvents();
+
+  // Now update "d" (was at rank 3 with sentinel) to jump into top-2
+  // If cache wasn't invalidated, d's oldRank would be UINT64_MAX and
+  // recomputeTopNGroups would incorrectly think d wasn't in top-5 before.
+  h.ranking().updateSortValue(ftn("d"), 110); // d becomes rank 0
+
+  // d should be selected for sub2 (entered top-2)
+  EXPECT_GE(h.selectCount(ftn("d"), sub2.get()), 1);
+
+  // d should NOT trigger a new selection for sub5 - it was already in top-5
+  // before the update (at rank 3). If cache was stale, this would incorrectly
+  // fire because oldRank=UINT64_MAX would make wasInTopN=false.
+  // After cache invalidation, oldRank=3 correctly makes wasInTopN=true for N=5.
+  EXPECT_EQ(h.selectCount(ftn("d"), sub5.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, ThresholdDecrease_CachedRanksRemainValid) {
+  // Tests that when a group is removed and threshold decreases, existing
+  // cached ranks (which are more than needed) remain valid.
+  RankingHarness h;
+  auto sub2 = makeSession();
+  auto sub5 = makeSession();
+
+  h.ranking().addSessionToTopNGroup(5, sub5, true);
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+
+  // Register tracks
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3
+  h.ranking().registerTrack(ftn("e"), 20, {});  // rank 4
+  h.clearEvents();
+
+  // Remove the larger group - threshold decreases
+  h.ranking().removeSessionFromTopNGroup(5, sub5);
+  h.clearEvents();
+
+  // Update a track that was in top-5 but outside top-2
+  // With threshold decreased, this track might have more cached rank than
+  // needed, but operations should still work correctly.
+  h.ranking().updateSortValue(ftn("c"), 110); // c becomes rank 0, enters top-2
+
+  EXPECT_GE(h.selectCount(ftn("c"), sub2.get()), 1);
+}
+
+TEST_F(PropertyRankingBaseTest, ThresholdIncrease_MultipleGroupsAddedSequentially) {
+  // Tests adding groups with increasing N values sequentially.
+  RankingHarness h;
+
+  // Start with N=1
+  auto sub1 = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub1, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.clearEvents();
+
+  // Add N=2 - threshold increases
+  auto sub2 = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+  h.clearEvents();
+
+  // Add N=3 - threshold increases again
+  auto sub3 = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub3, true);
+  h.clearEvents();
+
+  // Move "c" from rank 2 to rank 0
+  h.ranking().updateSortValue(ftn("c"), 110);
+
+  // c enters top-1, top-2 (was at rank 2, outside both)
+  // c was already in top-3 (rank 2 < 3), so sub3 should NOT be notified
+  EXPECT_GE(h.selectCount(ftn("c"), sub1.get()), 1);
+  EXPECT_GE(h.selectCount(ftn("c"), sub2.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("c"), sub3.get()), 0); // was already in top-3
+}
+
 } // namespace

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -1,0 +1,505 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Unit tests for PropertyRanking top-N base logic (no self-exclusion).
+ *
+ * Covers:
+ * - registerTrack + addSessionToTopNGroup → correct sessions notified at top-N boundary
+ * - updateSortValue fast path: no notification when threshold not crossed
+ * - updateSortValue slow path: correct promotions/evictions across multiple
+ *   TopNGroups with different N
+ * - removeTrack of a selected track → next eligible track promoted via
+ *   deselected queue, then ranked list
+ * - Multiple TopNGroups (N=1, N=3) on same ranking instance
+ * - deselectedQueue bounded by maxDeselected_; eviction callback fires when
+ *   queue overflows
+ * - Session removal cleans up TopNGroup; last session removes the group
+ */
+
+#include "relay/PropertyRanking.h"
+
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/test/MockMoQSession.h>
+#include <moxygen/test/Mocks.h>
+
+using namespace testing;
+using namespace moxygen;
+using namespace openmoq::moqx;
+
+namespace {
+
+const TrackNamespace kNs{{"test"}};
+constexpr uint64_t kProp = 0x100;
+
+FullTrackName ftn(const std::string& name) {
+  return FullTrackName{kNs, name};
+}
+
+// Thin wrapper: creates a PropertyRanking, records callbacks in vectors.
+class RankingHarness {
+public:
+  struct SelectEvent {
+    FullTrackName ftn;
+    MoQSession* session;
+    bool forward;
+  };
+  struct EvictEvent {
+    FullTrackName ftn;
+    MoQSession* session;
+  };
+
+  explicit RankingHarness(uint64_t maxDeselected = 5)
+      : ranking_(std::make_unique<PropertyRanking>(
+            kProp,
+            maxDeselected,
+            [this](
+                const FullTrackName& f,
+                const std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>& sessions
+            ) {
+              for (auto& [s, fwd] : sessions) {
+                selected_.push_back({f, s.get(), fwd});
+              }
+            },
+            [this](const FullTrackName& f, std::shared_ptr<MoQSession> s, bool fwd) {
+              selected_.push_back({f, s.get(), fwd});
+            },
+            [this](const FullTrackName& f, std::shared_ptr<MoQSession> s) {
+              evicted_.push_back({f, s.get()});
+            }
+        )) {}
+
+  PropertyRanking& ranking() { return *ranking_; }
+
+  // Count how many select events were fired for a given track
+  int selectCount(const FullTrackName& f) const {
+    int n = 0;
+    for (auto& e : selected_) {
+      if (e.ftn == f) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  // Count select events for a (track, session) pair
+  int selectCount(const FullTrackName& f, MoQSession* s) const {
+    int n = 0;
+    for (auto& e : selected_) {
+      if (e.ftn == f && e.session == s) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  int evictCount(const FullTrackName& f) const {
+    int n = 0;
+    for (auto& e : evicted_) {
+      if (e.ftn == f) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  void clearEvents() {
+    selected_.clear();
+    evicted_.clear();
+  }
+
+  std::vector<SelectEvent> selected_;
+  std::vector<EvictEvent> evicted_;
+
+private:
+  std::unique_ptr<PropertyRanking> ranking_;
+};
+
+// Minimal stub session (not a real MoQSession, just needs a unique address)
+// We use NiceMock<MockMoQSession> from moxygen mocks but that requires an
+// executor. Instead, we make shared_ptrs to distinct mock objects so that
+// the F14FastMap keys are unique pointers.
+//
+// PropertyRanking only stores shared_ptr<MoQSession> as map keys and passes
+// them back through callbacks — it never calls any MoQSession methods itself.
+// So we can cast a shared_ptr<MockMoQSession> (which IS a MoQSession) safely.
+
+class PropertyRankingBaseTest : public ::testing::Test {
+protected:
+  // PropertyRanking only stores shared_ptr<MoQSession> as map keys and passes
+  // them back through callbacks — it never calls any MoQSession methods.
+  // MockMoQSession has a default constructor for exactly this use case.
+  std::shared_ptr<MoQSession> makeSession() {
+    auto s = std::make_shared<NiceMock<moxygen::test::MockMoQSession>>();
+    sessions_.push_back(s);
+    return std::static_pointer_cast<MoQSession>(s);
+  }
+
+  std::vector<std::shared_ptr<NiceMock<moxygen::test::MockMoQSession>>> sessions_;
+};
+
+// ---------------------------------------------------------------------------
+// registerTrack + addSessionToTopNGroup
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, RegisterThenSubscribe_TopNBoundary) {
+  RankingHarness h;
+
+  // 3 tracks registered before any subscriber
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 70, {});
+  h.ranking().registerTrack(ftn("d"), 20, {});
+
+  // Subscriber joins wanting top-2
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, /*forward=*/true);
+
+  // Should have received exactly ftn("a") and ftn("b")
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 0);
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, SubscribeThenRegister_TopNBoundary) {
+  RankingHarness h;
+
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, /*forward=*/true);
+
+  // Tracks arrive after subscriber
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 70, {}); // rank 2 — not in top-2
+
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, ForwardFlagPassedThrough_False) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, /*forward=*/false);
+  h.ranking().registerTrack(ftn("a"), 10, {});
+
+  ASSERT_EQ(h.selected_.size(), 1u);
+  EXPECT_FALSE(h.selected_[0].forward);
+}
+
+TEST_F(PropertyRankingBaseTest, ForwardFlagPassedThrough_True) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, /*forward=*/true);
+  h.ranking().registerTrack(ftn("a"), 10, {});
+
+  ASSERT_EQ(h.selected_.size(), 1u);
+  EXPECT_TRUE(h.selected_[0].forward);
+}
+
+// ---------------------------------------------------------------------------
+// updateSortValue fast path
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, FastPath_NoNotificationWhenThresholdNotCrossed) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  // 4 tracks: top-2 = {a=90, b=80}; {c=70, d=50} are outside
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 70, {}); // rank 2 — just outside top-2
+  h.ranking().registerTrack(ftn("d"), 50, {}); // rank 3
+  h.clearEvents();
+
+  // Move "d" from rank 3 to rank 2 — still outside top-2, no notification
+  h.ranking().updateSortValue(ftn("d"), 75); // d=75 < c=70? no: 75>70 → d is rank 2, c rank 3
+  EXPECT_EQ(h.selected_.size(), 0u);
+
+  // Swap "a" and "b" within the selected zone — both stay in top-2
+  h.ranking().updateSortValue(ftn("a"), 79); // a=79 < b=80 → a is rank 1, still in top-2
+  EXPECT_EQ(h.selected_.size(), 0u);
+}
+
+TEST_F(PropertyRankingBaseTest, FastPath_SameValueNoNotification) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+  h.ranking().registerTrack(ftn("a"), 50, {});
+  h.clearEvents();
+
+  h.ranking().updateSortValue(ftn("a"), 50); // no change
+  EXPECT_EQ(h.selected_.size(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// updateSortValue slow path — promotions and evictions
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, SlowPath_TrackPromotedWhenCrossesThreshold) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 80, {});
+  h.ranking().registerTrack(ftn("b"), 60, {}); // rank 1 — not in top-1
+  h.clearEvents();
+
+  // "b" jumps to rank 0 — should be selected, "a" deselected
+  h.ranking().updateSortValue(ftn("b"), 90);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, SlowPath_MultipleTopNGroups) {
+  RankingHarness h;
+  auto sub1 = makeSession(); // wants top-1
+  auto sub3 = makeSession(); // wants top-3
+
+  h.ranking().addSessionToTopNGroup(1, sub1, true);
+  h.ranking().addSessionToTopNGroup(3, sub3, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 60, {});
+  h.ranking().registerTrack(ftn("d"), 40, {}); // rank 3 — NOT in top-3, not in top-1
+  h.clearEvents();
+
+  // "d" surpasses "a" — crosses threshold for both groups
+  h.ranking().updateSortValue(ftn("d"), 110);
+
+  // sub1 (top-1) should now receive "d"
+  EXPECT_GE(h.selectCount(ftn("d"), sub1.get()), 1);
+  // sub3 (top-3) should also receive "d" — it was NOT in top-3 before (rank 3),
+  // now it's rank 0 so sub3 should be notified
+  EXPECT_GE(h.selectCount(ftn("d"), sub3.get()), 1);
+}
+
+// ---------------------------------------------------------------------------
+// removeTrack of a selected track — promotion via deselected queue / ranked list
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, RemoveSelected_PromotesFromDeselectedQueue) {
+  // To test deselected-queue promotion, we need a track to have been selected,
+  // then fall out of selection (entering the queue), then be promoted on removeTrack.
+  //
+  // Setup: top-1, tracks a=90(selected), b=80
+  // Step 1: c registers at 95 — c→rank0(selected), a→rank1(deselected, enters queue)
+  // Step 2: remove c — a should be promoted from deselected queue
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 90, {}); // selected
+  h.ranking().registerTrack(ftn("b"), 80, {}); // rank 1, unselected
+  h.clearEvents();
+
+  // c arrives louder than a → a falls to deselected queue
+  h.ranking().registerTrack(ftn("c"), 95, {}); // c→rank0(selected), a→rank1(deselected queue)
+  h.clearEvents();
+
+  // Remove c (selected): a should be promoted from deselected queue
+  h.ranking().removeTrack(ftn("c"));
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveSelected_PromotesFromRankedList) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 70, {}); // rank 1
+  h.clearEvents();
+
+  h.ranking().removeTrack(ftn("a"));
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveDeselected_NoPromotionNeeded) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 90, {});
+  h.ranking().registerTrack(ftn("b"), 70, {}); // rank 1 — deselected
+  h.clearEvents();
+
+  // Removing a deselected track should not trigger any selection notification
+  h.ranking().removeTrack(ftn("b"));
+  EXPECT_EQ(h.selected_.size(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple TopNGroups with different N
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, TwoGroupsDifferentN_IndependentSelection) {
+  RankingHarness h;
+  auto sub1 = makeSession(); // top-1
+  auto sub3 = makeSession(); // top-3
+
+  h.ranking().addSessionToTopNGroup(1, sub1, true);
+  h.ranking().addSessionToTopNGroup(3, sub3, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 60, {});
+  h.ranking().registerTrack(ftn("d"), 40, {});
+
+  // sub1 should have received only "a"
+  EXPECT_EQ(h.selectCount(ftn("a"), sub1.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub1.get()), 0);
+
+  // sub3 should have received "a", "b", "c"
+  EXPECT_EQ(h.selectCount(ftn("a"), sub3.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub3.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("c"), sub3.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("d"), sub3.get()), 0);
+}
+
+// ---------------------------------------------------------------------------
+// deselectedQueue bounded by maxDeselected_
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, DeselectedQueueBounded_EvictionFires) {
+  // Only tracks that were previously *selected* enter the deselected queue.
+  // To overflow a queue with maxDeselected=2, we need 3 different tracks to
+  // have been selected at some point and then fall out.
+  //
+  // Strategy: top-1, rotate the "winner" 3 times so each loser enters the queue.
+  //   round 1: a=90 selected. Register b=95 → b selected, a enters queue (size 1).
+  //   round 2: c=100 registered → c selected, b enters queue (size 2, at limit).
+  //   round 3: d=110 registered → d selected, c enters queue (size 3 > max=2 → eviction).
+  RankingHarness h(/*maxDeselected=*/2);
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 90, {});  // selected
+  h.ranking().registerTrack(ftn("b"), 95, {});  // b→selected, a→deselected queue (size 1)
+  h.ranking().registerTrack(ftn("c"), 100, {}); // c→selected, b→deselected queue (size 2)
+  EXPECT_EQ(h.evicted_.size(), 0u);             // not yet
+
+  h.ranking().registerTrack(ftn("d"), 110, {}); // d→selected, c→deselected queue (size 3 > 2)
+  EXPECT_GE(h.evicted_.size(), 1u);             // oldest entry evicted
+}
+
+// ---------------------------------------------------------------------------
+// Session removal
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, RemoveSession_GroupRemainsIfOtherSessionsExist) {
+  RankingHarness h;
+  auto sub1 = makeSession();
+  auto sub2 = makeSession();
+
+  h.ranking().addSessionToTopNGroup(2, sub1, true);
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+
+  h.ranking().removeSessionFromTopNGroup(2, sub1);
+
+  const auto* grp = h.ranking().getTopNGroup(2);
+  ASSERT_NE(grp, nullptr);
+  EXPECT_EQ(grp->sessions.size(), 1u);
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveLastSession_GroupRemoved) {
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true);
+
+  h.ranking().removeSessionFromTopNGroup(3, sub);
+
+  EXPECT_EQ(h.ranking().getTopNGroup(3), nullptr);
+  EXPECT_TRUE(h.ranking().empty());
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveLastSession_ThresholdUpdated) {
+  RankingHarness h;
+  auto sub1 = makeSession();
+  auto sub2 = makeSession();
+
+  h.ranking().addSessionToTopNGroup(1, sub1, true);
+  h.ranking().addSessionToTopNGroup(3, sub2, true);
+
+  h.ranking().removeSessionFromTopNGroup(3, sub2); // group N=3 gone
+
+  // Only N=1 group remains; threshold should reflect that
+  EXPECT_NE(h.ranking().getTopNGroup(1), nullptr);
+  EXPECT_EQ(h.ranking().getTopNGroup(3), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// recomputeTopNGroups: track crosses one group threshold but not another
+// ---------------------------------------------------------------------------
+
+// TODO: Add tests for deselection/reselection notifications once onDeselected
+// and onReselected callbacks are implemented (see PropertyRanking.h TODO).
+// Tests needed:
+// - DeselectionNotification_WhenTrackFallsOutOfTopN
+// - ReselectionNotification_WhenPromotedFromQueue
+
+// This test validates that TopNGroups are evaluated independently: crossing
+// one N boundary doesn't affect groups where the track was already selected.
+TEST_F(PropertyRankingBaseTest, SlowPath_CrossesLowerThreshold_HigherGroupUnchanged) {
+  // N=2 group and N=4 group. A track moves from rank 3 (inside N=4, outside
+  // N=2) to rank 1 (inside both). Only the N=2 group should fire a selection
+  // notification; the N=4 group's state is unchanged (track was already
+  // selected there).
+  RankingHarness h;
+  auto sub2 = makeSession(); // top-2
+  auto sub4 = makeSession(); // top-4
+
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+  h.ranking().addSessionToTopNGroup(4, sub4, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 — in top-4, not top-2
+  h.clearEvents();
+
+  // d jumps to rank 1: crosses the N=2 boundary (3→1), stays inside N=4
+  h.ranking().updateSortValue(ftn("d"), 90); // order: a=100, d=90, b=80, c=60
+
+  // sub2 should be notified about d entering top-2
+  EXPECT_EQ(h.selectCount(ftn("d"), sub2.get()), 1);
+  // sub4 should NOT be notified — d was already in its top-4
+  EXPECT_EQ(h.selectCount(ftn("d"), sub4.get()), 0);
+  // b was at rank 1 (selected for both), falls to rank 2: leaves top-2
+  // sub2 gets no additional select events (b was demoted, not selected)
+  EXPECT_EQ(h.selectCount(ftn("b"), sub2.get()), 0);
+}
+
+// ---------------------------------------------------------------------------
+// removeTrack fallback: ranked list scan promotes highest non-selected track
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, RemoveSelected_FallbackPicksHighestNonSelected) {
+  // top-2, tracks a=100(sel), b=80(sel), c=60, d=40
+  // Remove a: fallback scan should promote c (rank 2, highest non-selected),
+  // not d (rank 3).
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 60, {});
+  h.ranking().registerTrack(ftn("d"), 40, {});
+  h.clearEvents();
+
+  h.ranking().removeTrack(ftn("a"));
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 0); // b was already selected
+}
+
+} // namespace

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -807,4 +807,438 @@ TEST_F(PropertyRankingBaseTest, SentinelFix_SubsequentUpdateSortValueCorrect) {
   EXPECT_EQ(h.selectCount(ftn("e"), sub4.get()), 0);
 }
 
+// ---------------------------------------------------------------------------
+// Algorithm correctness: Step 4 cachedRank update verification
+// ---------------------------------------------------------------------------
+// These tests verify that cachedRank for OTHER tracks in the affected range
+// are updated correctly after updateSortValue Step 4.
+
+TEST_F(PropertyRankingBaseTest, UpdateSortValue_AffectedRanksCachedCorrectly) {
+  // Scenario: track "a" moves from rank 0 to rank 3.
+  // Tracks b, c, d should all shift up by 1, and their cachedRanks must be correct.
+  // Then update track "b" (which was in the affected range) - should work correctly.
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  // Initial: a=100(0), b=80(1), c=60(2), d=40(3), e=20(4)
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 60, {});
+  h.ranking().registerTrack(ftn("d"), 40, {});
+  h.ranking().registerTrack(ftn("e"), 20, {});
+  h.clearEvents();
+
+  // Drop "a" from rank 0 to rank 3 (value=35)
+  // New order: b=80(0), c=60(1), d=40(2), a=35(3), e=20(4)
+  h.ranking().updateSortValue(ftn("a"), 35);
+
+  // b should be selected (it's now rank 0, was rank 1)
+  // c enters top-2 (was rank 2, now rank 1)
+  EXPECT_GE(h.selectCount(ftn("c"), sub.get()), 1);
+  h.clearEvents();
+
+  // Now update "b" (was in affected range 0-3) to verify its cachedRank is correct
+  // Move b from rank 0 to rank 2 (value=45)
+  // New order: c=60(0), d=40(1), b=45(2)... wait, 45 < 60 and 45 > 40, so:
+  // c=60(0), b=45(1), d=40(2), a=35(3), e=20(4)
+  h.ranking().updateSortValue(ftn("b"), 45);
+
+  // b stays in top-2 (rank 0 -> rank 1), no new notification needed
+  // If b's cachedRank was wrong (e.g., still 1 from before), this would cause issues
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 0);
+
+  // d should NOT be selected (it's at rank 2, outside top-2)
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, UpdateSortValue_SequentialMovesOnSameTrack) {
+  // Verify cachedRank stays correct across multiple sequential updateSortValue calls
+  // on the same track.
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 80, {});
+  h.ranking().registerTrack(ftn("c"), 60, {});
+  h.ranking().registerTrack(ftn("d"), 40, {});
+  h.clearEvents();
+
+  // Move "d" up: 40 -> 90 (rank 3 -> rank 1, enters top-2)
+  h.ranking().updateSortValue(ftn("d"), 90);
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 1);
+  h.clearEvents();
+
+  // Move "d" down: 90 -> 50 (rank 1 -> rank 3, exits top-2)
+  // Order: a=100(0), b=80(1), c=60(2), d=50(3)
+  h.ranking().updateSortValue(ftn("d"), 50);
+  // d exits top-2, no selection notification (deselection not tested here)
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+  h.clearEvents();
+
+  // Move "d" back up: 50 -> 85 (rank 3 -> rank 1, enters top-2 again)
+  h.ranking().updateSortValue(ftn("d"), 85);
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 1);
+  h.clearEvents();
+
+  // Move "d" within top-2: 85 -> 110 (rank 1 -> rank 0)
+  // If cachedRank is wrong, this could cause spurious notification
+  h.ranking().updateSortValue(ftn("d"), 110);
+  // d was already selected, stays selected - no new notification
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, UpdateSortValue_ExactBoundaryPromotion) {
+  // Track moves from rank N to rank N-1 (exactly crosses into top-N)
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2 - last in top-3
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 - first outside top-3
+  h.clearEvents();
+
+  // Move "d" from rank 3 to rank 2 (exactly N-1), entering top-3
+  // d=65 > c=60, so order: a=100(0), b=80(1), d=65(2), c=60(3)
+  h.ranking().updateSortValue(ftn("d"), 65);
+
+  // d should be selected (entered top-3)
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 1);
+  // c should NOT get duplicate notification (it was demoted, not selected)
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, UpdateSortValue_ExactBoundaryDemotion) {
+  // Track moves from rank N-1 to rank N (exactly falls out of top-N)
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2 - last in top-3
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 - first outside top-3
+  h.clearEvents();
+
+  // Move "c" from rank 2 to rank 3 (exactly N), exiting top-3
+  // c=35 < d=40, so order: a=100(0), b=80(1), d=40(2), c=35(3)
+  h.ranking().updateSortValue(ftn("c"), 35);
+
+  // d should be promoted (entered top-3)
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 1);
+  // c exited, no select notification
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, UpdateSortValue_FallOutOfAllGroups) {
+  // Track at rank 0 falls out of ALL groups simultaneously
+  RankingHarness h;
+  auto sub2 = makeSession();
+  auto sub3 = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+  h.ranking().addSessionToTopNGroup(3, sub3, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0 - in both groups
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1 - in both groups
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2 - in sub3 only
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 - outside both
+  h.ranking().registerTrack(ftn("e"), 20, {});  // rank 4 - outside both
+  h.clearEvents();
+
+  // Drop "a" from rank 0 to rank 4 (value=10)
+  // New order: b=80(0), c=60(1), d=40(2), e=20(3), a=10(4)
+  h.ranking().updateSortValue(ftn("a"), 10);
+
+  // For sub2 (top-2): c promoted (was rank 2, now rank 1)
+  EXPECT_EQ(h.selectCount(ftn("c"), sub2.get()), 1);
+  // For sub3 (top-3): d promoted (was rank 3, now rank 2)
+  EXPECT_EQ(h.selectCount(ftn("d"), sub3.get()), 1);
+  // a should NOT be selected for either group
+  EXPECT_EQ(h.selectCount(ftn("a"), sub2.get()), 0);
+  EXPECT_EQ(h.selectCount(ftn("a"), sub3.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, RegisterTrack_ShiftedTracksHaveCorrectRanks) {
+  // Verify that registerTrack correctly increments cachedRank for shifted tracks,
+  // and subsequent updateSortValue on those tracks works correctly.
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  // Register tracks in order
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.clearEvents();
+
+  // Register a track that inserts at rank 1, shifting b and c down
+  h.ranking().registerTrack(ftn("d"), 90, {}); // d=90 goes to rank 1
+  // New order: a=100(0), d=90(1), b=80(2), c=60(3)
+
+  // d should be selected (rank 1, in top-2)
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 1);
+  h.clearEvents();
+
+  // b was shifted from rank 1 to rank 2. Verify its cachedRank is correct
+  // by doing an updateSortValue that should cross threshold.
+  // Move b from rank 2 to rank 0
+  h.ranking().updateSortValue(ftn("b"), 110);
+  // If b's cachedRank was still 1 (not updated to 2), this would be:
+  // oldRank=1, newRank=0, which doesn't cross threshold -> no notification (BUG)
+  // With correct cachedRank=2: oldRank=2, newRank=0, crosses threshold -> notification (CORRECT)
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+}
+
+TEST_F(PropertyRankingBaseTest, RemoveTrack_ShiftedTracksHaveCorrectRanks) {
+  // Verify that removeTrack correctly decrements cachedRank for shifted tracks,
+  // and subsequent updateSortValue on those tracks works correctly.
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3
+  h.clearEvents();
+
+  // Remove "a" at rank 0 - all subsequent tracks shift up
+  // New order: b=80(0), c=60(1), d=40(2)
+  h.ranking().removeTrack(ftn("a"));
+
+  // c should be promoted (rank 2 -> rank 1, enters top-2)
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 1);
+  h.clearEvents();
+
+  // d was shifted from rank 3 to rank 2. Verify its cachedRank is correct.
+  // Move d from rank 2 to rank 0
+  h.ranking().updateSortValue(ftn("d"), 110);
+  // If d's cachedRank was still 3 (not updated to 2), this would compute
+  // wasInTopN incorrectly -> possibly spurious notification
+  // With correct cachedRank=2: oldRank=2, newRank=0, crosses N=2 threshold
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 1);
+}
+
+TEST_F(PropertyRankingBaseTest, PromotionFromDeselectedQueue_CorrectCachedRank) {
+  // Verify that when a track is promoted from the deselected queue,
+  // its cachedRank (which may be stale) doesn't cause issues.
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0, selected
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1, selected
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.clearEvents();
+
+  // "d" registers at rank 0, pushing a to rank 1, b to rank 2 (enters deselected queue)
+  h.ranking().registerTrack(ftn("d"), 110, {});
+  // Order: d=110(0), a=100(1), b=80(2), c=60(3)
+  h.clearEvents();
+
+  // Remove "d" - b should be promoted from deselected queue
+  h.ranking().removeTrack(ftn("d"));
+  // Order: a=100(0), b=80(1), c=60(2)
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+  h.clearEvents();
+
+  // Now update b - should NOT cause spurious notification
+  // Move b within top-2 (rank 1 -> rank 0)
+  h.ranking().updateSortValue(ftn("b"), 105);
+  // b was already selected, stays selected
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases: Empty ranking, single track, tiebreaker scenarios
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, EdgeCase_EmptyRanking_NoErrors) {
+  // Operations on empty ranking should not crash
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true);
+
+  // No tracks registered - verify no events and no crashes
+  EXPECT_EQ(h.selected_.size(), 0u);
+
+  // Update non-existent track should silently fail
+  h.ranking().updateSortValue(ftn("nonexistent"), 100);
+  EXPECT_EQ(h.selected_.size(), 0u);
+
+  // Remove non-existent track should silently fail
+  h.ranking().removeTrack(ftn("nonexistent"));
+  EXPECT_EQ(h.selected_.size(), 0u);
+}
+
+TEST_F(PropertyRankingBaseTest, EdgeCase_SingleTrack) {
+  // Single track operations
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 50, {});
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
+  h.clearEvents();
+
+  // Update single track - stays in top-1
+  h.ranking().updateSortValue(ftn("a"), 100);
+  EXPECT_EQ(h.selected_.size(), 0u); // no change notification
+
+  // Remove single track
+  h.ranking().removeTrack(ftn("a"));
+  // No promotion possible (no other tracks)
+  EXPECT_EQ(h.selected_.size(), 0u);
+}
+
+TEST_F(PropertyRankingBaseTest, EdgeCase_SameValueTiebreaker) {
+  // Tracks with same value use arrival sequence (tiebreaker)
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  // All tracks have same value - should be ordered by arrival
+  h.ranking().registerTrack(ftn("a"), 50, {}); // arrives first, rank 0
+  h.ranking().registerTrack(ftn("b"), 50, {}); // arrives second, rank 1
+  h.ranking().registerTrack(ftn("c"), 50, {}); // arrives third, rank 2
+
+  // a and b should be selected (ranks 0,1)
+  EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 0);
+  h.clearEvents();
+
+  // Update "c" to same value - should stay at rank 2 (tiebreaker preserved)
+  h.ranking().updateSortValue(ftn("c"), 50);
+  EXPECT_EQ(h.selected_.size(), 0u); // no change
+}
+
+TEST_F(PropertyRankingBaseTest, EdgeCase_RemoveOnlySelectedTrack) {
+  // Remove the only selected track when there are other tracks to promote
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // selected
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1, not selected
+  h.clearEvents();
+
+  h.ranking().removeTrack(ftn("a"));
+  EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1); // b promoted
+}
+
+TEST_F(PropertyRankingBaseTest, EdgeCase_MultipleRemoves) {
+  // Sequential removes - verify ranks stay correct throughout
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3
+  h.ranking().registerTrack(ftn("e"), 20, {});  // rank 4
+  h.clearEvents();
+
+  // Remove a: b=80(0), c=60(1), d=40(2), e=20(3)
+  h.ranking().removeTrack(ftn("a"));
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 1); // c promoted
+  h.clearEvents();
+
+  // Remove b: c=60(0), d=40(1), e=20(2)
+  h.ranking().removeTrack(ftn("b"));
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 1); // d promoted
+  h.clearEvents();
+
+  // Remove c: d=40(0), e=20(1)
+  h.ranking().removeTrack(ftn("c"));
+  EXPECT_EQ(h.selectCount(ftn("e"), sub.get()), 1); // e promoted
+  h.clearEvents();
+
+  // Verify d is still rank 0 by moving it
+  h.ranking().updateSortValue(ftn("d"), 50);
+  // d stays at rank 0 (50 > 20), no notification
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, EdgeCase_RegisterAtAllPositions) {
+  // Register tracks at various positions to verify rank insertion logic
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true);
+
+  // Register in non-sequential order
+  h.ranking().registerTrack(ftn("mid"), 50, {});   // first track, rank 0
+  h.ranking().registerTrack(ftn("high"), 100, {}); // inserts at rank 0, mid shifts to 1
+  h.ranking().registerTrack(ftn("low"), 20, {});   // inserts at rank 2
+  h.ranking().registerTrack(ftn("highest"), 150, {}); // inserts at rank 0, shifts all
+
+  // Order: highest=150(0), high=100(1), mid=50(2), low=20(3)
+  // Top-3: highest, high, mid
+  // Note: "low" was selected when registered at rank 2, then demoted when "highest" arrived
+  EXPECT_EQ(h.selectCount(ftn("highest"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("high"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("mid"), sub.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("low"), sub.get()), 1); // was selected at rank 2, then demoted
+  h.clearEvents();
+
+  // Verify ranks by updating "low" to cross threshold (re-enter top-3)
+  h.ranking().updateSortValue(ftn("low"), 75);
+  // Order: highest=150(0), high=100(1), low=75(2), mid=50(3)
+  EXPECT_EQ(h.selectCount(ftn("low"), sub.get()), 1); // low re-promoted
+}
+
+TEST_F(PropertyRankingBaseTest, EdgeCase_LargeRankJump) {
+  // Track jumps many positions at once
+  RankingHarness h(/*maxDeselected=*/0); // threshold = N
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true); // threshold = 3
+
+  // Register 10 tracks
+  for (int i = 0; i < 10; i++) {
+    h.ranking().registerTrack(ftn(std::to_string(i)), 100 - i * 10, {});
+  }
+  // Order: 0=100(0), 1=90(1), 2=80(2), 3=70(3), 4=60(4), ...
+  h.clearEvents();
+
+  // Move track "9" (rank 9, value 10) to rank 0 (value 200)
+  h.ranking().updateSortValue(ftn("9"), 200);
+  // Order: 9=200(0), 0=100(1), 1=90(2), 2=80(3), ...
+  EXPECT_EQ(h.selectCount(ftn("9"), sub.get()), 1); // 9 enters top-3
+  h.clearEvents();
+
+  // Move track "9" back to rank 9 (value 5)
+  h.ranking().updateSortValue(ftn("9"), 5);
+  // Order: 0=100(0), 1=90(1), 2=80(2), ... 9=5(9)
+  EXPECT_EQ(h.selectCount(ftn("2"), sub.get()), 1); // 2 re-enters top-3
+}
+
+TEST_F(PropertyRankingBaseTest, EdgeCase_UpdateToExactlyPreviousValue) {
+  // Update track to a value that places it exactly where another track was
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.clearEvents();
+
+  // Move c to exactly b's value
+  h.ranking().updateSortValue(ftn("c"), 80);
+  // c has same value as b but arrived later, so c stays below b
+  // Order: a=100(0), b=80(1), c=80(2)
+  // c is still at rank 2, no threshold crossing
+  EXPECT_EQ(h.selected_.size(), 0u);
+
+  // Move c to just above b
+  h.ranking().updateSortValue(ftn("c"), 81);
+  // Order: a=100(0), c=81(1), b=80(2)
+  // c enters top-2
+  EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 1);
+}
+
 } // namespace

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -53,10 +53,21 @@ public:
     MoQSession* session;
   };
 
-  explicit RankingHarness(uint64_t maxDeselected = 5)
+  explicit RankingHarness(
+      uint64_t maxDeselected = 5,
+      std::chrono::milliseconds idleTimeout = std::chrono::milliseconds(0)
+  )
       : ranking_(std::make_unique<PropertyRanking>(
             kProp,
             maxDeselected,
+            idleTimeout,
+            [this](const FullTrackName& f) {
+              auto it = activityTimes_.find(f);
+              if (it == activityTimes_.end()) {
+                return std::chrono::steady_clock::time_point{};
+              }
+              return it->second;
+            },
             [this](
                 const FullTrackName& f,
                 const std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>& sessions
@@ -72,6 +83,11 @@ public:
               evicted_.push_back({f, s.get()});
             }
         )) {}
+
+  // Set a mock activity time for a track (used in idle tests)
+  void setActivityTime(const FullTrackName& f, std::chrono::steady_clock::time_point t) {
+    activityTimes_[f] = t;
+  }
 
   PropertyRanking& ranking() { return *ranking_; }
 
@@ -114,6 +130,8 @@ public:
 
   std::vector<SelectEvent> selected_;
   std::vector<EvictEvent> evicted_;
+  folly::F14FastMap<FullTrackName, std::chrono::steady_clock::time_point, FullTrackName::hash>
+      activityTimes_;
 
 private:
   std::unique_ptr<PropertyRanking> ranking_;
@@ -1239,6 +1257,118 @@ TEST_F(PropertyRankingBaseTest, EdgeCase_UpdateToExactlyPreviousValue) {
   // Order: a=100(0), c=81(1), b=80(2)
   // c enters top-2
   EXPECT_EQ(h.selectCount(ftn("c"), sub.get()), 1);
+}
+
+// ---------------------------------------------------------------------------
+// sweepIdle tests
+// ---------------------------------------------------------------------------
+
+TEST(PropertyRankingSweepIdle, IdleTrackEvictedAndReplacementPromoted) {
+  // Setup: 3 tracks, N=2 group, idleTimeout=100ms
+  RankingHarness h(5, std::chrono::milliseconds(100));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {});  // rank 0
+  h.ranking().registerTrack(ftn("b"), 90, {});   // rank 1
+  h.ranking().registerTrack(ftn("c"), 80, {});   // rank 2
+
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+  h.clearEvents();
+
+  // Set activity times: a and c are active (recent), b is idle (old)
+  auto now = std::chrono::steady_clock::now();
+  h.setActivityTime(ftn("a"), now);
+  h.setActivityTime(ftn("b"), now - std::chrono::milliseconds(200));  // idle
+  h.setActivityTime(ftn("c"), now);
+
+  // Sweep should evict b (idle) and promote c (next best)
+  h.ranking().sweepIdle();
+
+  // c should be promoted to replace b
+  EXPECT_EQ(h.selectCount(ftn("c")), 1);
+
+  // Check states: a and c selected, b deselected
+  auto* group = h.ranking().getTopNGroup(2);
+  ASSERT_NE(group, nullptr);
+  EXPECT_EQ(group->trackStates.at(ftn("a")), TrackState::Selected);
+  EXPECT_EQ(group->trackStates.at(ftn("b")), TrackState::Deselected);
+  EXPECT_EQ(group->trackStates.at(ftn("c")), TrackState::Selected);
+}
+
+TEST(PropertyRankingSweepIdle, TrackThatNeverPublishedIsTreatedAsIdle) {
+  // A track with epoch timestamp (never published) should be evicted
+  RankingHarness h(5, std::chrono::milliseconds(100));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {});  // rank 0
+  h.ranking().registerTrack(ftn("b"), 90, {});   // rank 1 - never sets activity time
+  h.ranking().registerTrack(ftn("c"), 80, {});   // rank 2
+
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+  h.clearEvents();
+
+  // Only set activity for a and c; b has epoch (never published)
+  auto now = std::chrono::steady_clock::now();
+  h.setActivityTime(ftn("a"), now);
+  h.setActivityTime(ftn("c"), now);
+  // b has no activity time set -> epoch -> treated as idle
+
+  h.ranking().sweepIdle();
+
+  // b should be evicted, c promoted
+  EXPECT_EQ(h.selectCount(ftn("c")), 1);
+
+  auto* group = h.ranking().getTopNGroup(2);
+  ASSERT_NE(group, nullptr);
+  EXPECT_EQ(group->trackStates.at(ftn("b")), TrackState::Deselected);
+  EXPECT_EQ(group->trackStates.at(ftn("c")), TrackState::Selected);
+}
+
+TEST(PropertyRankingSweepIdle, NoEvictionWhenIdleTimeoutIsZero) {
+  // idleTimeout=0 disables idle eviction
+  RankingHarness h(5, std::chrono::milliseconds(0));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 90, {});
+
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+  h.clearEvents();
+
+  // Even with old activity time, should not evict when timeout is 0
+  auto now = std::chrono::steady_clock::now();
+  h.setActivityTime(ftn("a"), now - std::chrono::hours(1));
+  h.setActivityTime(ftn("b"), now - std::chrono::hours(1));
+
+  h.ranking().sweepIdle();
+
+  // No promotions should occur
+  EXPECT_EQ(h.selectCount(ftn("a")), 0);
+  EXPECT_EQ(h.selectCount(ftn("b")), 0);
+}
+
+TEST(PropertyRankingSweepIdle, ActiveTracksNotEvicted) {
+  RankingHarness h(5, std::chrono::milliseconds(100));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 90, {});
+
+  h.ranking().addSessionToTopNGroup(2, sub, true);
+  h.clearEvents();
+
+  // Both tracks are active (recent activity)
+  auto now = std::chrono::steady_clock::now();
+  h.setActivityTime(ftn("a"), now);
+  h.setActivityTime(ftn("b"), now);
+
+  h.ranking().sweepIdle();
+
+  // No evictions
+  auto* group = h.ranking().getTopNGroup(2);
+  ASSERT_NE(group, nullptr);
+  EXPECT_EQ(group->trackStates.at(ftn("a")), TrackState::Selected);
+  EXPECT_EQ(group->trackStates.at(ftn("b")), TrackState::Selected);
 }
 
 } // namespace

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -52,6 +52,10 @@ public:
     FullTrackName ftn;
     MoQSession* session;
   };
+  struct DeselectedEvent {
+    FullTrackName ftn;
+    MoQSession* session;
+  };
 
   explicit RankingHarness(
       uint64_t maxDeselected = 5,
@@ -78,6 +82,9 @@ public:
             },
             [this](const FullTrackName& f, std::shared_ptr<MoQSession> s, bool fwd) {
               selected_.push_back({f, s.get(), fwd});
+            },
+            [this](const FullTrackName& f, std::shared_ptr<MoQSession> s) {
+              deselected_.push_back({f, s.get()});
             },
             [this](const FullTrackName& f, std::shared_ptr<MoQSession> s) {
               evicted_.push_back({f, s.get()});
@@ -123,12 +130,24 @@ public:
     return n;
   }
 
+  int deselectCount(const FullTrackName& f) const {
+    int n = 0;
+    for (auto& e : deselected_) {
+      if (e.ftn == f) {
+        n++;
+      }
+    }
+    return n;
+  }
+
   void clearEvents() {
     selected_.clear();
+    deselected_.clear();
     evicted_.clear();
   }
 
   std::vector<SelectEvent> selected_;
+  std::vector<DeselectedEvent> deselected_;
   std::vector<EvictEvent> evicted_;
   folly::F14FastMap<FullTrackName, std::chrono::steady_clock::time_point, FullTrackName::hash>
       activityTimes_;

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -1171,9 +1171,9 @@ TEST_F(PropertyRankingBaseTest, EdgeCase_RegisterAtAllPositions) {
   h.ranking().addSessionToTopNGroup(3, sub, true);
 
   // Register in non-sequential order
-  h.ranking().registerTrack(ftn("mid"), 50, {});   // first track, rank 0
-  h.ranking().registerTrack(ftn("high"), 100, {}); // inserts at rank 0, mid shifts to 1
-  h.ranking().registerTrack(ftn("low"), 20, {});   // inserts at rank 2
+  h.ranking().registerTrack(ftn("mid"), 50, {});      // first track, rank 0
+  h.ranking().registerTrack(ftn("high"), 100, {});    // inserts at rank 0, mid shifts to 1
+  h.ranking().registerTrack(ftn("low"), 20, {});      // inserts at rank 2
   h.ranking().registerTrack(ftn("highest"), 150, {}); // inserts at rank 0, shifts all
 
   // Order: highest=150(0), high=100(1), mid=50(2), low=20(3)

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -502,4 +502,78 @@ TEST_F(PropertyRankingBaseTest, RemoveSelected_FallbackPicksHighestNonSelected) 
   EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 0); // b was already selected
 }
 
+// ---------------------------------------------------------------------------
+// Two-phase algorithm: multiple adjacent groups handled in single traversal
+// ---------------------------------------------------------------------------
+
+TEST_F(PropertyRankingBaseTest, MultipleAdjacentGroups_SingleTraversalDemotion) {
+  // Tests that registerTrack correctly demotes tracks at multiple boundary positions
+  // in a single traversal when multiple TopNGroups have adjacent N values.
+  RankingHarness h;
+  auto sub2 = makeSession(); // top-2
+  auto sub3 = makeSession(); // top-3
+  auto sub4 = makeSession(); // top-4
+
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+  h.ranking().addSessionToTopNGroup(3, sub3, true);
+  h.ranking().addSessionToTopNGroup(4, sub4, true);
+
+  // Register tracks at positions 0,1,2,3
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3
+  h.clearEvents();
+
+  // Register a track that becomes rank 0, pushing everyone down
+  // This should trigger demotions at positions 2, 3, 4 for groups N=2, N=3, N=4
+  h.ranking().registerTrack(ftn("e"), 110, {}); // e becomes rank 0
+
+  // e should be selected for all three groups
+  EXPECT_EQ(h.selectCount(ftn("e"), sub2.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("e"), sub3.get()), 1);
+  EXPECT_EQ(h.selectCount(ftn("e"), sub4.get()), 1);
+
+  // After e enters:
+  // - sub2 (top-2): e, a selected; b demoted at position 2
+  // - sub3 (top-3): e, a, b selected; c demoted at position 3
+  // - sub4 (top-4): e, a, b, c selected; d demoted at position 4
+  // Note: b was selected for sub2 initially, now demoted
+  //       c was selected for sub3 initially, now demoted
+  //       d was selected for sub4 initially, now demoted
+}
+
+TEST_F(PropertyRankingBaseTest, MultipleAdjacentGroups_SingleTraversalPromotion) {
+  // Tests that recomputeTopNGroups correctly promotes tracks at multiple boundary
+  // positions in a single traversal when a track falls out of multiple groups.
+  RankingHarness h;
+  auto sub2 = makeSession(); // top-2
+  auto sub3 = makeSession(); // top-3
+  auto sub4 = makeSession(); // top-4
+
+  h.ranking().addSessionToTopNGroup(2, sub2, true);
+  h.ranking().addSessionToTopNGroup(3, sub3, true);
+  h.ranking().addSessionToTopNGroup(4, sub4, true);
+
+  // Register tracks: a=100, b=80, c=60, d=40, e=20
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3
+  h.ranking().registerTrack(ftn("e"), 20, {});  // rank 4
+  h.clearEvents();
+
+  // Drop "a" to rank 4 (value=10), falling out of all three groups
+  // This should promote tracks at positions 1, 2, 3 for the respective groups
+  h.ranking().updateSortValue(ftn("a"), 10);
+
+  // After a drops: order is b=80(0), c=60(1), d=40(2), e=20(3), a=10(4)
+  // - sub2 (top-2): b, c selected (c promoted at position 1)
+  // - sub3 (top-3): b, c, d selected (d promoted at position 2)
+  // - sub4 (top-4): b, c, d, e selected (e promoted at position 3)
+  EXPECT_GE(h.selectCount(ftn("c"), sub2.get()), 1); // c promoted into top-2
+  EXPECT_GE(h.selectCount(ftn("d"), sub3.get()), 1); // d promoted into top-3
+  EXPECT_GE(h.selectCount(ftn("e"), sub4.get()), 1); // e promoted into top-4
+}
+
 } // namespace

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -682,4 +682,129 @@ TEST_F(PropertyRankingBaseTest, ThresholdIncrease_MultipleGroupsAddedSequentiall
   EXPECT_EQ(h.selectCount(ftn("c"), sub3.get()), 0); // was already in top-3
 }
 
+// ---------------------------------------------------------------------------
+// Sentinel cachedRank fix: promotion from beyond threshold
+// ---------------------------------------------------------------------------
+// These tests validate that tracks promoted from beyond the selection threshold
+// (with cachedRank = UINT64_MAX sentinel) get their cachedRank fixed correctly.
+// Bug scenario: Track at rank >= selectionThreshold has sentinel cachedRank.
+// If promoted without fixing cachedRank, subsequent updateSortValue uses stale
+// UINT64_MAX causing incorrect wasInTopN computation and spurious notifications.
+
+TEST_F(PropertyRankingBaseTest, RemoveTrackFallback_FixesSentinelCachedRank) {
+  // Scenario from Alan's bug report:
+  // N=3, 4 tracks registered (track at rank 3 has sentinel cachedRank).
+  // Remove track at rank 2 -> fallback scan promotes track from rank 3.
+  // Track must have correct cachedRank=2 (new position) for updateSortValue.
+  RankingHarness h;
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true);
+
+  // With N=3 and maxDeselected=5 (default), selectionThreshold = 3+5 = 8.
+  // All 4 tracks get accurate cachedRank (0,1,2,3 < 8).
+  // To trigger sentinel, we need tracks at rank >= threshold.
+  // Use maxDeselected=0 to set threshold = N = 3.
+  RankingHarness h2(/*maxDeselected=*/0);
+  auto sub2 = makeSession();
+  h2.ranking().addSessionToTopNGroup(3, sub2, true);
+
+  h2.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h2.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h2.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h2.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 - has sentinel cachedRank
+
+  // Verify d was selected initially (part of top-3... wait, N=3 means ranks 0,1,2)
+  // Actually ranks 0,1,2 are in top-3, so d at rank 3 is NOT selected.
+  h2.clearEvents();
+
+  // Remove c (rank 2, selected) -> fallback scan promotes d (rank 3 -> rank 2)
+  h2.ranking().removeTrack(ftn("c"));
+  EXPECT_EQ(h2.selectCount(ftn("d"), sub2.get()), 1); // d promoted
+
+  // Critical: subsequent updateSortValue on d should NOT cause spurious notification.
+  // If cachedRank wasn't fixed, d would have UINT64_MAX and wasInTopN would be false,
+  // causing duplicate selection notification.
+  h2.clearEvents();
+
+  // Move d within top-3 (from rank 2 to rank 0)
+  h2.ranking().updateSortValue(ftn("d"), 110);
+  // d was already selected (rank 2), now rank 0 - still selected, no new notification
+  EXPECT_EQ(h2.selectCount(ftn("d"), sub2.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, PromoteTrackInGroup_FixesSentinelCachedRank) {
+  // Test that promoteTrackInGroup (via recomputeTopNGroups slow path) also
+  // fixes sentinel cachedRank when promoting a track from beyond threshold.
+  //
+  // Scenario: N=2, 4 tracks. Track at rank 3 has sentinel.
+  // Track at rank 0 falls to rank 3 -> track at rank 2 (position N-1=1 after shift)
+  // gets promoted. But we want to test rank 3 promotion.
+  //
+  // Better scenario: N=3, threshold=3 (maxDeselected=0), 5 tracks.
+  // Track at rank 4 has sentinel. Track at rank 0 falls out -> promotes rank 3.
+  RankingHarness h(/*maxDeselected=*/0);
+  auto sub = makeSession();
+  h.ranking().addSessionToTopNGroup(3, sub, true); // threshold = 3
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0 - selected
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1 - selected
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2 - selected
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 - sentinel cachedRank
+  h.ranking().registerTrack(ftn("e"), 20, {});  // rank 4 - sentinel cachedRank
+  h.clearEvents();
+
+  // Drop "a" from rank 0 to rank 4 (value=10)
+  // New order: b=80(0), c=60(1), d=40(2), e=20(3), a=10(4)
+  // Promotion at position N-1=2: d gets promoted
+  h.ranking().updateSortValue(ftn("a"), 10);
+
+  // d should be selected (promoted into top-3)
+  EXPECT_GE(h.selectCount(ftn("d"), sub.get()), 1);
+  h.clearEvents();
+
+  // Now update d - should NOT cause spurious notification
+  // Move d within top-3 (from rank 2 to rank 0)
+  h.ranking().updateSortValue(ftn("d"), 90);
+  // d was already selected at rank 2, now rank 0 - no new notification
+  EXPECT_EQ(h.selectCount(ftn("d"), sub.get()), 0);
+}
+
+TEST_F(PropertyRankingBaseTest, SentinelFix_SubsequentUpdateSortValueCorrect) {
+  // Comprehensive test: verify that after sentinel fix, the promoted track's
+  // subsequent movements are handled correctly.
+  RankingHarness h(/*maxDeselected=*/0);
+  auto sub2 = makeSession();
+  auto sub4 = makeSession();
+  h.ranking().addSessionToTopNGroup(2, sub2, true); // N=2
+  h.ranking().addSessionToTopNGroup(4, sub4, true); // N=4, threshold=4
+
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3
+  h.ranking().registerTrack(ftn("e"), 20, {});  // rank 4 - sentinel
+
+  // Initial state: sub2 gets a,b; sub4 gets a,b,c,d
+  h.clearEvents();
+
+  // Remove "c" (rank 2, selected for sub4 only)
+  // After removal: a=100(0), b=80(1), d=40(2), e=20(3)
+  // For sub4 (N=4): d shifts to rank 2 (still selected), e shifts to rank 3 (promoted)
+  // e had sentinel cachedRank, now should have cachedRank=3
+  h.ranking().removeTrack(ftn("c"));
+
+  // e should be promoted into sub4's top-4
+  EXPECT_GE(h.selectCount(ftn("e"), sub4.get()), 1);
+  h.clearEvents();
+
+  // Now move e from rank 3 to rank 1 (entering sub2's top-2)
+  h.ranking().updateSortValue(ftn("e"), 90);
+  // Order: a=100(0), e=90(1), b=80(2), d=40(3)
+
+  // e enters sub2 (was rank 3, now rank 1)
+  EXPECT_GE(h.selectCount(ftn("e"), sub2.get()), 1);
+  // e should NOT get duplicate notification for sub4 (was already selected at rank 3)
+  EXPECT_EQ(h.selectCount(ftn("e"), sub4.get()), 0);
+}
+
 } // namespace

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -1268,9 +1268,9 @@ TEST(PropertyRankingSweepIdle, IdleTrackEvictedAndReplacementPromoted) {
   RankingHarness h(5, std::chrono::milliseconds(100));
   auto sub = makeSession();
 
-  h.ranking().registerTrack(ftn("a"), 100, {});  // rank 0
-  h.ranking().registerTrack(ftn("b"), 90, {});   // rank 1
-  h.ranking().registerTrack(ftn("c"), 80, {});   // rank 2
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 90, {});  // rank 1
+  h.ranking().registerTrack(ftn("c"), 80, {});  // rank 2
 
   h.ranking().addSessionToTopNGroup(2, sub, true);
   h.clearEvents();
@@ -1278,7 +1278,7 @@ TEST(PropertyRankingSweepIdle, IdleTrackEvictedAndReplacementPromoted) {
   // Set activity times: a and c are active (recent), b is idle (old)
   auto now = std::chrono::steady_clock::now();
   h.setActivityTime(ftn("a"), now);
-  h.setActivityTime(ftn("b"), now - std::chrono::milliseconds(200));  // idle
+  h.setActivityTime(ftn("b"), now - std::chrono::milliseconds(200)); // idle
   h.setActivityTime(ftn("c"), now);
 
   // Sweep should evict b (idle) and promote c (next best)
@@ -1300,9 +1300,9 @@ TEST(PropertyRankingSweepIdle, TrackThatNeverPublishedIsTreatedAsIdle) {
   RankingHarness h(5, std::chrono::milliseconds(100));
   auto sub = makeSession();
 
-  h.ranking().registerTrack(ftn("a"), 100, {});  // rank 0
-  h.ranking().registerTrack(ftn("b"), 90, {});   // rank 1 - never sets activity time
-  h.ranking().registerTrack(ftn("c"), 80, {});   // rank 2
+  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
+  h.ranking().registerTrack(ftn("b"), 90, {});  // rank 1 - never sets activity time
+  h.ranking().registerTrack(ftn("c"), 80, {});  // rank 2
 
   h.ranking().addSessionToTopNGroup(2, sub, true);
   h.clearEvents();

--- a/test/PropertyRankingSelfExclusionTest.cpp
+++ b/test/PropertyRankingSelfExclusionTest.cpp
@@ -1,0 +1,594 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/PropertyRanking.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <moxygen/test/MockMoQSession.h>
+
+#include <memory>
+#include <vector>
+
+using namespace openmoq::moqx;
+using namespace moxygen;
+using ::testing::NiceMock;
+
+namespace {
+
+// Helpers
+FullTrackName ftn(const std::string& ns, const std::string& name) {
+  return FullTrackName{TrackNamespace{{ns}}, name};
+}
+
+class PropertyRankingSelfExclusionTest : public ::testing::Test {
+protected:
+  struct SelectRecord {
+    FullTrackName ftn;
+    MoQSession* session;
+    bool forward;
+  };
+
+  struct EvictRecord {
+    FullTrackName ftn;
+    MoQSession* session;
+  };
+
+  std::vector<SelectRecord> selected_;
+  std::vector<EvictRecord> evicted_;
+
+  // PropertyRanking only stores shared_ptr<MoQSession> as map keys and passes
+  // them back through callbacks — it never calls any MoQSession methods itself.
+  // MockMoQSession has a default constructor for exactly this use case.
+  std::shared_ptr<MoQSession> makeSession() {
+    auto s = std::make_shared<NiceMock<moxygen::test::MockMoQSession>>();
+    sessions_.push_back(s);
+    return s;
+  }
+
+  std::unique_ptr<PropertyRanking> makeRanking(uint64_t maxDeselected = 100) {
+    return std::make_unique<PropertyRanking>(
+        /*propertyType=*/1,
+        maxDeselected,
+        /*idleTimeout=*/std::chrono::milliseconds{0},
+        /*getLastActivity=*/nullptr,
+        /*onBatchSelected=*/
+        [this](
+            const FullTrackName& f,
+            const std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>& sessions
+        ) {
+          for (auto& [s, fwd] : sessions) {
+            selected_.push_back({f, s.get(), fwd});
+          }
+        },
+        /*onSelected=*/
+        [this](const FullTrackName& f, std::shared_ptr<MoQSession> s, bool fwd) {
+          selected_.push_back({f, s.get(), fwd});
+        },
+        /*onEvicted=*/
+        [this](const FullTrackName& f, std::shared_ptr<MoQSession> s) {
+          evicted_.push_back({f, s.get()});
+        }
+    );
+  }
+
+  bool wasSelected(const FullTrackName& f, MoQSession* s) {
+    for (auto& r : selected_) {
+      if (r.ftn == f && r.session == s) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  int countSelected(const FullTrackName& f, MoQSession* s) {
+    int n = 0;
+    for (auto& r : selected_) {
+      if (r.ftn == f && r.session == s) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  bool wasEvicted(const FullTrackName& f, MoQSession* s) {
+    for (auto& r : evicted_) {
+      if (r.ftn == f && r.session == s) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::vector<std::shared_ptr<NiceMock<moxygen::test::MockMoQSession>>> sessions_;
+};
+
+// Publisher subscribes with TRACK_FILTER: own track is never notified.
+// Self-exclusion is automatic based on RankedEntry::publisher.
+TEST_F(PropertyRankingSelfExclusionTest, PublisherDoesNotReceiveOwnTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+  auto track = ftn("ns", "self");
+
+  r->registerTrack(track, 100, pub);
+  r->addSessionToTopNGroup(3, pub, true);
+
+  EXPECT_FALSE(wasSelected(track, pub.get()));
+}
+
+// Viewer in the same group DOES receive the publisher's track.
+TEST_F(PropertyRankingSelfExclusionTest, ViewerReceivesPublisherTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+  auto viewer = makeSession();
+  auto track = ftn("ns", "self");
+
+  r->registerTrack(track, 100, pub);
+  r->addSessionToTopNGroup(3, pub, true);
+  r->addSessionToTopNGroup(3, viewer, true);
+
+  EXPECT_FALSE(wasSelected(track, pub.get()));
+  EXPECT_TRUE(wasSelected(track, viewer.get()));
+}
+
+// Mixed group: viewer sees all top-N; publisher-subscriber sees top-N
+// excluding its own track.
+TEST_F(PropertyRankingSelfExclusionTest, MixedGroup_ViewerAndPublisherSubscriber) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+  auto viewer = makeSession();
+
+  auto self = ftn("ns", "pub-track");
+  auto other1 = ftn("ns", "other1");
+  auto other2 = ftn("ns", "other2");
+
+  r->registerTrack(other1, 90, {});
+  r->registerTrack(other2, 80, {});
+  r->registerTrack(self, 70, pub);
+
+  // N=3: viewer sees all 3; publisher sees only the 2 non-self tracks.
+  r->addSessionToTopNGroup(3, pub, true);
+  r->addSessionToTopNGroup(3, viewer, true);
+
+  EXPECT_TRUE(wasSelected(other1, viewer.get()));
+  EXPECT_TRUE(wasSelected(other2, viewer.get()));
+  EXPECT_TRUE(wasSelected(self, viewer.get()));
+
+  EXPECT_TRUE(wasSelected(other1, pub.get()));
+  EXPECT_TRUE(wasSelected(other2, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+}
+
+// computeWaterlineKey: publisher with N=2 and 1 self-track should be notified
+// of exactly 2 non-self tracks, with the waterline at the 2nd non-self.
+TEST_F(PropertyRankingSelfExclusionTest, WaterlineSelectsNonSelfTracks) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3"); // Rank 3 (worst) — should NOT be selected (N=2)
+
+  // Register with descending values so order is t1 > t2 > self > t3.
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(t3, 60, {});
+
+  r->addSessionToTopNGroup(2, pub, true);
+
+  // N=2 non-self: t1 (rank 0) and t2 (rank 1). t3 is the 3rd non-self → excluded.
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+}
+
+// Publisher with >1 self-track: waterline computed over non-self tracks only.
+TEST_F(PropertyRankingSelfExclusionTest, MultipleSelfTracks_WaterlineCorrect) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  // Values: t1=100, s1=90, t2=80, s2=70, t3=60
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(s1, 90, pub);
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(s2, 70, pub);
+  r->registerTrack(t3, 60, {});
+
+  // N=2 non-self: publisher should receive t1 and t2 only.
+  r->addSessionToTopNGroup(2, pub, true);
+
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(s1, pub.get()));
+  EXPECT_FALSE(wasSelected(s2, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+}
+
+// Self-track value change: waterline is recomputed, and the selection set
+// for the publisher updates accordingly.
+// Scenario: N=2, 2 self-tracks interspersed with non-self tracks.
+// Initial order: t1(100) > s1(90) > t2(80) > s2(70) > t3(60).
+// Non-self top-2: t1, t2. Publisher sees t1, t2.
+// s1 drops to 50 → new order: t1(100) > t2(80) > s2(70) > t3(60) > s1(50).
+// Non-self top-2 is still t1, t2. Publisher still sees t1, t2. No change.
+TEST_F(PropertyRankingSelfExclusionTest, SelfTrackValueChange_NoEffectOnViewSet) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(s1, 90, pub);
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(s2, 70, pub);
+  r->registerTrack(t3, 60, {});
+
+  r->addSessionToTopNGroup(2, pub, true);
+
+  selected_.clear();
+  // s1 drops from 90 to 50. Waterline recomputed: non-self top-2 still t1, t2.
+  r->updateSortValue(s1, 50);
+
+  // Publisher should not be spuriously notified.
+  EXPECT_FALSE(wasSelected(t1, pub.get()));
+  EXPECT_FALSE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+  EXPECT_FALSE(wasSelected(s1, pub.get()));
+}
+
+// Self-track value change causes outsider to enter publisher's view.
+// N=2, initial: t1(100) > t2(80) > self(70) > outsider(10).
+// Non-self top-2: t1, t2. Publisher sees t1, t2.
+// self rises to 95 → order: t1(100) > self(95) > t2(80) > outsider(10).
+// Non-self top-2: t1 (rank 0), t2 (rank 2). outsider still rank 3 → not selected.
+// Now self rises to 110 → order: self(110) > t1(100) > t2(80) > outsider(10).
+// Non-self top-2: t1 (rank 1), t2 (rank 2). outsider still not selected. No change.
+TEST_F(PropertyRankingSelfExclusionTest, SelfTrackRises_OutsiderStaysOut) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto outsider = ftn("ns", "outsider");
+
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(outsider, 10, {});
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(outsider, pub.get()));
+
+  // Self rises through ranks — outsider should not be selected.
+  selected_.clear();
+  r->updateSortValue(self, 110);
+  EXPECT_FALSE(wasSelected(outsider, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+}
+
+// Outsider enters publisher's top-N because a non-self track drops out.
+// N=2, initial: t1(100) > t2(80) > self(70) > outsider(10).
+// Non-self top-2: t1, t2.
+// t2 drops to 5 → order: t1(100) > self(70) > outsider(10) > t2(5).
+// Non-self top-2: t1 (rank 0), outsider (rank 2). Publisher sees outsider now.
+TEST_F(PropertyRankingSelfExclusionTest, NonSelfTrackDrops_OutsiderEntersPublisherView) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto outsider = ftn("ns", "outsider");
+
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(outsider, 10, {});
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_FALSE(wasSelected(outsider, pub.get()));
+
+  // t2 drops below outsider.
+  selected_.clear();
+  evicted_.clear();
+  r->updateSortValue(t2, 5);
+  EXPECT_TRUE(wasSelected(outsider, pub.get()));
+  EXPECT_TRUE(wasEvicted(t2, pub.get())); // t2 left publisher's view — must be evicted
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+}
+
+// Publisher with self-tracks both inside and outside the shared top-N.
+// N=3: shared top-3 = t1, s1 (self), t2. Publisher sees t1, t2 (excludes s1).
+// s2 (self, rank 4) is outside shared top-3, so waterline = t2's key.
+// t3 (rank 5, non-self) is below waterline → not selected for publisher.
+TEST_F(PropertyRankingSelfExclusionTest, SelfTracksInsideAndOutsideTopN) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  // Order: t1(100) > s1(90) > t2(80) > s2(70) > t3(60)
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(s1, 90, pub);
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(s2, 70, pub);
+  r->registerTrack(t3, 60, {});
+
+  // N=3: shared top-3 = t1, s1, t2.
+  // Non-self top-3: t1 (rank 0), t2 (rank 2), t3 (rank 4).
+  // Waterline = key of 3rd non-self = t3's key (value=60).
+  r->addSessionToTopNGroup(3, pub, true);
+
+  EXPECT_TRUE(wasSelected(t1, pub.get()));  // rank 0, non-self → selected
+  EXPECT_FALSE(wasSelected(s1, pub.get())); // self → excluded
+  EXPECT_TRUE(wasSelected(t2, pub.get()));  // rank 2, non-self → selected
+  EXPECT_FALSE(wasSelected(s2, pub.get())); // self → excluded
+  EXPECT_TRUE(wasSelected(t3, pub.get()));  // rank 4, 3rd non-self → at waterline → selected
+}
+
+// A track registered after the publisher has already subscribed enters the
+// publisher's personal top-N and displaces the previous waterline track.
+//
+// Setup: t1(100), t2(80), self(70) registered; publisher subscribes N=2.
+// Publisher sees t1, t2.  newcomer(90) registered → enters rank 1.
+// Non-self top-2: t1, newcomer.  t2 displaced and must be evicted.
+TEST_F(PropertyRankingSelfExclusionTest, RegisterTrack_AfterPublisherSubscribed) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto newcomer = ftn("ns", "newcomer");
+
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(self, 70, pub);
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  // newcomer enters at rank 1 (above t2, below t1).
+  r->registerTrack(newcomer, 90, {});
+
+  EXPECT_TRUE(wasSelected(newcomer, pub.get())); // newcomer entered publisher's top-2
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));        // t2 displaced
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));       // t1 stays
+  EXPECT_FALSE(wasSelected(self, pub.get()));    // self never selected
+}
+
+// When a track in the publisher's personal selection is removed, the publisher
+// receives an eviction and the replacement track is selected.
+//
+// Setup: t1(100), t2(80), self(70), t3(60).  Publisher with {self}, N=2.
+// Publisher sees t1, t2.  removeTrack(t2) → self promoted to shared top-2;
+// reconcile produces: evict t2, select t3 (new 2nd non-self); self excluded.
+TEST_F(PropertyRankingSelfExclusionTest, RemoveTrack_WithPublisherInGroup) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(t3, 60, {});
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  r->removeTrack(t2);
+
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));     // t2 removed — evicted from publisher
+  EXPECT_TRUE(wasSelected(t3, pub.get()));    // t3 is the new 2nd non-self
+  EXPECT_FALSE(wasSelected(self, pub.get())); // self excluded even when promoted in shared view
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));    // t1 stays
+}
+
+// Two publisher-subscribers in the same group each exclude only their own
+// self-track; they can still receive each other's tracks.
+//
+// s1(100) > s2(90) > t1(80) > t2(70) > t3(60).  N=3.
+// pub1 {s1}: non-self top-3 = s2, t1, t2.
+// pub2 {s2}: non-self top-3 = s1, t1, t2.
+//
+// After s1 drops to 55: pub2's non-self top-3 shifts to t1, t2, t3 — s1 evicted,
+// t3 selected.  pub1's view is unchanged (s1 is its own self-track, skipped).
+TEST_F(PropertyRankingSelfExclusionTest, TwoPublisherSessions_IndependentSelfExclusion) {
+  auto r = makeRanking();
+  auto pub1 = makeSession();
+  auto pub2 = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  r->registerTrack(s1, 100, pub1);
+  r->registerTrack(s2, 90, pub2);
+  r->registerTrack(t1, 80, {});
+  r->registerTrack(t2, 70, {});
+  r->registerTrack(t3, 60, {});
+
+  r->addSessionToTopNGroup(3, pub1, true);
+  r->addSessionToTopNGroup(3, pub2, true);
+
+  // pub1 sees s2, t1, t2 (not s1).
+  EXPECT_FALSE(wasSelected(s1, pub1.get()));
+  EXPECT_TRUE(wasSelected(s2, pub1.get()));
+  EXPECT_TRUE(wasSelected(t1, pub1.get()));
+  EXPECT_TRUE(wasSelected(t2, pub1.get()));
+  EXPECT_FALSE(wasSelected(t3, pub1.get()));
+
+  // pub2 sees s1, t1, t2 (not s2).
+  EXPECT_TRUE(wasSelected(s1, pub2.get()));
+  EXPECT_FALSE(wasSelected(s2, pub2.get()));
+  EXPECT_TRUE(wasSelected(t1, pub2.get()));
+  EXPECT_TRUE(wasSelected(t2, pub2.get()));
+  EXPECT_FALSE(wasSelected(t3, pub2.get()));
+
+  // s1 drops out of non-self top-3 for pub2; t3 enters.
+  // pub1 is unaffected (s1 is its self-track — its waterline doesn't change).
+  selected_.clear();
+  evicted_.clear();
+  r->updateSortValue(s1, 55); // s1: rank 0 → rank 4 (below t3)
+
+  EXPECT_TRUE(wasEvicted(s1, pub2.get()));   // s1 left pub2's view
+  EXPECT_TRUE(wasSelected(t3, pub2.get()));  // t3 entered pub2's view
+  EXPECT_FALSE(wasSelected(t3, pub1.get())); // pub1 unaffected
+  EXPECT_FALSE(wasEvicted(s1, pub1.get()));  // pub1 never received s1
+}
+
+// Viewer subscribes first, then registers a track (becoming a publisher).
+// The newly-registered track becomes a self-track and must be excluded.
+//
+// Setup: t1(100), t2(80), t3(60) registered.  Session subscribes N=2 as viewer.
+// Viewer sees t1, t2.  Session then publishes new track "self" at rank 1 (value=90).
+// Session now is a publisher-subscriber. Non-self top-2: t1, t2.
+// The new track "self" must be excluded and t3 stays out.
+TEST_F(PropertyRankingSelfExclusionTest, ViewerBecomesPublisher_ByRegisteringTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+  auto self = ftn("ns", "self");
+
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(t3, 60, {});
+
+  // Subscribe as viewer first (no self-tracks yet)
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  // Now the session registers its own track at rank 1
+  r->registerTrack(self, 90, pub);
+
+  // The session is now a publisher-subscriber. Its new track is self and excluded.
+  // Non-self top-2: still t1, t2. The session should not see "self" selected.
+  EXPECT_FALSE(wasSelected(self, pub.get())); // self is excluded
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));    // t1 stays
+  EXPECT_FALSE(wasEvicted(t2, pub.get()));    // t2 stays
+  EXPECT_FALSE(wasSelected(t3, pub.get()));   // t3 stays out
+}
+
+// Viewer subscribes, then registers a track that IS currently being delivered.
+// That track becomes a self-track and must be evicted; a replacement enters.
+//
+// Setup: t1(100), t2(80), t3(60) registered.  Session subscribes N=2 as viewer.
+// Viewer sees t1, t2.  Session then publishes t2 (claiming ownership).
+// Session now is a publisher-subscriber. Non-self top-2: t1, t3.
+// t2 must be evicted and t3 must be selected.
+TEST_F(PropertyRankingSelfExclusionTest, ViewerBecomesPublisher_ClaimsDeliveredTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  // t2 is initially registered with no publisher
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(t3, 60, {});
+
+  // Subscribe as viewer first
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+
+  // Remove t2 so we can re-register it with the publisher
+  r->removeTrack(t2);
+
+  selected_.clear();
+  evicted_.clear();
+
+  // Now the session registers t2 as its own track
+  r->registerTrack(t2, 80, pub);
+
+  // t2 is now a self-track → evicted. t3 enters as replacement.
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));   // t2 now self-track → evicted
+  EXPECT_TRUE(wasSelected(t3, pub.get()));  // t3 enters publisher's top-2
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));  // t1 stays
+}
+
+// Bug: non-self track rises above the publisher's waterline, displacing the
+// previous Nth non-self track.  The displaced track must be evicted from the
+// publisher's delivery; without that eviction the publisher receives N+1 tracks.
+//
+// N=2, initial: t1(100) > t2(80) > self(70) > outsider(30).
+// Non-self top-2: t1, t2.  outsider rises to 85 → non-self top-2: t1, outsider.
+// t2 must be evicted and outsider must be selected.
+TEST_F(PropertyRankingSelfExclusionTest, NonSelfTrackRises_DisplacesWaterlineTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto outsider = ftn("ns", "outsider");
+
+  r->registerTrack(t1, 100, {});
+  r->registerTrack(t2, 80, {});
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(outsider, 30, {});
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(outsider, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+  r->updateSortValue(outsider, 85); // outsider rises above t2
+
+  EXPECT_TRUE(wasSelected(outsider, pub.get())); // outsider entered publisher's top-2
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));        // t2 displaced — must be evicted
+  EXPECT_FALSE(wasSelected(self, pub.get()));    // self never selected
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));       // t1 stayed in top-2
+}
+
+} // namespace

--- a/test/PropertyRankingSelfExclusionTest.cpp
+++ b/test/PropertyRankingSelfExclusionTest.cpp
@@ -37,7 +37,13 @@ protected:
     MoQSession* session;
   };
 
+  struct DeselectedRecord {
+    FullTrackName ftn;
+    MoQSession* session;
+  };
+
   std::vector<SelectRecord> selected_;
+  std::vector<DeselectedRecord> deselected_;
   std::vector<EvictRecord> evicted_;
 
   // PropertyRanking only stores shared_ptr<MoQSession> as map keys and passes
@@ -67,6 +73,10 @@ protected:
         /*onSelected=*/
         [this](const FullTrackName& f, std::shared_ptr<MoQSession> s, bool fwd) {
           selected_.push_back({f, s.get(), fwd});
+        },
+        /*onDeselected=*/
+        [this](const FullTrackName& f, std::shared_ptr<MoQSession> s) {
+          deselected_.push_back({f, s.get()});
         },
         /*onEvicted=*/
         [this](const FullTrackName& f, std::shared_ptr<MoQSession> s) {
@@ -309,6 +319,7 @@ TEST_F(PropertyRankingSelfExclusionTest, NonSelfTrackDrops_OutsiderEntersPublish
 
   // t2 drops below outsider.
   selected_.clear();
+  deselected_.clear();
   evicted_.clear();
   r->updateSortValue(t2, 5);
   EXPECT_TRUE(wasSelected(outsider, pub.get()));
@@ -373,6 +384,7 @@ TEST_F(PropertyRankingSelfExclusionTest, RegisterTrack_AfterPublisherSubscribed)
   EXPECT_TRUE(wasSelected(t2, pub.get()));
 
   selected_.clear();
+  deselected_.clear();
   evicted_.clear();
 
   // newcomer enters at rank 1 (above t2, below t1).
@@ -409,6 +421,7 @@ TEST_F(PropertyRankingSelfExclusionTest, RemoveTrack_WithPublisherInGroup) {
   EXPECT_TRUE(wasSelected(t2, pub.get()));
 
   selected_.clear();
+  deselected_.clear();
   evicted_.clear();
 
   r->removeTrack(t2);
@@ -465,6 +478,7 @@ TEST_F(PropertyRankingSelfExclusionTest, TwoPublisherSessions_IndependentSelfExc
   // s1 drops out of non-self top-3 for pub2; t3 enters.
   // pub1 is unaffected (s1 is its self-track — its waterline doesn't change).
   selected_.clear();
+  deselected_.clear();
   evicted_.clear();
   r->updateSortValue(s1, 55); // s1: rank 0 → rank 4 (below t3)
 
@@ -501,6 +515,7 @@ TEST_F(PropertyRankingSelfExclusionTest, ViewerBecomesPublisher_ByRegisteringTra
   EXPECT_FALSE(wasSelected(t3, pub.get()));
 
   selected_.clear();
+  deselected_.clear();
   evicted_.clear();
 
   // Now the session registers its own track at rank 1
@@ -544,15 +559,16 @@ TEST_F(PropertyRankingSelfExclusionTest, ViewerBecomesPublisher_ClaimsDeliveredT
   r->removeTrack(t2);
 
   selected_.clear();
+  deselected_.clear();
   evicted_.clear();
 
   // Now the session registers t2 as its own track
   r->registerTrack(t2, 80, pub);
 
   // t2 is now a self-track → evicted. t3 enters as replacement.
-  EXPECT_TRUE(wasEvicted(t2, pub.get()));   // t2 now self-track → evicted
-  EXPECT_TRUE(wasSelected(t3, pub.get()));  // t3 enters publisher's top-2
-  EXPECT_FALSE(wasEvicted(t1, pub.get()));  // t1 stays
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));  // t2 now self-track → evicted
+  EXPECT_TRUE(wasSelected(t3, pub.get())); // t3 enters publisher's top-2
+  EXPECT_FALSE(wasEvicted(t1, pub.get())); // t1 stays
 }
 
 // Bug: non-self track rises above the publisher's waterline, displacing the
@@ -582,6 +598,7 @@ TEST_F(PropertyRankingSelfExclusionTest, NonSelfTrackRises_DisplacesWaterlineTra
   EXPECT_FALSE(wasSelected(outsider, pub.get()));
 
   selected_.clear();
+  deselected_.clear();
   evicted_.clear();
   r->updateSortValue(outsider, 85); // outsider rises above t2
 

--- a/test/TopNFilterTest.cpp
+++ b/test/TopNFilterTest.cpp
@@ -10,6 +10,8 @@
 #include <folly/portability/GTest.h>
 #include <moxygen/test/Mocks.h>
 
+#include <thread>
+
 using namespace testing;
 using namespace moxygen;
 using namespace openmoq::moqx;
@@ -271,6 +273,69 @@ TEST_F(TopNFilterTest, DatagramTriggersCheckProperties) {
   hdr.extensions = makeExt(kPropA, 99);
   filter_->datagram(hdr, nullptr, false);
   EXPECT_EQ(called, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Activity tracking: activityTarget_ and onActivity callback
+// ---------------------------------------------------------------------------
+
+TEST_F(TopNFilterTest, ActivityTargetOnlyUpdatedOnPropertyMatch) {
+  std::chrono::steady_clock::time_point ts{};
+  filter_->setActivityTarget(&ts);
+  filter_->registerObserver(kPropA, PropertyObserver{});
+
+  // No match: timestamp not written
+  filter_->checkProperties(makeExt(kPropB, 99));
+  EXPECT_EQ(ts, std::chrono::steady_clock::time_point{});
+
+  // Match: timestamp written
+  filter_->checkProperties(makeExt(kPropA, 1));
+  auto ts1 = ts;
+  EXPECT_NE(ts1, std::chrono::steady_clock::time_point{});
+
+  // Sleep then match again: timestamp updated
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  filter_->checkProperties(makeExt(kPropA, 2));
+  EXPECT_GT(ts, ts1);
+}
+
+TEST_F(TopNFilterTest, OnActivityCallbackBehavior) {
+  int activityCount = 0;
+  int valueChangedCount = 0;
+  filter_->registerObserver(
+      kPropA,
+      PropertyObserver{
+          .onValueChanged = [&](uint64_t) { valueChangedCount++; },
+          .onActivity = [&]() { activityCount++; },
+      }
+  );
+
+  // Threshold=0 (default): onActivity never fires
+  filter_->checkProperties(makeExt(kPropA, 1));
+  filter_->checkProperties(makeExt(kPropA, 1));
+  EXPECT_EQ(activityCount, 0);
+
+  // Enable threshold
+  filter_->setActivityThreshold(std::chrono::hours(1));
+
+  // Value changes: onValueChanged fires, NOT onActivity
+  filter_->checkProperties(makeExt(kPropA, 42));
+  EXPECT_EQ(valueChangedCount, 2); // includes earlier call
+  EXPECT_EQ(activityCount, 0);
+
+  // Same value: onActivity fires
+  filter_->checkProperties(makeExt(kPropA, 42));
+  EXPECT_EQ(valueChangedCount, 2);
+  EXPECT_EQ(activityCount, 1);
+
+  // Same value immediately: throttled
+  filter_->checkProperties(makeExt(kPropA, 42));
+  EXPECT_EQ(activityCount, 1);
+
+  // No property match: neither callback fires
+  filter_->checkProperties(makeExt(kPropB, 99));
+  EXPECT_EQ(valueChangedCount, 2);
+  EXPECT_EQ(activityCount, 1);
 }
 
 } // namespace


### PR DESCRIPTION
When a session publishes a track while also holding a TRACK_FILTER subscription, that track is registered as a self-track in PropertyRanking so the publisher never receives its own stream in their top-N selection.

Three integration points:

publish(): addPublishedTrackToSession is called before registerTrack so
  that notifications fired during registration already see the self-track
  exclusion, preventing the brief window where a publisher would receive
  its own track.

subscribeNamespace(): tracks already published by this session are passed
  to addSessionToTopNGroup as the initial self-exclusion set, covering the
  case where a session subscribes after it has already been publishing.

onPublishDone(): removePublishedTrackFromSession is called before erasing
  from the publishes map so the publisher's selection can be reconciled
  and any replacement track notified.

PropertyRanking::registerTrack also gains an else-branch that reconciles publisher-subscriber sessions for tracks landing outside the shared top-N: a publisher's personal top-N extends further than the shared top-N (self- tracks consume slots), so tracks at rank >= N may still be in their view.

Adds three publisher-subscriber integration tests to MoqxTrackFilterTest: subscribe-before-publish, publish-before-subscribe, and viewer-sees-self- track-while-publisher-does-not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/167)
<!-- Reviewable:end -->
