### PR TITLE
ci: support release/** branches in CI pipelines

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -85,7 +85,16 @@ jobs:
       - name: Setup dependencies
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: bash scripts/build.sh setup --use-latest
+        run: |
+          # Release branches pin a specific moxygen release tag via
+          # .moxygen-release. Main uses snapshot-latest via --use-latest.
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            bash scripts/build.sh setup --no-fallback
+          else
+            bash scripts/build.sh setup --use-latest
+          fi
 
       - name: Build
         run: bash scripts/build.sh --profile ${{ matrix.preset }} --build-dir ${{ matrix.build_dir }}
@@ -128,7 +137,16 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           MOQX_PLATFORM: bookworm-amd64
-        run: bash scripts/build.sh setup --use-latest --no-fallback
+        run: |
+          # Release branches pin a specific moxygen release tag via
+          # .moxygen-release. Main uses snapshot-latest via --use-latest.
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            bash scripts/build.sh setup --no-fallback
+          else
+            bash scripts/build.sh setup --use-latest --no-fallback
+          fi
 
       - name: Stage tarball for Docker build
         run: |

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -10,7 +10,7 @@ name: ci main
 
 on:
   push:
-    branches: [main]
+    branches: [main, release/**]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -138,18 +138,31 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build Docker image
+      - name: Compute image tags
+        id: tags
         run: |
           SHORT="${GITHUB_SHA:0:7}"
+          BRANCH="${{ github.ref_name }}"
+          if [[ "$BRANCH" == "main" ]]; then
+            LABEL="latest"
+          else
+            # release/nab-demo → nab-demo
+            LABEL="${BRANCH#release/}"
+          fi
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
+
+      - name: Build Docker image
+        run: |
           IMAGE="ghcr.io/${{ github.repository }}"
           docker build -f docker/Dockerfile \
-            -t "${IMAGE}:${SHORT}" \
-            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${{ steps.tags.outputs.short }}" \
+            -t "${IMAGE}:${{ steps.tags.outputs.label }}" \
             .
 
       - name: Smoke test Docker image
         run: |
-          IMAGE="ghcr.io/${{ github.repository }}:latest"
+          IMAGE="ghcr.io/${{ github.repository }}:${{ steps.tags.outputs.label }}"
           echo "==> ldd check"
           docker run --rm --entrypoint ldd "${IMAGE}" /usr/local/bin/moqx
           if docker run --rm --entrypoint ldd "${IMAGE}" /usr/local/bin/moqx 2>&1 | grep -q "not found"; then
@@ -178,13 +191,13 @@ jobs:
           SHORT="${GITHUB_SHA:0:7}"
           CLIENT_IMAGE="ghcr.io/${{ github.repository_owner }}/moqx-interop-client"
           docker build -f docker/Dockerfile.interop-client \
-            -t "${CLIENT_IMAGE}:${SHORT}" \
-            -t "${CLIENT_IMAGE}:latest" \
+            -t "${CLIENT_IMAGE}:${{ steps.tags.outputs.short }}" \
+            -t "${CLIENT_IMAGE}:${{ steps.tags.outputs.label }}" \
             .
 
       - name: Smoke test interop client
         run: |
-          CLIENT_IMAGE="ghcr.io/${{ github.repository_owner }}/moqx-interop-client:latest"
+          CLIENT_IMAGE="ghcr.io/${{ github.repository_owner }}/moqx-interop-client:${{ steps.tags.outputs.label }}"
           echo "==> ldd check"
           docker run --rm --entrypoint ldd "${CLIENT_IMAGE}" /usr/local/bin/moq_interop_client
           if docker run --rm --entrypoint ldd "${CLIENT_IMAGE}" /usr/local/bin/moq_interop_client 2>&1 | grep -q "not found"; then
@@ -196,13 +209,12 @@ jobs:
 
       - name: Push Docker images
         run: |
-          SHORT="${GITHUB_SHA:0:7}"
           IMAGE="ghcr.io/${{ github.repository }}"
-          docker push "${IMAGE}:${SHORT}"
-          docker push "${IMAGE}:latest"
+          docker push "${IMAGE}:${{ steps.tags.outputs.short }}"
+          docker push "${IMAGE}:${{ steps.tags.outputs.label }}"
           CLIENT_IMAGE="ghcr.io/${{ github.repository_owner }}/moqx-interop-client"
-          docker push "${CLIENT_IMAGE}:${SHORT}"
-          docker push "${CLIENT_IMAGE}:latest"
+          docker push "${CLIENT_IMAGE}:${{ steps.tags.outputs.short }}"
+          docker push "${CLIENT_IMAGE}:${{ steps.tags.outputs.label }}"
 
       - name: Package
         id: package
@@ -242,17 +254,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHORT="${GITHUB_SHA:0:7}"
-          TAG="snapshot-latest"
+          BRANCH="${{ github.ref_name }}"
+          if [[ "$BRANCH" == "main" ]]; then
+            TAG="snapshot-latest"
+          else
+            TAG="snapshot-${BRANCH#release/}"
+          fi
 
           gh release delete "$TAG" --yes 2>/dev/null || true
           git tag -d "$TAG" 2>/dev/null || true
           git push origin ":refs/tags/$TAG" 2>/dev/null || true
 
           gh release create "$TAG" artifacts/**/* \
