### PR TITLE
feat: include publisher address and peer ID in /state namespace tree

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1566,7 +1566,17 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
   visitor.onNamespaceTreeBegin();
   std::function<void(std::string_view, const NamespaceNode&)> walkNode;
   walkNode = [&](std::string_view childKey, const NamespaceNode& node) {
-    visitor.beginNamespaceNode(childKey, node.trackNamespace_, node.sessions.size());
+    std::string publisherAddr;
+    if (node.sourceSession) {
+      publisherAddr = node.sourceSession->getPeerAddress().describe();
+    }
+    visitor.beginNamespaceNode(
+        childKey,
+        node.trackNamespace_,
+        node.sessions.size(),
+        publisherAddr,
+        node.sourcePeerID
+    );
     for (const auto& [key, child] : node.children) {
       walkNode(key, *child);
     }

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -70,7 +70,9 @@ public:
   virtual void beginNamespaceNode(
       std::string_view childKey,
       const moxygen::TrackNamespace& ns,
-      size_t sessionCount
+      size_t sessionCount,
+      std::string_view publisherAddress,
+      std::string_view peerID
   ) = 0;
   virtual void endNamespaceNode() = 0;
   virtual void onNamespaceTreeEnd() = 0;

--- a/src/admin/StateHandler.cpp
+++ b/src/admin/StateHandler.cpp
@@ -88,7 +88,9 @@ public:
   void beginNamespaceNode(
       std::string_view childKey,
       const moxygen::TrackNamespace& ns,
-      size_t sessionCount
+      size_t sessionCount,
+      std::string_view publisherAddress,
+      std::string_view peerID
   ) override {
     if (!childKey.empty()) {
       w_.key(childKey);
@@ -102,6 +104,12 @@ public:
     w_.endArray();
     w_.key("namespace_subscribers");
     w_.uintVal(static_cast<uint64_t>(sessionCount));
+    if (!publisherAddress.empty()) {
+      w_.field("publisher", publisherAddress);
+    }
+    if (!peerID.empty()) {
+      w_.field("peer_id", peerID);
+    }
     w_.key("children");
     w_.beginObject();
   }


### PR DESCRIPTION
Nodes that have a sourceSession now emit a "publisher" field (peer IP) in the namespace tree. Nodes sourced from a peer relay also emit "peer_id". Both fields are omitted when empty, so intermediate nodes are unaffected.

Note: nodes without a source session are just housekeeping, and will be elided in some future performance optimization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/220)
<!-- Reviewable:end -->
