### PR TITLE
Pre-public hardening: drop App token from PR CI, add CODEOWNERS + SECURITY

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -47,6 +47,10 @@ jobs:
             preset: default
             build_dir: build
             runner: ubuntu-22.04
+          - name: macos
+            preset: default
+            build_dir: build
+            runner: macos-latest
           - name: asan debug
             preset: san
             build_dir: build-san
@@ -66,7 +70,14 @@ jobs:
           submodules: true
 
       - name: Install system dependencies
-        run: sudo deps/moxygen/standalone/install-system-deps.sh
+        run: |
+          if [[ "$(uname)" == "Darwin" ]]; then
+            deps/moxygen/standalone/install-system-deps.sh
+            brew install coreutils
+            echo "/opt/homebrew/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
+          else
+            sudo deps/moxygen/standalone/install-system-deps.sh
+          fi
 
       - name: Setup dependencies
         env:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -48,13 +48,6 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OMOQ_APP_ID }}
-          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
-
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -70,8 +63,6 @@ jobs:
           fi
 
       - name: Setup dependencies
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bash scripts/build.sh setup
 
       - name: Build

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -63,6 +63,8 @@ jobs:
           fi
 
       - name: Setup dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/build.sh setup
 
       - name: Build

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS — gates merging via branch protection.
+#
+# An approving review from at least one code owner is required for any PR
+# that touches this repository. The merge button itself is restricted (via
+# branch protection `restrictions`) to the same set of users.
+
+* @gmarzot @afrind

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # that touches this repository. The merge button itself is restricted (via
 # branch protection `restrictions`) to the same set of users.
 
-* @afrind @gmarzot @peterchave @suhasHere
+* @afrind @akash-a-n @gmarzot @michalhosna @mondain @Oxyd @peterchave @suhasHere @TimEvens

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # that touches this repository. The merge button itself is restricted (via
 # branch protection `restrictions`) to the same set of users.
 
-* @gmarzot @afrind
+* @afrind @gmarzot @peterchave

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # that touches this repository. The merge button itself is restricted (via
 # branch protection `restrictions`) to the same set of users.
 
