### PR TITLE
fix: guard against publisher reconnect during upstream subscribe

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1045,14 +1045,21 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
     // The iterator returned from emplace does not survive across coroutine
     // resumption, so both the guard and updating the RelaySubscription below
     // require another lookup in the subscriptions_ map.
-    auto g = folly::makeGuard([this, trackName = subReq.fullTrackName] {
-      auto it = subscriptions_.find(trackName);
-      if (it != subscriptions_.end()) {
-        it->second.promise.setException(std::runtime_error("failed"));
-        XLOG(DBG4) << "Erasing subscription to " << it->first;
-        subscriptions_.erase(it);
-      }
-    });
+    // Capture forwarder identity: a reconnecting publisher may replace this
+    // entry before we resume, leaving a new entry with a satisfied promise.
+    auto g = folly::makeGuard(
+        [this, trackName = subReq.fullTrackName, weakForwarder = std::weak_ptr(forwarder)] {
+          auto it = subscriptions_.find(trackName);
+          if (it != subscriptions_.end() && it->second.forwarder == weakForwarder.lock()) {
+            it->second.promise.setException(std::runtime_error("failed"));
+            XLOG(DBG4) << "Erasing subscription to " << it->first;
+            subscriptions_.erase(it);
+          } else {
+            // Entry was replaced by a reconnecting publisher; don't touch it.
+            XLOG(DBG4) << "Skipping stale guard for " << trackName;
+          }
+        }
+    );
     // Add subscriber first in case objects come before subscribe OK.
     auto subscriber = forwarder->addSubscriber(std::move(session), subReq, std::move(consumer));
     if (!subscriber) {
@@ -1097,10 +1104,19 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
     auto it = subscriptions_.find(subReq.fullTrackName);
     // There are cases that remove the subscription like failing to
     // publish a datagram that was received before the subscribeOK
-    // and then gets flushed
+    // and then gets flushed.  Also guard against a reconnecting publisher
+    // replacing the entry while we were suspended.
     if (it == subscriptions_.end()) {
       XLOG(ERR) << "Subscription is GONE, returning exception";
       co_yield folly::coro::co_error(std::runtime_error("subscription is gone"));
+    }
+    if (it->second.forwarder != forwarder) {
+      XLOG(ERR) << "Subscription replaced by reconnecting publisher: " << subReq.fullTrackName;
+      co_return folly::makeUnexpected(SubscribeError{
+          subReq.requestID,
+          SubscribeErrorCode::INTERNAL_ERROR,
+          "publisher reconnected during subscribe"
+      });
     }
     auto& rsub = it->second;
     rsub.requestID = subRes.value()->subscribeOk().requestID;

--- a/test/MoqxRelayTest.cpp
+++ b/test/MoqxRelayTest.cpp
@@ -3516,4 +3516,171 @@ TEST_F(MoQRelayTest, BridgeHandleDestructorDoesNotEvictNewPublisher) {
   removeSession(session2);
 }
 
+// Regression test: publisher reconnects while a subscribe coroutine is
+// suspended at co_await upstreamSession->subscribe().  The reconnect
+// (doPublishNamespace for publisher 2) erases the subscribe-path subscriptions_
+// entry (upstream == publisherSession1 == nodePtr->sourceSession), then
+// publish() for the same FTN creates a new entry whose promise is already
+// satisfied.  The subscribe scope guard then calls setException() on the
+// already-satisfied promise → folly::PromiseAlreadySatisfied →
+// ScopeGuardImplBase::terminate() → std::terminate (exit code 139).
+//
+// Without the fix: crashes.  With the fix: subscribe returns an error cleanly.
+TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeScopeGuardCrash) {
+  auto publisherSession1 = createMockSession();
+  auto publisherSession2 = createMockSession();
+  auto subscriberSession = createMockSession();
+
+  // Publisher 1 announces the namespace so subscribe() will find it as the
+  // upstream session and call publisherSession1->subscribe().
+  PublishNamespace pn;
+  pn.trackNamespace = kTestNamespace;
+  relay_->doPublishNamespace(pn, publisherSession1, nullptr);
+
+  // Configure publisher 1's subscribe() mock to simulate publisher reconnect
+  // inline (the relay calls this during co_await upstreamSession->subscribe()):
+  //   1. Publisher 2 re-announces the namespace — doPublishNamespace erases the
+  //      subscribe-path subscriptions_ entry because its upstream field equals
+  //      publisherSession1 == nodePtr->sourceSession.
+  //   2. Publisher 2 publishes the FTN — publish() emplaces a new subscriptions_
+  //      entry and immediately calls rsub.promise.setValue(folly::unit).
+  //   3. Returns an error, simulating the old session being cancelled.
+  // After the mock returns, the subscribe error path fires the scope guard which
+  // does subscriptions_.find(trackName), finds the new publish-path entry, and
+  // calls it->second.promise.setException() on an already-satisfied promise →
+  // PromiseAlreadySatisfied → terminate().
+  std::shared_ptr<TrackConsumer> pub2Consumer;
+  EXPECT_CALL(*publisherSession1, subscribe(_, _))
+      .WillOnce(
+          [this, publisherSession2, &pub2Consumer](SubscribeRequest, std::shared_ptr<TrackConsumer>)
+              -> folly::coro::Task<Publisher::SubscribeResult> {
+            // Step 1: publisher 2 takes over the namespace.
+            PublishNamespace pn2;
+            pn2.trackNamespace = kTestNamespace;
+            relay_->doPublishNamespace(pn2, publisherSession2, nullptr);
+
+            // Step 2: publisher 2 publishes the FTN, creating a new
+            // subscriptions_ entry with the promise already satisfied.
+            {
+              folly::RequestContextScopeGuard ctx;
+              folly::RequestContext::get()->setContextData(
+                  sessionRequestToken(),
+                  std::make_unique<MoQSession::MoQSessionRequestData>(publisherSession2)
+              );
+              PublishRequest pub;
+              pub.fullTrackName = kTestTrackName;
+              auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+              EXPECT_TRUE(res.hasValue()) << "publish in mock unexpectedly failed";
+              if (res.hasValue()) {
+                pub2Consumer = res->consumer;
+              }
+            }
+
+            // Step 3: return error — simulates the old upstream session being cancelled.
+            co_return folly::makeUnexpected(SubscribeError{
+                RequestID(0),
+                SubscribeErrorCode::INTERNAL_ERROR,
+                "upstream session cancelled"
+            });
+          }
+      );
+
+  withSessionContext(subscriberSession, [&]() {
+    SubscribeRequest sub;
+    sub.fullTrackName = kTestTrackName;
+    sub.requestID = RequestID(1);
+    sub.locType = LocationType::LargestObject;
+    auto result = folly::coro::blockingWait(
+        relay_->subscribe(std::move(sub), createMockConsumer()),
+        exec_.get()
+    );
+    // With the fix: subscribe returns an error without crashing.
+    // Without the fix: std::terminate is called before this assertion runs.
+    EXPECT_FALSE(result.hasValue()) << "subscribe should have failed (upstream cancelled)";
+  });
+
+  if (pub2Consumer) {
+    pub2Consumer->publishDone(
+        {RequestID(0), PublishDoneStatusCode::SESSION_CLOSED, 0, "test cleanup"}
+    );
+  }
+  relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2);
+}
+
+// Same reconnect scenario but the upstream subscribe returns OK instead of an
+// error.  Without the fix, the crash moves from the scope guard to the success
+// path: after g.dismiss(), subscriptions_.find() returns the new publish-path
+// entry (promise already satisfied), and rsub.promise.setValue() throws
+// PromiseAlreadySatisfied, which propagates as an unhandled coroutine exception.
+// With the fix: subscribe returns SUBSCRIBE_ERROR "publisher reconnected".
+TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeSuccessPathCrash) {
+  auto publisherSession1 = createMockSession();
+  auto publisherSession2 = createMockSession();
+  auto subscriberSession = createMockSession();
+
+  PublishNamespace pn;
+  pn.trackNamespace = kTestNamespace;
+  relay_->doPublishNamespace(pn, publisherSession1, nullptr);
+
+  std::shared_ptr<TrackConsumer> pub2Consumer;
+  EXPECT_CALL(*publisherSession1, subscribe(_, _))
+      .WillOnce(
+          [this,
+           publisherSession2,
+           &pub2Consumer](SubscribeRequest subReq, std::shared_ptr<TrackConsumer>)
+              -> folly::coro::Task<Publisher::SubscribeResult> {
+            PublishNamespace pn2;
+            pn2.trackNamespace = kTestNamespace;
+            relay_->doPublishNamespace(pn2, publisherSession2, nullptr);
+
+            {
+              folly::RequestContextScopeGuard ctx;
+              folly::RequestContext::get()->setContextData(
+                  sessionRequestToken(),
+                  std::make_unique<MoQSession::MoQSessionRequestData>(publisherSession2)
+              );
+              PublishRequest pub;
+              pub.fullTrackName = kTestTrackName;
+              auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+              EXPECT_TRUE(res.hasValue()) << "publish in mock unexpectedly failed";
+              if (res.hasValue()) {
+                pub2Consumer = res->consumer;
+              }
+            }
+
+            // Return success — the crash moves to rsub.promise.setValue() in the
+            // success path (after g.dismiss()), which finds the new publish-path
+            // entry whose promise is already satisfied.
+            SubscribeOk ok;
+            ok.requestID = subReq.requestID;
+            ok.trackAlias = TrackAlias(subReq.requestID.value);
+            ok.expires = std::chrono::milliseconds(0);
+            ok.groupOrder = GroupOrder::OldestFirst;
+            co_return std::make_shared<NiceMock<MockSubscriptionHandle>>(std::move(ok));
+          }
+      );
+
+  withSessionContext(subscriberSession, [&]() {
+    SubscribeRequest sub;
+    sub.fullTrackName = kTestTrackName;
+    sub.requestID = RequestID(1);
+    sub.locType = LocationType::LargestObject;
+    auto result = folly::coro::blockingWait(
+        relay_->subscribe(std::move(sub), createMockConsumer()),
+        exec_.get()
+    );
+    EXPECT_FALSE(result.hasValue()) << "subscribe should fail (publisher reconnected)";
+    if (result.hasError()) {
+      EXPECT_EQ(result.error().reasonPhrase, "publisher reconnected during subscribe");
+    }
+  });
+
+  if (pub2Consumer) {
+    pub2Consumer->publishDone(
+        {RequestID(0), PublishDoneStatusCode::SESSION_CLOSED, 0, "test cleanup"}
+    );
+  }
+  relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
When a publisher reconnects while a subscribe coroutine is suspended at co_await upstreamSession->subscribe(), doPublishNamespace() erases the subscribe-path subscriptions_ entry and publish() immediately creates a new entry for the same FTN with the promise already satisfied.

Two crash sites:

1. Error path (scope guard): the guard fires on co_return, finds the new entry by key, and calls setException() on the already-satisfied promise → folly::PromiseAlreadySatisfied → ScopeGuardImplBase::terminate() → std::terminate.

2. Success path: after g.dismiss(), subscriptions_.find() returns the new entry and rsub.promise.setValue() throws PromiseAlreadySatisfied, which propagates as an unhandled coroutine exception.

Fix: capture the forwarder as a weak_ptr in the scope guard and skip cleanup if the entry's forwarder no longer matches (error path).  After g.dismiss(), add the same identity check and return SUBSCRIBE_ERROR "publisher reconnected during subscribe" (success path).

Tests: PublishReconnectDuringSubscribeScopeGuardCrash and PublishReconnectDuringSubscribeSuccessPathCrash reproduce both sites.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/222)
<!-- Reviewable:end -->
