### PR TITLE
ci: add moqx-000 alias (DNS + cert SAN) to main deploy

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -393,6 +393,9 @@ jobs:
     runs-on: [self-hosted, linode]
     env:
       DOMAIN: moqx-main.ci.openmoq.org
+      # Legacy alias retained for the interop-runner (which still targets
+      # moqx-000) until that upstream config is updated. Drop when unused.
+      DOMAIN_ALIAS: moqx-000.ci.openmoq.org
       RELAY_PORT: 4433
       ADMIN_PORT: 8000
     steps:
@@ -410,20 +413,31 @@ jobs:
             echo "::error::Could not determine runner public IP"
             exit 1
           fi
-          echo "Ensuring A record: $DOMAIN → $IP"
+          echo "Ensuring A records: $DOMAIN → $IP, $DOMAIN_ALIAS → $IP"
           CHANGE_FILE=$(mktemp)
           cat > "$CHANGE_FILE" <<EOF
           {
-            "Comment": "moqx auto-deploy: $DOMAIN",
-            "Changes": [{
-              "Action": "UPSERT",
-              "ResourceRecordSet": {
-                "Name": "$DOMAIN",
-                "Type": "A",
-                "TTL": 300,
-                "ResourceRecords": [{"Value": "$IP"}]
+            "Comment": "moqx auto-deploy: $DOMAIN (+ alias $DOMAIN_ALIAS)",
+            "Changes": [
+              {
+                "Action": "UPSERT",
+                "ResourceRecordSet": {
+                  "Name": "$DOMAIN",
+                  "Type": "A",
+                  "TTL": 300,
+                  "ResourceRecords": [{"Value": "$IP"}]
+                }
+              },
+              {
+                "Action": "UPSERT",
+                "ResourceRecordSet": {
+                  "Name": "$DOMAIN_ALIAS",
+                  "Type": "A",
+                  "TTL": 300,
+                  "ResourceRecords": [{"Value": "$IP"}]
+                }
               }
-            }]
+            ]
           }
           EOF
           CHANGE_ID=$(aws route53 change-resource-record-sets \
@@ -439,16 +453,26 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OMOQ_CERTBOT_SECRET_ACCESS_KEY }}
         run: |
           CERT="/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
+          need_issue=false
           if [ ! -f "$CERT" ]; then
             echo "::warning::No cert for ${DOMAIN} — provisioning via Route53"
-            sudo -E certbot certonly --dns-route53 \
-              -d "$DOMAIN" --non-interactive --agree-tos \
-              --email gmarzot@openmoq.org
+            need_issue=true
           elif ! sudo openssl x509 -in "$CERT" -noout -checkend 2592000 2>/dev/null; then
             echo "::warning::Cert for ${DOMAIN} expires within 30 days — renewing"
-            sudo -E certbot renew --cert-name "$DOMAIN"
+            need_issue=true
+          elif ! sudo openssl x509 -in "$CERT" -noout -text | grep -qE "DNS:${DOMAIN_ALIAS}( |$|,)"; then
+            echo "::warning::Cert for ${DOMAIN} missing alias SAN ${DOMAIN_ALIAS} — expanding"
+            need_issue=true
           else
-            echo "Cert for ${DOMAIN} is valid"
+            echo "Cert for ${DOMAIN} is valid and includes ${DOMAIN_ALIAS}"
+          fi
+
+          if $need_issue; then
+            sudo -E certbot certonly --dns-route53 --expand \
+              --cert-name "$DOMAIN" \
+              -d "$DOMAIN" -d "$DOMAIN_ALIAS" \
+              --non-interactive --agree-tos \
+              --email gmarzot@openmoq.org
           fi
 
       - name: Log in to GHCR

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,6 +1,6 @@
 name: deploy relay
 
-# Ops controls for the CI relay (moqx-000.ci.openmoq.org).
+# Ops controls for the CI relay (moqx-main.ci.openmoq.org + moqx-000 alias).
 # Restart, redeploy with a specific image tag, or change verbose level.
 
 on:
@@ -17,7 +17,7 @@ on:
         default: ""
         type: string
       domain:
-        description: "DNS hostname (default: derived from branch — main→moqx-000, release/X→moqx-X)"
+        description: "DNS hostname (default: derived from branch — main→moqx-main, release/X→moqx-X)"
         required: false
         default: ""
         type: string


### PR DESCRIPTION
## Summary
Interop runner (englishm/moq-interop-runner) hardcodes \`https://moqx-000.ci.openmoq.org:4433/moq-relay\`. Our deploy rename to \`moqx-main.ci.openmoq.org\` left that URL broken at the cert layer — WebTransport handshake fails on the runner side due to TLS SAN mismatch (the moqx-main cert doesn't include moqx-000).

Add \`moqx-000.ci.openmoq.org\` as an alias maintained alongside moqx-main in both the Route53 UPSERT and the certbot cert on the main deploy. Cheaper than getting the upstream interop-runner PR landed.

## Changes
**ci-main.yml \`deploy\` job (main-only)**:
- Add \`DOMAIN_ALIAS: moqx-000.ci.openmoq.org\` env var
- Route53 UPSERT now writes both \`$DOMAIN\` and \`$DOMAIN_ALIAS\` A records in a single change batch
- Cert step checks that existing cert includes both \`$DOMAIN\` and \`$DOMAIN_ALIAS\` SANs; if missing (or cert missing / near expiry), runs \`certbot certonly --expand --cert-name $DOMAIN -d $DOMAIN -d $DOMAIN_ALIAS\`

**deploy-relay.yml drive-by**:
- Fix stale UI help text that said \`main→moqx-000\` (code actually derives \`moqx-\${LABEL}\` which is \`moqx-main\` on main)
- Update header comment

## Test plan
- [ ] CI green
- [ ] After merge to main: next ci-main deploy job expands cert to include both SANs, writes both A records
- [ ] \`openssl s_client\` shows both SANs on the cert
- [ ] Interop-runner against moqx-000 succeeds (WebTransport handshake no longer fails)

## Follow-ups
- Update englishm/moq-interop-runner config to point at moqx-main when convenient; drop \`DOMAIN_ALIAS\` here once that's landed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/239)
<!-- Reviewable:end -->
