### PR TITLE
fix: Two-stop idle sweep throttle and double-select fix in PropertyRanking

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1327,6 +1327,7 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
         propertyType,
         maxDeselected_,
         std::chrono::milliseconds(0), // idle eviction wired in subsequent commit
+        std::chrono::milliseconds(0), // sweepThrottle wired in subsequent commit
         nullptr,                      // getLastActivity wired in subsequent commit
         // Batch callback: called once per track-selected event with all sessions
         [this](

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -14,14 +14,16 @@ PropertyRanking::PropertyRanking(
     uint64_t propertyType,
     uint64_t maxDeselected,
     std::chrono::milliseconds idleTimeout,
+    std::chrono::milliseconds sweepThrottle,
     GetLastActivityFn getLastActivity,
     BatchSelectCallback onBatchSelected,
     SelectCallback onSelected,
     EvictCallback onEvicted
 )
     : propertyType_(propertyType), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
-      getLastActivity_(std::move(getLastActivity)), onBatchSelected_(std::move(onBatchSelected)),
-      onSelected_(std::move(onSelected)), onEvicted_(std::move(onEvicted)) {}
+      sweepThrottle_(sweepThrottle), getLastActivity_(std::move(getLastActivity)),
+      onBatchSelected_(std::move(onBatchSelected)), onSelected_(std::move(onSelected)),
+      onEvicted_(std::move(onEvicted)) {}
 
 void PropertyRanking::registerTrack(
     const moxygen::FullTrackName& ftn,
@@ -98,13 +100,15 @@ void PropertyRanking::updateSortValue(const moxygen::FullTrackName& ftn, uint64_
     return;
   }
 
-  // Opportunistic idle sweep: a value change is worth a quick idle check
-  sweepIdle();
-
   // SLOW PATH: value crossed a threshold, recompute TopNGroups
   XLOG(DBG4) << "updateSortValue slow path: " << ftn << " value=" << value << " rank " << oldRank
              << " -> " << newRank << " (threshold crossed)";
   recomputeTopNGroups(ftn, oldRank, newRank);
+
+  // Opportunistic idle sweep after recompute: evict any selected tracks still
+  // idle after rank-based displacement. Running after (not before) avoids
+  // double-selecting a track that recomputeTopNGroups already promoted.
+  sweepIdle();
 }
 
 void PropertyRanking::removeTrack(const moxygen::FullTrackName& ftn) {
@@ -465,6 +469,12 @@ void PropertyRanking::sweepIdle() {
   }
 
   auto now = std::chrono::steady_clock::now();
+
+  // Global throttle: skip if called too recently.
+  if (sweepThrottle_.count() > 0 && lastSweepTime_ && now - *lastSweepTime_ < sweepThrottle_) {
+    return;
+  }
+  lastSweepTime_ = now;
 
   for (auto& [n, topNGroup] : topNGroups_) {
     // Snapshot selected FTNs: deselecting mutates trackStates

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -147,17 +147,20 @@ public:
    *        TODO: Add onDeselected callback (when track enters deselected queue) and
    *        onReselected callback (when track is promoted from queue back to selected)
    *        to enable the relay to manage forwarding state for maxDeselected>0.
-   * @param idleTimeout     How long a selected track may be silent before
-   *                        being deselected. Zero disables idle eviction.
-   * @param getLastActivity Relay callback to read per-track activity time
-   * @param onBatchSelected Batch callback for viewer notifications (required)
-   * @param onSelected      Individual callback for per-session notifications
-   * @param onEvicted       Callback when track is evicted from deselected queue
+   * @param idleTimeout        How long a selected track may be silent before
+   *                           being deselected. Zero disables idle eviction.
+   * @param sweepThrottle      Minimum interval between sweepIdle runs. Zero
+   *                           disables the global throttle (useful in tests).
+   * @param getLastActivity    Relay callback to read per-track activity time
+   * @param onBatchSelected    Batch callback for viewer notifications (required)
+   * @param onSelected         Individual callback for per-session notifications
+   * @param onEvicted          Callback when track is evicted from deselected queue
    */
   PropertyRanking(
       uint64_t propertyType,
       uint64_t maxDeselected,
       std::chrono::milliseconds idleTimeout,
+      std::chrono::milliseconds sweepThrottle,
       GetLastActivityFn getLastActivity,
       BatchSelectCallback onBatchSelected,
       SelectCallback onSelected,
@@ -300,6 +303,8 @@ private:
   uint64_t propertyType_;
   uint64_t maxDeselected_;
   std::chrono::milliseconds idleTimeout_;
+  std::chrono::milliseconds sweepThrottle_;
+  std::optional<std::chrono::steady_clock::time_point> lastSweepTime_;
   GetLastActivityFn getLastActivity_;
   BatchSelectCallback onBatchSelected_;
   SelectCallback onSelected_;

--- a/src/relay/TopNFilter.cpp
+++ b/src/relay/TopNFilter.cpp
@@ -65,7 +65,7 @@ void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
 
     uint64_t value = *valueOpt;
     if (!entry.lastSeenValue || *entry.lastSeenValue != value) {
-      // Value changed: fire onValueChanged (not onActivity)
+      // Value changed: fire onValueChanged
       XLOG(DBG4) << "[TopNFilter] Property changed on " << ftn_ << ": propertyType=0x" << std::hex
                  << propertyType << std::dec << " oldValue=" << entry.lastSeenValue.value_or(0)
                  << " newValue=" << value;
@@ -73,8 +73,11 @@ void TopNFilter::checkProperties(const moxygen::Extensions& extensions) {
       if (entry.observer.onValueChanged) {
         entry.observer.onValueChanged(value);
       }
-    } else if (activityThrottleAllows && entry.observer.onActivity) {
-      // Property seen but value unchanged: fire onActivity (throttled)
+    }
+    // Fire onActivity regardless of whether value changed (throttled).
+    // Two-stop throttle: TopNFilter throttles per-track; PropertyRanking::sweepIdle
+    // throttles globally so repeated onActivity calls from many tracks are cheap.
+    if (activityThrottleAllows && entry.observer.onActivity) {
       entry.observer.onActivity();
       firedAnyActivity = true;
     }

--- a/src/relay/TopNFilter.h
+++ b/src/relay/TopNFilter.h
@@ -26,10 +26,10 @@ struct PropertyObserver {
   // Called when the track ends (PUBLISH_DONE received).
   std::function<void()> onTrackEnded;
 
-  // Called when the observed property is present but value is unchanged.
-  // Throttled to at most once per activityThreshold_. Complements onValueChanged:
-  // either onValueChanged fires (value changed) or onActivity fires (value same),
-  // never both on the same object. Used to trigger idle sweeps in PropertyRanking.
+  // Called when the observed property is present and the per-filter activity
+  // throttle allows it (at most once per activityThreshold_). Fires independently
+  // of onValueChanged — both can fire on the same checkProperties() call when the
+  // value changes. Used to trigger idle sweeps in PropertyRanking.
   std::function<void()> onActivity;
 };
 

--- a/test/PropertyRankingBaseTest.cpp
+++ b/test/PropertyRankingBaseTest.cpp
@@ -55,12 +55,14 @@ public:
 
   explicit RankingHarness(
       uint64_t maxDeselected = 5,
-      std::chrono::milliseconds idleTimeout = std::chrono::milliseconds(0)
+      std::chrono::milliseconds idleTimeout = std::chrono::milliseconds(0),
+      std::chrono::milliseconds sweepThrottle = std::chrono::milliseconds(0)
   )
       : ranking_(std::make_unique<PropertyRanking>(
             kProp,
             maxDeselected,
             idleTimeout,
+            sweepThrottle,
             [this](const FullTrackName& f) {
               auto it = activityTimes_.find(f);
               if (it == activityTimes_.end()) {
@@ -521,6 +523,61 @@ TEST_F(PropertyRankingBaseTest, RemoveSelected_FallbackPicksHighestNonSelected) 
 }
 
 // ---------------------------------------------------------------------------
+// sweepIdle + updateSortValue interaction tests
+// ---------------------------------------------------------------------------
+
+// When a value change triggers both recomputeTopNGroups() and sweepIdle() inside
+// updateSortValue(), the track that enters top-N must be notified exactly once.
+// recomputeTopNGroups runs first and selects b; sweepIdle runs after and must
+// not re-notify b because it is already Selected.
+TEST_F(PropertyRankingBaseTest, UpdateSortValue_SweepIdleAndRecomputeDoNotDoubleSelect) {
+  // idleTimeout=100ms so sweepIdle is active. maxDeselected=0 (immediate evict).
+  RankingHarness h(0, std::chrono::milliseconds(100));
+  auto sub = makeSession();
+
+  // a (100) is top-1; b (50) is outside. Neither has activity → both "never published".
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 50, {});
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+  h.clearEvents();
+
+  // Stamp b's activity so only a is idle.
+  h.setActivityTime(ftn("b"), std::chrono::steady_clock::now());
+
+  // b's value crosses the N=1 threshold (rank 1→0).
+  // recomputeTopNGroups selects b and demotes a; sweepIdle then runs but finds
+  // b active and a already deselected — b must be selected exactly once.
+  h.ranking().updateSortValue(ftn("b"), 200);
+
+  EXPECT_EQ(h.selectCount(ftn("b")), 1);
+}
+
+TEST_F(PropertyRankingBaseTest, SweepThrottle_SkipsRunIfCalledTooSoon) {
+  // sweepThrottle=500ms: a second sweepIdle() call within that window is a no-op.
+  RankingHarness h(0, std::chrono::milliseconds(100), std::chrono::milliseconds(500));
+  auto sub = makeSession();
+
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.ranking().registerTrack(ftn("b"), 90, {});
+  h.ranking().addSessionToTopNGroup(1, sub, true);
+  h.clearEvents();
+
+  // a is idle, b is active.
+  h.setActivityTime(ftn("b"), std::chrono::steady_clock::now());
+
+  // First sweep: a is idle → evicted, b promoted.
+  h.ranking().sweepIdle();
+  EXPECT_EQ(h.selectCount(ftn("b")), 1);
+
+  // Re-register a (so it's back as a candidate) and clear events.
+  h.ranking().registerTrack(ftn("a"), 100, {});
+  h.clearEvents();
+
+  // Second sweep immediately after: throttle suppresses it — a is NOT evicted again.
+  h.ranking().sweepIdle();
+  EXPECT_EQ(h.selectCount(ftn("a")), 0);
+}
+
 // sweepIdle tests
 // ---------------------------------------------------------------------------
 

--- a/test/TopNFilterTest.cpp
+++ b/test/TopNFilterTest.cpp
@@ -318,17 +318,18 @@ TEST_F(TopNFilterTest, OnActivityCallbackBehavior) {
   // Enable threshold
   filter_->setActivityThreshold(std::chrono::hours(1));
 
-  // Value changes: onValueChanged fires, NOT onActivity
+  // Value changes: onValueChanged fires AND onActivity fires (two-stop throttle:
+  // both can fire independently on the same object).
   filter_->checkProperties(makeExt(kPropA, 42));
   EXPECT_EQ(valueChangedCount, 2); // includes earlier call
-  EXPECT_EQ(activityCount, 0);
+  EXPECT_EQ(activityCount, 1);
 
-  // Same value: onActivity fires
+  // Same value immediately: onActivity throttled (hours(1) not elapsed)
   filter_->checkProperties(makeExt(kPropA, 42));
   EXPECT_EQ(valueChangedCount, 2);
   EXPECT_EQ(activityCount, 1);
 
-  // Same value immediately: throttled
+  // Same value again: still throttled
   filter_->checkProperties(makeExt(kPropA, 42));
   EXPECT_EQ(activityCount, 1);
 


### PR DESCRIPTION
- Move sweepIdle() after recomputeTopNGroups() in updateSortValue() to prevent double-selecting a track that recomputeTopNGroups already promoted (sweepIdle and recompute were both calling notifyTrackSelected for the same track when a value change crossed the top-N boundary)
- Add global sweepThrottle to PropertyRanking: sweepIdle() skips if called within sweepThrottle_ of the last run, preventing wasted work when many active tracks fire onActivity in quick succession
- Change TopNFilter onActivity from else-if to independent if so it fires alongside onValueChanged (two-stop throttle: per-track throttle in TopNFilter + global throttle in PropertyRanking::sweepIdle)
- Wire sweepThrottle placeholder into MoqxRelay stub constructor call

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/178)
<!-- Reviewable:end -->
