### PR TITLE
hotfix: disable macOS in ci-main, use --use-latest for all builds

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -47,10 +47,13 @@ jobs:
             preset: default
             build_dir: build
             runner: ubuntu-22.04
-          - name: macos
-            preset: default
-            build_dir: build
-            runner: macos-latest
+          # macOS disabled: moxygen tarball bakes brew Cellar versioned paths
+          # that break when the runner has different brew package versions.
+          # Re-enable once moxygen upstream fixes cmake to use opt symlinks.
+          # - name: macos
+          #   preset: default
+          #   build_dir: build
+          #   runner: macos-latest
           - name: asan debug
             preset: san
             build_dir: build-san
@@ -82,7 +85,7 @@ jobs:
       - name: Setup dependencies
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: bash scripts/build.sh setup --from-release --no-fallback
+        run: bash scripts/build.sh setup --use-latest
 
       - name: Build
         run: bash scripts/build.sh --profile ${{ matrix.preset }} --build-dir ${{ matrix.build_dir }}
@@ -125,7 +128,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           MOQX_PLATFORM: bookworm-amd64
-        run: bash scripts/build.sh setup --from-release --no-fallback
+        run: bash scripts/build.sh setup --use-latest
 
       - name: Stage tarball for Docker build
         run: |


### PR DESCRIPTION
## Summary

ci-main is red on all three jobs. Two fixes:

1. **Disable macOS** — same brew Cellar path drift as ci-pr (#200)
2. **Switch verify + publish builds to `--use-latest`** — `--from-release --no-fallback` rejects any submodule SHA that doesn't match snapshot-latest, which breaks whenever moxygen advances ahead of moqx's submodule pin

## Test plan

- [x] CI passes (check-format, linux, asan debug)
- [ ] After merge: ci-main on the merge commit goes green

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/202)
<!-- Reviewable:end -->
