### PR TITLE
ci: disable macOS PR build, use --use-latest for tarball setup

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -37,10 +37,13 @@ jobs:
             preset: default
             build_dir: build
             runner: ubuntu-22.04
-          - name: macos
-            preset: default
-            build_dir: build
-            runner: macos-latest
+          # macOS disabled: moxygen tarball bakes brew Cellar versioned paths
+          # that break when the runner has different brew package versions.
+          # Re-enable once moxygen upstream fixes cmake to use opt symlinks.
+          # - name: macos
+          #   preset: default
+          #   build_dir: build
+          #   runner: macos-latest
           - name: asan debug
             preset: san
             build_dir: build-san
@@ -65,7 +68,7 @@ jobs:
       - name: Setup dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/build.sh setup
+        run: bash scripts/build.sh setup --use-latest
 
       - name: Build
         run: bash scripts/build.sh --profile ${{ matrix.preset }} --build-dir ${{ matrix.build_dir }}

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -168,6 +168,7 @@ rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 tar xzf "${DOWNLOAD_DIR}/${TARBALL}" -C "$INSTALL_DIR"
 
+
 # ── Write cmake_prefix_path.txt ───────────────────────────────────────────────
 
 echo "$INSTALL_DIR" > "${SCRATCH}/cmake_prefix_path.txt"


### PR DESCRIPTION
## Summary

Two changes to unblock PR CI:

1. **Disable macOS in ci-pr.yml** — moxygen tarball bakes brew Cellar versioned paths (openssl, libsodium, etc.) that break when the GitHub runner has different brew package versions. Commented out with a note to re-enable once moxygen upstream fixes cmake to use stable `/opt/homebrew/opt/*` symlinks.

2. **Use `--use-latest` for PR CI setup** — always grabs the snapshot-latest tarball regardless of submodule pin. Prevents 25+ min source-build fallback when moxygen advances ahead of moqx's submodule. ci-main stays strict (`--from-release --no-fallback`) for production builds.

## Test plan

- [ ] CI passes (check-format, linux, asan debug — no macOS)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/200)
<!-- Reviewable:end -->
