### PR TITLE
test: assign unique ports per shell test for parallel execution

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 BUILD_DIR=${1:-build}
-ctest --test-dir "${BUILD_DIR}" --output-on-failure
+ctest --test-dir "${BUILD_DIR}" --output-on-failure --parallel

--- a/test/make_test_config.sh
+++ b/test/make_test_config.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# make_test_config.sh — write a minimal moqx test config to stdout.
+#
+# Usage: make_test_config.sh <listen_port> <admin_port> [--cert <file> --key <file>]
+#
+# Without --cert/--key the admin section uses plaintext: true.
+# With --cert/--key the admin section uses plaintext: false and includes TLS config.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <listen_port> <admin_port> [--cert <file> --key <file>]" >&2
+  exit 1
+fi
+
+LISTEN_PORT="$1"
+ADMIN_PORT="$2"
+shift 2
+
+CERT=""
+KEY=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cert) CERT="$2"; shift 2 ;;
+    --key)  KEY="$2";  shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+cat <<EOF
+listeners:
+  - name: main
+    udp:
+      socket:
+        address: "::"
+        port: ${LISTEN_PORT}
+    tls:
+      insecure: true
+    endpoint: "/moq-relay"
+services:
+  default:
+    match:
+      - authority: {any: true}
+        path: {prefix: "/"}
+    cache:
+      enabled: true
+      max_tracks: 100
+      max_groups_per_track: 3
+admin:
+  port: ${ADMIN_PORT}
+  address: "::1"
+EOF
+
+if [[ -n "$CERT" ]]; then
+  cat <<EOF
+  plaintext: false
+  tls:
+    cert_file: ${CERT}
+    key_file: ${KEY}
+EOF
+else
+  echo "  plaintext: true"
+fi

--- a/test/test_admin_cache_purge.sh
+++ b/test/test_admin_cache_purge.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 BINARY="${1:-$(dirname "$0")/../build/moqx}"
-TESTDIR="$(cd "$(dirname "$0")" && pwd)"
-ADMIN_PORT=9669
+# shellcheck source=test_ports.sh
+source "$(dirname "$0")/test_ports.sh"
+LISTEN_PORT=$TEST_CACHE_PURGE_LISTEN
+ADMIN_PORT=$TEST_CACHE_PURGE_ADMIN
 INFO_URL="http://localhost:${ADMIN_PORT}/info"
 PURGE_URL="http://localhost:${ADMIN_PORT}/cache/purge"
 
@@ -12,16 +14,21 @@ if [[ ! -x "$BINARY" ]]; then
   exit 1
 fi
 
-"$BINARY" --config="$TESTDIR/test.config.yaml" &
-MOQX_PID=$!
-
+TMPDIR=$(mktemp -d)
+MOQX_PID=""
 cleanup() {
   if [[ -n "${MOQX_PID:-}" ]]; then
     kill "$MOQX_PID" 2>/dev/null || true
     wait "$MOQX_PID" 2>/dev/null || true
   fi
+  rm -rf "$TMPDIR"
 }
 trap cleanup EXIT
+
+"$(dirname "$0")/make_test_config.sh" "$LISTEN_PORT" "$ADMIN_PORT" > "$TMPDIR/config.yaml"
+
+"$BINARY" --config="$TMPDIR/config.yaml" &
+MOQX_PID=$!
 
 # Wait for the admin server to become ready (up to 10 s).
 for i in $(seq 1 100); do

--- a/test/test_admin_cache_purge_race.sh
+++ b/test/test_admin_cache_purge_race.sh
@@ -24,12 +24,13 @@ set -euo pipefail
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 BINARY="${1:-$REPO/build/moqx}"
 MOQBIN="${MOQBIN:-$REPO/.scratch/moxygen-install/bin}"
+# shellcheck source=test_ports.sh
+source "$REPO/test/test_ports.sh"
 DATESERVER="$MOQBIN/moqdateserver"
 TEXTCLIENT="$MOQBIN/moqtextclient"
 
-# Use ports that don't collide with the other integration tests (9668/9669).
-RELAY_PORT=19678
-ADMIN_PORT=19679
+RELAY_PORT=$TEST_CACHE_PURGE_RACE_RELAY
+ADMIN_PORT=$TEST_CACHE_PURGE_RACE_ADMIN
 NAMESPACE="moq-date-purge-race"
 PURGE_URL="http://localhost:${ADMIN_PORT}/cache/purge"
 INFO_URL="http://localhost:${ADMIN_PORT}/info"

