### PR TITLE
fix: emit null for last_write_ms_ago on never-written tracks

### DIFF
--- a/src/admin/JsonWriter.h
+++ b/src/admin/JsonWriter.h
@@ -73,6 +73,11 @@ public:
     append(std::to_string(v));
     needsComma_ = true;
   }
+  void nullVal() {
+    maybeComma();
+    append("null");
+    needsComma_ = true;
+  }
 
   void field(std::string_view k, std::string_view v) {
     key(k);

--- a/src/admin/StateHandler.cpp
+++ b/src/admin/StateHandler.cpp
@@ -132,8 +132,14 @@ public:
       w_.endArray();
       w_.field("track_name", t.name.trackName);
       w_.field("end_of_track", t.endOfTrack);
-      auto msAgo = std::chrono::duration_cast<std::chrono::milliseconds>(now - t.lastWrite).count();
-      w_.field("last_write_ms_ago", static_cast<int64_t>(msAgo));
+      w_.key("last_write_ms_ago");
+      if (t.lastWrite == decltype(t.lastWrite)::min()) {
+        w_.nullVal();
+      } else {
+        auto msAgo =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - t.lastWrite).count();
+        w_.intVal(static_cast<int64_t>(msAgo));
+      }
       w_.key("groups");
       w_.beginArray();
       for (const auto& g : t.groups) {


### PR DESCRIPTION
Tracks allocated but never written have lastWrite == TimePoint::min(). Computing now - TimePoint::min() overflows int64_t, producing ~-9.22e12. Check for the sentinel and emit JSON null instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/217)
<!-- Reviewable:end -->
