### PR TITLE
docs: add CONTRIBUTING.md and docs/release.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,70 +1,56 @@
 # Contributing to moqx
 
-Thanks for your interest in moqx. This doc covers how we develop,
-review, and merge changes. For build instructions see
-[BUILD.md](BUILD.md); for runtime see [RUNNING.md](RUNNING.md). For
-architecture and planning material, see [docs/](docs/).
+For build see [BUILD.md](BUILD.md); for runtime, [RUNNING.md](RUNNING.md);
+for architecture and planning material, [docs/](docs/).
 
 ## Guiding principle
 
 > Producing code in the era of AI is cheap. Reviewer attention is the
-> scarce resource. We optimize our workflow for human review.
+> scarce resource.
 
 ## Pull request scope
 
-**One PR = one cohesive thesis.** A reviewer should be able to read
-the title and predict the diff.
+**One PR = one cohesive thesis.** A reviewer should read the title and
+predict the diff.
 
-- ✅ "fix: guard against publisher reconnect during upstream subscribe"
-- ❌ "various fixes and cleanups" (no thesis)
-- ❌ "feature X + refactor Y + bump Z" (split it)
+- ✅ `fix: guard against publisher reconnect during upstream subscribe`
+- ❌ `various fixes and cleanups`
+- ❌ `feature X + refactor Y + bump Z` (split it)
 
-If you notice an unrelated fix while working, open a second PR.
-Independent PRs land in parallel; bundled PRs stall on the slowest
-reviewer.
+Spot an unrelated fix while working? Open a second PR.
 
 ## PR state
 
-A PR that looks useful and has all checks green will be merged when a
-maintainer is available. No extra nudge needed. Use PR state to signal
-intent:
+Useful PRs with all checks green are merged when a maintainer is
+available. Signal intent:
 
-- **Draft** — not ready for review. Reviewers aren't auto-requested.
-  CI still runs, so you can iterate on green checks before asking for
-  review.
-- **Ready** (non-draft, no `WIP:` prefix) — ready for review and
-  ready to merge once review and CI pass.
-- **`WIP:` prefix** in the title — ready for review and CI, but not
-  yet ready for merge. Maintainers won't merge `WIP:` PRs regardless
-  of check state.
+- **Draft** — not ready for review. No auto-reviewer request; CI still runs.
+- **Ready** (non-draft, no `WIP:` prefix) — merge when green.
+- **`WIP:` prefix** — ready for review and CI, not for merge.
 
 ## How to contribute
 
-This is a public repository and accepts fork-based PRs from anyone.
+moqx is public — fork-based PRs welcome.
 
-- **Outside contributors**: fork the repo, push a branch, open a PR
-  against `main`.
-- **Org members**: push a feature branch directly to this repo, open a
-  PR against `main`.
+- Outside contributors: fork, branch, PR against `main`.
+- Org members: branch directly on this repo, PR against `main`.
 
-CI runs on every PR with no secrets exposed. Publish, release, and
-deploy only run on `push: main` after merge.
+PRs run CI with no secrets. Publish, release, and deploy run only on
+`push: main` after merge.
 
 ## Reviews
 
-At least one approving review is required before merge. The reviewer
-pool is small — be patient, and reciprocate by reviewing others.
+At least one approving review is required. The reviewer pool is small —
+be patient, reciprocate.
 
-**Admin override** (`gh pr merge --admin`) is reserved for:
-- CI/infrastructure repairs where branch protection itself is the block.
-- Release-critical merges under demo-window urgency.
-- Documentation-only changes when waiting costs more than reviewing.
+**Admin override** (`gh pr merge --admin`) is for:
+- CI/infrastructure repairs blocked by branch protection itself.
+- Release-critical merges under urgency.
+- Docs-only changes when waiting costs more than reviewing.
 
 Note the override in the PR description: `Admin override: <reason>`.
 
 ## CI
-
-Two workflow files gate changes:
 
 - `ci pr` — format, build (linux + asan debug), tests. Must pass before merge.
 - `ci main` — publish / release / deploy on push to `main` and `release/*`.
@@ -73,39 +59,34 @@ See [docs/ci-architecture.md](docs/ci-architecture.md).
 
 ## Branches
 
-- `main` — rolling head; `snapshot-latest` image builds from here.
+- `main` — rolling head; `snapshot-latest` builds from here.
 - `release/<name>` — pinned demo / customer release branches. See
   [docs/release.md](docs/release.md).
 - `devops/*`, `feature/*`, `fix/*`, `hotfix/*` — convention only, no enforcement.
 
 ## Merge
 
