### PR TITLE
ci-main: release-notes wording on release/* (rebased)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -377,7 +377,7 @@ jobs:
           **Built:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
           **Docker:** \`ghcr.io/${{ github.repository }}:${SHORT}\`
 
-          This pre-release is automatically replaced on every push to \`main\`.
+          This pre-release is automatically replaced on every push to \`${{ github.ref_name }}\`.
           EOF
           )"
 


### PR DESCRIPTION
## Summary
Rebased on current main. Original PR had two fixes; the Package-step `:latest` → `rolling` change was absorbed into main via #226 (arm64 multiplatform) and is no longer needed here.

**What's left (1 line):** release-notes wording — main had hardcoded \`main\`; release/nab-demo uses \`\${{ github.ref_name }}\` (commit 40bc6644). This brings main into harmony with release/nab-demo per the "fixes in release/* also land on main" rule.

## Test plan
- [ ] PR CI green
- [ ] After merge: next \`ci main\` release note on snapshot-latest reads "replaced on every push to \`main\`" (unchanged wording on main runs) — still correct; the fix only changes behavior if a release/* branch publishes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/224)
<!-- Reviewable:end -->
