### PR TITLE
admin: augment /state with property ranking info per namespace node

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1544,7 +1544,18 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
   visitor.onNamespaceTreeBegin();
   std::function<void(std::string_view, const NamespaceNode&)> walkNode;
   walkNode = [&](std::string_view childKey, const NamespaceNode& node) {
-    visitor.beginNamespaceNode(childKey, node.trackNamespace_, node.sessions.size());
+    std::vector<PropertyRanking::RankingSnapshot> snapshots;
+    for (const auto& [propType, ranking] : node.rankings) {
+      snapshots.push_back(ranking->getSnapshot());
+    }
+    std::sort(
+        snapshots.begin(),
+        snapshots.end(),
+        [](const PropertyRanking::RankingSnapshot& a, const PropertyRanking::RankingSnapshot& b) {
+          return a.propertyType < b.propertyType;
+        }
+    );
+    visitor.beginNamespaceNode(childKey, node.trackNamespace_, node.sessions.size(), snapshots);
     for (const auto& [key, child] : node.children) {
       walkNode(key, *child);
     }

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -66,11 +66,13 @@ public:
   // --- Namespace tree section ---
   virtual void onNamespaceTreeBegin() = 0;
   // Depth-first traversal. childKey is the map key in the parent's children
-  // map; empty string for the root node.
+  // map; empty string for the root node. rankings is non-empty only for nodes
+  // that have active PropertyRanking instances (TRACK_FILTER subscribers).
   virtual void beginNamespaceNode(
       std::string_view childKey,
       const moxygen::TrackNamespace& ns,
-      size_t sessionCount
+      size_t sessionCount,
+      const std::vector<PropertyRanking::RankingSnapshot>& rankings
   ) = 0;
   virtual void endNamespaceNode() = 0;
   virtual void onNamespaceTreeEnd() = 0;

--- a/src/admin/StateHandler.cpp
+++ b/src/admin/StateHandler.cpp
@@ -20,6 +20,7 @@
 #include "MoqxRelayContext.h"
 #include "admin/AdminServer.h"
 #include "admin/JsonWriter.h"
+#include "relay/PropertyRanking.h"
 
 namespace openmoq::moqx::admin {
 
@@ -88,7 +89,8 @@ public:
   void beginNamespaceNode(
       std::string_view childKey,
       const moxygen::TrackNamespace& ns,
-      size_t sessionCount
+      size_t sessionCount,
+      const std::vector<PropertyRanking::RankingSnapshot>& rankings
   ) override {
     if (!childKey.empty()) {
       w_.key(childKey);
@@ -102,6 +104,49 @@ public:
     w_.endArray();
     w_.key("namespace_subscribers");
     w_.uintVal(static_cast<uint64_t>(sessionCount));
+    if (!rankings.empty()) {
+      w_.key("property_rankings");
+      w_.beginArray();
+      for (const auto& r : rankings) {
+        w_.beginObject();
+        w_.field("property_type", r.propertyType);
+        w_.key("num_tracks");
+        w_.uintVal(static_cast<uint64_t>(r.numTracks));
+        w_.key("num_unselected");
+        w_.uintVal(static_cast<uint64_t>(r.numUnselected));
+        w_.key("top_tracks");
+        w_.beginArray();
+        for (const auto& t : r.topTracks) {
+          w_.beginObject();
+          w_.key("namespace");
+          w_.beginArray();
+          for (const auto& s : t.ftn.trackNamespace.trackNamespace) {
+            w_.strVal(s);
+          }
+          w_.endArray();
+          w_.field("track_name", t.ftn.trackName);
+          w_.field("rank", t.rank);
+          w_.field("value", t.value);
+          w_.field("subscriber_published", t.subscriberPublished);
+          w_.endObject();
+        }
+        w_.endArray();
+        w_.key("groups");
+        w_.beginArray();
+        for (const auto& g : r.groups) {
+          w_.beginObject();
+          w_.field("n", g.maxSelected);
+          w_.key("num_sessions");
+          w_.uintVal(static_cast<uint64_t>(g.numSessions));
+          w_.key("deselected_queue_size");
+          w_.uintVal(static_cast<uint64_t>(g.deselectedQueueSize));
+          w_.endObject();
+        }
+        w_.endArray();
+        w_.endObject();
+      }
+      w_.endArray();
+    }
     w_.key("children");
     w_.beginObject();
   }

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -725,4 +725,70 @@ void PropertyRanking::sweepIdle() {
   }
 }
 
+PropertyRanking::RankingSnapshot PropertyRanking::getSnapshot() const {
+  RankingSnapshot snapshot;
+  snapshot.propertyType = propertyType_;
+  snapshot.numTracks = trackIndexByName_.size();
+
+  // Compute window size = max over all groups of (N + max publisher track count in group).
+  // Also build the set of publisher raw pointers present as sessions in any group.
+  uint64_t windowSize = 0;
+  folly::F14FastSet<moxygen::MoQSession*> publisherSessions;
+  for (const auto& [n, group] : topNGroups_) {
+    uint64_t maxPubCount = 0;
+    for (const auto& [session, info] : group.sessions) {
+      auto it = publisherTrackCount_.find(session.get());
+      if (it != publisherTrackCount_.end()) {
+        publisherSessions.insert(session.get());
+        maxPubCount = std::max(maxPubCount, static_cast<uint64_t>(it->second));
+      }
+    }
+    windowSize = std::max(windowSize, n + maxPubCount);
+  }
+
+  // Walk rankedTracks_ from the top, emitting up to windowSize entries.
+  // Also compute numUnselected by checking whether each track is Selected in any group.
+  size_t numUnselected = 0;
+  uint64_t rank = 1;
+  for (const auto& [key, entry] : rankedTracks_) {
+    bool selectedInAnyGroup = false;
+    for (const auto& [n, group] : topNGroups_) {
+      auto it = group.trackStates.find(entry.ftn);
+      if (it != group.trackStates.end() && it->second == TrackState::Selected) {
+        selectedInAnyGroup = true;
+        break;
+      }
+    }
+    if (!selectedInAnyGroup) {
+      ++numUnselected;
+    }
+    if (rank <= windowSize) {
+      snapshot.topTracks.push_back(TrackRankSnapshot{
+          .ftn = entry.ftn,
+          .value = key.value,
+          .rank = rank,
+          .subscriberPublished = publisherSessions.count(entry.publisherRaw) > 0,
+      });
+    }
+    ++rank;
+  }
+  snapshot.numUnselected = numUnselected;
+
+  // Populate groups sorted ascending by maxSelected.
+  for (const auto& [n, group] : topNGroups_) {
+    snapshot.groups.push_back(GroupSnapshot{
+        .maxSelected = n,
+        .numSessions = group.sessions.size(),
+        .deselectedQueueSize = group.deselectedQueue.size(),
+    });
+  }
+  std::sort(
+      snapshot.groups.begin(),
+      snapshot.groups.end(),
+      [](const GroupSnapshot& a, const GroupSnapshot& b) { return a.maxSelected < b.maxSelected; }
+  );
+
+  return snapshot;
+}
+
 } // namespace openmoq::moqx

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -280,6 +280,32 @@ public:
     return it != topNGroups_.end() ? &it->second : nullptr;
   }
 