-PRs are squash-merged; the PR title becomes the commit message on
-`main`, so write titles that summarize the change well. Branch commit
-organization (rebase, amend, multiple commits) is up to the author —
-it has no effect on the merged result.
-
-If preserving multiple commits aids review or `git blame` (e.g., a
-refactor followed by a correctness fix you want to bisect separately),
-say so in the PR description and use a merge commit instead.
+PRs are squash-merged; the PR title becomes the commit message on `main`.
+Authors are encouraged to maintain a concise, informative commit
+history on the branch — it aids review. Request a merge commit in the
+PR description if preserving history on `main` is warranted.
 
 ## Local development
 
-Before submitting a PR:
+Before submitting:
 
-1. `clang-format-19 -i` changed C++ files (CI checks this).
-2. Build and run the test suite locally — faster feedback than CI.
+1. `clang-format-19 -i` changed C++ files.
+2. Build and run tests locally.
 3. Update [docs/config.md](docs/config.md) or [RUNNING.md](RUNNING.md)
    if you changed admin API or runtime config.
-4. Add tests for new behavior; bug fixes include a regression test.
+4. Add tests; bug fixes include a regression test.
 
 ## Issues
 
-GitHub Issues track bugs and feature work. Provide enough context —
-version, config, repro steps, logs — for a maintainer to reproduce.
+GitHub Issues track bugs and features. Include version, config, repro
+steps, logs.
 
 ## Security & License
 
