### PR TITLE
test: Add publisher-subscriber integration tests to MoqxTrackFilterTest

### DIFF
--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -64,9 +64,18 @@ void PropertyRanking::registerTrack(
       // If that track was Selected, demote it into the deselected queue.
       // Only fires when numTracks > N (otherwise no track to demote).
       demoteTrackAtRank(n, topNGroup);
+    } else {
+      // Track is outside the shared top-N, so viewers don't care. But a
+      // publisher-subscriber's effective top-N is smaller than N (their own
+      // self-tracks occupy some slots), so this track may enter their personal
+      // top-N even though it's outside the shared one. Reconcile to pick it up.
+      IterationGuard guard(*this);
+      for (auto& [session, info] : topNGroup.sessions) {
+        if (isPublisher(session)) {
+          reconcilePublisherSelection(info, n, session);
+        }
+      }
     }
-    // Tracks outside top N are not added to the deselected queue on register;
-    // they only enter the queue when they fall out of an already-selected position.
   }
 }
 

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -869,4 +869,96 @@ TEST_F(MoqxTrackFilterTest, FilterChainInstalledForBothPaths) {
   consumerC->publishDone(makePublishDone());
 }
 
+// ---------------------------------------------------------------------------
+// Tests: publisher-subscriber self-exclusion
+// ---------------------------------------------------------------------------
+
+// A session that subscribes with TRACK_FILTER before it starts publishing
+// must not receive its own track in the top-N selection.
+//
+// Setup: pub subscribes N=2, then publishes "self" (100).  Two other
+// sessions publish "a" (80) and "b" (60).  Non-self top-2 for pub are
+// "a" and "b"; pub must not receive its own "self" track.
+// Note: "b" is at shared rank 2 (outside shared top-2 of N=2) because
+// "self" occupies a slot, so this also exercises the out-of-shared-top-N
+// reconcile path for publisher-subscribers.
+TEST_F(MoqxTrackFilterTest, PublisherSubscriber_SubscribeBeforePublish_DoesNotReceiveOwnTrack) {
+  auto pub = makeSession();
+  auto other = makeSession();
+
+  // Subscribe before publishing.
+  doSubscribeFilter(pub, /*maxSelected=*/2);
+
+  auto cSelf = doPublish(pub, "self", 100); // pub's own track
+  auto cA = doPublish(other, "a", 80);      // other participant
+  auto cB = doPublish(other, "b", 60);      // other participant
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0); // own track excluded
+  EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(pub.get(), ftn("b")), 1);
+
+  cSelf->publishDone(makePublishDone());
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+}
+
+// A session that publishes before subscribing with TRACK_FILTER must still
+// have its already-published track excluded from its personal top-N.
+//
+// Setup: pub publishes "self" (100); another session publishes "a" (80) and
+// "b" (60).  pub subscribes N=2 — must see "a" and "b" but not "self".
+TEST_F(MoqxTrackFilterTest, PublisherSubscriber_PublishBeforeSubscribe_StillExcluded) {
+  auto pub = makeSession();
+  auto other = makeSession();
+
+  // Publish before subscribing.
+  auto cSelf = doPublish(pub, "self", 100);
+  auto cA = doPublish(other, "a", 80);
+  auto cB = doPublish(other, "b", 60);
+  exec_->driveFor(10);
+
+  // Late TRACK_FILTER subscription — self-track must be excluded.
+  doSubscribeFilter(pub, /*maxSelected=*/2);
+  exec_->driveFor(20);
+
+  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0);
+  EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(pub.get(), ftn("b")), 1);
+
+  cSelf->publishDone(makePublishDone());
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+}
+
+// A viewer receives all top-N tracks including the publisher-subscriber's
+// own track; the publisher-subscriber itself never receives its own stream.
+//
+// Setup: pub publishes "self" (100); another session publishes "a" (60).
+// viewer subscribes N=2 — gets both.  pub subscribes N=2 — gets "a" only.
+TEST_F(MoqxTrackFilterTest, PublisherSubscriber_ViewerReceivesSelfTrack) {
+  auto pub = makeSession();
+  auto other = makeSession();
+  auto viewer = makeSession();
+
+  auto cSelf = doPublish(pub, "self", 100);
+  auto cA = doPublish(other, "a", 60);
+  exec_->driveFor(10);
+
+  doSubscribeFilter(viewer, /*maxSelected=*/2);
+  doSubscribeFilter(pub, /*maxSelected=*/2);
+  exec_->driveFor(20);
+
+  // Viewer sees both tracks (including pub's self-track).
+  EXPECT_EQ(publishCount(viewer.get(), ftn("self")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+
+  // Publisher-subscriber never receives its own track.
+  EXPECT_EQ(publishCount(pub.get(), ftn("self")), 0);
+  EXPECT_EQ(publishCount(pub.get(), ftn("a")), 1);
+
+  cSelf->publishDone(makePublishDone());
+  cA->publishDone(makePublishDone());
+}
+
 } // namespace

--- a/test/PropertyRankingSelfExclusionTest.cpp
+++ b/test/PropertyRankingSelfExclusionTest.cpp
@@ -55,7 +55,8 @@ protected:
         maxDeselected,
         /*idleTimeout=*/std::chrono::milliseconds{0},
         /*sweepThrottle=*/std::chrono::milliseconds{0},
-        /*getLastActivity=*/nullptr,
+        /*getLastActivity=*/
+        [](const FullTrackName&) { return std::chrono::steady_clock::time_point{}; },
         /*onBatchSelected=*/
         [this](
             const FullTrackName& f,
@@ -591,6 +592,52 @@ TEST_F(PropertyRankingSelfExclusionTest, ViewerBecomesPublisher_ClaimsDeliveredT
   EXPECT_TRUE(wasEvicted(t2, pub.get()));  // t2 now self-track → evicted
   EXPECT_TRUE(wasSelected(t3, pub.get())); // t3 enters publisher's top-2
   EXPECT_FALSE(wasEvicted(t1, pub.get())); // t1 stays
+}
+
+// Track registers outside the shared top-N but within the publisher's
+// personal top-N.  This is the scenario the else-branch in
+// PropertyRanking::registerTrack was added to handle.
+//
+// N=2. Shared top-2: {t1(100), self(80)}.  Publisher subscribes: sees t1 only
+// (self excluded).  newcomer(60) registers at rank 2 (== N) — outside the
+// shared top-N, so viewers are unaffected.  However, self occupies a shared
+// slot, so the publisher's personal top-2 reaches to rank 2.  Without the
+// else-branch reconciliation the publisher would never learn about newcomer.
+TEST_F(
+    PropertyRankingSelfExclusionTest,
+    RegisterTrack_OutsideSharedTopN_InsidePublisherPersonalView
+) {
+  auto r = makeRanking();
+  auto pub = makeSession();
+  auto viewer = makeSession();
+
+  auto self = ftn("ns", "self");
+  auto t1 = ftn("ns", "t1");
+  auto newcomer = ftn("ns", "newcomer");
+
+  r->registerTrack(t1, 100, defaultPublisher_);
+  r->registerTrack(self, 80, pub);
+
+  // Shared top-2: {t1, self}.  Publisher sees t1; viewer sees t1 and self.
+  r->addSessionToTopNGroup(2, pub, true);
+  r->addSessionToTopNGroup(2, viewer, true);
+
+  EXPECT_TRUE(wasSelected(t1, pub.get()));
+  EXPECT_FALSE(wasSelected(self, pub.get()));
+  EXPECT_TRUE(wasSelected(t1, viewer.get()));
+  EXPECT_TRUE(wasSelected(self, viewer.get()));
+
+  selected_.clear();
+  evicted_.clear();
+
+  // newcomer lands at rank 2 (== N) — outside the shared top-N.
+  // Viewer is unaffected. Publisher's personal top-2 now covers {t1, newcomer}.
+  r->registerTrack(newcomer, 60, defaultPublisher_);
+
+  EXPECT_TRUE(wasSelected(newcomer, pub.get()));     // publisher picks up newcomer
+  EXPECT_FALSE(wasSelected(newcomer, viewer.get())); // viewer unaffected (rank >= N)
+  EXPECT_FALSE(wasSelected(self, pub.get()));        // self remains excluded
+  EXPECT_FALSE(wasEvicted(t1, pub.get()));           // t1 stays
 }
 
 // Publisher with an existing self-track registers a second self-track.


### PR DESCRIPTION

Adds three integration tests covering the case where a session both
publishes a track and holds a TRACK_FILTER subscription:

  subscribe-before-publish: session subscribes first, then publishes.
  publish-before-subscribe: session publishes first, then subscribes.
  viewer-sees-self-track: viewer receives the publisher's own track
    while the publisher-subscriber does not.

Co-Authored-By: Suhas Nandakumar <snandaku@cisco.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openmoq/moqx/pull/181).
* __->__ #181
* #180

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/181)
<!-- Reviewable:end -->
