### PR TITLE
ci: drop linux arm64 from verify-build; rely on publish docker

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -47,11 +47,9 @@ jobs:
             preset: default
             build_dir: build
             runner: ubuntu-22.04
-          - name: linux arm64
-            preset: default
-            build_dir: build
-            runner: ubuntu-22.04-arm
-            platform: bookworm-arm64
+          # arm64 is validated by the publish-side docker build (publish arm64
+          # entry below); skipped here to avoid the ubuntu-runner ↔ bookworm-tarball
+          # glog ABI mismatch. arm64 issues surface at the publish step.
           # macOS disabled: moxygen tarball bakes brew Cellar versioned paths
           # that break when the runner has different brew package versions.
           # Re-enable once moxygen upstream fixes cmake to use opt symlinks.

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -37,11 +37,9 @@ jobs:
             preset: default
             build_dir: build
             runner: ubuntu-22.04
-          - name: linux arm64
-            preset: default
-            build_dir: build
-            runner: ubuntu-22.04-arm
-            platform: bookworm-arm64
+          # arm64 is validated by the publish-side docker build (ci-main publish
+          # arm64 entry); skipped here to avoid the ubuntu-runner ↔ bookworm-tarball
+          # glog ABI mismatch. arm64 regressions surface at main-push time.
           # macOS disabled: moxygen tarball bakes brew Cellar versioned paths
           # that break when the runner has different brew package versions.
           # Re-enable once moxygen upstream fixes cmake to use opt symlinks.


### PR DESCRIPTION
## Summary
Removes the `linux arm64` matrix entry from both `ci-pr.yml` and `ci-main.yml` verify-build. Validates arm64 only via the publish-side `docker build` (FROM debian:bookworm), which is environment-aligned with the bookworm tarball.

## Why
The `moxygen-bookworm-arm64.tar.gz` is built inside debian:bookworm. Linking it on plain ubuntu-22.04-arm trips a glog ABI mismatch. After multiple iterations trying to make a GitHub Actions container step work (FetchContent quirks, safe.directory issues), the cleanest move is to mirror what amd64 publish does for bookworm: build inside a real Docker multi-stage with `FROM debian:bookworm AS builder`.

## Coverage tradeoff
arm64 PR-time signal is lost (was failing anyway). arm64 regressions now surface at main-push time via the publish docker build. macOS in PR CI (macos-15 = Apple Silicon) will close most of the gap when re-enabled, since macOS exercises arm64 ISA-level issues.

## Test plan
- [ ] PR CI green here (linux + asan-debug only)
- [ ] Pre-merge validation via throwaway `release/test-arm64-publish` branch — triggers full ci-main, exercises arm64 publish docker build

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/231)
<!-- Reviewable:end -->
