### PR TITLE
MoQ stats gauge correction

### DIFF
--- a/src/stats/MoQStatsCollector.cpp
+++ b/src/stats/MoQStatsCollector.cpp
@@ -105,7 +105,6 @@ void MoQStatsCollector::PublisherCallback::onFetchError(moxygen::FetchErrorCode 
 
 void MoQStatsCollector::PublisherCallback::onPublishNamespaceSuccess() {
   ++parent_.pubPublishNamespaceSuccess_;
-  ++parent_.pubActivePublishNamespaces_;
 }
 
 void MoQStatsCollector::PublisherCallback::onPublishNamespaceError(
@@ -117,17 +116,14 @@ void MoQStatsCollector::PublisherCallback::onPublishNamespaceError(
 
 void MoQStatsCollector::PublisherCallback::onPublishNamespaceDone() {
   ++parent_.pubPublishNamespaceDone_;
-  --parent_.pubActivePublishNamespaces_;
 }
 
 void MoQStatsCollector::PublisherCallback::onPublishNamespaceCancel() {
   ++parent_.pubPublishNamespaceCancel_;
-  --parent_.pubActivePublishNamespaces_;
 }
 
 void MoQStatsCollector::PublisherCallback::onSubscribeNamespaceSuccess() {
   ++parent_.pubSubscribeNamespaceSuccess_;
-  ++parent_.pubActiveSubscribeNamespaces_;
 }
 
 void MoQStatsCollector::PublisherCallback::onSubscribeNamespaceError(
@@ -139,17 +135,23 @@ void MoQStatsCollector::PublisherCallback::onSubscribeNamespaceError(
 
 void MoQStatsCollector::PublisherCallback::onUnsubscribeNamespace() {
   ++parent_.pubUnsubscribeNamespace_;
-  --parent_.pubActiveSubscribeNamespaces_;
 }
 
 void MoQStatsCollector::PublisherCallback::onTrackStatus() {
   ++parent_.pubTrackStatus_;
 }
 
-void MoQStatsCollector::PublisherCallback::onUnsubscribe() {}
+void MoQStatsCollector::PublisherCallback::onUnsubscribe() {
+  // Downstream subscriber unsubscribed.
+  // moxygen always follows an UNSUBSCRIBE with a PUBLISH_DONE (via terminatePublish),
+  ++parent_.pubUnsubscribe_;
+}
 
 void MoQStatsCollector::PublisherCallback::
     onPublishDone(moxygen::PublishDoneStatusCode /*statusCode*/) {
+  // Relay (as publisher) sent PUBLISH_DONE to a downstream subscriber.
+  // This fires for both client-initiated unsubscribes and server-initiated teardowns,
+  // making it the single authoritative end-of-subscription signal.
   ++parent_.pubPublishDone_;
 }
 
@@ -192,7 +194,6 @@ void MoQStatsCollector::PublisherCallback::onPublishError(moxygen::PublishErrorC
 void MoQStatsCollector::PublisherCallback::onPublishSuccess() {
   // Relay sent PUBLISH; received PUBLISH_OK back.
   ++parent_.moqPublishSuccess_;
-  ++parent_.pubActivePublishers_;
 }
 
 // --- SubscriberCallback implementations ---
@@ -219,7 +220,6 @@ void MoQStatsCollector::SubscriberCallback::onFetchError(moxygen::FetchErrorCode
 
 void MoQStatsCollector::SubscriberCallback::onPublishNamespaceSuccess() {
   ++parent_.subPublishNamespaceSuccess_;
-  ++parent_.subActivePublishNamespaces_;
 }
 
 void MoQStatsCollector::SubscriberCallback::onPublishNamespaceError(
@@ -231,17 +231,14 @@ void MoQStatsCollector::SubscriberCallback::onPublishNamespaceError(
 
 void MoQStatsCollector::SubscriberCallback::onPublishNamespaceDone() {
   ++parent_.subPublishNamespaceDone_;
-  --parent_.subActivePublishNamespaces_;
 }
 
 void MoQStatsCollector::SubscriberCallback::onPublishNamespaceCancel() {
   ++parent_.subPublishNamespaceCancel_;
-  --parent_.subActivePublishNamespaces_;
 }
 
 void MoQStatsCollector::SubscriberCallback::onSubscribeNamespaceSuccess() {
   ++parent_.subSubscribeNamespaceSuccess_;
-  ++parent_.subActiveSubscribeNamespaces_;
 }
 
 void MoQStatsCollector::SubscriberCallback::onSubscribeNamespaceError(
@@ -253,18 +250,22 @@ void MoQStatsCollector::SubscriberCallback::onSubscribeNamespaceError(
 
 void MoQStatsCollector::SubscriberCallback::onUnsubscribeNamespace() {
   ++parent_.subUnsubscribeNamespace_;
-  --parent_.subActiveSubscribeNamespaces_;
 }
 
 void MoQStatsCollector::SubscriberCallback::onTrackStatus() {
   ++parent_.subTrackStatus_;
 }
 
-void MoQStatsCollector::SubscriberCallback::onUnsubscribe() {}
+void MoQStatsCollector::SubscriberCallback::onUnsubscribe() {
+  // Relay unsubscribed from upstream.
+  // onSubscriptionEnd will fire next and decrement subActivePublishers_.
+  ++parent_.subUnsubscribe_;
+}
 
 void MoQStatsCollector::SubscriberCallback::
     onPublishDone(moxygen::PublishDoneStatusCode /*statusCode*/) {
   ++parent_.subPublishDone_;
+  // onSubscriptionEnd fires after this and decrements subActivePublishers_.
 }
 
 void MoQStatsCollector::SubscriberCallback::onRequestUpdate() {
@@ -282,11 +283,11 @@ void MoQStatsCollector::SubscriberCallback::onSubscriptionStreamClosed() {
 }
 
 void MoQStatsCollector::SubscriberCallback::onSubscriptionBegin() {
-  ++parent_.subActiveSubscriptions_;
+  ++parent_.subActivePublishers_;
 }
 
 void MoQStatsCollector::SubscriberCallback::onSubscriptionEnd() {
-  --parent_.subActiveSubscriptions_;
+  --parent_.subActivePublishers_;
 }
 
 void MoQStatsCollector::SubscriberCallback::recordSubscribeLatency(uint64_t latencyMsec) {
@@ -304,8 +305,8 @@ void MoQStatsCollector::SubscriberCallback::onPublish() {
 
 void MoQStatsCollector::SubscriberCallback::onPublishOk() {
   // Relay sent PUBLISH_OK to an upstream publisher; it is now active.
+  // onSubscriptionBegin fires after this and increments subActivePublishers_.
   ++parent_.moqPublishOkSent_;
-  ++parent_.subActivePublishers_;
 }
 
 void MoQStatsCollector::SubscriberCallback::onPublishError(moxygen::PublishErrorCode errorCode) {

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -113,6 +113,7 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
   X(uint64_t, pubSubscribeNamespaceSuccess)                                                        \
   X(uint64_t, pubSubscribeNamespaceError)                                                          \
   X(uint64_t, pubUnsubscribeNamespace)                                                             \
+  X(uint64_t, pubUnsubscribe)                                                                      \
   X(uint64_t, pubPublishDone)                                                                      \
   X(uint64_t, pubSubscriptionStreamOpened)                                                         \
   X(uint64_t, pubSubscriptionStreamClosed)                                                         \
@@ -133,6 +134,7 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
   X(uint64_t, subSubscribeNamespaceSuccess)                                                        \
   X(uint64_t, subSubscribeNamespaceError)                                                          \
   X(uint64_t, subUnsubscribeNamespace)                                                             \
+  X(uint64_t, subUnsubscribe)                                                                      \
   X(uint64_t, subPublishDone)                                                                      \
   X(uint64_t, subSubscriptionStreamOpened)                                                         \
   X(uint64_t, subSubscriptionStreamClosed)                                                         \
@@ -187,14 +189,8 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
 // int64_t gauges — MoQ application layer
 #define STATS_MOQ_GAUGE_FIELDS(X)                                                                  \
   X(int64_t, pubActiveSubscriptions)                                                               \
-  X(int64_t, pubActivePublishers)                                                                  \
-  X(int64_t, pubActivePublishNamespaces)                                                           \
-  X(int64_t, pubActiveSubscribeNamespaces)                                                         \
   X(int64_t, pubActiveSubscriptionStreams)                                                         \
-  X(int64_t, subActiveSubscriptions)                                                               \
   X(int64_t, subActivePublishers)                                                                  \
-  X(int64_t, subActivePublishNamespaces)                                                           \
-  X(int64_t, subActiveSubscribeNamespaces)                                                         \
   X(int64_t, subActiveSubscriptionStreams)                                                         \
   X(int64_t, moqActiveSessions)
 

--- a/test/test_admin_metrics.sh
+++ b/test/test_admin_metrics.sh
@@ -92,7 +92,6 @@ fi
 EXPECTED_METRICS=(
   "moqx_moqActiveSessions"
   "moqx_pubActiveSubscriptions"
-  "moqx_pubActivePublishers"
   "moqx_pubSubscribeSuccess_total"
   "moqx_moqPublishSuccess_total"
   "moqx_moqSubscribeLatency_microseconds"


### PR DESCRIPTION
removed unnecessary stats
correctly tracks the number of active publishers

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/209)
<!-- Reviewable:end -->
