### PR TITLE
moxygen-sync: fetch full history to avoid shallow submodule failure

### DIFF
--- a/.github/workflows/moxygen-sync.yml
+++ b/.github/workflows/moxygen-sync.yml
@@ -33,6 +33,11 @@ jobs:
           ref: main
           submodules: true
           token: ${{ steps.app-token.outputs.token }}
+          # Full history required so we can check out arbitrary moxygen
+          # SHAs inside the submodule. Shallow (default depth=1) creates
+          # shallow submodule clones, which fail with "unable to read
+          # tree" when checking out a SHA whose tree isn't present.
+          fetch-depth: 0
 
       # ══════════════════════════════════════════════════════════
       # PHASE A: Check for blocking sync PR


### PR DESCRIPTION
## Summary

The moxygen-sync job failed with \`fatal: unable to read tree\` when trying to check out a moxygen SHA in the submodule — [run 24401856289](https://github.com/openmoq/moqx/actions/runs/24401856289/job/71274317153).

### Root cause

\`actions/checkout@v4\` with default \`fetch-depth: 1\` and \`submodules: true\` creates shallow submodule clones. The shallow clone only contains the tree for whatever submodule SHA was pinned at checkout time. When the workflow later fetches the submodule and tries to check out a different SHA, git cannot reconstruct that SHA's tree from the shallow pack and aborts.

### Fix

\`fetch-depth: 0\` on the top-level checkout forces full history, which also deepens submodule clones enough to support cross-SHA checkouts.

One-line config change. Not related to the public-flip or token changes — the shallow-clone issue was latent and would have failed the same way at any point.

## Test plan

- [ ] CI passes
- [ ] After merge: next moxygen ci main dispatch succeeds the moqx sync job end-to-end

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/183)
<!-- Reviewable:end -->
