### PR TITLE
ci: release title branch label + fix sync-blocked Slack emoji

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -355,10 +355,12 @@ jobs:
           SHORT="${GITHUB_SHA:0:7}"
           BRANCH="${{ github.ref_name }}"
           if [[ "$BRANCH" == "main" ]]; then
+            LABEL="main"
             TAG="snapshot-latest"
           else
-            # release/nab-demo → snapshot-nab-demo-latest
-            TAG="snapshot-${BRANCH#release/}-latest"
+            # release/nab-demo → nab-demo → snapshot-nab-demo-latest
+            LABEL="${BRANCH#release/}"
+            TAG="snapshot-${LABEL}-latest"
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
@@ -368,7 +370,7 @@ jobs:
 
           gh release create "$TAG" artifacts/**/* \
             --target "$GITHUB_SHA" \
-            --title "Latest build ($SHORT)" \
+            --title "Latest build — ${LABEL} (${SHORT})" \
             --prerelease \
             --notes "$(cat <<EOF
           Rolling snapshot of the latest build from \`${{ github.ref_name }}\`.

--- a/.github/workflows/moxygen-sync.yml
+++ b/.github/workflows/moxygen-sync.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           PR_NUM="${{ steps.blocking.outputs.pr_num }}"
           PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM}"
-          TEXT=":pause_button: *${{ github.repository }}* moxygen sync paused: PR <${PR_URL}|#${PR_NUM}> pending"
+          TEXT=":no_entry: *${{ github.repository }}* moxygen sync blocked: PR <${PR_URL}|#${PR_NUM}> needs resolution"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --data "{\"text\": \"${TEXT}\"}"


### PR DESCRIPTION
## Summary
Two small Slack / GitHub Releases polish items. Both CI-only, targeted at main, forward-only (no retroactive change to existing releases or to release/nab-demo).

### 1. Branch label in snapshot release title ([ci-main.yml](.github/workflows/ci-main.yml))
Snapshot pre-releases from main and release/* both rendered as \`Latest build (<sha>)\` — identical card shape made it easy to conflate.

Before: \`Latest build (9d443d6)\`, \`Latest build (d4cd631)\`
After:  \`Latest build — main (9d443d6)\`, \`Latest build — nab-demo (d4cd631)\`

### 2. Sync-blocked Slack emoji ([moxygen-sync.yml](.github/workflows/moxygen-sync.yml))
\`:pause_button:\` wasn't rendering in bot-posted Slack messages (shown as literal text). Swap to \`:no_entry:\` (⛔) — in the core Slack emoji set alongside \`:x:\` and \`:white_check_mark:\` which already render from the same webhook path.

Also reword "paused" → "blocked" so the notification reads correctly: the sync is hard-gated until the existing PR is resolved.

Emoji vocabulary after this change:

| glyph | shortcode | meaning |
| --- | --- | --- |
| ✅ | \`:white_check_mark:\` | all-green pipeline |
| ❌ | \`:x:\` | hard pipeline failure |
| ⚠️ | \`:warning:\` | investigate something odd (unchanged) |
| ⛔ | \`:no_entry:\` | pipe halted until this obstruction clears |

## Scope notes
- Slack/email notification text elsewhere is unaffected by the title change (they build strings from \`github.ref_name\` directly).
- Moxygen has a parallel \`:pause_button:\` in \`omoq-upstream-sync.yml\` that wants the same swap — separate PR to that repo.
- Does not touch release/nab-demo. release/nab-demo's existing release records and workflow files are untouched.

## Test plan
- [x] CI green
- [ ] After merge to main: next ci-main push produces release titled \`Latest build — main (<sha>)\`
- [ ] After merge to main: next sync-blocked event renders ⛔ in Slack instead of literal \`:pause_button:\`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/235)
<!-- Reviewable:end -->