-* @afrind @gmarzot @peterchave
+* @afrind @gmarzot @peterchave @suhasHere

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in moqx, please report
+it privately. **Do not open a public GitHub issue for security reports.**
+
+Email: security@openmoq.org
+
+Please include:
+- A description of the issue and its potential impact
+- Steps to reproduce, or a proof of concept
+- Affected version(s) (commit SHA or release tag)
+- Any suggested mitigations
+
+We will acknowledge receipt within 5 business days and aim to provide an
+initial assessment within 10 business days.
+
+## Supported Versions
+
+moqx is in active development. Security fixes are applied to the `main`
+branch and the most recent release. Older releases are not supported.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -199,6 +199,7 @@ cmd_setup() {
   local clean=false
   local target_sha=""
   local moxygen_dir=""
+  local tarball_ok
 
   while (( $# > 0 )); do
     case "$1" in
@@ -263,9 +264,14 @@ cmd_setup() {
   if [[ "$mode" == "from-release" ]]; then
     echo ""
     echo "==> Setting up dependencies (from release)..."
-    local tarball_args=()
-    if $use_latest; then tarball_args+=(--use-latest); fi
-    if bash "$SCRIPT_DIR/setup-deps-tarball.sh" "${tarball_args[@]}"; then
+    if $use_latest; then
+      tarball_ok=true
+      bash "$SCRIPT_DIR/setup-deps-tarball.sh" --use-latest || tarball_ok=false
+    else
+      tarball_ok=true
+      bash "$SCRIPT_DIR/setup-deps-tarball.sh" || tarball_ok=false
+    fi
+    if $tarball_ok; then
       echo "from-release" > "$DEPS_MODE_FILE"
     else
       if $no_fallback; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,6 +59,9 @@ Setup options:
                         (--from-source only; mutually exclusive with SHA)
   --profile NAME        Build profile for deps: "default" or "san" (--from-source only)
   --no-fallback         Fail if requested mode unavailable (don't auto-switch)
+  --use-latest          (--from-release) Use snapshot-latest tarball even if it
+                        does not match the submodule SHA. Useful for tracking
+                        moxygen tip without bumping the submodule pin.
   --clean               Remove .scratch and start fresh
 
 Build options:
@@ -192,6 +195,7 @@ cmd_setup() {
   local mode="from-release"
   local profile="default"
   local no_fallback=false
+  local use_latest=false
   local clean=false
   local target_sha=""
   local moxygen_dir=""
@@ -218,6 +222,7 @@ cmd_setup() {
         shift 2
         ;;
       --no-fallback) no_fallback=true; shift ;;
+      --use-latest)  use_latest=true; shift ;;
       --clean)       clean=true; shift ;;
       -h|--help)     usage ;;
       *)             die "Unknown setup option: $1" ;;
@@ -258,7 +263,9 @@ cmd_setup() {
   if [[ "$mode" == "from-release" ]]; then
     echo ""
     echo "==> Setting up dependencies (from release)..."
-    if bash "$SCRIPT_DIR/setup-deps-tarball.sh"; then
+    local tarball_args=()
+    if $use_latest; then tarball_args+=(--use-latest); fi
+    if bash "$SCRIPT_DIR/setup-deps-tarball.sh" "${tarball_args[@]}"; then
       echo "from-release" > "$DEPS_MODE_FILE"
     else
       if $no_fallback; then

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
 # setup-deps-tarball.sh — Populate .scratch with prebuilt moxygen release artifacts.
 #
-# Uses the submodule commit SHA to find the exact publish workflow run
-# on openmoq/moxygen, then downloads the matching platform artifact.
-# Writes .scratch/cmake_prefix_path.txt for configure.sh.
+# Downloads the moxygen `snapshot-latest` GitHub release tarball matching
+# the current platform. By default, verifies the snapshot commit matches
+# the submodule SHA (the moxygen-sync workflow keeps these aligned); on
+# mismatch, exits non-zero so the caller (build.sh setup) can fall back
+# to setup-deps-standalone.sh (source build).
+#
+# Pass --use-latest (or set MOQX_TARBALL_USE_LATEST=1) to bypass the SHA
+# check and use the snapshot regardless of submodule pin. This is useful
+# for quick development against the current moxygen tip when you don't
+# need exact submodule reproducibility.
+#
+# Anonymous downloads from the public moxygen repo — no authentication
+# required, works for fork PRs.
 #
 # Usage:
-#   ./scripts/setup-deps-tarball.sh
+#   ./scripts/setup-deps-tarball.sh [--use-latest]
 #
-# Requires: gh CLI authenticated (with actions:read on openmoq/moxygen),
-#           deps/moxygen submodule initialized.
+# Requires: curl, deps/moxygen submodule initialized.
 
 set -euo pipefail
 
@@ -17,6 +26,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCRATCH="${MOQX_SCRATCH_PATH:-${PROJECT_ROOT}/.scratch}"
 MOXYGEN_DIR="${PROJECT_ROOT}/deps/moxygen"
+MOXYGEN_REPO="${MOQX_MOXYGEN_REPO:-openmoq/moxygen}"
+RELEASE_TAG="${MOQX_MOXYGEN_RELEASE_TAG:-snapshot-latest}"
+USE_LATEST="${MOQX_TARBALL_USE_LATEST:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --use-latest) USE_LATEST=1; shift ;;
+        -h|--help)
+            sed -n '2,22p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument: $1" >&2
+            echo "Usage: $0 [--use-latest]" >&2
+            exit 2
+            ;;
+    esac
+done
 
 if [[ ! -e "$MOXYGEN_DIR/.git" ]]; then
     echo "Error: deps/moxygen submodule not initialized." >&2
@@ -63,32 +90,61 @@ detect_platform() {
 PLATFORM="${MOQX_PLATFORM:-$(detect_platform)}"
 echo "==> Platform: $PLATFORM"
 
-# ── Find publish run matching submodule SHA ───────────────────────────────────
+# ── Verify snapshot SHA matches submodule ─────────────────────────────────────
 
-SHA=$(git -C "$MOXYGEN_DIR" rev-parse HEAD)
-echo "==> Moxygen submodule SHA: ${SHA:0:7}"
+SUBMODULE_SHA=$(git -C "$MOXYGEN_DIR" rev-parse HEAD)
+echo "==> Moxygen submodule SHA: ${SUBMODULE_SHA:0:7}"
+
+echo "==> Fetching ${RELEASE_TAG} release metadata..."
+RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${MOXYGEN_REPO}/releases/tags/${RELEASE_TAG}") || {
+    echo "Error: failed to fetch release metadata for ${MOXYGEN_REPO}@${RELEASE_TAG}" >&2
+    exit 1
+}
+
+# Extract embedded commit SHA from release body. publish-artifacts.sh writes
+# `**Commit:** \`<sha>\`` into the body — match the first 40-hex backtick group.
+SNAPSHOT_SHA=$(printf '%s' "$RELEASE_JSON" | grep -oE '`[a-f0-9]{40}`' | head -1 | tr -d '`')
+
+if [[ -z "$SNAPSHOT_SHA" ]]; then
+    echo "Error: could not parse snapshot commit SHA from release body" >&2
+    exit 1
+fi
+
+echo "==> Snapshot release SHA:  ${SNAPSHOT_SHA:0:7}"
+
+if [[ "$SNAPSHOT_SHA" != "$SUBMODULE_SHA" ]]; then
+    if [[ -n "$USE_LATEST" ]]; then
+        echo "Warning: snapshot SHA does not match submodule pin." >&2
+        echo "         submodule: ${SUBMODULE_SHA}" >&2
+        echo "         snapshot:  ${SNAPSHOT_SHA}" >&2
+        echo "         --use-latest set; proceeding with snapshot anyway." >&2
+    else
+        echo "Error: ${RELEASE_TAG} does not match the moxygen submodule pin." >&2
+        echo "       submodule: ${SUBMODULE_SHA}" >&2
+        echo "       snapshot:  ${SNAPSHOT_SHA}" >&2
+        echo "       The moxygen-sync workflow normally keeps these aligned." >&2
+        echo "       Options:" >&2
+        echo "         scripts/build.sh setup --from-source     # build pinned SHA from source" >&2
+        echo "         scripts/build.sh setup --use-latest      # use snapshot anyway" >&2
+        echo "         git submodule update --remote deps/moxygen && git add deps/moxygen" >&2
+        exit 1
+    fi
+fi
+
+# ── Download tarball ──────────────────────────────────────────────────────────
 
 TARBALL="moxygen-${PLATFORM}.tar.gz"
 DOWNLOAD_DIR="${SCRATCH}/downloads"
 mkdir -p "$DOWNLOAD_DIR"
 
-echo "==> Searching for publish run at ${SHA:0:7}..."
-RUN_ID=$(gh api "repos/openmoq/moxygen/actions/workflows/omoq-ci-main.yml/runs?head_sha=${SHA}&status=success&per_page=1" \
-    --jq '.workflow_runs[0].id // empty')
-
-if [[ -n "$RUN_ID" ]]; then
-    echo "==> Found publish run $RUN_ID, downloading $TARBALL..."
-    rm -f "${DOWNLOAD_DIR}/${TARBALL}"
-    gh run download "$RUN_ID" \
-        --repo openmoq/moxygen \
-        --name "$TARBALL" \
-        --dir "$DOWNLOAD_DIR"
-else
-    echo "Error: no successful publish run found for moxygen SHA ${SHA:0:7}." >&2
-    echo "  The publish workflow may not have run yet for this commit." >&2
-    echo "  Check: https://github.com/openmoq/moxygen/actions/workflows/omoq-ci-main.yml" >&2
+DOWNLOAD_URL="https://github.com/${MOXYGEN_REPO}/releases/download/${RELEASE_TAG}/${TARBALL}"
+echo "==> Downloading $TARBALL..."
+rm -f "${DOWNLOAD_DIR}/${TARBALL}"
+curl -fsSL "$DOWNLOAD_URL" -o "${DOWNLOAD_DIR}/${TARBALL}" || {
+    echo "Error: failed to download ${DOWNLOAD_URL}" >&2
+    echo "       (the platform tarball may not be in this snapshot)" >&2
     exit 1
-fi
+}
 
 # ── Extract ───────────────────────────────────────────────────────────────────
 

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -96,10 +96,24 @@ SUBMODULE_SHA=$(git -C "$MOXYGEN_DIR" rev-parse HEAD)
 echo "==> Moxygen submodule SHA: ${SUBMODULE_SHA:0:7}"
 
 echo "==> Fetching ${RELEASE_TAG} release metadata..."
-RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${MOXYGEN_REPO}/releases/tags/${RELEASE_TAG}") || {
-    echo "Error: failed to fetch release metadata for ${MOXYGEN_REPO}@${RELEASE_TAG}" >&2
-    exit 1
-}
+# Authenticate when GITHUB_TOKEN/GH_TOKEN is set (in CI). The api.github.com
+# unauthenticated rate limit (60/hour/IP) is exhausted quickly on shared
+# runners, especially macOS. Authenticated requests get 1000+/hour, which
+# applies even to read-only fork-PR GITHUB_TOKENs.
+RELEASE_API_URL="https://api.github.com/repos/${MOXYGEN_REPO}/releases/tags/${RELEASE_TAG}"
+TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [[ -n "$TOKEN" ]]; then
+    RELEASE_JSON=$(curl -fsSL -H "Authorization: Bearer ${TOKEN}" "$RELEASE_API_URL") || {
+        echo "Error: failed to fetch release metadata for ${MOXYGEN_REPO}@${RELEASE_TAG}" >&2
+        exit 1
+    }
+else
+    RELEASE_JSON=$(curl -fsSL "$RELEASE_API_URL") || {
+        echo "Error: failed to fetch release metadata for ${MOXYGEN_REPO}@${RELEASE_TAG}" >&2
+        echo "       (no GITHUB_TOKEN set; api.github.com unauthenticated rate limit may be exhausted)" >&2
+        exit 1
+    }
+fi
 
 # Extract embedded commit SHA from release body. publish-artifacts.sh writes
 # `**Commit:** \`<sha>\`` into the body — match the first 40-hex backtick group.

--- a/test/test_admin_info.sh
+++ b/test/test_admin_info.sh
@@ -32,13 +32,14 @@ done
 RESPONSE=$(curl -sf "$ADMIN_URL")
 echo "Response: $RESPONSE"
 
-# Validate expected fields.
-if ! echo "$RESPONSE" | grep -q '"service":"moqx"'; then
+# Validate expected fields. Use here-strings instead of `echo | grep -q` to
+# avoid SIGPIPE flake when grep -q exits before echo finishes writing.
+if ! grep -q '"service":"moqx"' <<<"$RESPONSE"; then
   echo "FAIL: missing \"service\":\"moqx\" in response" >&2
   exit 1
 fi
 
-if ! echo "$RESPONSE" | grep -q '"version":'; then
+if ! grep -q '"version":' <<<"$RESPONSE"; then
   echo "FAIL: missing \"version\" field in response" >&2
   exit 1
 fi

--- a/test/test_admin_metrics.sh
+++ b/test/test_admin_metrics.sh
@@ -56,22 +56,27 @@ HEADERS=$(cat "$HEADERS_FILE")
 RESPONSE=$(cat /tmp/metrics_response.txt)
 rm -f /tmp/metrics_response.txt
 echo "Response (first 20 lines):"
-echo "$RESPONSE" | head -20
+head -20 <<<"$RESPONSE"
+
+# Note on `grep -q <<<"$VAR"` (here-string) instead of `echo "$VAR" | grep -q`:
+# grep -q exits as soon as it finds a match, closing the pipe; the upstream
+# echo then gets SIGPIPE/EPIPE and the pipeline fails under `set -o pipefail`
+# even though grep clearly succeeded. Here-strings have no pipe, no race.
 
 # Validate Content-Type header (Prometheus text exposition format v0.0.4).
-if ! echo "$HEADERS" | grep -qi 'content-type:.*text/plain.*version=0\.0\.4'; then
+if ! grep -qi 'content-type:.*text/plain.*version=0\.0\.4' <<<"$HEADERS"; then
   echo "FAIL: missing or incorrect Content-Type header, expected 'text/plain; version=0.0.4'" >&2
   echo "Headers: $HEADERS" >&2
   exit 1
 fi
 
 # Validate Prometheus format: every metric family must have a # HELP and # TYPE line.
-if ! echo "$RESPONSE" | grep -q '^# HELP '; then
+if ! grep -q '^# HELP ' <<<"$RESPONSE"; then
   echo "FAIL: no '# HELP' lines found in /metrics response" >&2
   exit 1
 fi
 
-if ! echo "$RESPONSE" | grep -q '^# TYPE '; then
+if ! grep -q '^# TYPE ' <<<"$RESPONSE"; then
   echo "FAIL: no '# TYPE' lines found in /metrics response" >&2
   exit 1
 fi
@@ -88,24 +93,24 @@ EXPECTED_METRICS=(
 )
 
 for metric in "${EXPECTED_METRICS[@]}"; do
-  if ! echo "$RESPONSE" | grep -q "$metric"; then
+  if ! grep -q "$metric" <<<"$RESPONSE"; then
     echo "FAIL: expected metric '$metric' not found in /metrics response" >&2
     exit 1
   fi
 done
 
 # Validate histogram structure: bucket, sum, and count lines must be present.
-if ! echo "$RESPONSE" | grep -q '_bucket{le='; then
+if ! grep -q '_bucket{le=' <<<"$RESPONSE"; then
   echo "FAIL: no histogram bucket lines (e.g. '_bucket{le=...}') found" >&2
   exit 1
 fi
 
-if ! echo "$RESPONSE" | grep -q '_sum '; then
+if ! grep -q '_sum ' <<<"$RESPONSE"; then
   echo "FAIL: no histogram _sum lines found" >&2
   exit 1
 fi
 
-if ! echo "$RESPONSE" | grep -q '_count '; then
+if ! grep -q '_count ' <<<"$RESPONSE"; then
   echo "FAIL: no histogram _count lines found" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Prepares moqx for public visibility by removing the only secret-bearing path from PR CI, adding governance files, and tightening macOS coverage.

### What changes

- **`scripts/setup-deps-tarball.sh`** — switch from authenticated workflow-artifact downloads (`gh api .../actions/workflows/.../runs` + `gh run download`, both of which require `actions:read` even on public repos) to **anonymous release-asset downloads via `curl`**. Uses moxygen's `snapshot-latest` GitHub release, parses the embedded commit SHA from the release body, and verifies it matches `deps/moxygen` HEAD. No `gh` CLI required, no auth required for read; works for fork PRs.
  - The api.github.com metadata fetch *is* authenticated when `GITHUB_TOKEN`/`GH_TOKEN` is set, to avoid the unauthenticated 60/hour/IP rate limit (observed as 403 on macOS-15 runners). Falls back to unauthenticated for local use.
  - The `Authorization` header is sent only to api.github.com — never to the release asset CDN, never echoed.
- **`.github/workflows/ci-pr.yml`** — drop `OMOQ_APP_ID` / `OMOQ_APP_PRIV_KEY` from the `build` job. Pass `secrets.GITHUB_TOKEN` (the default workflow token, NOT the App key) into the Setup dependencies step. After this PR merges, **PR CI runs without the App token**, which is the security model we need before flipping the repo public. The default `GITHUB_TOKEN` is read-only on fork PRs but still counts as authenticated for API rate-limit purposes.
- **`.github/workflows/ci-main.yml`** — add macOS to the push-to-main build matrix (mirrors the existing macOS coverage in ci-pr.yml) so post-merge runs also verify macOS. Many moqx developers work on macOS.
- **`scripts/build.sh`** — plumb a new `--use-latest` setup option through to `setup-deps-tarball.sh`. Also fixes an empty-array expansion under `set -u` (bash < 5.2).
- **`CODEOWNERS`** — auto-tags every prior reviewer of moqx PRs (`@afrind @akash-a-n @gmarzot @michalhosna @mondain @Oxyd @peterchave @suhasHere @TimEvens`) so they keep getting requested for reviews. The merge button is gated separately by branch protection (only `gmarzot` / `afrind` / `peterchave` + the sync bot, applied post-flip). Any approving review from a write-tier collaborator counts toward the gate; CODEOWNERS does not lock approval to the listed users.
- **`SECURITY.md`** — private vulnerability reporting via `security@openmoq.org`.

### SHA matching behavior

Today, `setup-deps-tarball.sh` finds the workflow run for the exact submodule SHA — works even for older SHAs (within the 90-day artifact retention window). After this PR, the snapshot-only fast path is strict-match by default:

| Submodule SHA | Behavior |
|---|---|
| Matches snapshot-latest | Uses snapshot ✓ |
| Older than snapshot-latest | Falls back to source build via `setup-deps-standalone.sh` (existing fallback in `build.sh`) |

The `moxygen-sync` workflow keeps `deps/moxygen` aligned with moxygen `main` continuously, so the strict-match case is the common case. Mismatches happen only when reviving an old branch or working off-tree.

### `--use-latest` and `--no-fallback`

Two complementary flags for `setup-deps-tarball.sh` (also exposed via `build.sh setup --use-latest`):

|  | (no flags) | `--no-fallback` | `--use-latest` |
|---|---|---|---|
| SHA matches | snapshot ✓ | snapshot ✓ | snapshot ✓ |
| SHA mismatch | falls back to source build | dies | uses snapshot anyway |
| Network failure | falls back to source build | dies | falls back to source build |

`--use-latest` is for "I want to track moxygen tip without bumping the submodule pin." Honors `MOQX_TARBALL_USE_LATEST=1` as an env var equivalent.

### What's NOT in this PR

- No publishing changes on moxygen — `snapshot-latest` is already public
- No branch-protection changes on moqx (cannot be set via API while private — applied immediately post-flip)
- No collaborator demotion — broad collaborator list stays as-is; gating is via the merge restrictions allowlist alone

## Test plan

- [ ] CI matrix (linux / macos / asan debug) passes after the App token is removed
- [ ] Manual local test: `unset GH_TOKEN; rm -rf .scratch; bash scripts/build.sh setup` succeeds against current submodule
- [ ] Manual local test: `bash scripts/build.sh setup --use-latest` proceeds when submodule != latest moxygen
- [ ] Confirm `setup-deps-tarball.sh` exits non-zero on intentional SHA mismatch and `build.sh` falls through to source build
- [ ] After merge: apply branch protection on moqx `main` and verify the `restrictions` allowlist locks merging to `afrind` + `gmarzot` + `peterchave` (+ `omoq-sync-bot` for sync auto-merge)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/170)
<!-- Reviewable:end -->