+  // State snapshot for /state admin endpoint.
+  struct TrackRankSnapshot {
+    moxygen::FullTrackName ftn;
+    uint64_t value;
+    uint64_t rank;            // 1-based position in rankedTracks_
+    bool subscriberPublished; // publisher is a subscriber session in any group of this ranking
+  };
+  struct GroupSnapshot {
+    uint64_t maxSelected; // N
+    size_t numSessions;
+    size_t deselectedQueueSize;
+  };
+  struct RankingSnapshot {
+    uint64_t propertyType;
+    size_t numTracks;
+    // Tracks in rankedTracks_ not Selected in any group.
+    size_t numUnselected;
+    // Top tracks up to max(N + max_publisher_self_count) across all groups, rank-ordered.
+    std::vector<TrackRankSnapshot> topTracks;
+    std::vector<GroupSnapshot> groups; // sorted ascending by maxSelected
+  };
+
+  // Snapshot of current ranking state for the /state admin endpoint.
+  // Called on the relay worker EVB; O(T*G) walk is acceptable for a debug endpoint.
+  RankingSnapshot getSnapshot() const;
+
 private:
   uint64_t getRank(const RankKey& key) const;
 


### PR DESCRIPTION
For each namespace node with active PropertyRanking instances, the /state response now includes a property_rankings array. Each entry shows:
- num_tracks / num_unselected: total registered tracks and those below all selection windows
- top_tracks: the global ranked list up to max(N + max_publisher_self_count) across all groups, with rank, value, and self_published annotation
- groups: compact per-group summary (N, num_sessions, deselected_queue_size)

The window is sized to cover every session's personal view including publisher-subscribers who skip self-tracks. Nodes without rankings omit the field entirely.

JSON output shape
```
{
  "full_namespace": [...],
  "namespace_subscribers": 2,
  "property_rankings": [
    {
      "property_type": 1,
      "num_tracks": 10,
      "num_unselected": 6,
      "top_tracks": [
        {"namespace": [...], "track_name": "a", "rank": 1, "value": 95, "subscriber_published": false},
        {"namespace": [...], "track_name": "b", "rank": 2, "value": 87, "subscriber_published": true},
        {"namespace": [...], "track_name": "c", "rank": 3, "value": 72, "subscriber_published": false},
        {"namespace": [...], "track_name": "d", "rank": 4, "value": 61, "subscriber_published": true}
      ],
      "groups": [
        {"n": 3, "num_sessions": 5, "deselected_queue_size": 0},
        {"n": 5, "num_sessions": 2, "deselected_queue_size": 1}
      ]
    }
  ],
  "children": { ... }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/190)
<!-- Reviewable:end -->
