### PR TITLE
hotfix: defer system dep check until source build actually needed

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -128,7 +128,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           MOQX_PLATFORM: bookworm-amd64
-        run: bash scripts/build.sh setup --use-latest
+        run: bash scripts/build.sh setup --use-latest --no-fallback
 
       - name: Stage tarball for Docker build
         run: |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -244,15 +244,9 @@ cmd_setup() {
     fi
   fi
 
-  # Skip system dep check for from-release with --no-fallback (e.g. CI publish
-  # job that only downloads the tarball, doesn't build on the host).
-  if [[ "$mode" != "from-release" ]] || ! $no_fallback; then
-    echo "Checking system dependencies..."
-    if ! check_system_deps; then
-      die "Install missing dependencies and re-run."
-    fi
-    echo "  All system dependencies found."
-  fi
+  # System dep check is deferred until we know a source build is actually
+  # needed (see below). from-release mode downloads a prebuilt tarball and
+  # doesn't need system deps unless it falls back to source.
 
   if $clean; then
     echo "Cleaning .scratch..."
@@ -284,6 +278,11 @@ cmd_setup() {
   fi
 
   if [[ "$mode" == "from-source" ]]; then
+    echo "Checking system dependencies..."
+    if ! check_system_deps; then
+      die "Install missing dependencies and re-run."
+    fi
+    echo "  All system dependencies found."
     echo ""
     echo "==> Setting up dependencies (from source)..."
     bash "$SCRIPT_DIR/setup-deps-standalone.sh" --profile "$profile"


### PR DESCRIPTION
## Summary

`build.sh setup` checked system deps (libssl-dev, libglog-dev, etc.) eagerly — before even attempting the tarball download. This caused the publish job to fail on bare ubuntu-22.04 runners that only need to download a tarball, never compile.

### Fix

Move the dep check from before-tarball-attempt to right-before-source-build. The check now only runs when `mode == from-source` (either explicitly or after falling back from a failed tarball download). `from-release` paths never hit the check.

Also adds `--no-fallback` to ci-main's publish job setup call — publish only downloads a tarball for Docker image building, never compiles moxygen.

### Tested locally

```
--use-latest               → skips dep check, downloads tarball ✓
--use-latest --no-fallback → skips dep check, downloads tarball ✓
--from-source              → checks deps before source build ✓
```

## Test plan

- [x] CI passes (check-format, linux, asan debug)
- [ ] After merge: ci-main publish job succeeds on bare runner

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/203)
<!-- Reviewable:end -->
