### PR TITLE
feat: set forward=false on peer SUBSCRIBE_NAMESPACE

### DIFF
--- a/src/UpstreamProvider.cpp
+++ b/src/UpstreamProvider.cpp
@@ -32,6 +32,7 @@ SubscribeNamespace makePeerSubNs(std::optional<std::string> relayID) {
   SubscribeNamespace subNs;
   subNs.trackNamespacePrefix = {};
   subNs.options = SubscribeNamespaceOptions::BOTH;
+  subNs.forward = false;
   if (relayID) {
     subNs.params.insertParam(Parameter(
         static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),

--- a/test/UpstreamProviderTest.cpp
+++ b/test/UpstreamProviderTest.cpp
@@ -101,9 +101,11 @@ TEST(PeerSubNsHelpers, PeerSubNsRoundTrip) {
   EXPECT_EQ(*id, "my-relay-id");
   EXPECT_EQ(withID.trackNamespacePrefix, TrackNamespace{});
   EXPECT_EQ(withID.options, SubscribeNamespaceOptions::BOTH);
+  EXPECT_FALSE(withID.forward);
 
   auto withoutID = makePeerSubNs();
   EXPECT_FALSE(getPeerRelayID(withoutID).has_value());
+  EXPECT_FALSE(withoutID.forward);
 }
 
 TEST(PeerSubNsHelpers, NormalSubNsIsNotPeer) {


### PR DESCRIPTION
A relay-to-relay peering subNs is used to discover namespace topology, not to request object delivery. forward=true (the default) would incorrectly signal the upstream that it should start streaming objects before any downstream client has subscribed.

Set forward=false in makePeerSubNs() and add assertions in the PeerSubNsRoundTrip test to pin this behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/214)
<!-- Reviewable:end -->