-Report security issues via [SECURITY.md](SECURITY.md). Do not file
-public issues for security reports. By contributing to moqx, you agree
-your contributions are licensed under the project's [LICENSE](LICENSE).
+Report security issues via [SECURITY.md](SECURITY.md) — not public
+issues. Contributions are licensed under [LICENSE](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,84 +1,84 @@
 # Contributing to moqx
 
-Thanks for your interest in moqx. This doc covers how we develop, review, and merge changes. For build instructions see [BUILD.md](BUILD.md); for runtime see [RUNNING.md](RUNNING.md); for the CI/automation reference see [docs/ci-architecture.md](docs/ci-architecture.md); for the release branch model see [docs/release.md](docs/release.md).
+Thanks for your interest in moqx. This doc covers how we develop,
+review, and merge changes. For build instructions see
+[BUILD.md](BUILD.md); for runtime see [RUNNING.md](RUNNING.md); for the
+CI reference see [docs/ci-architecture.md](docs/ci-architecture.md);
+for the release branch model see [docs/release.md](docs/release.md).
 
 ## Guiding principle
 
-> **Producing code in the era of AI is cheap. Reviewer attention is the scarce resource.** We optimize our workflow for easiest human review.
+> Producing code in the era of AI is cheap. Reviewer attention is the
+> scarce resource. We optimize our workflow for human review.
 
-Everything below follows from that.
+## Pull request scope
 
-## Pull Request Scope
-
-**One PR = one cohesive thesis.** A reviewer should be able to read the title and predict the diff. Examples:
+**One PR = one cohesive thesis.** A reviewer should be able to read
+the title and predict the diff.
 
 - ✅ "fix: guard against publisher reconnect during upstream subscribe"
-- ✅ "ci-main: make Package + release notes branch-symmetric"
 - ❌ "various fixes and cleanups" (no thesis)
-- ❌ "implement feature X + refactor Y + bump Z" (multiple theses → split)
+- ❌ "feature X + refactor Y + bump Z" (split it)
 
-If you're tempted to add an unrelated change because "it's a small fix and I'm here anyway," open a second PR. Independent PRs land in parallel; bundled PRs stall on the slowest reviewer.
-
-### One PR = one commit (target)
-
-Authors should land changes as a single squashed commit on `main`. We do **not** preserve dev-time commit noise (typo fixes, "address review", WIP) in the merged history.
-
-- **Author squashes before merge.** Either rebase locally or use the GitHub "Squash and merge" button. The squashed commit message should match the PR title and reference the issue/PR.
-- **Reviewable.io supports per-commit review** — feel free to keep dev commits during review for easier diffing, then squash at merge time.
-- **Stacks** of related PRs are encouraged when work is logically separable. [Sapling](https://sapling-scm.com/) makes managing stacks much easier than `git rebase -i`.
-- **Feature branches** are fine when a stack of PRs needs to land coherently before promoting to `main` — open PRs against the feature branch, then a final PR from feature-branch → `main`.
-
-### Flexibility
-
-These are defaults, not laws. If preserving multiple commits genuinely aids review or `git blame` (e.g., a refactor + correctness fix that you want to bisect separately), say so in the PR description and use a merge commit. Be ready to defend the choice.
+If you notice an unrelated fix while working, open a second PR.
+Independent PRs land in parallel; bundled PRs stall on the slowest
+reviewer.
 
 ## Reviews
 
-- All PRs require at least one approving review before merge.
-- The reviewer pool is small — be patient, and reciprocate by reviewing others.
-- For trivial CI/docs/dependency-bump PRs, self-merge with admin override is acceptable when no reviewer is available within the urgency window. **Note the override in the PR description.**
+At least one approving review is required before merge. The reviewer
+pool is small — be patient, and reciprocate by reviewing others.
 
-### Admin overrides
+**Admin override** (`gh pr merge --admin`) is reserved for:
+- CI/infrastructure repairs where branch protection itself is the block.
+- Release-critical merges under demo-window urgency.
+- Documentation-only changes when waiting costs more than reviewing.
 
-Branch protection on `main` and `release/*` requires reviews. Admin override (`gh pr merge --admin`) is reserved for:
-
-- **CI/infrastructure repairs** where the protection itself is what's blocking the fix.
-- **Release-critical merges** under demo-window urgency when the reviewer pool is unreachable.
-- **Documentation-only changes** where the cost of waiting outweighs the value of review.
-
-Every admin override should be noted in the PR description (one line: "Admin override: <reason>") so it's auditable in `git log` and the merge UI.
+Note the override in the PR description: `Admin override: <reason>`.
 
 ## CI
 
-Two workflow files gate all changes:
+Two workflow files gate changes:
 
-- **`ci pr`** runs on every PR — format check, build (linux + asan debug), tests. Must pass before merge.
-- **`ci main`** runs on push to `main` and `release/*` — full publish/release/notify pipeline.
+- `ci pr` — format, build (linux + asan debug), tests. Must pass before merge.
+- `ci main` — publish / release / deploy on push to `main` and `release/*`.
 
-See [docs/ci-architecture.md](docs/ci-architecture.md) for the full workflow reference.
+See [docs/ci-architecture.md](docs/ci-architecture.md).
 
 ## Branches
 
-- **`main`** — rolling head. Floats forward continuously via `snapshot-latest` builds.
-- **`release/<name>`** — pinned demo / customer release branches. See [docs/release.md](docs/release.md).
-- **`devops/*`** — working branches for infra/CI/docs work (your namespace).
-- **`feat/*`, `fix/*`, etc.** — convention only; no enforcement.
+- `main` — rolling head; `snapshot-latest` image builds from here.
+- `release/<name>` — pinned demo / customer release branches. See
+  [docs/release.md](docs/release.md).
+- `devops/*`, `feat/*`, `fix/*` — convention only, no enforcement.
+
+## Merge
+
+PRs are squash-merged; the PR title becomes the commit message on
+`main`, so write titles that summarize the change well. Branch commit
+organization (rebase, amend, multiple commits) is up to the author —
+it has no effect on the merged result.
+
+If preserving multiple commits aids review or `git blame` (e.g., a
+refactor followed by a correctness fix you want to bisect separately),
+say so in the PR description and use a merge commit instead.
 
 ## Local development
 
-See [BUILD.md](BUILD.md) for build instructions and [RUNNING.md](RUNNING.md) for running the relay locally.
-
 Before submitting a PR:
 
-1. `clang-format-19 -i` your changed C++ files (CI checks this).
-2. Build and run the test suite locally — `ci pr` will catch you, but local feedback is faster.
-3. If you changed the admin API or runtime config, update [docs/config.md](docs/config.md) and/or [RUNNING.md](RUNNING.md).
-4. Write tests for new behavior. Bug fixes should include a regression test.
+1. `clang-format-19 -i` changed C++ files (CI checks this).
+2. Build and run the test suite locally — faster feedback than CI.
+3. Update [docs/config.md](docs/config.md) or [RUNNING.md](RUNNING.md)
+   if you changed admin API or runtime config.
+4. Add tests for new behavior; bug fixes include a regression test.
 
 ## Issues
 
-GitHub Issues track bugs and feature work. Provide enough context (version, config, repro steps, logs) for a maintainer to reproduce.
+GitHub Issues track bugs and feature work. Provide enough context —
+version, config, repro steps, logs — for a maintainer to reproduce.
 
 ## License
 
-By contributing to moqx, you agree your contributions are licensed under the project's [LICENSE](LICENSE).
+By contributing to moqx, you agree your contributions are licensed
+under the project's [LICENSE](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,8 @@
 
 Thanks for your interest in moqx. This doc covers how we develop,
 review, and merge changes. For build instructions see
-[BUILD.md](BUILD.md); for runtime see [RUNNING.md](RUNNING.md); for the
-CI reference see [docs/ci-architecture.md](docs/ci-architecture.md);
-for the release branch model see [docs/release.md](docs/release.md).
+[BUILD.md](BUILD.md); for runtime see [RUNNING.md](RUNNING.md). For
+architecture and planning material, see [docs/](docs/).
 
 ## Guiding principle
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,34 @@
 # Contributing to moqx
 
-For build see [BUILD.md](BUILD.md); for runtime, [RUNNING.md](RUNNING.md);
-for architecture and planning material, [docs/](docs/).
+This document describes current guidelines for contributing to the `moqx` project, and related OpenMOQ repos. Openness and community participation are foundational principles of the OpenMOQ Consortium. All are welcome and encouraged to use the software here freely, and contribute to testing, fixing, and enhancing the code when possible.
 
-## Guiding principle
+The following describes the general philosophy and approach for handling contributions. The process remains flexible and subject to review, and may change in the future. The ultimate goal is to facilitate the production of high-quality, high-performance, professional-grade software.
 
-> Producing code in the era of AI is cheap. Reviewer attention is the
-> scarce resource.
+## Pull request scope and content
 
-## Pull request scope
+**Each PR should address a single and logically cohesive thesis.**
 
-**One PR = one cohesive thesis.** A reviewer should read the title and
-predict the diff.
+This makes reviews more approachable and more likely to occur. Avoid bundling various unrelated changes and ad hoc changes.
 
-- ✅ `fix: guard against publisher reconnect during upstream subscribe`
-- ❌ `various fixes and cleanups`
-- ❌ `feature X + refactor Y + bump Z` (split it)
+The following is a list of ideals for PR content — developer discretion and sound judgement is expected:
 
-Spot an unrelated fix while working? Open a second PR.
+- The title should clearly reflect the functional impact of the PR (in most cases this becomes the commit message on the merge commit).
+- The description should contain additional technical details and solution rationale.
+- If the PR addresses an existing issue, reference it in the description — `Fixes #N` to auto-close on merge, or `Refs #N` for partial or related work.
+- Tests or other evaluation criteria should be included for independent pass/fail evaluation (including unit tests where possible).
+- Relevant logs, developer test output, or other supporting material may be attached to support the review process.
 
 ## PR state
 
-Useful PRs with all checks green are merged when a maintainer is
-available. Signal intent:
+PRs with all checks passing may be merged by maintainers at unpredictable times based on availability and relative priority. The author can signal merge intent in the following ways:
 
 - **Draft** — not ready for review. No auto-reviewer request; CI still runs.
-- **Ready** (non-draft, no `WIP:` prefix) — merge when green.
-- **`WIP:` prefix** — ready for review and CI, not for merge.
+- **`WIP:` prefix** — ready for review and CI, not ready for merge.
+- **Ready** (non-draft, no `WIP:` prefix) — merge when all checks pass (manual for now).
 
 ## How to contribute
 
-moqx is public — fork-based PRs welcome.
+`moqx` is a public repo — fork-based PRs are welcome.
 
 - Outside contributors: fork, branch, PR against `main`.
 - Org members: branch directly on this repo, PR against `main`.
@@ -46,9 +44,7 @@ be patient, reciprocate.
 **Admin override** (`gh pr merge --admin`) is for:
 - CI/infrastructure repairs blocked by branch protection itself.
 - Release-critical merges under urgency.
-- Docs-only changes when waiting costs more than reviewing.
-
-Note the override in the PR description: `Admin override: <reason>`.
+- Docs-only or other low/no-risk changes.
 
 ## CI
 
@@ -59,17 +55,22 @@ See [docs/ci-architecture.md](docs/ci-architecture.md).
 
 ## Branches
 
+The following branch naming conventions are offered as developer guidance:
+
 - `main` — rolling head; `snapshot-latest` builds from here.
-- `release/<name>` — pinned demo / customer release branches. See
-  [docs/release.md](docs/release.md).
+- `release/<name>` — pinned demo / customer release branches. See [docs/release.md](docs/release.md).
 - `devops/*`, `feature/*`, `fix/*`, `hotfix/*` — convention only, no enforcement.
+
+The specific suffix branch name is up to the developer — something informative is often helpful (please clean up stale branches).
 
 ## Merge
 
 PRs are squash-merged; the PR title becomes the commit message on `main`.
 Authors are encouraged to maintain a concise, informative commit
-history on the branch — it aids review. Request a merge commit in the
+history on the branch — it aids review. Authors may request a merge commit in the
 PR description if preserving history on `main` is warranted.
+
+> **Note:** *Delete branch on merge* is the current default setting.
 
 ## Local development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,31 @@ If you notice an unrelated fix while working, open a second PR.
 Independent PRs land in parallel; bundled PRs stall on the slowest
 reviewer.
 
+## PR state
+
+A PR that looks useful and has all checks green will be merged when a
+maintainer is available. No extra nudge needed. Use PR state to signal
+intent:
+
+- **Draft** — not ready for merge or review. Draft PRs don't
+  auto-request reviewers and don't run CI.
+- **Ready** (non-draft) — ready for merge once review and CI pass.
+- **Prefix title with `WIP:`** — you want review and CI feedback, but
+  are not yet ready for the PR to be merged. Maintainers won't merge
+  `WIP:` PRs regardless of check state.
+
+## How to contribute
+
+This is a public repository and accepts fork-based PRs from anyone.
+
+- **Outside contributors**: fork the repo, push a branch, open a PR
+  against `main`.
+- **Org members**: push a feature branch directly to this repo, open a
+  PR against `main`.
+
+CI runs on every PR with no secrets exposed. Publish, release, and
+deploy only run on `push: main` after merge.
+
 ## Reviews
 
 At least one approving review is required before merge. The reviewer
@@ -78,7 +103,8 @@ Before submitting a PR:
 GitHub Issues track bugs and feature work. Provide enough context —
 version, config, repro steps, logs — for a maintainer to reproduce.
 
-## License
+## Security & License
 
-By contributing to moqx, you agree your contributions are licensed
-under the project's [LICENSE](LICENSE).
+Report security issues via [SECURITY.md](SECURITY.md). Do not file
+public issues for security reports. By contributing to moqx, you agree
+your contributions are licensed under the project's [LICENSE](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ See [docs/ci-architecture.md](docs/ci-architecture.md).
 - `main` — rolling head; `snapshot-latest` image builds from here.
 - `release/<name>` — pinned demo / customer release branches. See
   [docs/release.md](docs/release.md).
-- `devops/*`, `feat/*`, `fix/*` — convention only, no enforcement.
+- `devops/*`, `feature/*`, `fix/*`, `hotfix/*` — convention only, no enforcement.
 
 ## Merge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,14 @@ A PR that looks useful and has all checks green will be merged when a
 maintainer is available. No extra nudge needed. Use PR state to signal
 intent:
 
-- **Draft** — not ready for merge or review. Draft PRs don't
-  auto-request reviewers and don't run CI.
-- **Ready** (non-draft) — ready for merge once review and CI pass.
-- **Prefix title with `WIP:`** — you want review and CI feedback, but
-  are not yet ready for the PR to be merged. Maintainers won't merge
-  `WIP:` PRs regardless of check state.
+- **Draft** — not ready for review. Reviewers aren't auto-requested.
+  CI still runs, so you can iterate on green checks before asking for
+  review.
+- **Ready** (non-draft, no `WIP:` prefix) — ready for review and
+  ready to merge once review and CI pass.
+- **`WIP:` prefix** in the title — ready for review and CI, but not
+  yet ready for merge. Maintainers won't merge `WIP:` PRs regardless
+  of check state.
 
 ## How to contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to moqx
+
+Thanks for your interest in moqx. This doc covers how we develop, review, and merge changes. For build instructions see [BUILD.md](BUILD.md); for runtime see [RUNNING.md](RUNNING.md); for the CI/automation reference see [docs/ci-architecture.md](docs/ci-architecture.md); for the release branch model see [docs/release.md](docs/release.md).
+
+## Guiding principle
+
+> **Producing code in the era of AI is cheap. Reviewer attention is the scarce resource.** We optimize our workflow for easiest human review.
+
+Everything below follows from that.
+
+## Pull Request Scope
+
+**One PR = one cohesive thesis.** A reviewer should be able to read the title and predict the diff. Examples:
+
+- ✅ "fix: guard against publisher reconnect during upstream subscribe"
+- ✅ "ci-main: make Package + release notes branch-symmetric"
+- ❌ "various fixes and cleanups" (no thesis)
+- ❌ "implement feature X + refactor Y + bump Z" (multiple theses → split)
+
+If you're tempted to add an unrelated change because "it's a small fix and I'm here anyway," open a second PR. Independent PRs land in parallel; bundled PRs stall on the slowest reviewer.
+
+### One PR = one commit (target)
+
+Authors should land changes as a single squashed commit on `main`. We do **not** preserve dev-time commit noise (typo fixes, "address review", WIP) in the merged history.
+
+- **Author squashes before merge.** Either rebase locally or use the GitHub "Squash and merge" button. The squashed commit message should match the PR title and reference the issue/PR.
+- **Reviewable.io supports per-commit review** — feel free to keep dev commits during review for easier diffing, then squash at merge time.
+- **Stacks** of related PRs are encouraged when work is logically separable. [Sapling](https://sapling-scm.com/) makes managing stacks much easier than `git rebase -i`.
+- **Feature branches** are fine when a stack of PRs needs to land coherently before promoting to `main` — open PRs against the feature branch, then a final PR from feature-branch → `main`.
+
+### Flexibility
+
+These are defaults, not laws. If preserving multiple commits genuinely aids review or `git blame` (e.g., a refactor + correctness fix that you want to bisect separately), say so in the PR description and use a merge commit. Be ready to defend the choice.
+
+## Reviews
+
+- All PRs require at least one approving review before merge.
+- The reviewer pool is small — be patient, and reciprocate by reviewing others.
+- For trivial CI/docs/dependency-bump PRs, self-merge with admin override is acceptable when no reviewer is available within the urgency window. **Note the override in the PR description.**
+
+### Admin overrides
+
+Branch protection on `main` and `release/*` requires reviews. Admin override (`gh pr merge --admin`) is reserved for:
+
+- **CI/infrastructure repairs** where the protection itself is what's blocking the fix.
+- **Release-critical merges** under demo-window urgency when the reviewer pool is unreachable.
+- **Documentation-only changes** where the cost of waiting outweighs the value of review.
+
+Every admin override should be noted in the PR description (one line: "Admin override: <reason>") so it's auditable in `git log` and the merge UI.
+
+## CI
+
+Two workflow files gate all changes:
+
+- **`ci pr`** runs on every PR — format check, build (linux + asan debug), tests. Must pass before merge.
+- **`ci main`** runs on push to `main` and `release/*` — full publish/release/notify pipeline.
+
+See [docs/ci-architecture.md](docs/ci-architecture.md) for the full workflow reference.
+
+## Branches
+
+- **`main`** — rolling head. Floats forward continuously via `snapshot-latest` builds.
+- **`release/<name>`** — pinned demo / customer release branches. See [docs/release.md](docs/release.md).
+- **`devops/*`** — working branches for infra/CI/docs work (your namespace).
+- **`feat/*`, `fix/*`, etc.** — convention only; no enforcement.
+
+## Local development
+
+See [BUILD.md](BUILD.md) for build instructions and [RUNNING.md](RUNNING.md) for running the relay locally.
+
+Before submitting a PR:
+
+1. `clang-format-19 -i` your changed C++ files (CI checks this).
+2. Build and run the test suite locally — `ci pr` will catch you, but local feedback is faster.
+3. If you changed the admin API or runtime config, update [docs/config.md](docs/config.md) and/or [RUNNING.md](RUNNING.md).
+4. Write tests for new behavior. Bug fixes should include a regression test.
+
+## Issues
+
+GitHub Issues track bugs and feature work. Provide enough context (version, config, repro steps, logs) for a maintainer to reproduce.
+
+## License
+
+By contributing to moqx, you agree your contributions are licensed under the project's [LICENSE](LICENSE).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,118 @@
+# Release Process
+
+This document describes the moqx release branch model, how release artifacts are produced, and how to cut a new release branch.
+
+For the underlying CI workflow reference, see [ci-architecture.md](ci-architecture.md). For day-to-day contributor workflow, see [../CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Branch Model
+
+| Branch | moxygen pin | Build target | Audience |
+|---|---|---|---|
+| `main` | floats — uses moxygen `snapshot-latest` via `--use-latest` | `ghcr.io/openmoq/moqx:main-latest` (also `:latest` alias) + `snapshot-latest` GitHub release | Continuous integration; auto-deployed to `moqx-main.ci.openmoq.org` |
+| `release/<name>` | **pinned** to a specific moxygen tag via [`.moxygen-release`](#moxygen-release-pin) | `ghcr.io/openmoq/moqx:<name>-latest` + `snapshot-<name>-latest` GitHub release | Demo / customer / event branches; manually deployed |
+| `devops/*`, `feat/*`, etc. | follows the branch they were cut from | (no `ci main` — only `ci pr` runs on PRs) | Working branches |
+
+`main` floats forward; `release/*` pins for reproducibility.
+
+## moxygen-release pin
+
+Release branches contain a top-level `.moxygen-release` file with a single line — the moxygen release tag (e.g. `v0.1.2`) the branch builds against.
+
+**This file is load-bearing**; do not remove it from a release branch.
+
+The contract is enforced in [`.github/workflows/ci-main.yml`](../.github/workflows/ci-main.yml) and [`ci-pr.yml`](../.github/workflows/ci-pr.yml):
+
+```bash
+# Release branches pin a specific moxygen release tag via
+# .moxygen-release. Main uses snapshot-latest via --use-latest.
+if [ -f .moxygen-release ]; then
+  export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+  bash scripts/build.sh setup --no-fallback
+else
+  bash scripts/build.sh setup --no-fallback --use-latest
+fi
+```
+
+The `deps/moxygen` submodule must point at the same commit the tag resolves to. CI does not cross-check, but a divergence will cause the build to download the wrong tarball.
+
+When merging `main` into a `release/*` branch, the `.moxygen-release` modify-vs-delete conflict resolves **in favor of keeping the file**, then bump it to match the merged submodule pin.
+
+## Snapshot Releases
+
+Every push to `main` or `release/*` produces a rolling pre-release on GitHub:
+
+- `main` → `snapshot-latest`
+- `release/<name>` → `snapshot-<name>-latest`
+
+Each push deletes and recreates the release at the new commit, so the tag always points at the most recent build. Releases are marked `--prerelease` and contain the binary tarball (`moqx-bookworm-amd64.tar.gz`).
+
+## Docker Image Tags
+
+Per-build images are pushed to `ghcr.io/openmoq/moqx`:
+
+| Tag | Contents | Lifecycle |
+|---|---|---|
+| `<short-sha>` | Exact build | Permanent |
+| `main-latest` | Most recent main build | Replaced on every push to `main` |
+| `latest` | Same as `main-latest` (back-compat alias) | Replaced on every push to `main` |
+| `<release-name>-latest` | Most recent build of `release/<name>` | Replaced on every push to that release branch |
+
+The interop client image (`ghcr.io/openmoq/moqx-interop-client`) follows the same tagging scheme.
+
+## Cutting a New Release Branch
+
+To open a new demo / customer release branch:
+
+1. **Create the branch from main** at the desired starting commit:
+   ```bash
+   git checkout -b release/<name> main
+   ```
+2. **Add the moxygen pin.** Pick the moxygen release tag your demo will run against (typically the latest `vX.Y.Z` whose hash is already on `main`):
+   ```bash
+   echo "v0.1.2" > .moxygen-release
+   git add .moxygen-release
+   git commit -m "release/<name>: pin moxygen v0.1.2"
+   git push origin release/<name>
+   ```
+3. **Verify CI.** Push triggers `ci main`. Confirm `snapshot-<name>-latest` and `ghcr.io/openmoq/moqx:<name>-latest` were produced successfully.
+4. **(Optional) Manually deploy** via the `deploy relay` workflow (`workflow_dispatch`), passing the release branch as the ref. The default deploy target is `moqx-<name>.ci.openmoq.org`.
+
+## Updating a Release Branch (sync from main)
+
+When a release branch needs to absorb fixes from `main`:
+
+1. Verify the moxygen tag you want to land on is already tagged (`vX.Y.Z`) and `main` builds against it cleanly. Pinning at a tag main has continuously CI-tested derisks the merge.
+2. Open a PR from a `devops/<branch>-vX.Y.Z` working branch into the release branch:
+   ```bash
+   git checkout -b devops/<release>-vX.Y.Z origin/release/<name>
+   git merge origin/main         # resolve .moxygen-release in favor of keeping
+   echo "vX.Y.Z" > .moxygen-release
+   git add .moxygen-release && git commit --amend --no-edit
+   git push origin devops/<release>-vX.Y.Z
+   gh pr create --base release/<name> --head devops/<release>-vX.Y.Z ...
+   ```
+3. **Use a merge commit (not squash)** when merging into a release branch — preserves the upstream commits' attribution and history on the release branch.
+4. (Recommended for first-time release branches) **dry-run** by pushing the merged commit as `release/<name>-test` first, watch a full `ci main` cycle end-to-end, then delete the throwaway branch + its `snapshot-<name>-test-latest` release + Docker tags before merging the real PR.
+
+## Tagged Releases
+
+> TODO (Alan): formal version tagging policy. Today, snapshot releases are the only published artifact. A tagged `vX.Y.Z` release flow (analogous to moxygen's `version release` workflow) is planned — see [issue TBD].
+
+## Deploy
+
+`main` auto-deploys to `moqx-main.ci.openmoq.org` after every successful `ci main` run.
+
+Release branches are deployed manually via the `deploy relay` workflow (`workflow_dispatch`):
+
+- Default domain: `moqx-<release-name>.ci.openmoq.org`
+- DNS A record auto-provisioned via Route53
+- TLS cert auto-provisioned/renewed via certbot + Route53 DNS challenge
+
+Inputs to `deploy relay` (all optional, branch-derived defaults):
+
+- `image_tag` — defaults to `<branch-label>-latest`
+- `domain` — defaults to `moqx-<branch-label>.ci.openmoq.org`
+- `restart_only` — restart the existing image without redeploying
+- `verbose` — GLOG verbosity level
+
+See [ci-architecture.md](ci-architecture.md) for the underlying workflow details.


### PR DESCRIPTION
## Summary
Two new docs capturing the team's dev workflow and the release-branch model we now have in place.

### `CONTRIBUTING.md` (new)
Entry-point doc. Captures the guiding principle — *"producing code in the era of AI is cheap; reviewer attention is the scarce resource"* — and the practices that follow:

- **PR scope** — one cohesive thesis per PR; split otherwise.
- **PR state signaling** — *Draft* (no auto-reviewer request, CI still runs); `WIP:` prefix (ready for review + CI, not yet for merge); plain title (ready to merge).
- **Reviews** — at least one approval; small reviewer pool; be patient + reciprocate.
- **Admin overrides** — reserved for CI/infra repairs blocked by branch protection itself, release-critical urgency, and docs-only PRs when waiting costs more than reviewing. Note the override in the PR description.
- **CI** — `ci pr` must pass before merge; `ci main` runs on push to `main` / `release/**`.
- **Branches** — `main`, `release/<name>`, working branches (`devops/*`, `feature/*`, `fix/*`, `hotfix/*` — convention only, no enforcement).
- **Merge** — PRs are squash-merged; the PR title becomes the commit message on `main`. Authors are *encouraged* (not required) to keep the branch history concise to aid review. Request a merge commit in the PR description if preserving history on `main` is warranted.
- Pointers to BUILD / RUNNING / ci-architecture / release docs.

### `docs/release.md` (new)
Captures the release-branch model validated end-to-end (PR #223, #232):

- **Branch model table** — `main` (rolling, `snapshot-latest` + `main-latest`/`latest`) vs `release/*` (pinned, `snapshot-<name>-latest` + `<name>-latest`) vs working branches.
- **`.moxygen-release` pin contract** — load-bearing on release branches; CI reads it to pin the moxygen tag. `main` omits it and floats via `--use-latest`.
- **Snapshot releases** — how rolling pre-releases are produced on every push.
- **Docker image tag taxonomy.**
- **Cutting a new release branch** — step-by-step.
- **Syncing a release branch from main** — step-by-step, including the throwaway-branch dry-run pattern used on `release/test-arm64-publish`.
- **Deploy flow** — auto for `main`, `workflow_dispatch` for `release/*`.
- **TODO: tagged release policy** — stub pointing to Alan's planned issue.

## Organization rationale
CONTRIBUTING.md kept tight (~100 lines) and external-facing. Release branch mechanics moved to `docs/release.md`. `docs/ci-architecture.md` already documents workflow files and stays unchanged.

| File | Purpose |
|---|---|
| README.md | Landing (existing) |
| BUILD.md, RUNNING.md | Build + runtime (existing) |
| **CONTRIBUTING.md** | **How to contribute (new)** |
| docs/ci-architecture.md | Workflow file reference (existing) |
| **docs/release.md** | **Release branch model + process (new)** |

## Harmonized with moxygen
Wording mirrors `openmoq/moxygen/OPENMOQ_CONTRIBUTING.md` (landed via #143 / #156). Both repos now read the same on squash/merge defaults, admin override, and branch conventions.

## Test plan
- [ ] Review for accuracy / tone
- [ ] CI green

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/225)
<!-- Reviewable:end -->