### PR TITLE
ci: skip test-reporter on fork PRs; explain in annotation

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -91,11 +91,19 @@ jobs:
           ASAN_OPTIONS: ${{ matrix.name == 'asan debug' && 'detect_leaks=1:abort_on_error=1' || '' }}
         run: bash scripts/build.sh test --build-dir ${{ matrix.build_dir }} -- --output-junit test-results.xml
 
+      # dorny/test-reporter writes a Check Run, which needs 'checks: write' on
+      # GITHUB_TOKEN. Fork-PR tokens are read-only regardless of workflow perms,
+      # so skip on cross-repo PRs. test-log output above still shows pass/fail.
       - name: Publish test results
         uses: dorny/test-reporter@v1.9.1
-        if: success() || failure()
+        if: ${{ (success() || failure()) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         with:
           name: "test (${{ matrix.name }})"
           path: ${{ matrix.build_dir }}/test-results.xml
           reporter: java-junit
           fail-on-empty: ${{ job.status == 'success' && 'true' || 'false' }}
+
+      - name: Note fork-PR reporter skip
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          echo "::notice::Publish test results skipped — fork-PR GITHUB_TOKEN lacks checks:write. Test-log output above is authoritative."


### PR DESCRIPTION
## Summary
Mirror of moxygen [#164](https://github.com/openmoq/moxygen/pull/164). \`dorny/test-reporter\` requires \`checks: write\` on \`GITHUB_TOKEN\`; fork-PR tokens are read-only regardless of workflow perms. Guard the reporter step to skip on cross-repo PRs; add a notice annotation explaining the skip.

## Effect
- **Same-repo PRs / sync PRs / main pushes**: no change.
- **Fork PRs**: reporter step shows Skipped with a ::notice:: annotation; test-log output above remains authoritative. Job goes green when tests pass.

## Test plan
- [ ] CI green on this PR (internal — reporter still runs)
- [ ] After merge: next fork PR (if any) runs clean with notice visible and green overall

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/240)
<!-- Reviewable:end -->