--- a/test/test_admin_info.sh
+++ b/test/test_admin_info.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 BINARY="${1:-$(dirname "$0")/../build/moqx}"
-TESTDIR="$(cd "$(dirname "$0")" && pwd)"
-ADMIN_PORT=9669
+# shellcheck source=test_ports.sh
+source "$(dirname "$0")/test_ports.sh"
+LISTEN_PORT=$TEST_ADMIN_INFO_LISTEN
+ADMIN_PORT=$TEST_ADMIN_INFO_ADMIN
 ADMIN_URL="http://localhost:${ADMIN_PORT}/info"
 
 if [[ ! -x "$BINARY" ]]; then
@@ -11,10 +13,19 @@ if [[ ! -x "$BINARY" ]]; then
   exit 1
 fi
 
-# Start moqx with test config in the background.
-"$BINARY" --config="$TESTDIR/test.config.yaml" &
+TMPDIR=$(mktemp -d)
+MOQX_PID=""
+cleanup() {
+  [[ -n "$MOQX_PID" ]] && kill "$MOQX_PID" 2>/dev/null; wait "$MOQX_PID" 2>/dev/null || true
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+"$(dirname "$0")/make_test_config.sh" "$LISTEN_PORT" "$ADMIN_PORT" > "$TMPDIR/config.yaml"
+
+# Start moqx with the generated config in the background.
+"$BINARY" --config="$TMPDIR/config.yaml" &
 MOQX_PID=$!
-trap 'kill "$MOQX_PID" 2>/dev/null; wait "$MOQX_PID" 2>/dev/null || true' EXIT
 
 # Wait for the admin server to become ready (up to 5 s).
 for i in $(seq 1 50); do

--- a/test/test_admin_metrics.sh
+++ b/test/test_admin_metrics.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 BINARY="${1:-$(dirname "$0")/../build/moqx}"
-TESTDIR="$(cd "$(dirname "$0")" && pwd)"
-ADMIN_PORT=9669
+# shellcheck source=test_ports.sh
+source "$(dirname "$0")/test_ports.sh"
+LISTEN_PORT=$TEST_ADMIN_METRICS_LISTEN
+ADMIN_PORT=$TEST_ADMIN_METRICS_ADMIN
 METRICS_URL="http://localhost:${ADMIN_PORT}/metrics"
 INFO_URL="http://localhost:${ADMIN_PORT}/info"
 
@@ -12,10 +14,8 @@ if [[ ! -x "$BINARY" ]]; then
   exit 1
 fi
 
-# Start moqx with test config in the background.
-"$BINARY" --config="$TESTDIR/test.config.yaml" &
-MOQX_PID=$!
-
+TMPDIR=$(mktemp -d)
+MOQX_PID=""
 # Cleanup function that ensures the process exits and port is released.
 cleanup() {
   if [[ -n "${MOQX_PID:-}" ]]; then
@@ -23,8 +23,15 @@ cleanup() {
     # Wait for process to exit and ensure port is released
     wait "$MOQX_PID" 2>/dev/null || true
   fi
+  rm -rf "$TMPDIR"
 }
 trap cleanup EXIT
+
+"$(dirname "$0")/make_test_config.sh" "$LISTEN_PORT" "$ADMIN_PORT" > "$TMPDIR/config.yaml"
+
+# Start moqx with the generated config in the background.
+"$BINARY" --config="$TMPDIR/config.yaml" &
+MOQX_PID=$!
 
 # Wait for the admin server to become ready (up to 10 s) using /info.
 # /metrics is significantly more expensive, so avoid using it for readiness.

--- a/test/test_admin_tls.sh
+++ b/test/test_admin_tls.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 BINARY="${1:-$(dirname "$0")/../build/moqx}"
 TESTDIR="$(cd "$(dirname "$0")" && pwd)"
-ADMIN_PORT=9671
-LISTEN_PORT=9666
+# shellcheck source=test_ports.sh
+source "$(dirname "$0")/test_ports.sh"
+LISTEN_PORT=$TEST_ADMIN_TLS_LISTEN
+ADMIN_PORT=$TEST_ADMIN_TLS_ADMIN
 
 if [[ ! -x "$BINARY" ]]; then
   echo "ERROR: binary not found or not executable: $BINARY" >&2
@@ -22,33 +24,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-cat > "$TMPDIR/config.yaml" <<EOF
-listeners:
-  - name: main
-    udp:
-      socket:
-        address: "::1"
-        port: ${LISTEN_PORT}
-    tls:
-      insecure: true
-    endpoint: "/moq-relay"
-services:
-  default:
-    match:
-      - authority: {any: true}
-        path: {prefix: "/"}
-    cache:
-      enabled: true
-      max_tracks: 100
-      max_groups_per_track: 3
-admin:
-  port: ${ADMIN_PORT}
-  address: "::1"
-  plaintext: false
-  tls:
-    cert_file: ${CERT}
-    key_file: ${KEY}
-EOF
+"$(dirname "$0")/make_test_config.sh" "$LISTEN_PORT" "$ADMIN_PORT" --cert "$CERT" --key "$KEY" > "$TMPDIR/config.yaml"
 
 ADMIN_URL="https://localhost:${ADMIN_PORT}/info"
 

--- a/test/test_ports.sh
+++ b/test/test_ports.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Central port registry for shell integration tests.
+#
+# Every test that binds a port must claim it here so tests can run in
+# parallel without conflicts.  Ports are assigned in sequential pairs
+# (UDP listener + admin HTTP).
+#
+# To add a new test:
+#   1. Append a new block below, incrementing from the highest port used.
+#   2. Source this file in your test: source "$(dirname "$0")/test_ports.sh"
+#   3. Use the exported variables for your LISTEN_PORT / ADMIN_PORT.
+#
+# To verify no duplicate ports exist:
+#   grep -Eo '[0-9]{4,5}' test/test_ports.sh | sort | uniq -d
+#   (should print nothing)
+
+# test_admin_info.sh
+TEST_ADMIN_INFO_LISTEN=9660
+TEST_ADMIN_INFO_ADMIN=9661
+
+# test_admin_metrics.sh
+TEST_ADMIN_METRICS_LISTEN=9662
+TEST_ADMIN_METRICS_ADMIN=9663
+
+# test_admin_tls.sh
+TEST_ADMIN_TLS_LISTEN=9664
+TEST_ADMIN_TLS_ADMIN=9665
+
+# test_admin_cache_purge.sh
+TEST_CACHE_PURGE_LISTEN=9666
+TEST_CACHE_PURGE_ADMIN=9667
+
+# test_relay_chain.sh  (two relay instances)
+TEST_RELAY_CHAIN_UPSTREAM=19668
+TEST_RELAY_CHAIN_UPSTREAM_ADMIN=19669
+TEST_RELAY_CHAIN_DOWNSTREAM=19670
+TEST_RELAY_CHAIN_DOWNSTREAM_ADMIN=19671
+
+# test_admin_cache_purge_race.sh
+TEST_CACHE_PURGE_RACE_RELAY=19678
+TEST_CACHE_PURGE_RACE_ADMIN=19679

--- a/test/test_relay_chain.sh
+++ b/test/test_relay_chain.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 BINARY="${1:-$REPO/build/moqx}"
 MOQBIN="${MOQBIN:-$REPO/.scratch/moxygen-install/bin}"
+# shellcheck source=test_ports.sh
+source "$REPO/test/test_ports.sh"
 
 # Parse --save-logs option (may appear anywhere in args)
 SAVE_LOGS=false
@@ -32,10 +34,10 @@ done
 DATESERVER="$MOQBIN/moqdateserver"
 TEXTCLIENT="$MOQBIN/moqtextclient"
 
-UPSTREAM_PORT=19668
-UPSTREAM_ADMIN_PORT=19669
-DOWNSTREAM_PORT=19670
-DOWNSTREAM_ADMIN_PORT=19671
+UPSTREAM_PORT=$TEST_RELAY_CHAIN_UPSTREAM
+UPSTREAM_ADMIN_PORT=$TEST_RELAY_CHAIN_UPSTREAM_ADMIN
+DOWNSTREAM_PORT=$TEST_RELAY_CHAIN_DOWNSTREAM
+DOWNSTREAM_ADMIN_PORT=$TEST_RELAY_CHAIN_DOWNSTREAM_ADMIN
 UPSTREAM_RELAY_ID="upstream-test"
 DOWNSTREAM_RELAY_ID="downstream-test"
 NAMESPACE="moq-date"


### PR DESCRIPTION
Introduces test/test_ports.sh as a central port registry — all six shell integration tests now source it instead of hardcoding port numbers. Ports are assigned in sequential pairs (UDP listener + admin HTTP) so every test can run concurrently without conflicts.

Adds test/make_test_config.sh to generate a minimal moqx config from port arguments (with optional TLS), replacing the repeated heredoc in each test. Enables --parallel in scripts/test.sh.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/197)
<!-- Reviewable:end -->