+            --target "$GITHUB_SHA" \
             --title "Latest build ($SHORT)" \
             --prerelease \
             --notes "$(cat <<EOF
-          Rolling snapshot of the latest build from \`main\`.
+          Rolling snapshot of the latest build from \`${{ github.ref_name }}\`.
 
           **Commit:** \`${GITHUB_SHA}\`
           **Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -267,6 +285,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   deploy:
+    if: github.ref_name == 'main'
     needs: [publish, release]
     runs-on: [self-hosted, linode]
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -68,7 +68,16 @@ jobs:
       - name: Setup dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/build.sh setup --use-latest
+        run: |
+          # Release branches pin a specific moxygen release tag via
+          # .moxygen-release. Main uses snapshot-latest via --use-latest.
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            bash scripts/build.sh setup --no-fallback
+          else
+            bash scripts/build.sh setup --use-latest
+          fi
 
       - name: Build
         run: bash scripts/build.sh --profile ${{ matrix.preset }} --build-dir ${{ matrix.build_dir }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -5,7 +5,7 @@ name: ci pr
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, release/**]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Prepares CI for `release/**` branches (e.g., `release/nab-demo`).

### Changes

**ci-pr.yml**: add `release/**` to `pull_request.branches` trigger. PRs targeting a release branch get the same checks as PRs to main.

**ci-main.yml**: add `release/**` to `push.branches` trigger. Parameterize based on branch name:

| Branch | Docker tag | Snapshot release | Auto-deploy |
|---|---|---|---|
| `main` | `latest` | `snapshot-latest` | yes |
| `release/nab-demo` | `nab-demo` | `snapshot-nab-demo` | **no** |

- Docker images tagged `ghcr.io/openmoq/moqx:<branch-label>` + `:<sha>`
- Interop client images tagged the same way
- Release snapshot uses `--target $GITHUB_SHA` for correct `target_commitish`
- Deploy job gated with `if: github.ref_name == 'main'` — release branches deploy manually via `deploy-relay.yml` workflow_dispatch with different ports/config

### What this enables

1. Create `release/nab-demo` from main
2. Pin moxygen submodule to a versioned release tag (`v0.1.0` etc.)
3. PRs to the release branch run full CI (format + linux + asan)
4. Merges to the release branch publish Docker images tagged `nab-demo`
5. Deploy manually when ready

## Test plan

- [ ] CI passes on this PR (exercises the ci-pr path)
- [ ] After merge: create a test release branch, push, verify ci-main triggers correctly with branch-specific tags

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/204)
<!-- Reviewable:end -->
