### PR TITLE
fix: Reconcile publisher-subscriber top-N from PropertyRanking::registerTrack

### DIFF
--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -64,9 +64,18 @@ void PropertyRanking::registerTrack(
       // If that track was Selected, demote it into the deselected queue.
       // Only fires when numTracks > N (otherwise no track to demote).
       demoteTrackAtRank(n, topNGroup);
+    } else {
+      // Track is outside the shared top-N, so viewers don't care. But a
+      // publisher-subscriber's effective top-N is smaller than N (their own
+      // self-tracks occupy some slots), so this track may enter their personal
+      // top-N even though it's outside the shared one. Reconcile to pick it up.
+      IterationGuard guard(*this);
+      for (auto& [session, info] : topNGroup.sessions) {
+        if (isPublisher(session)) {
+          reconcilePublisherSelection(info, n, session);
+        }
+      }
     }
-    // Tracks outside top N are not added to the deselected queue on register;
-    // they only enter the queue when they fall out of an already-selected position.
   }
 }
 

--- a/test/PropertyRankingSelfExclusionTest.cpp
+++ b/test/PropertyRankingSelfExclusionTest.cpp
@@ -55,7 +55,8 @@ protected:
         maxDeselected,
         /*idleTimeout=*/std::chrono::milliseconds{0},
         /*sweepThrottle=*/std::chrono::milliseconds{0},
-        /*getLastActivity=*/nullptr,
+        /*getLastActivity=*/
+        [](const FullTrackName&) { return std::chrono::steady_clock::time_point{}; },
         /*onBatchSelected=*/
         [this](
             const FullTrackName& f,
@@ -591,6 +592,52 @@ TEST_F(PropertyRankingSelfExclusionTest, ViewerBecomesPublisher_ClaimsDeliveredT
   EXPECT_TRUE(wasEvicted(t2, pub.get()));  // t2 now self-track → evicted
   EXPECT_TRUE(wasSelected(t3, pub.get())); // t3 enters publisher's top-2
   EXPECT_FALSE(wasEvicted(t1, pub.get())); // t1 stays
+}
+
+// Track registers outside the shared top-N but within the publisher's
+// personal top-N.  This is the scenario the else-branch in
+// PropertyRanking::registerTrack was added to handle.
+//
+// N=2. Shared top-2: {t1(100), self(80)}.  Publisher subscribes: sees t1 only
+// (self excluded).  newcomer(60) registers at rank 2 (== N) — outside the
+// shared top-N, so viewers are unaffected.  However, self occupies a shared
+// slot, so the publisher's personal top-2 reaches to rank 2.  Without the
+// else-branch reconciliation the publisher would never learn about newcomer.
+TEST_F(
+    PropertyRankingSelfExclusionTest,
+    RegisterTrack_OutsideSharedTopN_InsidePublisherPersonalView
+) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+  auto viewer = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto newcomer = ftn("ns", "newcomer");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(self, 80, pub);
+
+  // Shared top-2: {t1, self}.  Publisher sees t1; viewer sees t1 and self.
+  r->addSessionToTopNGroup(2, pub, true);
+  r->addSessionToTopNGroup(2, viewer, true);
+
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+  EXPECT_TRUE(wasSelected(t1, viewer.get()));
+  EXPECT_TRUE(wasSelected(self, viewer.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  // newcomer lands at rank 2 (== N) — outside the shared top-N.
+  // Viewer is unaffected. Publisher's personal top-2 now covers {t1, newcomer}.
+  r->registerTrack(newcomer, 60, defaultPublisher_);
+
+  EXPECT_TRUE(wasSelected(newcomer, pub.get()));     // publisher picks up newcomer
+  EXPECT_FALSE(wasSelected(newcomer, viewer.get())); // viewer unaffected (rank >= N)
+  EXPECT_FALSE(wasSelected(self, pub.get()));        // self remains excluded
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));           // t1 stays
 }
 
 // Publisher with an existing self-track registers a second self-track.


### PR DESCRIPTION

When a track lands outside the shared top-N, viewers have no interest in it.
However, a publisher-subscriber's effective top-N is smaller than N because
their own self-tracks occupy slots. Add an else-branch in registerTrack that
iterates sessions in the top-N group and calls reconcilePublisherSelection for
any publisher-subscriber, so those sessions pick up tracks that fall within
their personal top-N even though they are outside the shared top-N.

Also fix PropertyRankingSelfExclusionTest to pass a real getLastActivity
lambda instead of nullptr, matching the current constructor signature.

Co-Authored-By: Suhas Nandakumar <snandaku@cisco.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openmoq/moqx/pull/180).
* #181
* __->__ #180

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/180)
<!-- Reviewable:end -->
