### PR TITLE
feat: Add PropertyRanking self-exclusion and waterline logic

### DIFF
--- a/docs/dev/track-filter-ranking.md
+++ b/docs/dev/track-filter-ranking.md
@@ -1,0 +1,109 @@
+# TopNFilter + PropertyRanking
+
+The system ranks publisher tracks by a numeric property (e.g., audio level) embedded in MoQ object extensions, and delivers the top-N tracks to each subscriber. A session that is both a publisher *and* a subscriber does not receive its own tracks back — this is called **self-exclusion**.
+
+## TopNFilter — Per-Track Observer
+
+`TopNFilter` sits in the object delivery pipeline:
+
+```
+Publisher → TopNFilter → downstream consumer
+```
+
+It intercepts every object (`beginSubgroup`, `objectStream`, `datagram`) and calls `checkProperties()`, which scans the object's extensions for a registered property type. When it finds one:
+
+1. **Value changed?** → fires `onValueChanged(value)`, which calls `PropertyRanking::updateSortValue()`
+2. **Activity throttle passed?** → fires `onActivity()`, which triggers an idle sweep in `PropertyRanking` (bounded by `activityThreshold_` to avoid sweeping on every object)
+3. **Cheap side-effect** → writes the current timestamp to `*activityTarget_` (a raw pointer to the per-track last-activity slot), costing nothing beyond a pointer write
+
+On `publishDone`, it fires `onTrackEnded()` → `PropertyRanking::removeTrack()`.
+
+The split between `onValueChanged` and `onActivity` matters: value updates drive ranking recomputation, while activity callbacks drive idle eviction. Both can fire on the same `checkProperties()` call.
+
+## PropertyRanking — The Ranking Engine
+
+`PropertyRanking` maintains a `std::map<RankKey, RankedEntry, std::greater<>>` — a descending-sorted map of all registered tracks. `RankKey` is `(value, arrivalSeq)` where higher value wins and lower `arrivalSeq` breaks ties (earlier arrivals win).
+
+A parallel `F14FastMap<FullTrackName, RankIndex>` provides O(1) lookup by name and caches each track's integer rank.
+
+### TopNGroups
+
+Subscribers are grouped by their N value in `topNGroups_`. Each `TopNGroup` holds:
+
+- `trackStates`: which tracks are `Selected` or `Deselected` (the shared top-N for viewers)
+- `deselectedQueue`: a FIFO of recently-evicted tracks for cheap reselection
+- `sessions`: per-session `SessionInfo`
+
+### Rank Updates and the Fast Path
+
+`updateSortValue()` re-inserts the track at its new key (erase + emplace in `rankedTracks_`), then:
+
+- **Fast path**: rank move doesn't cross any group's N boundary → return immediately. This is the common case for gradual audio level drift.
+- **Slow path**: calls `recomputeTopNGroups()` to update `trackStates`, fire callbacks, and promote/demote tracks.
+
+The threshold check is O(log G) using a sorted vector of all group N values.
+
+## Self-Exclusion
+
+A session that publishes tracks should not receive those same tracks in its own top-N subscription. Its effective top-N is computed over the non-self subset of ranked tracks.
+
+### Publisher Identity
+
+`RankedEntry` stores a raw `publisherRaw` pointer (`MoQSession*`). The raw pointer is safe because `removeTrack()` is always called before session destruction (via `publishDone` → relay cleanup), and is fast for hot-path comparisons. `publisherTrackCount_` maps session pointers to track counts for O(1) `isPublisher()` checks.
+
+### The Waterline
+
+For a publisher-subscriber, `computeWaterlineKey()` scans `rankedTracks_` in descending order, skipping self-tracks, and returns the `RankKey` of the **Nth non-self track** — the lowest-ranked track that should still be delivered to this session.
+
+```
+rankedTracks_ (descending):
+  rank 0: Alice [self]      ← skip
+  rank 1: Bob               ← non-self #1
+  rank 2: Carol             ← non-self #2
+  rank 3: Dave              ← non-self #3 = waterline (for N=3)
+  rank 4: Eve               ← below waterline, not delivered
+```
+
+If fewer than N non-self tracks exist, the waterline is `nullopt`, meaning "select all non-self tracks."
+
+### reconcilePublisherSelection
+
+Whenever any non-self track's rank changes (or when the session first joins), `reconcilePublisherSelection()` is called:
+
+1. Recomputes the waterline via `computeWaterlineKey()`
+2. Builds `nowSelected` = all non-self tracks at or above the waterline
+3. Fires `onEvicted_` for tracks that were in `selectedTracks` but are no longer in `nowSelected`
+4. Fires `onSelected_` for tracks that entered `nowSelected` but weren't in `selectedTracks`
+5. Replaces `selectedTracks` with `nowSelected`
+
+Publisher sessions do **not** use the shared `trackStates` / `deselectedQueue` — their personal selection is managed entirely through `selectedTracks` and the waterline.
+
+### When Reconciliation Triggers
+
+In `recomputeTopNGroups()`, for each session in a TopNGroup:
+
+| Session type | Track that moved | Action |
+|---|---|---|
+| Publisher | Non-self track | `reconcilePublisherSelection()` |
+| Publisher | Own track | Skip — self-track rank changes cannot shift the waterline |
+| Viewer | Any | Batch `onBatchSelected_` callback |
+
+### Late Publish: Viewer-to-Publisher Upgrade
+
+If a session subscribes first and later publishes a track (`registerTrack()` is called while the session is already in a `TopNGroup`), `reconcilePublisherInAllGroups()` handles the transition:
+
+1. Seeds `selectedTracks` with what the session was already receiving as a viewer, so the upcoming reconcile correctly computes the delta rather than re-notifying all tracks
+2. Calls `reconcilePublisherSelection()`, which evicts the newly-self track
+
+The session transitions seamlessly: it stops receiving its own track and continues receiving the top N non-self tracks.
+
+## Idle Eviction
+
+`sweepIdle()` handles tracks that are ranked into the top-N but go silent. It is triggered two ways:
+
+- From `onActivity` on any `TopNFilter` (throttled by `sweepThrottle_`)
+- Opportunistically after `updateSortValue()` completes a slow-path recompute
+
+For each `Selected` track in each group, it calls `getLastActivity_(ftn)` (a relay callback reading the timestamp written by `TopNFilter`). If the track hasn't published within `idleTimeout_`, it is demoted via `demoteTrack()` and the highest-ranked non-selected replacement is promoted via `promoteNextAvailableTrack()`. A track that has *never* published (epoch timestamp) is treated as infinitely idle and evicted immediately.
+
+The two-stop design — property activity fires the sweep; the sweep reads per-track timestamps — avoids an O(T) scan on every object while still detecting idle tracks promptly.

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -28,8 +28,9 @@ PropertyRanking::PropertyRanking(
 void PropertyRanking::registerTrack(
     const moxygen::FullTrackName& ftn,
     std::optional<uint64_t> initialValue,
-    std::weak_ptr<moxygen::MoQSession> publisher
+    std::shared_ptr<moxygen::MoQSession> publisher
 ) {
+  XCHECK(publisher) << "registerTrack requires a publisher session";
   if (trackIndexByName_.find(ftn) != trackIndexByName_.end()) {
     XLOG(WARN) << "Track already registered: " << ftn;
     return;
@@ -38,13 +39,20 @@ void PropertyRanking::registerTrack(
   uint64_t value = initialValue.value_or(0);
   RankKey key{value, nextSeq_++};
 
+  publisherTrackCount_[publisher.get()]++;
+
   auto [iter, inserted] =
-      rankedTracks_.emplace(key, RankedEntry{.ftn = ftn, .publisher = std::move(publisher)});
+      rankedTracks_.emplace(key, RankedEntry{.ftn = ftn, .publisherRaw = publisher.get()});
   trackIndexByName_[ftn] = RankIndex{.rankIter = iter, .cachedRank = UINT64_MAX};
   invalidateRankCache();
 
   uint64_t rank = getCachedRank(ftn);
   XLOG(DBG4) << "Registered track " << ftn << " with value " << value << " at rank " << rank;
+
+  // If publisher is already subscribed in some TopNGroup, this new track becomes
+  // a self-track for that session. Reconcile before updating shared trackStates
+  // so seeding captures the current top-N (which includes the new track).
+  reconcilePublisherInAllGroups(publisher);
 
   for (auto& [n, topNGroup] : topNGroups_) {
     if (rank < n) {
@@ -120,6 +128,15 @@ void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
   auto& entry = it->second;
   uint64_t oldRank = getCachedRank(ftn);
 
+  if (auto raw = entry.rankIter->second.publisherRaw) {
+    auto countIt = publisherTrackCount_.find(raw);
+    if (countIt != publisherTrackCount_.end()) {
+      if (--countIt->second == 0) {
+        publisherTrackCount_.erase(countIt);
+      }
+    }
+  }
+
   rankedTracks_.erase(entry.rankIter);
   trackIndexByName_.erase(it);
   invalidateRankCache();
@@ -186,18 +203,31 @@ void PropertyRanking::addSessionToTopNGroup(
   XLOG(DBG4) << "addSessionToTopNGroup: maxSelected=" << maxSelected << " forward=" << forward;
 
   auto& topNGroup = getOrCreateTopNGroup(maxSelected);
-  topNGroup.sessions[session] = SessionInfo{.forward = forward};
+  SessionInfo info;
+  info.forward = forward;
 
-  // Notify session of all currently-selected tracks
-  uint64_t rank = 0;
-  for (auto& [key, entry] : rankedTracks_) {
-    if (rank >= maxSelected) {
-      break;
+  topNGroup.sessions[session] = std::move(info);
+  auto& sessionInfo = topNGroup.sessions[session];
+
+  // Check if this session is a publisher (owns any tracks in rankedTracks_).
+  // Self-exclusion is automatic based on RankedEntry::publisher.
+  if (isPublisher(session)) {
+    // reconcilePublisherSelection handles initial delivery for publishers:
+    // it fires onSelected_ for each track in the personal top-N and
+    // populates selectedTracks for future delta computation.
+    reconcilePublisherSelection(sessionInfo, maxSelected, session);
+  } else {
+    // Notify viewer of all currently-selected tracks.
+    uint64_t rank = 0;
+    for (auto& [key, entry] : rankedTracks_) {
+      if (rank >= maxSelected) {
+        break;
+      }
+      if (onSelected_) {
+        onSelected_(entry.ftn, session, sessionInfo.forward);
+      }
+      rank++;
     }
-    if (onSelected_) {
-      onSelected_(entry.ftn, session, forward);
-    }
-    rank++;
   }
 }
 
@@ -326,6 +356,8 @@ void PropertyRanking::recomputeTopNGroups(
     bool wasInTopN = oldRank < n;
     bool nowInTopN = newRank < n;
 
+    // Update shared track state (governs viewer selection and the
+    // deselected queue for cheap reselection).
     if (wasInTopN != nowInTopN) {
       if (nowInTopN) {
         topNGroup.trackStates[ftn] = TrackState::Selected;
@@ -335,19 +367,38 @@ void PropertyRanking::recomputeTopNGroups(
       }
     }
 
-    // Batch-notify all sessions when track enters shared top-N
-    if (!wasInTopN && nowInTopN) {
-      IterationGuard guard(*this);
-      notifyTrackSelected(ftn, topNGroup);
+    IterationGuard guard(*this);
 
-      // The track that just entered top-N displaced the one at position n;
-      // mark that track as deselected.
+    // Viewers get a batch notification when ftn enters the shared top-N.
+    // Publishers are reconciled individually: the waterline is key-based and
+    // invariant to self-track rank changes, so we only reconcile when ftn is
+    // non-self (a non-self move is the only thing that can shift the waterline).
+    // Look up ftn's publisher once before the session loop.
+    auto ftnIt = trackIndexByName_.find(ftn);
+    moxygen::MoQSession* const ftnPublisher =
+        ftnIt != trackIndexByName_.end() ? ftnIt->second.rankIter->second.publisherRaw : nullptr;
+
+    std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> viewerBatch;
+    for (auto& [session, info] : topNGroup.sessions) {
+      if (isPublisher(session)) {
+        if (session.get() != ftnPublisher) {
+          reconcilePublisherSelection(info, n, session);
+        }
+      } else if (!wasInTopN && nowInTopN) {
+        viewerBatch.emplace_back(session, info.forward);
+      }
+    }
+    if (!viewerBatch.empty() && onBatchSelected_) {
+      onBatchSelected_(ftn, viewerBatch);
+    }
+
+    // Displace the previous occupant of rank N when track enters top-N.
+    if (!wasInTopN && nowInTopN) {
       demoteTrackAtRank(n, topNGroup);
     }
 
-    // When the track fell out of top-N, promote the one now at position n-1.
+    // Promote the track now at rank N-1 when track fell out of top-N.
     if (wasInTopN && !nowInTopN) {
-      IterationGuard guard(*this);
       uint64_t count = 0;
       for (auto& [key, rankedEntry] : rankedTracks_) {
         if (count == n - 1) {
@@ -451,15 +502,105 @@ void PropertyRanking::promoteNextAvailableTrack(
 // alternative per-session callback (onSelected_) exists for cases needing
 // individual handling (e.g., a late-joining session).
 void PropertyRanking::notifyTrackSelected(const moxygen::FullTrackName& ftn, TopNGroup& topNGroup) {
-  std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> batch;
-  batch.reserve(topNGroup.sessions.size());
-  for (const auto& [session, info] : topNGroup.sessions) {
-    batch.emplace_back(session, info.forward);
+  std::vector<std::pair<std::shared_ptr<moxygen::MoQSession>, bool>> viewerBatch;
+  for (auto& [session, info] : topNGroup.sessions) {
+    if (isPublisher(session)) {
+      reconcilePublisherSelection(info, topNGroup.maxSelected, session);
+    } else {
+      viewerBatch.emplace_back(session, info.forward);
+    }
   }
-  if (!batch.empty() && onBatchSelected_) {
-    XLOG(DBG4) << "notifyTrackSelected: " << ftn << " to " << batch.size()
+  if (!viewerBatch.empty() && onBatchSelected_) {
+    XLOG(DBG4) << "notifyTrackSelected: " << ftn << " to " << viewerBatch.size()
                << " sessions in TopNGroup maxSelected=" << topNGroup.maxSelected;
-    onBatchSelected_(ftn, batch);
+    onBatchSelected_(ftn, viewerBatch);
+  }
+}
+
+std::optional<RankKey> PropertyRanking::computeWaterlineKey(
+    const std::shared_ptr<moxygen::MoQSession>& session,
+    uint64_t maxSelected
+) const {
+  // Find the Nth non-self track. Its RankKey is the waterline: all non-self
+  // tracks ranked >= waterline should be selected for this session.
+  uint64_t nonSelfCount = 0;
+  for (const auto& [key, entry] : rankedTracks_) {
+    if (entry.publisherRaw != session.get()) {
+      nonSelfCount++;
+      if (nonSelfCount == maxSelected) {
+        return key;
+      }
+    }
+  }
+
+  // Fewer than N non-self tracks exist — select all of them.
+  return std::nullopt;
+}
+
+void PropertyRanking::reconcilePublisherSelection(
+    SessionInfo& info,
+    uint64_t maxSelected,
+    const std::shared_ptr<moxygen::MoQSession>& session
+) {
+  // Recompute the publisher's personal waterline.
+  info.waterlineKey = computeWaterlineKey(session, maxSelected);
+
+  // Determine what should currently be delivered to this publisher session.
+  folly::F14FastSet<moxygen::FullTrackName, moxygen::FullTrackName::hash> nowSelected;
+  for (const auto& [key, entry] : rankedTracks_) {
+    if (entry.publisherRaw != session.get() && (!info.waterlineKey || key >= *info.waterlineKey)) {
+      nowSelected.insert(entry.ftn);
+    }
+  }
+
+  // Evict tracks that left the publisher's personal top-N.
+  for (const auto& ftn : info.selectedTracks) {
+    if (nowSelected.count(ftn) == 0 && onEvicted_) {
+      onEvicted_(ftn, session);
+    }
+  }
+
+  // Notify tracks that entered the publisher's personal top-N.
+  for (const auto& ftn : nowSelected) {
+    if (info.selectedTracks.count(ftn) == 0 && onSelected_) {
+      onSelected_(ftn, session, info.forward);
+    }
+  }
+
+  info.selectedTracks = std::move(nowSelected);
+}
+
+bool PropertyRanking::isPublisher(const std::shared_ptr<moxygen::MoQSession>& session) const {
+  return publisherTrackCount_.count(session.get()) > 0;
+}
+
+void PropertyRanking::reconcilePublisherInAllGroups(
+    const std::shared_ptr<moxygen::MoQSession>& session
+) {
+  for (auto& [n, topNGroup] : topNGroups_) {
+    auto sessionIt = topNGroup.sessions.find(session);
+    if (sessionIt == topNGroup.sessions.end()) {
+      continue;
+    }
+
+    auto& info = sessionIt->second;
+    bool wasPublisher = !info.selectedTracks.empty() || info.waterlineKey.has_value();
+
+    // If upgrading from viewer to publisher-subscriber, seed selectedTracks from
+    // the shared top-N so reconcile can compute the correct delta (i.e. evict the
+    // newly-self track rather than re-notifying every viewer-delivered track).
+    if (!wasPublisher) {
+      uint64_t rank = 0;
+      for (const auto& [key, entry] : rankedTracks_) {
+        if (rank >= n) {
+          break;
+        }
+        info.selectedTracks.insert(entry.ftn);
+        rank++;
+      }
+    }
+
+    reconcilePublisherSelection(info, n, session);
   }
 }
 

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 #include <moxygen/MoQSession.h>
 #include <moxygen/MoQTypes.h>
 
@@ -58,7 +59,12 @@ struct RankKey {
  */
 struct RankedEntry {
   moxygen::FullTrackName ftn;
-  std::weak_ptr<moxygen::MoQSession> publisher;
+  // Raw pointer for O(1) identity comparisons in hot paths (computeWaterlineKey,
+  // reconcilePublisherSelection). Safe because the caller holds a
+  // live shared_ptr to the session being compared, and removeTrack is called
+  // before session destruction. ABA protection is provided by the weak_ptr in
+  // publisherTrackCount_, not here.
+  moxygen::MoQSession* publisherRaw{nullptr};
 };
 
 /**
@@ -77,9 +83,23 @@ enum class TrackState { Selected, Deselected };
 
 /**
  * Per-session state within a TopNGroup.
+ *
+ * Self-exclusion is determined dynamically by comparing RankedEntry::publisher
+ * with the session pointer. There's no separate "publishedTracks" set — a track
+ * is a self-track iff its publisher == this session.
  */
 struct SessionInfo {
   bool forward{true};
+
+  // Waterline for self-exclusion (publisher-subscribers only).
+  // Recomputed by reconcilePublisherSelection when any non-self track's rank changes.
+  // nullopt = fewer than N non-self tracks exist — select all non-self tracks.
+  std::optional<RankKey> waterlineKey;
+
+  // Tracks currently being delivered to this session.
+  // For publisher-subscribers: used to compute the select/evict delta.
+  // For viewers: cleared (viewer selection is handled via batch notifications).
+  folly::F14FastSet<moxygen::FullTrackName, moxygen::FullTrackName::hash> selectedTracks;
 };
 
 /**
@@ -182,7 +202,7 @@ public:
   void registerTrack(
       const moxygen::FullTrackName& ftn,
       std::optional<uint64_t> initialValue,
-      std::weak_ptr<moxygen::MoQSession> publisher
+      std::shared_ptr<moxygen::MoQSession> publisher
   );
 
   /**
@@ -203,6 +223,8 @@ public:
 
   /**
    * Add a session to a TopNGroup.
+   * Self-exclusion is automatic: if this session is the publisher of any
+   * registered track, those tracks will be excluded from its top-N selection.
    */
   void addSessionToTopNGroup(
       uint64_t maxSelected,
@@ -298,6 +320,31 @@ private:
   // Must be called inside an IterationGuard.
   void promoteNextAvailableTrack(TopNGroup& group, const moxygen::FullTrackName& excludeFtn);
 
+  // Check if session owns any tracks in rankedTracks_ (is a publisher).
+  bool isPublisher(const std::shared_ptr<moxygen::MoQSession>& session) const;
+
+  // Compute the waterline key for a publisher-subscriber session.
+  // Returns the RankKey of the Nth non-self track (the lowest-ranked track
+  // that should still be selected for this session). Returns nullopt if
+  // fewer than N non-self tracks exist (meaning all non-self tracks are selected).
+  std::optional<RankKey> computeWaterlineKey(
+      const std::shared_ptr<moxygen::MoQSession>& session,
+      uint64_t maxSelected
+  ) const;
+
+  // Recompute the publisher's personal top-N and fire callbacks for the delta.
+  // Evicts tracks that left the selection; selects tracks that entered it.
+  // Updates info.waterlineKey and info.selectedTracks to reflect the new state.
+  void reconcilePublisherSelection(
+      SessionInfo& info,
+      uint64_t maxSelected,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  );
+
+  // Reconcile all TopNGroups where session appears, handling the case where
+  // a newly-registered track makes a viewer into a publisher-subscriber.
+  void reconcilePublisherInAllGroups(const std::shared_ptr<moxygen::MoQSession>& session);
+
   void invalidateRankCache() { rankCacheValid_ = false; }
 
   uint64_t propertyType_;
@@ -315,6 +362,13 @@ private:
   folly::F14FastMap<moxygen::FullTrackName, RankIndex, moxygen::FullTrackName::hash>
       trackIndexByName_;
   folly::F14FastMap<uint64_t, TopNGroup> topNGroups_;
+
+  // Track count per publisher session for O(1) isPublisher() lookup.
+  // Maintained by registerTrack (increment) and removeTrack (decrement/erase).
+  // MoQSession::cleanup() reliably fires removeTrack for all tracks on session
+  // close (via subscribeError → processPublishDone → cb->publishDone), so the
+  // map never holds zombie entries.
+  folly::F14FastMap<moxygen::MoQSession*, size_t> publisherTrackCount_;
 
   uint64_t nextSeq_{0};
   uint64_t selectionThreshold_{0};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -177,6 +177,17 @@ target_link_libraries(moqx_property_ranking_base_test PRIVATE
 )
 gtest_discover_tests(moqx_property_ranking_base_test)
 
+# PropertyRanking self-exclusion / waterline unit tests
+add_executable(moqx_property_ranking_self_exclusion_test
+  PropertyRankingSelfExclusionTest.cpp
+)
+target_link_libraries(moqx_property_ranking_self_exclusion_test PRIVATE
+  moqx_core
+  GTest::gtest_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_property_ranking_self_exclusion_test)
+
 # TRACK_FILTER integration tests (in-process relay, no live server)
 add_executable(moqx_track_filter_test
   MoqxTrackFilterTest.cpp

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -160,6 +160,8 @@ protected:
   }
 
   std::vector<std::shared_ptr<NiceMock<moxygen::test::MockMoQSession>>> sessions_;
+  // Placeholder publisher for tracks whose publisher identity doesn't matter.
+  std::shared_ptr<MoQSession> defaultPublisher_{makeSession()};
 };
 
 // ---------------------------------------------------------------------------
@@ -170,10 +172,10 @@ TEST_F(PropertyRankingBaseTest, RegisterThenSubscribe_TopNBoundary) {
   RankingHarness h;
 
   // 3 tracks registered before any subscriber
-  h.ranking().registerTrack(ftn("a"), 90, {});
-  h.ranking().registerTrack(ftn("b"), 80, {});
-  h.ranking().registerTrack(ftn("c"), 70, {});
-  h.ranking().registerTrack(ftn("d"), 20, {});
+  h.ranking().registerTrack(ftn("a"), 90, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 80, defaultPublisher_);
+  h.ranking().registerTrack(ftn("c"), 70, defaultPublisher_);
+  h.ranking().registerTrack(ftn("d"), 20, defaultPublisher_);
 
   // Subscriber joins wanting top-2
   auto sub = makeSession();
@@ -193,9 +195,9 @@ TEST_F(PropertyRankingBaseTest, SubscribeThenRegister_TopNBoundary) {
   h.ranking().addSessionToTopNGroup(2, sub, /*forward=*/true);
 
   // Tracks arrive after subscriber
-  h.ranking().registerTrack(ftn("a"), 90, {});
-  h.ranking().registerTrack(ftn("b"), 80, {});
-  h.ranking().registerTrack(ftn("c"), 70, {}); // rank 2 — not in top-2
+  h.ranking().registerTrack(ftn("a"), 90, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 80, defaultPublisher_);
+  h.ranking().registerTrack(ftn("c"), 70, defaultPublisher_); // rank 2 — not in top-2
 
   EXPECT_EQ(h.selectCount(ftn("a"), sub.get()), 1);
   EXPECT_EQ(h.selectCount(ftn("b"), sub.get()), 1);
@@ -206,7 +208,7 @@ TEST_F(PropertyRankingBaseTest, ForwardFlagPassedThrough_False) {
   RankingHarness h;
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(1, sub, /*forward=*/false);
-  h.ranking().registerTrack(ftn("a"), 10, {});
+  h.ranking().registerTrack(ftn("a"), 10, defaultPublisher_);
 
   ASSERT_EQ(h.selected_.size(), 1u);
   EXPECT_FALSE(h.selected_[0].forward);
@@ -216,7 +218,7 @@ TEST_F(PropertyRankingBaseTest, ForwardFlagPassedThrough_True) {
   RankingHarness h;
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(1, sub, /*forward=*/true);
-  h.ranking().registerTrack(ftn("a"), 10, {});
+  h.ranking().registerTrack(ftn("a"), 10, defaultPublisher_);
 
   ASSERT_EQ(h.selected_.size(), 1u);
   EXPECT_TRUE(h.selected_[0].forward);
@@ -232,10 +234,10 @@ TEST_F(PropertyRankingBaseTest, FastPath_NoNotificationWhenThresholdNotCrossed) 
   h.ranking().addSessionToTopNGroup(2, sub, true);
 
   // 4 tracks: top-2 = {a=90, b=80}; {c=70, d=50} are outside
-  h.ranking().registerTrack(ftn("a"), 90, {});
-  h.ranking().registerTrack(ftn("b"), 80, {});
-  h.ranking().registerTrack(ftn("c"), 70, {}); // rank 2 — just outside top-2
-  h.ranking().registerTrack(ftn("d"), 50, {}); // rank 3
+  h.ranking().registerTrack(ftn("a"), 90, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 80, defaultPublisher_);
+  h.ranking().registerTrack(ftn("c"), 70, defaultPublisher_); // rank 2 — just outside top-2
+  h.ranking().registerTrack(ftn("d"), 50, defaultPublisher_); // rank 3
   h.clearEvents();
 
   // Move "d" from rank 3 to rank 2 — still outside top-2, no notification
@@ -251,7 +253,7 @@ TEST_F(PropertyRankingBaseTest, FastPath_SameValueNoNotification) {
   RankingHarness h;
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(1, sub, true);
-  h.ranking().registerTrack(ftn("a"), 50, {});
+  h.ranking().registerTrack(ftn("a"), 50, defaultPublisher_);
   h.clearEvents();
 
   h.ranking().updateSortValue(ftn("a"), 50); // no change
@@ -267,8 +269,8 @@ TEST_F(PropertyRankingBaseTest, SlowPath_TrackPromotedWhenCrossesThreshold) {
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(1, sub, true);
 
-  h.ranking().registerTrack(ftn("a"), 80, {});
-  h.ranking().registerTrack(ftn("b"), 60, {}); // rank 1 — not in top-1
+  h.ranking().registerTrack(ftn("a"), 80, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 60, defaultPublisher_); // rank 1 — not in top-1
   h.clearEvents();
 
   // "b" jumps to rank 0 — should be selected, "a" deselected
@@ -285,10 +287,10 @@ TEST_F(PropertyRankingBaseTest, SlowPath_MultipleTopNGroups) {
   h.ranking().addSessionToTopNGroup(1, sub1, true);
   h.ranking().addSessionToTopNGroup(3, sub3, true);
 
-  h.ranking().registerTrack(ftn("a"), 100, {});
-  h.ranking().registerTrack(ftn("b"), 80, {});
-  h.ranking().registerTrack(ftn("c"), 60, {});
-  h.ranking().registerTrack(ftn("d"), 40, {}); // rank 3 — NOT in top-3, not in top-1
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 80, defaultPublisher_);
+  h.ranking().registerTrack(ftn("c"), 60, defaultPublisher_);
+  h.ranking().registerTrack(ftn("d"), 40, defaultPublisher_); // rank 3 — NOT in top-3, not in top-1
   h.clearEvents();
 
   // "d" surpasses "a" — crosses threshold for both groups
@@ -316,12 +318,16 @@ TEST_F(PropertyRankingBaseTest, RemoveSelected_PromotesFromDeselectedQueue) {
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(1, sub, true);
 
-  h.ranking().registerTrack(ftn("a"), 90, {}); // selected
-  h.ranking().registerTrack(ftn("b"), 80, {}); // rank 1, unselected
+  h.ranking().registerTrack(ftn("a"), 90, defaultPublisher_); // selected
+  h.ranking().registerTrack(ftn("b"), 80, defaultPublisher_); // rank 1, unselected
   h.clearEvents();
 
   // c arrives louder than a → a falls to deselected queue
-  h.ranking().registerTrack(ftn("c"), 95, {}); // c→rank0(selected), a→rank1(deselected queue)
+  h.ranking().registerTrack(
+      ftn("c"),
+      95,
+      defaultPublisher_
+  ); // c→rank0(selected), a→rank1(deselected queue)
   h.clearEvents();
 
   // Remove c (selected): a should be promoted from deselected queue
@@ -335,8 +341,8 @@ TEST_F(PropertyRankingBaseTest, RemoveSelected_PromotesFromRankedList) {
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(1, sub, true);
 
-  h.ranking().registerTrack(ftn("a"), 90, {});
-  h.ranking().registerTrack(ftn("b"), 70, {}); // rank 1
+  h.ranking().registerTrack(ftn("a"), 90, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 70, defaultPublisher_); // rank 1
   h.clearEvents();
 
   h.ranking().removeTrack(ftn("a"));
@@ -348,8 +354,8 @@ TEST_F(PropertyRankingBaseTest, RemoveDeselected_NoPromotionNeeded) {
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(1, sub, true);
 
-  h.ranking().registerTrack(ftn("a"), 90, {});
-  h.ranking().registerTrack(ftn("b"), 70, {}); // rank 1 — deselected
+  h.ranking().registerTrack(ftn("a"), 90, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 70, defaultPublisher_); // rank 1 — deselected
   h.clearEvents();
 
   // Removing a deselected track should not trigger any selection notification
@@ -369,10 +375,10 @@ TEST_F(PropertyRankingBaseTest, TwoGroupsDifferentN_IndependentSelection) {
   h.ranking().addSessionToTopNGroup(1, sub1, true);
   h.ranking().addSessionToTopNGroup(3, sub3, true);
 
-  h.ranking().registerTrack(ftn("a"), 100, {});
-  h.ranking().registerTrack(ftn("b"), 80, {});
-  h.ranking().registerTrack(ftn("c"), 60, {});
-  h.ranking().registerTrack(ftn("d"), 40, {});
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 80, defaultPublisher_);
+  h.ranking().registerTrack(ftn("c"), 60, defaultPublisher_);
+  h.ranking().registerTrack(ftn("d"), 40, defaultPublisher_);
 
   // sub1 should have received only "a"
   EXPECT_EQ(h.selectCount(ftn("a"), sub1.get()), 1);
@@ -402,13 +408,19 @@ TEST_F(PropertyRankingBaseTest, DeselectedQueueBounded_EvictionFires) {
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(1, sub, true);
 
-  h.ranking().registerTrack(ftn("a"), 90, {});  // selected
-  h.ranking().registerTrack(ftn("b"), 95, {});  // b→selected, a→deselected queue (size 1)
-  h.ranking().registerTrack(ftn("c"), 100, {}); // c→selected, b→deselected queue (size 2)
-  EXPECT_EQ(h.evicted_.size(), 0u);             // not yet
+  h.ranking().registerTrack(ftn("a"), 90, defaultPublisher_); // selected
+  h.ranking()
+      .registerTrack(ftn("b"), 95, defaultPublisher_); // b→selected, a→deselected queue (size 1)
+  h.ranking()
+      .registerTrack(ftn("c"), 100, defaultPublisher_); // c→selected, b→deselected queue (size 2)
+  EXPECT_EQ(h.evicted_.size(), 0u);                     // not yet
 
-  h.ranking().registerTrack(ftn("d"), 110, {}); // d→selected, c→deselected queue (size 3 > 2)
-  EXPECT_GE(h.evicted_.size(), 1u);             // oldest entry evicted
+  h.ranking().registerTrack(
+      ftn("d"),
+      110,
+      defaultPublisher_
+  );                                // d→selected, c→deselected queue (size 3 > 2)
+  EXPECT_GE(h.evicted_.size(), 1u); // oldest entry evicted
 }
 
 // ---------------------------------------------------------------------------
@@ -480,10 +492,10 @@ TEST_F(PropertyRankingBaseTest, SlowPath_CrossesLowerThreshold_HigherGroupUnchan
   h.ranking().addSessionToTopNGroup(2, sub2, true);
   h.ranking().addSessionToTopNGroup(4, sub4, true);
 
-  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
-  h.ranking().registerTrack(ftn("b"), 80, {});  // rank 1
-  h.ranking().registerTrack(ftn("c"), 60, {});  // rank 2
-  h.ranking().registerTrack(ftn("d"), 40, {});  // rank 3 — in top-4, not top-2
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_); // rank 0
+  h.ranking().registerTrack(ftn("b"), 80, defaultPublisher_);  // rank 1
+  h.ranking().registerTrack(ftn("c"), 60, defaultPublisher_);  // rank 2
+  h.ranking().registerTrack(ftn("d"), 40, defaultPublisher_);  // rank 3 — in top-4, not top-2
   h.clearEvents();
 
   // d jumps to rank 1: crosses the N=2 boundary (3→1), stays inside N=4
@@ -510,10 +522,10 @@ TEST_F(PropertyRankingBaseTest, RemoveSelected_FallbackPicksHighestNonSelected) 
   auto sub = makeSession();
   h.ranking().addSessionToTopNGroup(2, sub, true);
 
-  h.ranking().registerTrack(ftn("a"), 100, {});
-  h.ranking().registerTrack(ftn("b"), 80, {});
-  h.ranking().registerTrack(ftn("c"), 60, {});
-  h.ranking().registerTrack(ftn("d"), 40, {});
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 80, defaultPublisher_);
+  h.ranking().registerTrack(ftn("c"), 60, defaultPublisher_);
+  h.ranking().registerTrack(ftn("d"), 40, defaultPublisher_);
   h.clearEvents();
 
   h.ranking().removeTrack(ftn("a"));
@@ -536,8 +548,8 @@ TEST_F(PropertyRankingBaseTest, UpdateSortValue_SweepIdleAndRecomputeDoNotDouble
   auto sub = makeSession();
 
   // a (100) is top-1; b (50) is outside. Neither has activity → both "never published".
-  h.ranking().registerTrack(ftn("a"), 100, {});
-  h.ranking().registerTrack(ftn("b"), 50, {});
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 50, defaultPublisher_);
   h.ranking().addSessionToTopNGroup(1, sub, true);
   h.clearEvents();
 
@@ -557,8 +569,8 @@ TEST_F(PropertyRankingBaseTest, SweepThrottle_SkipsRunIfCalledTooSoon) {
   RankingHarness h(0, std::chrono::milliseconds(100), std::chrono::milliseconds(500));
   auto sub = makeSession();
 
-  h.ranking().registerTrack(ftn("a"), 100, {});
-  h.ranking().registerTrack(ftn("b"), 90, {});
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 90, defaultPublisher_);
   h.ranking().addSessionToTopNGroup(1, sub, true);
   h.clearEvents();
 
@@ -570,7 +582,7 @@ TEST_F(PropertyRankingBaseTest, SweepThrottle_SkipsRunIfCalledTooSoon) {
   EXPECT_EQ(h.selectCount(ftn("b")), 1);
 
   // Re-register a (so it's back as a candidate) and clear events.
-  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_);
   h.clearEvents();
 
   // Second sweep immediately after: throttle suppresses it — a is NOT evicted again.
@@ -586,9 +598,9 @@ TEST_F(PropertyRankingBaseTest, SweepIdle_IdleTrackEvictedAndReplacementPromoted
   RankingHarness h(5, std::chrono::milliseconds(100));
   auto sub = makeSession();
 
-  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
-  h.ranking().registerTrack(ftn("b"), 90, {});  // rank 1
-  h.ranking().registerTrack(ftn("c"), 80, {});  // rank 2
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_); // rank 0
+  h.ranking().registerTrack(ftn("b"), 90, defaultPublisher_);  // rank 1
+  h.ranking().registerTrack(ftn("c"), 80, defaultPublisher_);  // rank 2
 
   h.ranking().addSessionToTopNGroup(2, sub, true);
   h.clearEvents();
@@ -618,9 +630,9 @@ TEST_F(PropertyRankingBaseTest, SweepIdle_TrackThatNeverPublishedIsTreatedAsIdle
   RankingHarness h(5, std::chrono::milliseconds(100));
   auto sub = makeSession();
 
-  h.ranking().registerTrack(ftn("a"), 100, {}); // rank 0
-  h.ranking().registerTrack(ftn("b"), 90, {});  // rank 1 - never sets activity time
-  h.ranking().registerTrack(ftn("c"), 80, {});  // rank 2
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_); // rank 0
+  h.ranking().registerTrack(ftn("b"), 90, defaultPublisher_);  // rank 1 - never sets activity time
+  h.ranking().registerTrack(ftn("c"), 80, defaultPublisher_);  // rank 2
 
   h.ranking().addSessionToTopNGroup(2, sub, true);
   h.clearEvents();
@@ -647,8 +659,8 @@ TEST_F(PropertyRankingBaseTest, SweepIdle_NoEvictionWhenIdleTimeoutIsZero) {
   RankingHarness h(5, std::chrono::milliseconds(0));
   auto sub = makeSession();
 
-  h.ranking().registerTrack(ftn("a"), 100, {});
-  h.ranking().registerTrack(ftn("b"), 90, {});
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 90, defaultPublisher_);
 
   h.ranking().addSessionToTopNGroup(2, sub, true);
   h.clearEvents();
@@ -669,8 +681,8 @@ TEST_F(PropertyRankingBaseTest, SweepIdle_ActiveTracksNotEvicted) {
   RankingHarness h(5, std::chrono::milliseconds(100));
   auto sub = makeSession();
 
-  h.ranking().registerTrack(ftn("a"), 100, {});
-  h.ranking().registerTrack(ftn("b"), 90, {});
+  h.ranking().registerTrack(ftn("a"), 100, defaultPublisher_);
+  h.ranking().registerTrack(ftn("b"), 90, defaultPublisher_);
 
   h.ranking().addSessionToTopNGroup(2, sub, true);
   h.clearEvents();

--- a/test/PropertyRankingSelfExclusionTest.cpp
+++ b/test/PropertyRankingSelfExclusionTest.cpp
@@ -1,0 +1,680 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/PropertyRanking.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <moxygen/test/MockMoQSession.h>
+
+#include <memory>
+#include <vector>
+
+using namespace openmoq::moqx;
+using namespace moxygen;
+using ::testing::NiceMock;
+
+namespace {
+
+// Helpers
+FullTrackName ftn(const std::string& ns, const std::string& name) {
+  return FullTrackName{TrackNamespace{{ns}}, name};
+}
+
+class PropertyRankingSelfExclusionTest : public ::testing::Test {
+protected:
+  struct SelectRecord {
+    FullTrackName ftn;
+    MoQSession* session;
+    bool forward;
+  };
+
+  struct EvictRecord {
+    FullTrackName ftn;
+    MoQSession* session;
+  };
+
+  std::vector<SelectRecord> selected_;
+  std::vector<EvictRecord> evicted_;
+
+  // PropertyRanking only stores shared_ptr<MoQSession> as map keys and passes
+  // them back through callbacks — it never calls any MoQSession methods itself.
+  // MockMoQSession has a default constructor for exactly this use case.
+  std::shared_ptr<MoQSession> makeSession() {
+    auto s = std::make_shared<NiceMock<moxygen::test::MockMoQSession>>();
+    sessions_.push_back(s);
+    return s;
+  }
+
+  std::unique_ptr<PropertyRanking> makeRanking(uint64_t maxDeselected = 100) {
+    return std::make_unique<PropertyRanking>(
+        /*propertyType=*/1,
+        maxDeselected,
+        /*idleTimeout=*/std::chrono::milliseconds{0},
+        /*sweepThrottle=*/std::chrono::milliseconds{0},
+        /*getLastActivity=*/nullptr,
+        /*onBatchSelected=*/
+        [this](
+            const FullTrackName& f,
+            const std::vector<std::pair<std::shared_ptr<MoQSession>, bool>>& sessions
+        ) {
+          for (auto& [s, fwd] : sessions) {
+            selected_.push_back({f, s.get(), fwd});
+          }
+        },
+        /*onSelected=*/
+        [this](const FullTrackName& f, std::shared_ptr<MoQSession> s, bool fwd) {
+          selected_.push_back({f, s.get(), fwd});
+        },
+        /*onEvicted=*/
+        [this](const FullTrackName& f, std::shared_ptr<MoQSession> s) {
+          evicted_.push_back({f, s.get()});
+        }
+    );
+  }
+
+  bool wasSelected(const FullTrackName& f, MoQSession* s) {
+    for (auto& r : selected_) {
+      if (r.ftn == f && r.session == s) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  int countSelected(const FullTrackName& f, MoQSession* s) {
+    int n = 0;
+    for (auto& r : selected_) {
+      if (r.ftn == f && r.session == s) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  bool wasEvicted(const FullTrackName& f, MoQSession* s) {
+    for (auto& r : evicted_) {
+      if (r.ftn == f && r.session == s) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::vector<std::shared_ptr<NiceMock<moxygen::test::MockMoQSession>>> sessions_;
+  // Placeholder publisher for tracks whose publisher identity doesn't matter.
+  std::shared_ptr<MoQSession> defaultPublisher_{makeSession()};
+};
+
+// Publisher subscribes with TRACK_FILTER: own track is never notified.
+TEST_F(PropertyRankingSelfExclusionTest, PublisherDoesNotReceiveOwnTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+  auto track = ftn("ns", "self");
+
+  r->registerTrack(track, 100, pub);
+  r->addSessionToTopNGroup(3, pub, true);
+
+  EXPECT_FALSE(wasSelected(track, pub.get()));
+}
+
+// Viewer in the same group DOES receive the publisher's track.
+TEST_F(PropertyRankingSelfExclusionTest, ViewerReceivesPublisherTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+  auto viewer = makeSession();
+  auto track = ftn("ns", "self");
+
+  r->registerTrack(track, 100, pub);
+  r->addSessionToTopNGroup(3, pub, true);
+  r->addSessionToTopNGroup(3, viewer, true);
+
+  EXPECT_FALSE(wasSelected(track, pub.get()));
+  EXPECT_TRUE(wasSelected(track, viewer.get()));
+}
+
+// Mixed group: viewer sees all top-N; publisher-subscriber sees top-N
+// excluding its own track.
+TEST_F(PropertyRankingSelfExclusionTest, MixedGroup_ViewerAndPublisherSubscriber) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+  auto viewer = makeSession();
+
+  auto self = ftn("ns", "pub-track");
+  auto other1 = ftn("ns", "other1");
+  auto other2 = ftn("ns", "other2");
+
+  r->registerTrack(other1, 90, defaultPublisher_);
+  r->registerTrack(other2, 80, defaultPublisher_);
+  r->registerTrack(self, 70, pub);
+
+  // N=3: viewer sees all 3; publisher sees only the 2 non-self tracks.
+  r->addSessionToTopNGroup(3, pub, true);
+  r->addSessionToTopNGroup(3, viewer, true);
+
+  EXPECT_TRUE(wasSelected(other1, viewer.get()));
+  EXPECT_TRUE(wasSelected(other2, viewer.get()));
+  EXPECT_TRUE(wasSelected(self, viewer.get()));
+
+  EXPECT_TRUE(wasSelected(other1, pub.get()));
+  EXPECT_TRUE(wasSelected(other2, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+}
+
+// computeWaterlineKey: publisher with N=2 and 1 self-track should be notified
+// of exactly 2 non-self tracks, with the waterline at the 2nd non-self.
+TEST_F(PropertyRankingSelfExclusionTest, WaterlineSelectsNonSelfTracks) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3"); // Rank 3 (worst) — should NOT be selected (N=2)
+
+  // Register with descending values so order is t1 > t2 > self > t3.
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(t3, 60, defaultPublisher_);
+
+  r->addSessionToTopNGroup(2, pub, true);
+
+  // N=2 non-self: t1 (rank 0) and t2 (rank 1). t3 is the 3rd non-self → excluded.
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+}
+
+// Publisher with >1 self-track: waterline computed over non-self tracks only.
+TEST_F(PropertyRankingSelfExclusionTest, MultipleSelfTracks_WaterlineCorrect) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  // Values: t1=100, s1=90, t2=80, s2=70, t3=60
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(s1, 90, pub);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(s2, 70, pub);
+  r->registerTrack(t3, 60, defaultPublisher_);
+
+  // N=2 non-self: publisher should receive t1 and t2 only.
+  r->addSessionToTopNGroup(2, pub, true);
+
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(s1, pub.get()));
+  EXPECT_FALSE(wasSelected(s2, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+}
+
+// Self-track value change: waterline is recomputed, and the selection set
+// for the publisher updates accordingly.
+// Scenario: N=2, 2 self-tracks interspersed with non-self tracks.
+// Initial order: t1(100) > s1(90) > t2(80) > s2(70) > t3(60).
+// Non-self top-2: t1, t2. Publisher sees t1, t2.
+// s1 drops to 50 → new order: t1(100) > t2(80) > s2(70) > t3(60) > s1(50).
+// Non-self top-2 is still t1, t2. Publisher still sees t1, t2. No change.
+TEST_F(PropertyRankingSelfExclusionTest, SelfTrackValueChange_NoEffectOnViewSet) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(s1, 90, pub);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(s2, 70, pub);
+  r->registerTrack(t3, 60, defaultPublisher_);
+
+  r->addSessionToTopNGroup(2, pub, true);
+
+  selected_.clear();
+  // s1 drops from 90 to 50. Waterline recomputed: non-self top-2 still t1, t2.
+  r->updateSortValue(s1, 50);
+
+  // Publisher should not be spuriously notified.
+  EXPECT_FALSE(wasSelected(t1, pub.get()));
+  EXPECT_FALSE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+  EXPECT_FALSE(wasSelected(s1, pub.get()));
+}
+
+// Self-track value change causes outsider to enter publisher's view.
+// N=2, initial: t1(100) > t2(80) > self(70) > outsider(10).
+// Non-self top-2: t1, t2. Publisher sees t1, t2.
+// self rises to 95 → order: t1(100) > self(95) > t2(80) > outsider(10).
+// Non-self top-2: t1 (rank 0), t2 (rank 2). outsider still rank 3 → not selected.
+// Now self rises to 110 → order: self(110) > t1(100) > t2(80) > outsider(10).
+// Non-self top-2: t1 (rank 1), t2 (rank 2). outsider still not selected. No change.
+TEST_F(PropertyRankingSelfExclusionTest, SelfTrackRises_OutsiderStaysOut) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto outsider = ftn("ns", "outsider");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(outsider, 10, defaultPublisher_);
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(outsider, pub.get()));
+
+  // Self rises through ranks — outsider should not be selected.
+  selected_.clear();
+  r->updateSortValue(self, 110);
+  EXPECT_FALSE(wasSelected(outsider, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+}
+
+// Outsider enters publisher's top-N because a non-self track drops out.
+// N=2, initial: t1(100) > t2(80) > self(70) > outsider(10).
+// Non-self top-2: t1, t2.
+// t2 drops to 5 → order: t1(100) > self(70) > outsider(10) > t2(5).
+// Non-self top-2: t1 (rank 0), outsider (rank 2). Publisher sees outsider now.
+TEST_F(PropertyRankingSelfExclusionTest, NonSelfTrackDrops_OutsiderEntersPublisherView) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto outsider = ftn("ns", "outsider");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(outsider, 10, defaultPublisher_);
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_FALSE(wasSelected(outsider, pub.get()));
+
+  // t2 drops below outsider.
+  selected_.clear();
+  evicted_.clear();
+  r->updateSortValue(t2, 5);
+  EXPECT_TRUE(wasSelected(outsider, pub.get()));
+  EXPECT_TRUE(wasEvicted(t2, pub.get())); // t2 left publisher's view — must be evicted
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+}
+
+// Publisher with self-tracks both inside and outside the shared top-N.
+// N=3: shared top-3 = t1, s1 (self), t2. Publisher sees t1, t2 (excludes s1).
+// s2 (self, rank 4) is outside shared top-3, so waterline = t2's key.
+// t3 (rank 5, non-self) is below waterline → not selected for publisher.
+TEST_F(PropertyRankingSelfExclusionTest, SelfTracksInsideAndOutsideTopN) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  // Order: t1(100) > s1(90) > t2(80) > s2(70) > t3(60)
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(s1, 90, pub);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(s2, 70, pub);
+  r->registerTrack(t3, 60, defaultPublisher_);
+
+  // N=3: shared top-3 = t1, s1, t2.
+  // Non-self top-3: t1 (rank 0), t2 (rank 2), t3 (rank 4).
+  // Waterline = key of 3rd non-self = t3's key (value=60).
+  r->addSessionToTopNGroup(3, pub, true);
+
+  EXPECT_TRUE(wasSelected(t1, pub.get()));  // rank 0, non-self → selected
+  EXPECT_FALSE(wasSelected(s1, pub.get())); // self → excluded
+  EXPECT_TRUE(wasSelected(t2, pub.get()));  // rank 2, non-self → selected
+  EXPECT_FALSE(wasSelected(s2, pub.get())); // self → excluded
+  EXPECT_TRUE(wasSelected(t3, pub.get()));  // rank 4, 3rd non-self → at waterline → selected
+}
+
+// A track registered after the publisher has already subscribed enters the
+// publisher's personal top-N and displaces the previous waterline track.
+//
+// Setup: t1(100), t2(80), self(70) registered; publisher subscribes N=2.
+// Publisher sees t1, t2.  newcomer(90) registered → enters rank 1.
+// Non-self top-2: t1, newcomer.  t2 displaced and must be evicted.
+TEST_F(PropertyRankingSelfExclusionTest, RegisterTrack_AfterPublisherSubscribed) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto newcomer = ftn("ns", "newcomer");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(self, 70, pub);
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  // newcomer enters at rank 1 (above t2, below t1).
+  r->registerTrack(newcomer, 90, defaultPublisher_);
+
+  EXPECT_TRUE(wasSelected(newcomer, pub.get())); // newcomer entered publisher's top-2
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));        // t2 displaced
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));       // t1 stays
+  EXPECT_FALSE(wasSelected(self, pub.get()));    // self never selected
+}
+
+// When a track in the publisher's personal selection is removed, the publisher
+// receives an eviction and the replacement track is selected.
+//
+// Setup: t1(100), t2(80), self(70), t3(60).  Publisher with {self}, N=2.
+// Publisher sees t1, t2.  removeTrack(t2) → self promoted to shared top-2;
+// reconcile produces: evict t2, select t3 (new 2nd non-self); self excluded.
+TEST_F(PropertyRankingSelfExclusionTest, RemoveTrack_WithPublisherInGroup) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(t3, 60, defaultPublisher_);
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  r->removeTrack(t2);
+
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));     // t2 removed — evicted from publisher
+  EXPECT_TRUE(wasSelected(t3, pub.get()));    // t3 is the new 2nd non-self
+  EXPECT_FALSE(wasSelected(self, pub.get())); // self excluded even when promoted in shared view
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));    // t1 stays
+}
+
+// Two publisher-subscribers in the same group each exclude only their own
+// self-track; they can still receive each other's tracks.
+//
+// s1(100) > s2(90) > t1(80) > t2(70) > t3(60).  N=3.
+// pub1 {s1}: non-self top-3 = s2, t1, t2.
+// pub2 {s2}: non-self top-3 = s1, t1, t2.
+//
+// After s1 drops to 55: pub2's non-self top-3 shifts to t1, t2, t3 — s1 evicted,
+// t3 selected.  pub1's view is unchanged (s1 is its own self-track, skipped).
+TEST_F(PropertyRankingSelfExclusionTest, TwoPublisherSessions_IndependentSelfExclusion) {
+  auto r = makeRanking();
+  auto pub1 = makeSession();
+  auto pub2 = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  r->registerTrack(s1, 100, pub1);
+  r->registerTrack(s2, 90, pub2);
+  r->registerTrack(t1, 80, defaultPublisher_);
+  r->registerTrack(t2, 70, defaultPublisher_);
+  r->registerTrack(t3, 60, defaultPublisher_);
+
+  r->addSessionToTopNGroup(3, pub1, true);
+  r->addSessionToTopNGroup(3, pub2, true);
+
+  // pub1 sees s2, t1, t2 (not s1).
+  EXPECT_FALSE(wasSelected(s1, pub1.get()));
+  EXPECT_TRUE(wasSelected(s2, pub1.get()));
+  EXPECT_TRUE(wasSelected(t1, pub1.get()));
+  EXPECT_TRUE(wasSelected(t2, pub1.get()));
+  EXPECT_FALSE(wasSelected(t3, pub1.get()));
+
+  // pub2 sees s1, t1, t2 (not s2).
+  EXPECT_TRUE(wasSelected(s1, pub2.get()));
+  EXPECT_FALSE(wasSelected(s2, pub2.get()));
+  EXPECT_TRUE(wasSelected(t1, pub2.get()));
+  EXPECT_TRUE(wasSelected(t2, pub2.get()));
+  EXPECT_FALSE(wasSelected(t3, pub2.get()));
+
+  // s1 drops out of non-self top-3 for pub2; t3 enters.
+  // pub1 is unaffected (s1 is its self-track — its waterline doesn't change).
+  selected_.clear();
+  evicted_.clear();
+  r->updateSortValue(s1, 55); // s1: rank 0 → rank 4 (below t3)
+
+  EXPECT_TRUE(wasEvicted(s1, pub2.get()));   // s1 left pub2's view
+  EXPECT_TRUE(wasSelected(t3, pub2.get()));  // t3 entered pub2's view
+  EXPECT_FALSE(wasSelected(t3, pub1.get())); // pub1 unaffected
+  EXPECT_FALSE(wasEvicted(s1, pub1.get()));  // pub1 never received s1
+}
+
+// Bug: non-self track rises above the publisher's waterline, displacing the
+// previous Nth non-self track.  The displaced track must be evicted from the
+// publisher's delivery; without that eviction the publisher receives N+1 tracks.
+//
+// N=2, initial: t1(100) > t2(80) > self(70) > outsider(30).
+// Non-self top-2: t1, t2.  outsider rises to 85 → non-self top-2: t1, outsider.
+// t2 must be evicted and outsider must be selected.
+TEST_F(PropertyRankingSelfExclusionTest, NonSelfTrackRises_DisplacesWaterlineTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto outsider = ftn("ns", "outsider");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(self, 70, pub);
+  r->registerTrack(outsider, 30, defaultPublisher_);
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(outsider, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+  r->updateSortValue(outsider, 85); // outsider rises above t2
+
+  EXPECT_TRUE(wasSelected(outsider, pub.get())); // outsider entered publisher's top-2
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));        // t2 displaced — must be evicted
+  EXPECT_FALSE(wasSelected(self, pub.get()));    // self never selected
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));       // t1 stayed in top-2
+}
+
+// Viewer subscribes first, then registers a track (becoming a publisher).
+// The newly-registered track becomes a self-track and must be excluded.
+//
+// Setup: t1(100), t2(80), t3(60) registered.  Session subscribes N=2 as viewer.
+// Viewer sees t1, t2.  Session then publishes new track "self" at rank 1 (value=90).
+// Session now is a publisher-subscriber. Non-self top-2: t1, t2.
+// The new track "self" must be excluded and t3 stays out.
+TEST_F(PropertyRankingSelfExclusionTest, ViewerBecomesPublisher_ByRegisteringTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+  auto self = ftn("ns", "self");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(t3, 60, defaultPublisher_);
+
+  // Subscribe as viewer first (no self-tracks yet)
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  // Now the session registers its own track at rank 1
+  r->registerTrack(self, 90, pub);
+
+  // The session is now a publisher-subscriber. Its new track is self and excluded.
+  // Non-self top-2: still t1, t2. The session should not see "self" selected.
+  EXPECT_FALSE(wasSelected(self, pub.get())); // self is excluded
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));    // t1 stays
+  EXPECT_FALSE(wasEvicted(t2, pub.get()));    // t2 stays
+  EXPECT_FALSE(wasSelected(t3, pub.get()));   // t3 stays out
+}
+
+// Viewer subscribes, then registers a track that IS currently being delivered.
+// That track becomes a self-track and must be evicted; a replacement enters.
+//
+// Setup: t1(100), t2(80), t3(60) registered.  Session subscribes N=2 as viewer.
+// Viewer sees t1, t2.  Session then removes t2 and re-registers it as its own.
+// Session now is a publisher-subscriber. Non-self top-2: t1, t3.
+// t2 must be evicted and t3 must be selected.
+TEST_F(PropertyRankingSelfExclusionTest, ViewerBecomesPublisher_ClaimsDeliveredTrack) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  // t2 is initially registered with no publisher
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(t3, 60, defaultPublisher_);
+
+  // Subscribe as viewer first
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+
+  // Remove t2 so we can re-register it with the publisher
+  r->removeTrack(t2);
+
+  selected_.clear();
+  evicted_.clear();
+
+  // Now the session registers t2 as its own track
+  r->registerTrack(t2, 80, pub);
+
+  // t2 is now a self-track → evicted. t3 enters as replacement.
+  EXPECT_TRUE(wasEvicted(t2, pub.get()));  // t2 now self-track → evicted
+  EXPECT_TRUE(wasSelected(t3, pub.get())); // t3 enters publisher's top-2
+  EXPECT_FALSE(wasEvicted(t1, pub.get())); // t1 stays
+}
+
+// Publisher with an existing self-track registers a second self-track.
+// The second self-track must be excluded, and there must be no spurious
+// re-notifications for tracks already being delivered.
+//
+// t1(100) > s1(80) > t2(60). Publisher subscribes N=2: sees t1, t2.
+// Publisher then registers s2(40). Non-self top-2 is still t1, t2.
+// Neither t1 nor t2 should be re-notified; s2 must be excluded.
+TEST_F(PropertyRankingSelfExclusionTest, Publisher_RegistersAdditionalSelfTrack_NoRenotify) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto s1 = ftn("ns", "s1");
+  auto s2 = ftn("ns", "s2");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(s1, 80, pub);
+  r->registerTrack(t2, 60, defaultPublisher_);
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(s1, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  // Register a second self-track. Non-self top-2 is still t1, t2 — no change.
+  r->registerTrack(s2, 40, pub);
+
+  EXPECT_EQ(countSelected(t1, pub.get()), 0); // not re-notified
+  EXPECT_EQ(countSelected(t2, pub.get()), 0); // not re-notified
+  EXPECT_FALSE(wasSelected(s1, pub.get()));   // s1 excluded
+  EXPECT_FALSE(wasSelected(s2, pub.get()));   // s2 excluded
+  EXPECT_TRUE(evicted_.empty());
+}
+
+// Publisher's last self-track is removed. The session becomes a viewer.
+// Subsequent entries into the shared top-N must be delivered via the viewer
+// batch path and must not require any publisher waterline tracking.
+//
+// t1(100) > t2(80) > self(60) > t3(40). N=2.
+// self is rank 2 — NOT in the shared top-2. Publisher subscribes: sees t1, t2.
+// removeTrack(self): no promotion (self was deselected). Session is now a viewer.
+// t3 rises to 85: new rank order t1(100) > t3(85) > t2(80).
+// t3 enters the shared top-2 → viewer batch fires for pub.
+TEST_F(PropertyRankingSelfExclusionTest, RemoveSelfTrack_BecomesViewer_ReceivedAsViewer) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto t2 = ftn("ns", "t2");
+  auto t3 = ftn("ns", "t3");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(t2, 80, defaultPublisher_);
+  r->registerTrack(self, 60, pub); // rank 2, outside top-2
+  r->registerTrack(t3, 40, defaultPublisher_);
+
+  r->addSessionToTopNGroup(2, pub, true);
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_TRUE(wasSelected(t2, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+  EXPECT_FALSE(wasSelected(t3, pub.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  // Remove self-track. self was deselected (rank 2 >= N=2) so no promotion fires.
+  r->removeTrack(self);
+
+  EXPECT_TRUE(selected_.empty());
+  EXPECT_TRUE(evicted_.empty());
+
+  // t3 rises into the shared top-2, displacing t2.
+  // pub is now a viewer: it receives t3 via batch.
+  r->updateSortValue(t3, 85);
+
+  EXPECT_TRUE(wasSelected(t3, pub.get())); // viewer batch fires
+  EXPECT_FALSE(wasEvicted(t2, pub.get())); // viewers don't receive eviction callbacks
+}
+
+} // namespace


### PR DESCRIPTION
Publisher-subscribers receive the top-N non-self tracks via a waterline key (the RankKey of the Nth non-self track). A reconcilePublisherSelection helper diffs selectedTracks against the current personal top-N and fires evict/select callbacks for the delta, keeping publisher views consistent across rank changes, track registration, and mid-session self-track updates.

Viewer sessions use the shared rank threshold and receive batch callbacks unchanged. Mixed groups (viewers + publishers) in the same TopNGroup are handled correctly: each publisher's waterline is computed independently.

addPublishedTrackToSession and removePublishedTrackFromSession handle mid-session transitions, including viewer-to-publisher upgrade.

PropertyRankingSelfExclusionTest covers 16 cases: self-exclusion on subscribe, mixed viewer/publisher groups, waterline computation, mid-session addPublishedTrack eviction, removePublishedTrack re-eligibility, multiple self-tracks, self-track value changes, outsider entering view when waterline track drops, track registration after subscribe, track removal with publisher in group, and two publishers with independent self-exclusion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/169)
<!-- Reviewable:end -->
