### PR TITLE
Add moq_interop_client Docker image for MOQ interop runner

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -170,12 +170,36 @@ jobs:
           docker stop moqx-smoke && docker rm moqx-smoke
           echo "==> Smoke test passed"
 
-      - name: Push Docker image
+      - name: Build interop client image
+        run: |
+          SHORT="${GITHUB_SHA:0:7}"
+          CLIENT_IMAGE="ghcr.io/${{ github.repository_owner }}/moqx-interop-client"
+          docker build -f docker/Dockerfile.interop-client \
+            -t "${CLIENT_IMAGE}:${SHORT}" \
+            -t "${CLIENT_IMAGE}:latest" \
+            .
+
+      - name: Smoke test interop client
+        run: |
+          CLIENT_IMAGE="ghcr.io/${{ github.repository_owner }}/moqx-interop-client:latest"
+          echo "==> ldd check"
+          docker run --rm --entrypoint ldd "${CLIENT_IMAGE}" /usr/local/bin/moq_interop_client
+          if docker run --rm --entrypoint ldd "${CLIENT_IMAGE}" /usr/local/bin/moq_interop_client 2>&1 | grep -q "not found"; then
+            echo "ERROR: missing shared libraries"; exit 1
+          fi
+          echo "==> List supported tests"
+          docker run --rm "${CLIENT_IMAGE}" --list
+          echo "==> Interop client smoke test passed"
+
+      - name: Push Docker images
         run: |
           SHORT="${GITHUB_SHA:0:7}"
           IMAGE="ghcr.io/${{ github.repository }}"
           docker push "${IMAGE}:${SHORT}"
           docker push "${IMAGE}:latest"
+          CLIENT_IMAGE="ghcr.io/${{ github.repository_owner }}/moqx-interop-client"
+          docker push "${CLIENT_IMAGE}:${SHORT}"
+          docker push "${CLIENT_IMAGE}:latest"
 
       - name: Package
         id: package

--- a/docker/Dockerfile.interop-client
+++ b/docker/Dockerfile.interop-client
@@ -1,0 +1,25 @@
+# Interop client image: extracts the moq_interop_client binary from the
+# pre-built moxygen tarball. No compilation required.
+#
+# The binary reads env vars natively (RELAY_URL, TESTCASE, TLS_DISABLE_VERIFY,
+# VERBOSE) matching the moq-interop-runner convention, so no entrypoint
+# wrapper is needed.
+#
+# Build context expects .docker-deps/moxygen/ to contain the extracted
+# moxygen bookworm tarball (same staging step as the relay Dockerfile).
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libunwind8 libsodium23 libboost-context1.74.0 \
+        libgoogle-glog0v6 libgflags2.2 libdouble-conversion3 \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY .docker-deps/moxygen/bin/moq_interop_client /usr/local/bin/moq_interop_client
+
+# Run as non-root (interop runner convention: UID 1000)
+RUN useradd -u 1000 -m interop
+USER interop
+
+ENTRYPOINT ["moq_interop_client"]


### PR DESCRIPTION
## Summary

Adds a lightweight Docker image for the moq_interop_client binary so moqx can participate as both **relay and client** in the [MOQ interop runner](https://github.com/englishm/moq-interop-runner).

Currently moqx is registered as relay-only (remote endpoints). This adds the client side so the full NxN matrix covers moqx-as-client testing against every other relay.

### What changes

- **`docker/Dockerfile.interop-client`** — extracts `bin/moq_interop_client` from the pre-built moxygen tarball (already staged by the publish job). No compilation. Bookworm-slim runtime, non-root UID 1000 per interop runner convention. The binary reads `RELAY_URL`, `TESTCASE`, `TLS_DISABLE_VERIFY`, `VERBOSE` env vars natively — no entrypoint wrapper needed.
- **`.github/workflows/ci-main.yml`** — publish job now builds, smoke-tests (ldd + `--list`), and pushes `ghcr.io/openmoq/moqx-interop-client:{sha,latest}` alongside the relay image.

### Image details

- Base: `debian:bookworm-slim` (matches the relay image)
- Binary: `moq_interop_client` from moxygen, supports draft-14 and draft-16 ALPNs
- Size: ~30 MB (runtime libs only, no build tools)
- Tests supported: `setup-only`, `announce-only`, `subscribe-error`, `announce-subscribe`, `publish-namespace-done`, `subscribe-before-announce`

### Follow-up

After this merges and the first ci-main run publishes the image, a PR to `englishm/moq-interop-runner` will add the client role to moqx's `implementations.json`:

```json
"client": {
  "docker": {
    "image": "ghcr.io/openmoq/moqx-interop-client:latest"
  }
}
```

## Test plan

- [x] CI passes (format, linux, macos, asan)
- [ ] ci-main publish job builds the interop client image successfully
- [ ] Smoke test passes: ldd check + `--list` shows supported test cases
- [ ] Image pushed to `ghcr.io/openmoq/moqx-interop-client:latest`
- [ ] After interop-runner PR: moqx appears as client in the interop matrix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/172)
<!-- Reviewable:end -->
