### PR TITLE
fix: prevent premature idle eviction and deterministic retroactive track registration

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -545,8 +545,8 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   // /conf/room1, so we must walk up the ancestor chain.
   for (NamespaceNode* node = nodePtr.get(); node != nullptr; node = node->parent_) {
     for (auto& [propertyType, ranking] : node->rankings) {
-      auto initialValue = pub.extensions.getIntExtension(propertyType);
-      ranking->registerTrack(pub.fullTrackName, initialValue, session);
+      auto initialPropertyValue = pub.extensions.getIntExtension(propertyType);
+      ranking->registerTrack(pub.fullTrackName, initialPropertyValue, session);
       topNFilter->registerObserver(
           propertyType,
           PropertyObserver{
@@ -1387,13 +1387,28 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
       auto [prefix, current] = queue.front();
       queue.pop_front();
 
-      // Register tracks at this level
+      // Collect tracks at this level with their last-activity time and current
+      // property value, then sort by lastObjectTime ascending so arrivalSeq
+      // assignment matches what would have happened if the subscription arrived
+      // before the publishers.
+      struct RetroTrack {
+        std::string trackName;
+        std::shared_ptr<moxygen::MoQSession> publishSession;
+        std::optional<uint64_t> initialPropertyValue;
+        std::chrono::steady_clock::time_point lastObjectTime;
+      };
+      std::vector<RetroTrack> retroTracks;
+      retroTracks.reserve(current->publishes.size());
+
       for (auto& [trackName, publishSession] : current->publishes) {
         FullTrackName ftn{prefix, trackName};
-        std::optional<uint64_t> initialValue;
+        std::optional<uint64_t> initialPropertyValue;
+        std::chrono::steady_clock::time_point lastObjectTime{};
         auto subIt = subscriptions_.find(ftn);
         if (subIt != subscriptions_.end()) {
-          initialValue = subIt->second.forwarder->extensions().getIntExtension(propertyType);
+          lastObjectTime = subIt->second.lastObjectTime;
+          initialPropertyValue =
+              subIt->second.forwarder->extensions().getIntExtension(propertyType);
           // Wire value-change, track-ended, and activity observers on the existing TopNFilter.
           if (subIt->second.topNFilter) {
             auto rankingPtr = ranking;
@@ -1408,7 +1423,20 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
             );
           }
         }
-        ranking->registerTrack(ftn, initialValue, publishSession);
+        retroTracks.push_back({trackName, publishSession, initialPropertyValue, lastObjectTime});
+      }
+
+      std::sort(
+          retroTracks.begin(),
+          retroTracks.end(),
+          [](const RetroTrack& a, const RetroTrack& b) {
+            return a.lastObjectTime < b.lastObjectTime;
+          }
+      );
+
+      for (const auto& t : retroTracks) {
+        FullTrackName ftn{prefix, t.trackName};
+        ranking->registerTrack(ftn, t.initialPropertyValue, t.publishSession);
         XLOG(DBG4) << "[getOrCreateRanking] Retroactively registered track " << ftn;
       }
 

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -256,7 +256,7 @@ private:
     moxygen::TrackNamespace trackNamespace_;
     folly::F14FastMap<std::string, std::shared_ptr<NamespaceNode>> children;
 
-    // Maps a track name to a the session performing the PUBLISH
+    // Maps a track name to the session performing the PUBLISH
     folly::F14FastMap<std::string, std::shared_ptr<moxygen::MoQSession>> publishes;
 
     // Info stored per SUBSCRIBE_NAMESPACE subscriber
@@ -313,7 +313,8 @@ private:
         std::shared_ptr<moxygen::MoQForwarder> f,
         std::shared_ptr<moxygen::MoQSession> u
     )
-        : forwarder(std::move(f)), upstream(std::move(u)) {}
+        : forwarder(std::move(f)), upstream(std::move(u)),
+          lastObjectTime(std::chrono::steady_clock::now()) {}
 
     std::shared_ptr<moxygen::MoQForwarder> forwarder;
     std::shared_ptr<moxygen::MoQSession> upstream;
@@ -326,8 +327,9 @@ private:
     std::shared_ptr<TopNFilter> topNFilter;
 
     // Written by TopNFilter on every object arrival; read by PropertyRanking::sweepIdle
-    // via the getLastActivity_ callback. Default-constructed (epoch) = always-idle.
-    std::chrono::steady_clock::time_point lastObjectTime{};
+    // via the getLastActivity_ callback. Initialized to now() so newly registered tracks
+    // are not immediately eligible for idle eviction.
+    std::chrono::steady_clock::time_point lastObjectTime;
   };
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;

--- a/src/relay/PropertyRanking.cpp
+++ b/src/relay/PropertyRanking.cpp
@@ -27,7 +27,7 @@ PropertyRanking::PropertyRanking(
 
 void PropertyRanking::registerTrack(
     const moxygen::FullTrackName& ftn,
-    std::optional<uint64_t> initialValue,
+    std::optional<uint64_t> initialPropertyValue,
     std::shared_ptr<moxygen::MoQSession> publisher
 ) {
   XCHECK(publisher) << "registerTrack requires a publisher session";
@@ -36,7 +36,7 @@ void PropertyRanking::registerTrack(
     return;
   }
 
-  uint64_t value = initialValue.value_or(0);
+  uint64_t value = initialPropertyValue.value_or(0);
   RankKey key{value, nextSeq_++};
 
   publisherTrackCount_[publisher.get()]++;

--- a/src/relay/PropertyRanking.h
+++ b/src/relay/PropertyRanking.h
@@ -201,7 +201,7 @@ public:
    */
   void registerTrack(
       const moxygen::FullTrackName& ftn,
-      std::optional<uint64_t> initialValue,
+      std::optional<uint64_t> initialPropertyValue,
       std::shared_ptr<moxygen::MoQSession> publisher
   );
 

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -103,7 +103,10 @@ protected:
           ON_CALL(*consumer, setTrackAlias(_))
               .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
           ON_CALL(*consumer, objectStream(_, _, _))
-              .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+              .WillByDefault(Invoke([this, raw, ftn = pub.fullTrackName](const auto&, auto, bool) {
+                objectsPerTrack_[raw][ftn]++;
+                return folly::makeExpected<MoQPublishError>(folly::unit);
+              }));
           ON_CALL(*consumer, publishDone(_))
               .WillByDefault(Invoke([this, raw, ftn = pub.fullTrackName](PublishDone) mutable {
                 publishDoneCount_[raw][ftn]++;
@@ -139,6 +142,16 @@ protected:
   int publishDoneCount(MockMoQSession* s, const FullTrackName& ftn) const {
     auto it = publishDoneCount_.find(s);
     if (it == publishDoneCount_.end()) {
+      return 0;
+    }
+    auto it2 = it->second.find(ftn);
+    return it2 != it->second.end() ? it2->second : 0;
+  }
+
+  // How many objects were delivered to the session for ftn
+  int objectCount(MockMoQSession* s, const FullTrackName& ftn) const {
+    auto it = objectsPerTrack_.find(s);
+    if (it == objectsPerTrack_.end()) {
       return 0;
     }
     auto it2 = it->second.find(ftn);
@@ -226,7 +239,11 @@ protected:
     ok.trackAlias = TrackAlias(0);
     ok.expires = std::chrono::milliseconds(0);
     ok.groupOrder = GroupOrder::Default;
-    return std::make_shared<NiceMock<MockSubscriptionHandle>>(std::move(ok));
+    auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(std::move(ok));
+    // Configure the mock to return success for requestUpdate calls
+    ON_CALL(*handle, requestUpdateResult())
+        .WillByDefault(Return(folly::makeExpected<RequestError>(RequestOk{})));
+    return handle;
   }
 
   FullTrackName ftn(const std::string& name) const { return FullTrackName{kNs, name}; }
@@ -264,6 +281,8 @@ protected:
 
   // per-session record of which FTNs were pushed via publish()
   std::map<MoQSession*, std::vector<FullTrackName>> publishedTracks_;
+  // per-session, per-FTN count of objectStream() calls received
+  std::map<MoQSession*, std::map<FullTrackName, int>> objectsPerTrack_;
   // per-session, per-FTN count of publishDone() calls received
   std::map<MoQSession*, std::map<FullTrackName, int>> publishDoneCount_;
 };
@@ -340,6 +359,56 @@ TEST_F(MoqxTrackFilterTest, PublishFirst_LateSubscriber_GetsTopN) {
   cA->publishDone(makePublishDone());
   cB->publishDone(makePublishDone());
   cC->publishDone(makePublishDone());
+}
+
+// Initial track property values must drive ranking regardless of publish order.
+// Publish a(40), b(100), c(80): value order selects b+c, but arrivalSeq order
+// would select a+b — verifying that forwarder extensions are used as initialPropertyValue.
+TEST_F(MoqxTrackFilterTest, PublishFirst_LateSubscriber_InitialValuesRankCorrectly) {
+  auto pubSess = makeSession();
+
+  auto cA = doPublish(pubSess, "a", 40);
+  auto cB = doPublish(pubSess, "b", 100);
+  auto cC = doPublish(pubSess, "c", 80);
+  exec_->driveFor(10);
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/2);
+  exec_->driveFor(10);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("c")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 0);
+
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
+  cC->publishDone(makePublishDone());
+}
+
+// Retroactive registration must assign arrivalSeq in lastObjectTime (construction
+// time) ascending order, not alphabetically. Publish in order c→a→b with equal
+// values; alphabetical would select a+b, but publish-time order should select c+a.
+TEST_F(MoqxTrackFilterTest, PublishFirst_LateSubscriber_TieBreaksByPublishTime) {
+  auto pubSess = makeSession();
+
+  auto cC = doPublish(pubSess, "c");
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  auto cA = doPublish(pubSess, "a");
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  auto cB = doPublish(pubSess, "b");
+  exec_->driveFor(10);
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/2);
+  exec_->driveFor(10);
+
+  EXPECT_EQ(publishCount(viewer.get(), ftn("c")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("a")), 1);
+  EXPECT_EQ(publishCount(viewer.get(), ftn("b")), 0);
+
+  cC->publishDone(makePublishDone());
+  cA->publishDone(makePublishDone());
+  cB->publishDone(makePublishDone());
 }
 
 // ---------------------------------------------------------------------------
@@ -513,6 +582,49 @@ TEST_F(MoqxTrackFilterTest, PublishFirst_LateSubscriber_ValueChangeUpdatesRankin
 
   consumerLoud->publishDone(makePublishDone());
   consumerQuiet->publishDone(makePublishDone());
+}
+
+// When selected tracks have not emitted their first object yet, the relay must
+// not idle-evict them before that first cycle completes. This guards the
+// boundary case seen in the live load test where rank N was replaced by N+1.
+TEST_F(MoqxTrackFilterTest, FirstObjectCycle_DoesNotEvictSelectedTracksBeforeFirstObject) {
+  relay_ = std::make_shared<MoqxRelay>(
+      config::CacheConfig{0, 0},
+      /*relayID=*/"",
+      /*maxDeselected=*/0,
+      /*idleTimeout=*/std::chrono::seconds(10),
+      /*activityThreshold=*/std::chrono::milliseconds(1)
+  );
+  relay_->setAllowedNamespacePrefix(kPrefix);
+
+  std::vector<std::shared_ptr<MockMoQSession>> publishers;
+  std::vector<std::shared_ptr<TrackConsumer>> consumers;
+  publishers.reserve(7);
+  consumers.reserve(7);
+
+  for (int i = 0; i < 7; ++i) {
+    auto publisher = makeSession();
+    publishers.push_back(publisher);
+    consumers.push_back(doPublish(publisher, folly::to<std::string>("p", i)));
+  }
+  exec_->driveFor(10);
+
+  auto viewer = makeSession();
+  doSubscribeFilter(viewer, /*maxSelected=*/6);
+  exec_->driveFor(20);
+
+  for (int i = 0; i < 7; ++i) {
+    sendValue(consumers[i], static_cast<uint64_t>(70 - i));
+    exec_->driveFor(5);
+  }
+  exec_->driveFor(30);
+
+  EXPECT_GT(objectCount(viewer.get(), ftn("p5")), 0);
+  EXPECT_EQ(objectCount(viewer.get(), ftn("p6")), 0);
+
+  for (auto& consumer : consumers) {
+    consumer->publishDone(makePublishDone());
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION

- Initialize RelaySubscription::lastObjectTime to now() in the constructor
  so newly registered tracks are not immediately eligible for idle eviction
- In getOrCreateRanking(), sort tracks by lastObjectTime ascending before
  assigning arrivalSeq, so retroactive registration reflects publish order
  and matches what would have happened if the subscription arrived first
- Use forwarder extensions as initial property value during retroactive
  registration

Add three tests:
- FirstObjectCycle: verifies selected tracks are not evicted before their
  first object arrives
- InitialValuesRankCorrectly: verifies forwarder extension values drive
  initial ranking regardless of publish order
- TieBreaksByPublishTime: verifies publish-time order breaks ties in
  retroactive registration, not alphabetical order

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/198)
<!-- Reviewable:end -->
