### PR TITLE
fix: suppress peer namespace echo on reconnect

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -24,8 +24,12 @@ namespace openmoq::moqx {
 // no handle map needed.
 class MoqxRelayNamespaceHandle : public Publisher::NamespacePublishHandle {
 public:
-  MoqxRelayNamespaceHandle(std::weak_ptr<MoqxRelay> relay, std::shared_ptr<MoQSession> session)
-      : relay_(std::move(relay)), session_(std::move(session)) {}
+  MoqxRelayNamespaceHandle(
+      std::weak_ptr<MoqxRelay> relay,
+      std::shared_ptr<MoQSession> session,
+      std::string peerID = {}
+  )
+      : relay_(std::move(relay)), session_(std::move(session)), peerID_(std::move(peerID)) {}
 
   void namespaceMsg(const TrackNamespace& suffix) override {
     auto relay = relay_.lock();
@@ -34,7 +38,7 @@ public:
     }
     PublishNamespace pubNs;
     pubNs.trackNamespace = suffix;
-    relay->doPublishNamespace(std::move(pubNs), session_, nullptr);
+    relay->doPublishNamespace(std::move(pubNs), session_, nullptr, peerID_);
   }
 
   void namespaceDoneMsg(const TrackNamespace& suffix) override {
@@ -48,11 +52,19 @@ public:
 private:
   std::weak_ptr<MoqxRelay> relay_;
   std::shared_ptr<MoQSession> session_;
+  std::string peerID_;
 };
 
-std::shared_ptr<Publisher::NamespacePublishHandle>
-makeNamespaceBridgeHandle(std::weak_ptr<MoqxRelay> relay, std::shared_ptr<MoQSession> session) {
-  return std::make_shared<MoqxRelayNamespaceHandle>(std::move(relay), std::move(session));
+std::shared_ptr<Publisher::NamespacePublishHandle> makeNamespaceBridgeHandle(
+    std::weak_ptr<MoqxRelay> relay,
+    std::shared_ptr<MoQSession> session,
+    std::string peerID
+) {
+  return std::make_shared<MoqxRelayNamespaceHandle>(
+      std::move(relay),
+      std::move(session),
+      std::move(peerID)
+  );
 }
 
 folly::coro::Task<void> MoqxRelay::onUpstreamConnect(std::shared_ptr<MoQSession> session) {
@@ -150,7 +162,8 @@ std::shared_ptr<MoqxRelay::NamespaceNode> MoqxRelay::findNamespaceNode(
 std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespace(
     PublishNamespace pubNs,
     std::shared_ptr<MoQSession> session,
-    std::shared_ptr<Subscriber::PublishNamespaceCallback> callback
+    std::shared_ptr<Subscriber::PublishNamespaceCallback> callback,
+    std::string peerID
 ) {
   XLOG(DBG1) << __func__ << " ns=" << pubNs.trackNamespace;
   // check auth
@@ -204,6 +217,7 @@ std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespac
 
   bool wasEmpty = !nodePtr->hasLocalSessions();
   nodePtr->sourceSession = session;
+  nodePtr->sourcePeerID = std::move(peerID);
   nodePtr->publishNamespaceCallback = std::move(callback);
   nodePtr->trackNamespace_ = pubNs.trackNamespace;
   nodePtr->setPublishNamespaceOk({.requestID = pubNs.requestID, .requestSpecificParams = {}});
@@ -353,6 +367,7 @@ void MoqxRelay::doPublishNamespaceDone(
   }
 
   nodePtr->sourceSession = nullptr;
+  nodePtr->sourcePeerID.clear();
   nodePtr->publishNamespaceCallback.reset();
 
   // Notify downstream namespace subscribers
@@ -742,10 +757,14 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   // Relay peering: if the incoming subNs carries a relay auth token, the peer
   // is a relay. Reciprocate with our own peer subNs so the peer gets our
   // namespace announcements as publishers connect.
+  std::string incomingPeerID;
   if (auto peerID = !relayID_.empty() ? getPeerRelayID(subNs) : std::nullopt) {
+    incomingPeerID = *peerID;
     XLOG(INFO) << __func__ << ": peer relay detected peer_id=" << *peerID
                << ", reciprocating peer subNs";
-    auto handle = makeNamespaceBridgeHandle(weak_from_this(), session);
+    // Tag with the peer's relay ID so we suppress echoing these namespaces
+    // back to that peer on reconnect.
+    auto handle = makeNamespaceBridgeHandle(weak_from_this(), session, incomingPeerID);
     auto recipResult = co_await session->subscribeNamespace(
         makePeerSubNs(),
         handle
@@ -822,7 +841,8 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   while (!nodes.empty()) {
     auto [prefix, nodePtr] = std::move(*nodes.begin());
     nodes.pop_front();
-    if (nodePtr->sourceSession && nodePtr->sourceSession != session) {
+    if (nodePtr->sourceSession && nodePtr->sourceSession != session &&
+        (incomingPeerID.empty() || nodePtr->sourcePeerID != incomingPeerID)) {
       if (getDraftMajorVersion(*maybeNegotiatedVersion) >= 16) {
         if (subNs.options == SubscribeNamespaceOptions::NAMESPACE ||
             subNs.options == SubscribeNamespaceOptions::BOTH) {

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -203,7 +203,8 @@ public:
   std::shared_ptr<moxygen::Subscriber::PublishNamespaceHandle> doPublishNamespace(
       moxygen::PublishNamespace pubNs,
       std::shared_ptr<moxygen::MoQSession> session,
-      std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback> callback
+      std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback> callback,
+      std::string peerID = {}
   );
 
   void doPublishNamespaceDone(
@@ -291,6 +292,8 @@ private:
         namespacesPublished;
     // The session that PUBLISH_NAMESPACEd this node
     std::shared_ptr<moxygen::MoQSession> sourceSession;
+    // Peer relay ID that sourced this namespace (empty for local publishers)
+    std::string sourcePeerID;
     std::shared_ptr<PublishNamespaceCallback> publishNamespaceCallback;
 
     MoqxRelay& relay_;
@@ -441,7 +444,8 @@ private:
 // Used for both the initiating (UpstreamProvider) and reciprocal (MoqxRelay) paths.
 std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> makeNamespaceBridgeHandle(
     std::weak_ptr<MoqxRelay> relay,
-    std::shared_ptr<moxygen::MoQSession> session
+    std::shared_ptr<moxygen::MoQSession> session,
+    std::string peerID = {}
 );
 
 } // namespace openmoq::moqx

--- a/test/MoqxRelayTest.cpp
+++ b/test/MoqxRelayTest.cpp
@@ -8,6 +8,7 @@
 
 #include "MoqxRelay.h"
 #include "TestUtils.h"
+#include "UpstreamProvider.h"
 #include <folly/coro/BlockingWait.h>
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/GMock.h>
@@ -3272,6 +3273,174 @@ TEST_F(MoQRelayTest, Subscribe_SecondForwardingSubscriber_SingleRequestUpdate) {
   for (int i = 0; i < 3; i++) {
     exec_->drive();
   }
+}
+
+// ============================================================
+// Peer relay namespace loop prevention tests
+// ============================================================
+
+// Regression test: when a peer relay reconnects and subscribes to our
+// namespaces, we must not echo back namespaces that originally came FROM that
+// peer — doing so overwrites the real publisher in the namespace tree and
+// breaks data flow for downstream subscribers.
+//
+// Scenario (relay acts as sg-sin-2-1, upstream is jp-osa-1):
+//   1. jp-osa-1 (session1) announces namespace NS to our relay.
+//   2. session1 drops (old QUIC connection not yet reaped).
+//   3. jp-osa-1 reconnects (session2) and sends a peer SUBSCRIBE_NAMESPACE.
+//   4. Bug: the relay walks its tree, finds NS with sourceSession=session1,
+//      session1 != session2, and delivers NS back to session2 — echo loop.
+//   5. Fix: NS is tagged with sourcePeerID="jp-osa-1" so the peer ID check
+//      suppresses the delivery regardless of session identity.
+//
+// Production relays negotiate draft-16 (empty prefix allowed).  The delivery
+// path for draft-16 is synchronous: namespacePublishHandle->namespaceMsg().
+TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBackOnReconnect) {
+  // Relay must have a relayID for peer detection to activate.
+  relay_ = std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1");
+  relay_->setAllowedNamespacePrefix(kAllowedPrefix);
+
+  // Step 1: session1 is the peer's old (unreaped) connection.  Inject NS as
+  // if it arrived from peer "jp-osa-1" via the bridge handle.
+  auto session1 = createMockSession();
+  auto bridgeHandle = makeNamespaceBridgeHandle(relay_, session1, "jp-osa-1");
+  bridgeHandle->namespaceMsg(kTestNamespace);
+  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+
+  // Step 2: jp-osa-1 reconnects as session2 and sends a peer SUBSCRIBE_NAMESPACE.
+  // Peer-to-peer sessions negotiate draft-16 (empty prefix is a 16+ feature).
+  auto session2 = createMockSession();
+  ON_CALL(*session2, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft16)));
+
+  // The relay delivers existing namespaces via namespacePublishHandle->namespaceMsg
+  // (draft-16 synchronous path).  Use a mock handle to detect any echo.
+  auto nsHandle = std::make_shared<NiceMock<MockNamespacePublishHandle>>();
+  bool echoedBack = false;
+  ON_CALL(*nsHandle, namespaceMsg(_)).WillByDefault([&echoedBack](const TrackNamespace&) {
+    echoedBack = true;
+  });
+
+  withSessionContext(session2, [&]() {
+    // makePeerSubNs("jp-osa-1") carries jp-osa-1's relay ID in the auth token.
+    auto task = relay_->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle);
+    folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  EXPECT_FALSE(echoedBack) << "Relay echoed a peer's own namespace back to it on reconnect";
+
+  removeSession(session1);
+  removeSession(session2);
+}
+
+// Complement: namespaces from LOCAL publishers (not from the peer) must still
+// be delivered when that peer subscribes.
+TEST_F(MoQRelayTest, LocalNamespaceDeliveredToPeerOnReconnect) {
+  relay_ = std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1");
+  relay_->setAllowedNamespacePrefix(kAllowedPrefix);
+
+  // Local publisher session announces kTestNamespace.
+  auto localPublisher = createMockSession();
+  doPublishNamespace(localPublisher, kTestNamespace);
+
+  // Peer "jp-osa-1" subscribes with a draft-16 session.
+  auto peerSession = createMockSession();
+  ON_CALL(*peerSession, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft16)));
+
+  auto nsHandle = std::make_shared<NiceMock<MockNamespacePublishHandle>>();
+  bool delivered = false;
+  ON_CALL(*nsHandle, namespaceMsg(_)).WillByDefault([&delivered](const TrackNamespace&) {
+    delivered = true;
+  });
+
+  withSessionContext(peerSession, [&]() {
+    auto task = relay_->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle);
+    folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+  EXPECT_TRUE(delivered) << "Relay failed to deliver a local namespace to a peer subscriber";
+
+  removeSession(localPublisher);
+  removeSession(peerSession);
+}
+
+// A mock session that simulates a peer announcing peerNs when the relay
+// calls subscribeNamespace on it (the reciprocal leg).
+class PeerAnnounceSession : public NiceMock<MockMoQSession> {
+public:
+  explicit PeerAnnounceSession(std::shared_ptr<MoQExecutor> exec, TrackNamespace peerNs)
+      : NiceMock<MockMoQSession>(std::move(exec)), peerNs_(std::move(peerNs)) {}
+
+  folly::coro::Task<Publisher::SubscribeNamespaceResult> subscribeNamespace(
+      SubscribeNamespace subNs,
+      std::shared_ptr<Publisher::NamespacePublishHandle> handle
+  ) override {
+    if (handle) {
+      handle->namespaceMsg(peerNs_);
+    }
+    co_return std::make_shared<NiceMock<MockSubscribeNamespaceHandle>>(
+        SubscribeNamespaceOk{subNs.requestID}
+    );
+  }
+
+private:
+  TrackNamespace peerNs_;
+};
+
+// Full production-path regression test: verifies that the peerID stored on
+// namespace nodes via the reciprocal bridge handle is the INCOMING peer's relay
+// ID (not our own relayID_).
+//
+// Bug: makeNamespaceBridgeHandle was passed relayID_ ("sg-sin-2-1") instead of
+// incomingPeerID ("jp-osa-1"), so nodes got sourcePeerID="sg-sin-2-1".  On
+// reconnect the check "sg-sin-2-1" != "jp-osa-1" is true and the namespace
+// was echoed back — the loop survived.
+//
+// Unlike PeerNamespaceNotEchoedBackOnReconnect (which injects the namespace
+// directly via makeNamespaceBridgeHandle), this test goes through the full
+// relay_->subscribeNamespace() production path so the bug in the call-site is
+// exercised.
+TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBack_FullProductionPath) {
+  relay_ = std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1");
+  relay_->setAllowedNamespacePrefix(kAllowedPrefix);
+
+  // Step 1: jp-osa-1 connects as session1.  It will announce kTestNamespace
+  // to us via the reciprocal bridge handle when we subscribe to it.
+  auto session1 = std::make_shared<PeerAnnounceSession>(exec_, kTestNamespace);
+  ON_CALL(*session1, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft16)));
+  getOrCreateMockState(session1);
+
+  auto nsHandle1 = std::make_shared<NiceMock<MockNamespacePublishHandle>>();
+  withSessionContext(session1, [&]() {
+    auto task = relay_->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle1);
+    folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  // kTestNamespace should now be in the tree with sourcePeerID="jp-osa-1".
+  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+
+  // Step 2: jp-osa-1 reconnects as session2 and re-subscribes.
+  // kTestNamespace must NOT be echoed back.
+  auto session2 = createMockSession();
+  ON_CALL(*session2, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft16)));
+
+  auto nsHandle2 = std::make_shared<NiceMock<MockNamespacePublishHandle>>();
+  bool echoedBack = false;
+  ON_CALL(*nsHandle2, namespaceMsg(_)).WillByDefault([&echoedBack](const TrackNamespace&) {
+    echoedBack = true;
+  });
+
+  withSessionContext(session2, [&]() {
+    auto task = relay_->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle2);
+    folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  EXPECT_FALSE(echoedBack) << "Relay echoed peer namespace back on reconnect (production path)";
+
+  removeSession(session1);
+  removeSession(session2);
 }
 
 } // namespace moxygen::test


### PR DESCRIPTION
When a peer relay reconnects and sends SUBSCRIBE_NAMESPACE, the relay was echoing back namespaces that originally came from that peer because the session identity check (sourceSession != newSession) passed for the new connection.

Tag each NamespaceNode with sourcePeerID and skip delivery when that ID matches the subscribing peer's relay ID, regardless of session identity. Also clear sourcePeerID in doPublishNamespaceDone alongside sourceSession so nodes never carry a stale peer tag after retraction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/218)
<!-- Reviewable:end -->
