### PR TITLE
Extract NamespaceTree to its own file, privatize node fields, split tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ FetchContent_MakeAvailable(reflectcpp)
 # --- Core library ---
 
 add_library(moqx_core STATIC
+  src/NamespaceTree.cpp
   src/MoqxRelay.cpp
   src/MoqxRelayContext.cpp
   src/MoqxRelayServer.cpp

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -134,45 +134,6 @@ folly::coro::Task<void> MoqxRelay::doNewGroupRequestUpdate(
   }
 }
 
-std::shared_ptr<MoqxRelay::NamespaceNode> MoqxRelay::findNamespaceNode(
-    const TrackNamespace& ns,
-    bool createMissingNodes,
-    MatchType matchType,
-    std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>*
-        sessions
-) {
-  std::shared_ptr<NamespaceNode> nodePtr(std::shared_ptr<void>(), &publishNamespaceRoot_);
-  TrackNamespace partialNs;
-  for (auto i = 0ul; i < ns.size(); i++) {
-    if (sessions) {
-      // Extract session pointers with their subscriber info from the map
-      for (const auto& [session, info] : nodePtr->sessions) {
-        sessions->emplace_back(session, info);
-      }
-    }
-    auto& name = ns[i];
-    partialNs.append(name);
-    auto it = nodePtr->children.find(name);
-    if (it == nodePtr->children.end()) {
-      if (createMissingNodes) {
-        auto node = std::make_shared<NamespaceNode>(*this, nodePtr.get());
-        node->trackNamespace_ = partialNs;
-        nodePtr->children.emplace(name, node);
-        // Don't increment yet - only when content is actually added
-        nodePtr = std::move(node);
-      } else if (matchType == MatchType::Prefix && nodePtr.get() != &publishNamespaceRoot_) {
-        return nodePtr;
-      } else {
-        XLOG(ERR) << "prefix not found in publishNamespace tree";
-        return nullptr;
-      }
-    } else {
-      nodePtr = it->second;
-    }
-  }
-  return nodePtr;
-}
-
 std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespace(
     PublishNamespace pubNs,
     std::shared_ptr<MoQSession> session,
@@ -184,61 +145,26 @@ std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespac
   if (!pubNs.trackNamespace.startsWith(allowedNamespacePrefix_)) {
     return nullptr;
   }
-  std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>
-      sessions;
-  auto nodePtr = findNamespaceNode(
+  auto [nodePtr, sessions, replacedSession] = namespaceTree_.setPublisher(
       pubNs.trackNamespace,
-      /*createMissingNodes=*/true,
-      MatchType::Exact,
-      &sessions
+      session,
+      std::move(callback),
+      std::move(peerID),
+      pubNs.requestID
   );
-
-  // Log if there is already a session that has publishNamespace-d this track
-  if (nodePtr->sourceSession) {
-    XLOG(WARNING) << "PublishNamespace: Existing session (" << nodePtr->sourceSession.get()
+  if (replacedSession) {
+    XLOG(WARNING) << "PublishNamespace: Existing session (" << replacedSession.get()
                   << ") has already published trackNamespace=" << pubNs.trackNamespace;
-    // Since we don't fully support multiple publishers -- cancel the old
-    // publishNamespace and remove ongoing subscriptions to this publisher
-    // in that namespace.  Note: it could have publishNamespace-d a more
-    // specific namespace which hasn't been overridden by the new publisher, but
-    // for now we don't support that.
-    if (nodePtr->publishNamespaceCallback) {
-      nodePtr->publishNamespaceCallback->publishNamespaceCancel(
-          PublishNamespaceErrorCode::CANCELLED,
-          "New publisher"
-      );
-      nodePtr->publishNamespaceCallback.reset();
-    }
+    // Remove ongoing subscriptions for the replaced publisher.
     for (auto it = subscriptions_.begin(); it != subscriptions_.end();) {
-      // Check if the subscription's FullTrackName is in this namespace
       if (it->first.trackNamespace.startsWith(pubNs.trackNamespace) &&
-          it->second.upstream == nodePtr->sourceSession) {
+          it->second.upstream == replacedSession) {
         XLOG(DBG4) << "Erasing subscription to " << it->first;
         it = subscriptions_.erase(it);
       } else {
         ++it;
       }
     }
-    nodePtr->sourceSession.reset();
-  }
-
-  // Include sessions that subscribed exactly this namespace as well.
-  // findNamespaceNode(..., &sessions) collects subscribers attached to prefixes
-  // along the path, but does not include this node's own sessions.
-  for (const auto& [outSession, info] : nodePtr->sessions) {
-    sessions.emplace_back(outSession, info);
-  }
-
-  bool wasEmpty = !nodePtr->hasLocalSessions();
-  nodePtr->sourceSession = session;
-  nodePtr->sourcePeerID = std::move(peerID);
-  nodePtr->publishNamespaceCallback = std::move(callback);
-  nodePtr->trackNamespace_ = pubNs.trackNamespace;
-  nodePtr->setPublishNamespaceOk({.requestID = pubNs.requestID, .requestSpecificParams = {}});
-
-  // If this is the first content added to this node, notify parent
-  if (wasEmpty && nodePtr->parent_) {
-    nodePtr->parent_->incrementActiveChildren();
   }
   for (auto& [outSession, info] : sessions) {
     if (outSession != session && (info.options == SubscribeNamespaceOptions::NAMESPACE ||
@@ -279,81 +205,15 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespac
 folly::coro::Task<void> MoqxRelay::publishNamespaceToSession(
     std::shared_ptr<MoQSession> session,
     PublishNamespace pubNs,
-    std::shared_ptr<NamespaceNode> nodePtr
+    std::shared_ptr<NamespaceTree::NamespaceNode> nodePtr
 ) {
   auto publishNamespaceHandle = co_await session->publishNamespace(pubNs);
   if (publishNamespaceHandle.hasError()) {
     XLOG(ERR) << "PublishNamespace failed err=" << publishNamespaceHandle.error().reasonPhrase;
   } else {
     // This can race with unsubscribeNamespace
-    nodePtr->namespacesPublished[session] = std::move(publishNamespaceHandle.value());
+    nodePtr->addDraft14PublishNamespaceHandle(session, std::move(publishNamespaceHandle.value()));
   }
-}
-
-// NamespaceNode ref count management methods for pruning
-void MoqxRelay::NamespaceNode::incrementActiveChildren() {
-  activeChildCount_++;
-  // Propagate up if this was the first active child
-  if (activeChildCount_ == 1 && parent_ && !hasLocalSessions()) {
-    parent_->incrementActiveChildren();
-  }
-}
-
-void MoqxRelay::NamespaceNode::decrementActiveChildren() {
-  XCHECK_GT(activeChildCount_, 0);
-  activeChildCount_--;
-}
-
-// Walk up the tree to find and prune the highest empty ancestor
-void MoqxRelay::NamespaceNode::tryPruneChild(const std::string& childKey) {
-  auto it = children.find(childKey);
-  if (it == children.end()) {
-    return;
-  }
-
-  auto childNode = it->second.get();
-  if (childNode->shouldKeep()) {
-    return;
-  }
-
-  // Walk up the tree, decrementing counts, to find highest empty ancestor
-  // Track the key to remove and the parent to remove it from
-  std::string keyToRemove = childKey;
-  NamespaceNode* parentOfNodeToRemove = this;
-  NamespaceNode* current = this;
-
-  while (current) {
-    XCHECK_GT(current->activeChildCount_, 0);
-    current->activeChildCount_--;
-
-    // If current still has content or children after decrement, stop walking
-    // Remove keyToRemove from parentOfNodeToRemove
-    if (current->hasLocalSessions() || current->activeChildCount_ > 0) {
-      break;
-    }
-
-    // Current is now empty too - if it has a parent, continue walking up
-    if (!current->parent_) {
-      // We've reached root - can't remove root, so stop
-      break;
-    }
-
-    // Current is empty and not root, so it becomes the new candidate for
-    // removal Find the key for current in its parent's children map
-    for (const auto& [key, node] : current->parent_->children) {
-      if (node.get() == current) {
-        keyToRemove = key;
-        parentOfNodeToRemove = current->parent_;
-        break;
-      }
-    }
-
-    current = current->parent_;
-  }
-
-  // Remove the highest empty node from its parent
-  XLOG(DBG1) << "Pruning empty subtree at: " << keyToRemove;
-  parentOfNodeToRemove->children.erase(keyToRemove);
 }
 
 void MoqxRelay::doPublishNamespaceDone(
@@ -361,48 +221,26 @@ void MoqxRelay::doPublishNamespaceDone(
     std::shared_ptr<MoQSession> session
 ) {
   XLOG(DBG1) << __func__ << " ns=" << trackNamespace;
-  // Node would be useful if there were back links
-  auto nodePtr = findNamespaceNode(trackNamespace);
-  if (!nodePtr) {
-    // Node was already pruned, nothing to do, maybe app called unannouce twice?
-    XLOG(DBG1) << "Node already pruned for ns=" << trackNamespace;
+  auto result = namespaceTree_.unpublishNamespace(trackNamespace, session);
+  if (result.hasError()) {
+    if (result.error() == NamespaceTree::Error::NodeNotFound) {
+      XLOG(DBG1) << "Node already pruned for ns=" << trackNamespace;
+    } else {
+      XLOG(DBG1) << "Ignoring publishNamespaceDone for ns=" << trackNamespace
+                 << " (no owner or non-owner session)";
+    }
     return;
   }
-
-  // Track if node had local content before modification
-  bool hadLocalContent = nodePtr->hasLocalSessions();
-
-  // Only allow publishNamespaceDone if there is an owner and the caller is that
-  // owner
-  if (nodePtr->sourceSession == nullptr || nodePtr->sourceSession != session) {
-    XLOG(DBG1) << "Ignoring publishNamespaceDone for ns=" << trackNamespace
-               << " (no owner or non-owner session)";
-    return;
+  // Draft <= 15: dispatch publishNamespaceDone on each subscriber's executor
+  for (auto& [sess, handle] : result.value().legacyHandles) {
+    sess->getExecutor()->add([h = handle] { h->publishNamespaceDone(); });
   }
-
-  nodePtr->sourceSession = nullptr;
-  nodePtr->sourcePeerID.clear();
-  nodePtr->publishNamespaceCallback.reset();
-
-  // Notify downstream namespace subscribers
-  std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>
-      sessions;
-  findNamespaceNode(
-      trackNamespace,
-      /*createMissingNodes=*/false,
-      MatchType::Exact,
-      &sessions
-  );
-  // Also include sessions at the target node itself
-  for (const auto& [sessionPtr, info] : nodePtr->sessions) {
-    sessions.emplace_back(sessionPtr, info);
-  }
-  for (auto& [outSession, info] : sessions) {
+  // Draft >= 16: send NAMESPACE_DONE on the bidi stream
+  for (auto& [outSession, info] : result.value().subscribers) {
     if (outSession != session && (info.options == SubscribeNamespaceOptions::NAMESPACE ||
                                   info.options == SubscribeNamespaceOptions::BOTH)) {
       auto maybeVersion = outSession->getNegotiatedVersion();
       if (maybeVersion.has_value() && getDraftMajorVersion(*maybeVersion) >= 16) {
-        // Draft 16+: send NAMESPACE_DONE on the bidi stream
         if (info.namespacePublishHandle) {
           TrackNamespace suffix(std::vector<std::string>(
               trackNamespace.trackNamespace.begin() + info.trackNamespacePrefix.size(),
@@ -410,28 +248,12 @@ void MoqxRelay::doPublishNamespaceDone(
           ));
           info.namespacePublishHandle->namespaceDoneMsg(suffix);
         }
-      } else {
-        // Draft <= 15: send PUBLISH_NAMESPACE_DONE on the existing stream
-        auto it = nodePtr->namespacesPublished.find(outSession);
-        if (it != nodePtr->namespacesPublished.end()) {
-          auto exec = outSession->getExecutor();
-          exec->add([publishNamespaceHandle = it->second] {
-            publishNamespaceHandle->publishNamespaceDone();
-          });
-        }
       }
     }
   }
-  nodePtr->namespacesPublished.clear();
-
-  // Prune if node became empty and has a parent
-  if (hadLocalContent && !nodePtr->shouldKeep() && nodePtr->parent_ &&
-      !trackNamespace.trackNamespace.empty()) {
-    nodePtr->parent_->tryPruneChild(trackNamespace.trackNamespace.back());
-  }
 }
 
-void MoqxRelay::publishNamespaceDone(const TrackNamespace& trackNamespace, NamespaceNode*) {
+void MoqxRelay::onPublishNamespaceDone(const TrackNamespace& trackNamespace) {
   doPublishNamespaceDone(trackNamespace, MoQSession::getRequestSession());
 }
 
@@ -441,18 +263,7 @@ void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
   auto it = subscriptions_.find(ftn);
   if (it != subscriptions_.end()) {
     if (it->second.isPublish) {
-      // Remove from publishes map
-      auto nodePtr = findNamespaceNode(ftn.trackNamespace);
-      if (nodePtr) {
-        bool hadLocalContent = nodePtr->hasLocalSessions();
-        nodePtr->publishes.erase(ftn.trackName);
-
-        // Prune if node became empty and has a parent
-        if (hadLocalContent && !nodePtr->shouldKeep() && nodePtr->parent_ &&
-            !ftn.trackNamespace.trackNamespace.empty()) {
-          nodePtr->parent_->tryPruneChild(ftn.trackNamespace.trackNamespace.back());
-        }
-      }
+      namespaceTree_.unpublishTrack(ftn.trackNamespace, ftn.trackName);
     }
 
     // Clear the handle and upstream - this signals publisher is done
@@ -486,40 +297,22 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
     );
   }
 
-  // Find All Nodes that Subscribed to this namespace (including
-  // prefix ns)
-  std::vector<std::pair<std::shared_ptr<MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>
-      sessions = {};
-  auto nodePtr = findNamespaceNode(
-      pub.fullTrackName.trackNamespace,
-      /*createMissingNodes=*/true,
-      MatchType::Exact,
-      &sessions
-  );
-  // Extract session pointers with their subscriber info from the map
-  for (const auto& [sessionPtr, info] : nodePtr->sessions) {
-    sessions.emplace_back(sessionPtr, info);
-  }
-
   auto session = MoQSession::getRequestSession();
-  bool wasEmpty = !nodePtr->hasLocalSessions();
 
+  // Handle duplicate publisher at relay level before registering in the tree.
+  // Move the forwarder out and erase the entry BEFORE calling publishDone.
+  // publishDone iterates subscribers via forEachSubscriber; if a subscriber
+  // has no open subgroups, drainSubscriber → onEmpty fires. If the entry
+  // still existed, onEmpty would erase it (destroying the forwarder) while
+  // forEachSubscriber is still iterating → use-after-free.
+  // handle is null when the previous publisher already terminated (e.g.
+  // reconnect after a dropped connection with subscribers still draining open
+  // subgroups).  onPublishDone() already reset handle and drained the
+  // forwarder, so skip both calls to avoid a null deref and a double
+  // publishDone.
   auto it = subscriptions_.find(pub.fullTrackName);
   if (it != subscriptions_.end()) {
-    // someone already published this FTN, we don't support
-    // multipublisher
     XLOG(DBG1) << "New publisher for existing subscription";
-    nodePtr->publishes.erase(pub.fullTrackName.trackName);
-    // Move the forwarder out and erase the entry BEFORE calling publishDone.
-    // publishDone iterates subscribers via forEachSubscriber; if a subscriber
-    // has no open subgroups, drainSubscriber → onEmpty fires. If the entry
-    // still existed, onEmpty would erase it (destroying the forwarder) while
-    // forEachSubscriber is still iterating → use-after-free.
-    // handle is null when the previous publisher already terminated (e.g.
-    // reconnect after a dropped connection with subscribers still draining open
-    // subgroups).  onPublishDone() already reset handle and drained the
-    // forwarder, so skip both calls to avoid a null deref and a double
-    // publishDone.
     auto oldHandle = std::move(it->second.handle);
     auto oldForwarder = std::move(it->second.forwarder);
     XLOG(DBG4) << "Erasing subscription to " << it->first;
@@ -534,18 +327,9 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
       );
     }
   }
-  auto res = nodePtr->publishes.emplace(pub.fullTrackName.trackName, session);
-  XCHECK(res.second) << "Duplicate publish";
-
-  // If this is the first content added to this node, notify parent
-  if (wasEmpty && nodePtr->hasLocalSessions() && nodePtr->parent_) {
-    nodePtr->parent_->incrementActiveChildren();
-  }
 
   // Create Forwarder for this publish
   auto forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
-
-  // Set Forwarder Params
   forwarder->setExtensions(pub.extensions);
 
   auto subRes = subscriptions_.emplace(
@@ -568,25 +352,26 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   topNFilter->setActivityTarget(&rsub.lastObjectTime);
   topNFilter->setActivityThreshold(activityThreshold_);
 
-  // Register track with all PropertyRankings along the path from root to this
-  // node (inclusive). Rankings exist at nodes where TRACK_FILTER subscribers
-  // subscribed. A subscriber at /conf should see tracks published under
-  // /conf/room1, so we must walk up the ancestor chain.
-  for (NamespaceNode* node = nodePtr.get(); node != nullptr; node = node->parent_) {
-    for (auto& [propertyType, ranking] : node->rankings) {
-      auto initialPropertyValue = pub.extensions.getIntExtension(propertyType);
-      ranking->registerTrack(pub.fullTrackName, initialPropertyValue, session);
-      topNFilter->registerObserver(
-          propertyType,
-          PropertyObserver{
-              .onValueChanged = [ranking, ftn = pub.fullTrackName](uint64_t value
-                                ) { ranking->updateSortValue(ftn, value); },
-              .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); },
-              .onActivity = [ranking]() { ranking->sweepIdle(); }
-          }
-      );
-    }
-  }
+  // Register in the namespace tree. The ranking callback fires once per
+  // PropertyRanking on the path from this node to the root — registering the
+  // track and wiring observers so TRACK_FILTER subscribers see it.
+  auto [nodePtr, sessions] = namespaceTree_.addPublish(
+      pub.fullTrackName,
+      session,
+      [&](uint64_t propertyType, const std::shared_ptr<PropertyRanking>& ranking) {
+        auto initialPropertyValue = pub.extensions.getIntExtension(propertyType);
+        ranking->registerTrack(pub.fullTrackName, initialPropertyValue, session);
+        topNFilter->registerObserver(
+            propertyType,
+            PropertyObserver{
+                .onValueChanged = [ranking, ftn = pub.fullTrackName](uint64_t value
+                                  ) { ranking->updateSortValue(ftn, value); },
+                .onTrackEnded = [ranking, ftn = pub.fullTrackName]() { ranking->removeTrack(ftn); },
+                .onActivity = [ranking]() { ranking->sweepIdle(); }
+            }
+        );
+      }
+  );
 
   uint64_t nSubscribers = 0;
   bool hasTrackFilterSub = false;
@@ -806,8 +591,6 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
         "empty"
     });
   }
-  auto nodePtr = findNamespaceNode(subNs.trackNamespacePrefix, /*createMissingNodes=*/true);
-
   SubscribeNamespaceOptions effectiveOptions;
   effectiveOptions = subNs.options;
 
@@ -820,11 +603,10 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
     }
   }
 
-  // Check if this is the first session subscriber for this node
-  bool wasEmpty = !nodePtr->hasLocalSessions();
-  nodePtr->sessions.emplace(
+  auto nodePtr = namespaceTree_.addNamespaceSubscriber(
+      subNs.trackNamespacePrefix,
       session,
-      NamespaceNode::NamespaceSubscriberInfo{
+      NamespaceTree::NamespaceNode::NamespaceSubscriberInfo{
           subNs.forward,
           effectiveOptions,
           namespacePublishHandle,
@@ -842,72 +624,61 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
     ranking->addSessionToTopNGroup(trackFilter->maxSelected, session, subNs.forward);
   }
 
-  // If this is the first content added to this node, notify parent
-  if (wasEmpty && nodePtr->hasLocalSessions() && nodePtr->parent_) {
-    nodePtr->parent_->incrementActiveChildren();
-  }
-
   // Find all nested PublishNamespaces/Publishes and forward
-  std::deque<std::tuple<TrackNamespace, std::shared_ptr<NamespaceNode>>> nodes{
-      {subNs.trackNamespacePrefix, nodePtr}
-  };
   auto exec = session->getExecutor();
-  while (!nodes.empty()) {
-    auto [prefix, nodePtr] = std::move(*nodes.begin());
-    nodes.pop_front();
-    if (nodePtr->sourceSession && nodePtr->sourceSession != session &&
-        (incomingPeerID.empty() || nodePtr->sourcePeerID != incomingPeerID)) {
-      if (getDraftMajorVersion(*maybeNegotiatedVersion) >= 16) {
-        if (subNs.options == SubscribeNamespaceOptions::NAMESPACE ||
-            subNs.options == SubscribeNamespaceOptions::BOTH) {
-          // Compute the suffix: prefix minus subNs.trackNamespacePrefix
-          TrackNamespace suffix(std::vector<std::string>(
-              prefix.trackNamespace.begin() + subNs.trackNamespacePrefix.size(),
-              prefix.trackNamespace.end()
-          ));
-          namespacePublishHandle->namespaceMsg(suffix);
+  namespaceTree_.forEachNodeInSubtree(
+      subNs.trackNamespacePrefix,
+      nodePtr,
+      [&](const TrackNamespace& prefix, std::shared_ptr<NamespaceTree::NamespaceNode> node) {
+        if (node->publisherSession() && node->publisherSession() != session &&
+            (incomingPeerID.empty() || node->publisherPeerID() != incomingPeerID)) {
+          if (getDraftMajorVersion(*maybeNegotiatedVersion) >= 16) {
+            if (subNs.options == SubscribeNamespaceOptions::NAMESPACE ||
+                subNs.options == SubscribeNamespaceOptions::BOTH) {
+              // Compute the suffix: prefix minus subNs.trackNamespacePrefix
+              TrackNamespace suffix(std::vector<std::string>(
+                  prefix.trackNamespace.begin() + subNs.trackNamespacePrefix.size(),
+                  prefix.trackNamespace.end()
+              ));
+              namespacePublishHandle->namespaceMsg(suffix);
+            }
+          } else {
+            // TODO: Auth/params
+            co_withExecutor(
+                exec,
+                publishNamespaceToSession(session, {subNs.requestID, prefix}, node)
+            )
+                .start();
+          }
         }
-      } else {
-        // TODO: Auth/params
-        co_withExecutor(
-            exec,
-            publishNamespaceToSession(session, {subNs.requestID, prefix}, nodePtr)
-        )
-            .start();
-      }
-    }
-    for (auto& publishEntry : nodePtr->publishes) {
-      auto& publishSession = publishEntry.second;
-      FullTrackName ftn{prefix, publishEntry.first};
-      auto subscriptionIt = subscriptions_.find(ftn);
-      if (subscriptionIt == subscriptions_.end()) {
-        XLOG(ERR) << "Invalid state, no subscription for publish ftn=" << ftn;
-        continue;
-      }
-      auto& forwarder = subscriptionIt->second.forwarder;
-      auto maybeNegotiatedVersion = session->getNegotiatedVersion();
-      CHECK(maybeNegotiatedVersion.has_value());
+        node->forEachPublish([&](const std::string& trackName,
+                                 const std::shared_ptr<MoQSession>& publishSession) {
+          FullTrackName ftn{prefix, trackName};
+          auto subscriptionIt = subscriptions_.find(ftn);
+          if (subscriptionIt == subscriptions_.end()) {
+            XLOG(ERR) << "Invalid state, no subscription for publish ftn=" << ftn;
+            return;
+          }
+          auto& forwarder = subscriptionIt->second.forwarder;
+          auto maybeNegotiatedVersion = session->getNegotiatedVersion();
+          CHECK(maybeNegotiatedVersion.has_value());
 
-      // TRACK_FILTER subscribers: PropertyRanking drives selection via
-      // onTrackSelected; skip direct publish here.
-      if (trackFilter) {
-        continue;
-      }
+          // TRACK_FILTER subscribers: PropertyRanking drives selection via
+          // onTrackSelected; skip direct publish here.
+          if (trackFilter) {
+            return;
+          }
 
-      if (getDraftMajorVersion(*maybeNegotiatedVersion) <= 15 ||
-          (subNs.options == SubscribeNamespaceOptions::BOTH ||
-           subNs.options == SubscribeNamespaceOptions::PUBLISH)) {
-        if (publishSession != session) {
-          co_withExecutor(exec, publishToSession(session, forwarder, subNs.forward)).start();
-        }
+          if (getDraftMajorVersion(*maybeNegotiatedVersion) <= 15 ||
+              (subNs.options == SubscribeNamespaceOptions::BOTH ||
+               subNs.options == SubscribeNamespaceOptions::PUBLISH)) {
+            if (publishSession != session) {
+              co_withExecutor(exec, publishToSession(session, forwarder, subNs.forward)).start();
+            }
+          }
+        });
       }
-    }
-    for (auto& nextNodeIt : nodePtr->children) {
-      TrackNamespace nodePrefix(prefix);
-      nodePrefix.append(nextNodeIt.first);
-      nodes.emplace_back(std::forward_as_tuple(nodePrefix, nextNodeIt.second));
-    }
-  }
+  );
   co_return std::make_shared<NamespaceSubscription>(
       shared_from_this(),
       std::move(session),
@@ -923,56 +694,19 @@ void MoqxRelay::unsubscribeNamespace(
   XLOG(DBG1) << __func__ << " nsp=" << trackNamespacePrefix;
   // Clean up the reciprocal peer subNs handle for this session if present.
   peerSubNsHandles_.erase(session.get());
-  auto nodePtr = findNamespaceNode(trackNamespacePrefix);
-  if (!nodePtr) {
-    // TODO: maybe error?
-    return;
+  auto result = namespaceTree_.removeNamespaceSubscriber(trackNamespacePrefix, session);
+  if (result.hasError() && result.error() == NamespaceTree::Error::NotSubscribed) {
+    XLOG(DBG1) << "Namespace prefix was not subscribed by this session";
   }
-
-  // Track if node had local content before modification
-  bool hadLocalContent = nodePtr->hasLocalSessions();
-
-  auto it = nodePtr->sessions.find(session);
-  if (it != nodePtr->sessions.end()) {
-    // If session used TRACK_FILTER, remove it from the PropertyRanking group.
-    if (it->second.trackFilter) {
-      auto rankingIt = nodePtr->rankings.find(it->second.trackFilter->propertyType);
-      if (rankingIt != nodePtr->rankings.end()) {
-        rankingIt->second->removeSessionFromTopNGroup(it->second.trackFilter->maxSelected, session);
-      }
-    }
-
-    nodePtr->sessions.erase(it);
-
-    // Prune if node became empty and has a parent
-    if (hadLocalContent && !nodePtr->shouldKeep() && nodePtr->parent_ &&
-        !trackNamespacePrefix.trackNamespace.empty()) {
-      nodePtr->parent_->tryPruneChild(trackNamespacePrefix.trackNamespace.back());
-    }
-    return;
-  }
-  // TODO: error?
-  XLOG(DBG1) << "Namespace prefix was not subscribed by this session";
-}
-
-std::shared_ptr<MoQSession> MoqxRelay::findPublishNamespaceSession(const TrackNamespace& ns) {
-  /*
-   * This function is called from subscribe() and fetch().
-   * We use MatchType::Prefix here because the relay routes SUBSCRIBE and FETCH
-   * to the publisher who published the closest matching broader
-   * namespace, not necessarily the exact match.
-   */
-  auto nodePtr = findNamespaceNode(ns, /*createMissingNodes=*/false, MatchType::Prefix);
-  if (!nodePtr) {
-    return nullptr;
-  }
-  return nodePtr->sourceSession;
 }
 
 MoqxRelay::PublishState MoqxRelay::findPublishState(const FullTrackName& ftn) {
   PublishState state;
-  auto nodePtr =
-      findNamespaceNode(ftn.trackNamespace, /*createMissingNodes=*/false, MatchType::Exact);
+  auto nodePtr = namespaceTree_.findNode(
+      ftn.trackNamespace,
+      /*createMissingNodes=*/false,
+      NamespaceTree::MatchType::Exact
+  );
 
   if (!nodePtr) {
     // Node doesn't exist - tree was properly pruned
@@ -981,10 +715,7 @@ MoqxRelay::PublishState MoqxRelay::findPublishState(const FullTrackName& ftn) {
 
   state.nodeExists = true;
 
-  auto it = nodePtr->publishes.find(ftn.trackName);
-  if (it != nodePtr->publishes.end()) {
-    state.session = it->second;
-  }
+  state.session = nodePtr->findPublishSession(ftn.trackName);
 
   return state;
 }
@@ -1000,7 +731,7 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
   // second-subscriber path if that happened, avoiding a double
   // promise.setValue() crash (folly::PromiseAlreadySatisfied → std::terminate).
   if (subscriptionIt == subscriptions_.end() && upstream_) {
-    if (!findPublishNamespaceSession(subReq.fullTrackName.trackNamespace)) {
+    if (!namespaceTree_.findPublisherSession(subReq.fullTrackName.trackNamespace)) {
       co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
       subscriptionIt = subscriptions_.find(subReq.fullTrackName);
     }
@@ -1016,7 +747,7 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
           {subReq.requestID, SubscribeErrorCode::TRACK_NOT_EXIST, "namespace required"}
       ));
     }
-    auto upstreamSession = findPublishNamespaceSession(subReq.fullTrackName.trackNamespace);
+    auto upstreamSession = namespaceTree_.findPublisherSession(subReq.fullTrackName.trackNamespace);
     if (!upstreamSession) {
       // no such namespace has been published
       co_return folly::makeUnexpected(SubscribeError(
@@ -1194,10 +925,10 @@ MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
     }
   }
 
-  auto upstreamSession = findPublishNamespaceSession(fetch.fullTrackName.trackNamespace);
+  auto upstreamSession = namespaceTree_.findPublisherSession(fetch.fullTrackName.trackNamespace);
   if (!upstreamSession && upstream_) {
     co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
-    upstreamSession = findPublishNamespaceSession(fetch.fullTrackName.trackNamespace);
+    upstreamSession = namespaceTree_.findPublisherSession(fetch.fullTrackName.trackNamespace);
   }
   if (!upstreamSession) {
     // Attempt to find matching upstream subscription (from publish)
@@ -1271,10 +1002,12 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatus(TrackStat
     co_return trackStatusOk;
   } else {
     // No subscription - forward to upstream
-    auto upstreamSession = findPublishNamespaceSession(trackStatus.fullTrackName.trackNamespace);
+    auto upstreamSession =
+        namespaceTree_.findPublisherSession(trackStatus.fullTrackName.trackNamespace);
     if (!upstreamSession && upstream_) {
       co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
-      upstreamSession = findPublishNamespaceSession(trackStatus.fullTrackName.trackNamespace);
+      upstreamSession =
+          namespaceTree_.findPublisherSession(trackStatus.fullTrackName.trackNamespace);
     }
     if (!upstreamSession) {
       XLOG(DBG1) << "No upstream session for track: " << trackStatus.fullTrackName;
@@ -1377,11 +1110,11 @@ void MoqxRelay::newGroupRequested(MoQForwarder* forwarder, uint64_t group) {
 // TRACK_FILTER support
 
 std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
-    std::shared_ptr<NamespaceNode> node,
+    std::shared_ptr<NamespaceTree::NamespaceNode> node,
     uint64_t propertyType,
     const TrackNamespace& ns
 ) {
-  auto& ranking = node->rankings[propertyType];
+  auto& ranking = namespaceTree_.getOrInsertRanking(*node, propertyType);
   if (!ranking) {
     ranking = std::make_shared<PropertyRanking>(
         propertyType,
@@ -1417,74 +1150,66 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
 
     // Retroactively register tracks already published under this node and all
     // descendants. A subscriber at /conf should see tracks at /conf/room1/track1.
-    // Use BFS to traverse the subtree and register all published tracks.
-    std::deque<std::pair<TrackNamespace, NamespaceNode*>> queue;
-    queue.emplace_back(ns, node.get());
+    namespaceTree_.forEachNodeInSubtree(
+        ns,
+        node,
+        [&](const TrackNamespace& prefix, std::shared_ptr<NamespaceTree::NamespaceNode> current) {
+          // Collect tracks at this level with their last-activity time and current
+          // property value, then sort by lastObjectTime ascending so arrivalSeq
+          // assignment matches what would have happened if the subscription arrived
+          // before the publishers.
+          struct RetroTrack {
+            std::string trackName;
+            std::shared_ptr<moxygen::MoQSession> publishSession;
+            std::optional<uint64_t> initialPropertyValue;
+            std::chrono::steady_clock::time_point lastObjectTime;
+          };
+          std::vector<RetroTrack> retroTracks;
+          retroTracks.reserve(current->publishCount());
 
-    while (!queue.empty()) {
-      auto [prefix, current] = queue.front();
-      queue.pop_front();
-
-      // Collect tracks at this level with their last-activity time and current
-      // property value, then sort by lastObjectTime ascending so arrivalSeq
-      // assignment matches what would have happened if the subscription arrived
-      // before the publishers.
-      struct RetroTrack {
-        std::string trackName;
-        std::shared_ptr<moxygen::MoQSession> publishSession;
-        std::optional<uint64_t> initialPropertyValue;
-        std::chrono::steady_clock::time_point lastObjectTime;
-      };
-      std::vector<RetroTrack> retroTracks;
-      retroTracks.reserve(current->publishes.size());
-
-      for (auto& [trackName, publishSession] : current->publishes) {
-        FullTrackName ftn{prefix, trackName};
-        std::optional<uint64_t> initialPropertyValue;
-        std::chrono::steady_clock::time_point lastObjectTime{};
-        auto subIt = subscriptions_.find(ftn);
-        if (subIt != subscriptions_.end()) {
-          lastObjectTime = subIt->second.lastObjectTime;
-          initialPropertyValue =
-              subIt->second.forwarder->extensions().getIntExtension(propertyType);
-          // Wire value-change, track-ended, and activity observers on the existing TopNFilter.
-          if (subIt->second.topNFilter) {
-            auto rankingPtr = ranking;
-            subIt->second.topNFilter->registerObserver(
-                propertyType,
-                PropertyObserver{
-                    .onValueChanged = [rankingPtr, ftn](uint64_t value
-                                      ) { rankingPtr->updateSortValue(ftn, value); },
-                    .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); },
-                    .onActivity = [rankingPtr]() { rankingPtr->sweepIdle(); }
-                }
+          current->forEachPublish([&](const std::string& trackName,
+                                      const std::shared_ptr<MoQSession>& publishSession) {
+            FullTrackName ftn{prefix, trackName};
+            std::optional<uint64_t> initialPropertyValue;
+            std::chrono::steady_clock::time_point lastObjectTime{};
+            auto subIt = subscriptions_.find(ftn);
+            if (subIt != subscriptions_.end()) {
+              lastObjectTime = subIt->second.lastObjectTime;
+              initialPropertyValue =
+                  subIt->second.forwarder->extensions().getIntExtension(propertyType);
+              // Wire value-change, track-ended, and activity observers on the existing TopNFilter.
+              if (subIt->second.topNFilter) {
+                auto rankingPtr = ranking;
+                subIt->second.topNFilter->registerObserver(
+                    propertyType,
+                    PropertyObserver{
+                        .onValueChanged = [rankingPtr, ftn](uint64_t value
+                                          ) { rankingPtr->updateSortValue(ftn, value); },
+                        .onTrackEnded = [rankingPtr, ftn]() { rankingPtr->removeTrack(ftn); },
+                        .onActivity = [rankingPtr]() { rankingPtr->sweepIdle(); }
+                    }
+                );
+              }
+            }
+            retroTracks.push_back({trackName, publishSession, initialPropertyValue, lastObjectTime}
             );
+          });
+
+          std::sort(
+              retroTracks.begin(),
+              retroTracks.end(),
+              [](const RetroTrack& a, const RetroTrack& b) {
+                return a.lastObjectTime < b.lastObjectTime;
+              }
+          );
+
+          for (const auto& t : retroTracks) {
+            FullTrackName ftn{prefix, t.trackName};
+            ranking->registerTrack(ftn, t.initialPropertyValue, t.publishSession);
+            XLOG(DBG4) << "[getOrCreateRanking] Retroactively registered track " << ftn;
           }
         }
-        retroTracks.push_back({trackName, publishSession, initialPropertyValue, lastObjectTime});
-      }
-
-      std::sort(
-          retroTracks.begin(),
-          retroTracks.end(),
-          [](const RetroTrack& a, const RetroTrack& b) {
-            return a.lastObjectTime < b.lastObjectTime;
-          }
-      );
-
-      for (const auto& t : retroTracks) {
-        FullTrackName ftn{prefix, t.trackName};
-        ranking->registerTrack(ftn, t.initialPropertyValue, t.publishSession);
-        XLOG(DBG4) << "[getOrCreateRanking] Retroactively registered track " << ftn;
-      }
-
-      // Queue children for traversal
-      for (auto& [childKey, childNode] : current->children) {
-        TrackNamespace childPrefix(prefix);
-        childPrefix.append(childKey);
-        queue.emplace_back(childPrefix, childNode.get());
-      }
-    }
+    );
   }
   return ranking;
 }
@@ -1580,25 +1305,22 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
   visitor.onSubscriptionsEnd();
 
   visitor.onNamespaceTreeBegin();
-  std::function<void(std::string_view, const NamespaceNode&)> walkNode;
-  walkNode = [&](std::string_view childKey, const NamespaceNode& node) {
-    std::string publisherAddr;
-    if (node.sourceSession) {
-      publisherAddr = node.sourceSession->getPeerAddress().describe();
-    }
-    visitor.beginNamespaceNode(
-        childKey,
-        node.trackNamespace_,
-        node.sessions.size(),
-        publisherAddr,
-        node.sourcePeerID
-    );
-    for (const auto& [key, child] : node.children) {
-      walkNode(key, *child);
-    }
-    visitor.endNamespaceNode();
-  };
-  walkNode("", publishNamespaceRoot_);
+  namespaceTree_.walkTree(
+      [&](std::string_view childKey, const NamespaceTree::NamespaceNode& node) {
+        std::string publisherAddr;
+        if (node.publisherSession()) {
+          publisherAddr = node.publisherSession()->getPeerAddress().describe();
+        }
+        visitor.beginNamespaceNode(
+            childKey,
+            node.trackNamespace,
+            node.subscriberCount(),
+            publisherAddr,
+            node.publisherPeerID()
+        );
+      },
+      [&]() { visitor.endNamespaceNode(); }
+  );
   visitor.onNamespaceTreeEnd();
 
   if (cache_) {

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "NamespaceTree.h"
 #include "UpstreamProvider.h"
 #include "config/Config.h"
 #include "relay/PropertyRanking.h"
@@ -89,7 +90,8 @@ public:
 class MoqxRelay : public moxygen::Publisher,
                   public moxygen::Subscriber,
                   public std::enable_shared_from_this<MoqxRelay>,
-                  public moxygen::MoQForwarder::Callback {
+                  public moxygen::MoQForwarder::Callback,
+                  public NamespaceTree::Callback {
 public:
   // Default for maxDeselected (tracks kept in deselected queue before eviction).
   // Set to 0 until pause/resume forwarding callbacks are wired in PropertyRanking;
@@ -187,9 +189,10 @@ public:
   ) override;
 
   std::shared_ptr<moxygen::MoQSession> findPublishNamespaceSession(const moxygen::TrackNamespace& ns
-  );
+  ) {
+    return namespaceTree_.findPublisherSession(ns);
+  }
 
-  // Wrapper for compatibility - returns single session as vector
   std::vector<std::shared_ptr<moxygen::MoQSession>>
   findPublishNamespaceSessions(const moxygen::TrackNamespace& ns) {
     auto session = findPublishNamespaceSession(ns);
@@ -239,88 +242,9 @@ private:
 
   void onPublishDone(const moxygen::FullTrackName& ftn);
 
-  struct NamespaceNode : public moxygen::Subscriber::PublishNamespaceHandle {
-    explicit NamespaceNode(MoqxRelay& relay, NamespaceNode* parent = nullptr)
-        : relay_(relay), parent_(parent) {}
+  void onPublishNamespaceDone(const moxygen::TrackNamespace& ns) override;
 
-    void publishNamespaceDone() override { relay_.publishNamespaceDone(trackNamespace_, this); }
-
-    folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate reqUpdate
-    ) override {
-      co_return folly::makeUnexpected(moxygen::RequestError{
-          reqUpdate.requestID,
-          moxygen::RequestErrorCode::NOT_SUPPORTED,
-          "REQUEST_UPDATE not supported for relay PUBLISH_NAMESPACE"
-      });
-    }
-
-    // Helper to check if THIS node (excluding children) has content
-    bool hasLocalSessions() const {
-      return !publishes.empty() || !sessions.empty() || !namespacesPublished.empty() ||
-             sourceSession != nullptr;
-    }
-
-    // Check if node should be kept (has content OR non-empty children)
-    bool shouldKeep() const { return hasLocalSessions() || activeChildCount_ > 0; }
-
-    using moxygen::Subscriber::PublishNamespaceHandle::setPublishNamespaceOk;
-
-    moxygen::TrackNamespace trackNamespace_;
-    folly::F14FastMap<std::string, std::shared_ptr<NamespaceNode>> children;
-
-    // Maps a track name to the session performing the PUBLISH
-    folly::F14FastMap<std::string, std::shared_ptr<moxygen::MoQSession>> publishes;
-
-    // Info stored per SUBSCRIBE_NAMESPACE subscriber
-    struct NamespaceSubscriberInfo {
-      bool forward{true};
-      moxygen::SubscribeNamespaceOptions options{moxygen::SubscribeNamespaceOptions::BOTH};
-      // Handle for sending NAMESPACE / NAMESPACE_DONE on the bidi stream
-      // (draft 16+). Null for draft <= 15.
-      std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> namespacePublishHandle;
-      // The namespace prefix this subscriber used for SUBSCRIBE_NAMESPACE
-      moxygen::TrackNamespace trackNamespacePrefix;
-      // TRACK_FILTER parameters (non-null when subscriber uses top-N filtering)
-      std::optional<moxygen::TrackFilter> trackFilter;
-    };
-
-    // PropertyRanking instances per property type for TRACK_FILTER subscribers
-    folly::F14FastMap<uint64_t, std::shared_ptr<PropertyRanking>> rankings;
-
-    // Sessions with a SUBSCRIBE_NAMESPACE here, with their preferences
-    folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, NamespaceSubscriberInfo> sessions;
-    // All active PUBLISH_NAMESPACEs for this node (includes prefix sessions)
-    folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, std::shared_ptr<PublishNamespaceHandle>>
-        namespacesPublished;
-    // The session that PUBLISH_NAMESPACEd this node
-    std::shared_ptr<moxygen::MoQSession> sourceSession;
-    // Peer relay ID that sourced this namespace (empty for local publishers)
-    std::string sourcePeerID;
-    std::shared_ptr<PublishNamespaceCallback> publishNamespaceCallback;
-
-    MoqxRelay& relay_;
-
-    // Pruning support: parent pointer and active child count
-    NamespaceNode* parent_{nullptr}; // back link (raw pointer, parent owns us)
-    size_t activeChildCount_{0};     // count of children with content
-
-    friend class MoqxRelay;
-
-    void incrementActiveChildren();
-    void decrementActiveChildren();
-    void tryPruneChild(const std::string& childKey);
-  };
-
-  NamespaceNode publishNamespaceRoot_{*this};
-  enum class MatchType { Exact, Prefix };
-  std::shared_ptr<NamespaceNode> findNamespaceNode(
-      const moxygen::TrackNamespace& ns,
-      bool createMissingNodes = false,
-      MatchType matchType = MatchType::Exact,
-      std::vector<
-          std::pair<std::shared_ptr<moxygen::MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>*
-          sessions = nullptr
-  );
+  NamespaceTree namespaceTree_{*this};
 
   struct RelaySubscription {
     RelaySubscription(
@@ -353,7 +277,7 @@ private:
   folly::coro::Task<void> publishNamespaceToSession(
       std::shared_ptr<moxygen::MoQSession> session,
       moxygen::PublishNamespace pubNs,
-      std::shared_ptr<NamespaceNode> nodePtr
+      std::shared_ptr<NamespaceTree::NamespaceNode> nodePtr
   );
 
   folly::coro::Task<void> publishToSession(
@@ -370,8 +294,6 @@ private:
       std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
       uint64_t newGroupRequestValue
   );
-
-  void publishNamespaceDone(const moxygen::TrackNamespace& trackNamespace, NamespaceNode* node);
 
   // TRACK_FILTER support
 
@@ -393,7 +315,7 @@ private:
   // Retroactively registers any tracks already published under that node.
   // ns must be the full namespace of `node` (used as BFS seed for track registration).
   std::shared_ptr<PropertyRanking> getOrCreateRanking(
-      std::shared_ptr<NamespaceNode> node,
+      std::shared_ptr<NamespaceTree::NamespaceNode> node,
       uint64_t propertyType,
       const moxygen::TrackNamespace& ns
   );

--- a/src/NamespaceTree.cpp
+++ b/src/NamespaceTree.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NamespaceTree.h"
+#include <folly/logging/xlog.h>
+
+using namespace moxygen;
+
+namespace openmoq::moqx {
+
+void NamespaceTree::incrementActiveChildren(NamespaceNode& node) {
+  node.activeChildCount_++;
+  // Propagate up if this was the first active child and the parent itself has
+  // no local content (otherwise the parent is already counted).
+  if (node.activeChildCount_ == 1 && node.parent_ && !node.hasContent()) {
+    incrementActiveChildren(*node.parent_);
+  }
+}
+
+// Walk up the tree to find and prune the highest empty ancestor.
+void NamespaceTree::tryPruneChild(NamespaceNode& parentNode, const std::string& childKey) {
+  auto it = parentNode.children_.find(childKey);
+  if (it == parentNode.children_.end()) {
+    return;
+  }
+
+  auto* childNode = it->second.get();
+  if (shouldKeep(*childNode)) {
+    return;
+  }
+
+  // Walk up, decrementing counts, to find the highest empty ancestor to remove.
+  std::string keyToRemove = childKey;
+  NamespaceNode* parentOfNodeToRemove = &parentNode;
+  NamespaceNode* current = &parentNode;
+
+  while (current) {
+    XCHECK_GT(current->activeChildCount_, 0);
+    current->activeChildCount_--;
+
+    if (current->hasContent() || current->activeChildCount_ > 0) {
+      break;
+    }
+
+    if (!current->parent_) {
+      break; // root — can't remove
+    }
+
+    for (const auto& [key, node] : current->parent_->children_) {
+      if (node.get() == current) {
+        keyToRemove = key;
+        parentOfNodeToRemove = current->parent_;
+        break;
+      }
+    }
+
+    current = current->parent_;
+  }
+
+  XLOG(DBG1) << "Pruning empty subtree at: " << keyToRemove;
+  parentOfNodeToRemove->children_.erase(keyToRemove);
+}
+
+void NamespaceTree::notifyParentIfFirstContent(NamespaceNode& node, bool wasEmpty) {
+  if (wasEmpty && node.hasContent() && node.parent_) {
+    incrementActiveChildren(*node.parent_);
+  }
+}
+
+void NamespaceTree::tryPruneSelf(NamespaceNode& node, bool hadContent, const TrackNamespace& ns) {
+  if (hadContent && !shouldKeep(node) && node.parent_ && !ns.trackNamespace.empty()) {
+    tryPruneChild(*node.parent_, ns.trackNamespace.back());
+  }
+}
+
+std::shared_ptr<MoQSession> NamespaceTree::findPublisherSession(const TrackNamespace& ns) {
+  auto nodePtr = findNode(ns, /*createMissingNodes=*/false, MatchType::Prefix);
+  return nodePtr ? nodePtr->publisherSession_ : nullptr;
+}
+
+NamespaceTree::SetPublisherResult NamespaceTree::setPublisher(
+    const TrackNamespace& ns,
+    std::shared_ptr<MoQSession> session,
+    std::shared_ptr<Subscriber::PublishNamespaceCallback> callback,
+    std::string peerID,
+    RequestID requestID
+) {
+  SetPublisherResult result;
+  auto node = findNode(ns, /*createMissingNodes=*/true, MatchType::Exact, &result.subscribers);
+
+  if (node->publisherSession_) {
+    result.replacedSession = node->publisherSession_;
+    if (node->publishNamespaceCallback_) {
+      node->publishNamespaceCallback_->publishNamespaceCancel(
+          PublishNamespaceErrorCode::CANCELLED,
+          "New publisher"
+      );
+      node->publishNamespaceCallback_.reset();
+    }
+    node->publisherSession_.reset();
+  }
+
+  for (const auto& [sess, info] : node->subscribers_) {
+    result.subscribers.emplace_back(sess, info);
+  }
+
+  {
+    NodeMutationGuard guard(*this, *node, ns);
+    node->publisherSession_ = std::move(session);
+    node->publisherPeerID_ = std::move(peerID);
+    node->publishNamespaceCallback_ = std::move(callback);
+    node->trackNamespace = ns;
+    node->setPublishNamespaceOk({.requestID = requestID, .requestSpecificParams = {}});
+  }
+
+  result.node = std::move(node);
+  return result;
+}
+
+folly::Expected<NamespaceTree::UnpublishNamespaceResult, NamespaceTree::Error>
+NamespaceTree::unpublishNamespace(
+    const TrackNamespace& ns,
+    const std::shared_ptr<MoQSession>& session
+) {
+  auto node = findNode(ns);
+  if (!node) {
+    return folly::makeUnexpected(Error::NodeNotFound);
+  }
+  if (node->publisherSession_ == nullptr || node->publisherSession_ != session) {
+    return folly::makeUnexpected(Error::NotOwner);
+  }
+
+  UnpublishNamespaceResult result;
+  findNode(ns, /*createMissingNodes=*/false, MatchType::Exact, &result.subscribers);
+  for (const auto& [sess, info] : node->subscribers_) {
+    result.subscribers.emplace_back(sess, info);
+  }
+  for (auto& [sess, handle] : node->draft14PubNsHandles_) {
+    result.legacyHandles.emplace_back(sess, handle);
+  }
+
+  NodeMutationGuard guard(*this, *node, ns);
+  node->publisherSession_ = nullptr;
+  node->publisherPeerID_.clear();
+  node->publishNamespaceCallback_.reset();
+  node->draft14PubNsHandles_.clear();
+
+  return result;
+}
+
+folly::Expected<folly::Unit, NamespaceTree::Error>
+NamespaceTree::unpublishTrack(const TrackNamespace& ns, const std::string& trackName) {
+  auto node = findNode(ns);
+  if (!node) {
+    return folly::makeUnexpected(Error::NodeNotFound);
+  }
+  NodeMutationGuard guard(*this, *node, ns);
+  node->publishes_.erase(trackName);
+  return folly::unit;
+}
+
+NamespaceTree::AddPublishResult NamespaceTree::addPublish(
+    const FullTrackName& ftn,
+    std::shared_ptr<MoQSession> session,
+    OnRankingFn onRanking
+) {
+  AddPublishResult result;
+  result.node = findNode(
+      ftn.trackNamespace,
+      /*createMissingNodes=*/true,
+      MatchType::Exact,
+      &result.subscribers
+  );
+  for (const auto& [sess, info] : result.node->subscribers_) {
+    result.subscribers.emplace_back(sess, info);
+  }
+  {
+    NodeMutationGuard guard(*this, *result.node, ftn.trackNamespace);
+    result.node->publishes_.insert_or_assign(ftn.trackName, session);
+  }
+  if (onRanking) {
+    for (const NamespaceNode* node = result.node.get(); node != nullptr; node = node->parent_) {
+      for (const auto& [propertyType, ranking] : node->rankings_) {
+        if (ranking) {
+          onRanking(propertyType, ranking);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+std::shared_ptr<PropertyRanking>&
+NamespaceTree::getOrInsertRanking(NamespaceNode& node, uint64_t propertyType) {
+  return node.rankings_[propertyType];
+}
+
+std::shared_ptr<NamespaceTree::NamespaceNode> NamespaceTree::addNamespaceSubscriber(
+    const TrackNamespace& ns,
+    std::shared_ptr<MoQSession> session,
+    NamespaceNode::NamespaceSubscriberInfo info
+) {
+  auto node = findNode(ns, /*createMissingNodes=*/true);
+  NodeMutationGuard guard(*this, *node, ns);
+  node->subscribers_.emplace(std::move(session), std::move(info));
+  return node;
+}
+
+folly::Expected<folly::Unit, NamespaceTree::Error> NamespaceTree::removeNamespaceSubscriber(
+    const TrackNamespace& ns,
+    const std::shared_ptr<MoQSession>& session
+) {
+  auto node = findNode(ns);
+  if (!node) {
+    return folly::makeUnexpected(Error::NodeNotFound);
+  }
+  auto it = node->subscribers_.find(session);
+  if (it == node->subscribers_.end()) {
+    return folly::makeUnexpected(Error::NotSubscribed);
+  }
+  if (it->second.trackFilter) {
+    auto rankingIt = node->rankings_.find(it->second.trackFilter->propertyType);
+    if (rankingIt != node->rankings_.end()) {
+      rankingIt->second->removeSessionFromTopNGroup(it->second.trackFilter->maxSelected, session);
+    }
+  }
+  NodeMutationGuard guard(*this, *node, ns);
+  node->subscribers_.erase(it);
+  return folly::unit;
+}
+
+std::shared_ptr<NamespaceTree::NamespaceNode> NamespaceTree::findNode(
+    const TrackNamespace& ns,
+    bool createMissingNodes,
+    MatchType matchType,
+    SessionSubscriberList* subscribers
+) {
+  std::shared_ptr<NamespaceNode> nodePtr(std::shared_ptr<void>(), &root_);
+  TrackNamespace partialNs;
+  for (auto i = 0ul; i < ns.size(); i++) {
+    if (subscribers) {
+      for (const auto& [session, info] : nodePtr->subscribers_) {
+        subscribers->emplace_back(session, info);
+      }
+    }
+    auto& name = ns[i];
+    partialNs.append(name);
+    auto it = nodePtr->children_.find(name);
+    if (it == nodePtr->children_.end()) {
+      if (createMissingNodes) {
+        auto node = std::make_shared<NamespaceNode>(*this, nodePtr.get());
+        node->trackNamespace = partialNs;
+        nodePtr->children_.emplace(name, node);
+        nodePtr = std::move(node);
+      } else if (matchType == MatchType::Prefix && nodePtr.get() != &root_) {
+        return nodePtr;
+      } else {
+        XLOG(DBG1) << "namespace node not found: " << ns;
+        return nullptr;
+      }
+    } else {
+      nodePtr = it->second;
+    }
+  }
+  return nodePtr;
+}
+
+} // namespace openmoq::moqx

--- a/src/NamespaceTree.h
+++ b/src/NamespaceTree.h
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "relay/PropertyRanking.h"
+#include <folly/Expected.h>
+#include <folly/Unit.h>
+#include <folly/container/F14Map.h>
+#include <moxygen/MoQSession.h>
+#include <moxygen/MoQTypes.h>
+
+#include <deque>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace openmoq::moqx {
+
+// Hierarchical tree tracking PUBLISH_NAMESPACE announcements and
+// SUBSCRIBE_NAMESPACE subscriptions. Relay-specific notifications are
+// delivered via Callback.
+class NamespaceTree {
+public:
+  struct Callback {
+    virtual ~Callback() = default;
+    // Fired when a node's publishNamespaceDone() fires; caller must identify
+    // the session via MoQSession::getRequestSession().
+    virtual void onPublishNamespaceDone(const moxygen::TrackNamespace& ns) = 0;
+  };
+
+  struct NamespaceNode : public moxygen::Subscriber::PublishNamespaceHandle {
+    explicit NamespaceNode(NamespaceTree& tree, NamespaceNode* parent = nullptr)
+        : tree_(tree), parent_(parent) {}
+
+    moxygen::TrackNamespace trackNamespace;
+
+    void publishNamespaceDone() override { tree_.onNodeDone(trackNamespace); }
+
+    folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate reqUpdate
+    ) override {
+      co_return folly::makeUnexpected(moxygen::RequestError{
+          reqUpdate.requestID,
+          moxygen::RequestErrorCode::NOT_SUPPORTED,
+          "REQUEST_UPDATE not supported for relay PUBLISH_NAMESPACE"
+      });
+    }
+
+    bool hasContent() const {
+      return !publishes_.empty() || !subscribers_.empty() || !draft14PubNsHandles_.empty() ||
+             publisherSession_ != nullptr;
+    }
+
+    using moxygen::Subscriber::PublishNamespaceHandle::setPublishNamespaceOk;
+
+    struct NamespaceSubscriberInfo {
+      bool forward{true};
+      moxygen::SubscribeNamespaceOptions options{moxygen::SubscribeNamespaceOptions::BOTH};
+      // Handle for NAMESPACE/NAMESPACE_DONE on the bidi stream (draft 16+); null for draft <= 15.
+      std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> namespacePublishHandle;
+      moxygen::TrackNamespace trackNamespacePrefix;
+      std::optional<moxygen::TrackFilter> trackFilter;
+    };
+
+    std::shared_ptr<moxygen::MoQSession> publisherSession() const { return publisherSession_; }
+    const std::string& publisherPeerID() const { return publisherPeerID_; }
+
+    size_t subscriberCount() const { return subscribers_.size(); }
+
+    std::shared_ptr<moxygen::MoQSession> findPublishSession(const std::string& trackName) const {
+      auto it = publishes_.find(trackName);
+      return it != publishes_.end() ? it->second : nullptr;
+    }
+
+    size_t publishCount() const { return publishes_.size(); }
+
+    template <typename Fn> void forEachPublish(Fn&& fn) const {
+      for (const auto& [trackName, session] : publishes_) {
+        fn(trackName, session);
+      }
+    }
+
+    void addDraft14PublishNamespaceHandle(
+        std::shared_ptr<moxygen::MoQSession> session,
+        std::shared_ptr<moxygen::Subscriber::PublishNamespaceHandle> handle
+    ) {
+      draft14PubNsHandles_.emplace(std::move(session), std::move(handle));
+    }
+
+  private:
+    friend class NamespaceTree;
+
+    NamespaceTree& tree_;
+    NamespaceNode* parent_{nullptr};
+    size_t activeChildCount_{0};
+    std::shared_ptr<moxygen::MoQSession> publisherSession_;
+    std::string publisherPeerID_;
+    folly::F14FastMap<std::string, std::shared_ptr<moxygen::MoQSession>> publishes_;
+    folly::F14FastMap<std::shared_ptr<moxygen::MoQSession>, NamespaceSubscriberInfo> subscribers_;
+    folly::F14FastMap<std::string, std::shared_ptr<NamespaceNode>> children_;
+    std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback> publishNamespaceCallback_;
+    folly::F14FastMap<uint64_t, std::shared_ptr<PropertyRanking>> rankings_;
+    // Per-subscriber handles for draft<=14 (one per publishNamespace() call), keyed by session.
+    folly::F14FastMap<
+        std::shared_ptr<moxygen::MoQSession>,
+        std::shared_ptr<moxygen::Subscriber::PublishNamespaceHandle>>
+        draft14PubNsHandles_;
+  };
+
+  using SessionSubscriberList = std::vector<
+      std::pair<std::shared_ptr<moxygen::MoQSession>, NamespaceNode::NamespaceSubscriberInfo>>;
+
+  using LegacyDoneHandleList = std::vector<std::pair<
+      std::shared_ptr<moxygen::MoQSession>,
+      std::shared_ptr<moxygen::Subscriber::PublishNamespaceHandle>>>;
+
+  struct UnpublishNamespaceResult {
+    SessionSubscriberList subscribers;
+    LegacyDoneHandleList legacyHandles;
+  };
+
+  explicit NamespaceTree(Callback& cb) : cb_(cb), root_(*this) {}
+
+  enum class MatchType { Exact, Prefix };
+  enum class Error { NodeNotFound, NotOwner, NotSubscribed };
+
+  // Longest-prefix match for the publisher of ns; null if none found.
+  std::shared_ptr<moxygen::MoQSession> findPublisherSession(const moxygen::TrackNamespace& ns);
+
+  std::shared_ptr<NamespaceNode> findNode(
+      const moxygen::TrackNamespace& ns,
+      bool createMissingNodes = false,
+      MatchType matchType = MatchType::Exact,
+      SessionSubscriberList* subscribers = nullptr
+  );
+
+  // Result of setPublisher. node is the target node; subscribers are all
+  // prefix + exact sessions; replacedSession is non-null when an existing
+  // publisher was displaced (caller must clean up its track subscriptions).
+  struct SetPublisherResult {
+    std::shared_ptr<NamespaceNode> node;
+    SessionSubscriberList subscribers;
+    std::shared_ptr<moxygen::MoQSession> replacedSession;
+  };
+
+  SetPublisherResult setPublisher(
+      const moxygen::TrackNamespace& ns,
+      std::shared_ptr<moxygen::MoQSession> session,
+      std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback> callback,
+      std::string peerID,
+      moxygen::RequestID requestID
+  );
+
+  // NodeNotFound: node already pruned (ignorable). NotOwner: session mismatch (log and ignore).
+  folly::Expected<UnpublishNamespaceResult, Error> unpublishNamespace(
+      const moxygen::TrackNamespace& ns,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  );
+
+  // NodeNotFound means the node was already pruned, which is ignorable.
+  folly::Expected<folly::Unit, Error>
+  unpublishTrack(const moxygen::TrackNamespace& ns, const std::string& trackName);
+
+  struct AddPublishResult {
+    std::shared_ptr<NamespaceNode> node;
+    SessionSubscriberList subscribers;
+  };
+  using OnRankingFn = std::function<void(uint64_t, const std::shared_ptr<PropertyRanking>&)>;
+
+  // Records ftn.trackName→session, collects prefix+exact subscribers, and
+  // calls onRanking for every non-null PropertyRanking at the node and ancestors.
+  AddPublishResult addPublish(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQSession> session,
+      OnRankingFn onRanking = {}
+  );
+
+  // Returns the node so the caller can wire up PropertyRanking if needed.
+  std::shared_ptr<NamespaceNode> addNamespaceSubscriber(
+      const moxygen::TrackNamespace& ns,
+      std::shared_ptr<moxygen::MoQSession> session,
+      NamespaceNode::NamespaceSubscriberInfo info
+  );
+
+  // NodeNotFound and NotSubscribed are both ignorable (already gone).
+  folly::Expected<folly::Unit, Error> removeNamespaceSubscriber(
+      const moxygen::TrackNamespace& ns,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  );
+
+  // Returns the PropertyRanking slot for propertyType at node, inserting null if absent.
+  std::shared_ptr<PropertyRanking>& getOrInsertRanking(NamespaceNode& node, uint64_t propertyType);
+
+  // DFS walk. begin(childKey, node) is called on entry; end() on exit after
+  // all children. childKey is empty for the root.
+  template <typename BeginFn, typename EndFn> void walkTree(BeginFn&& begin, EndFn&& end) const {
+    std::function<void(std::string_view, const NamespaceNode&)> walk;
+    walk = [&](std::string_view key, const NamespaceNode& node) {
+      begin(key, node);
+      for (const auto& [childKey, child] : node.children_) {
+        walk(childKey, *child);
+      }
+      end();
+    };
+    walk("", root_);
+  }
+
+  // BFS from startNode. Calls fn(prefix, node) for startNode and every descendant.
+  template <typename Fn>
+  void forEachNodeInSubtree(
+      const moxygen::TrackNamespace& startNs,
+      std::shared_ptr<NamespaceNode> startNode,
+      Fn&& fn
+  ) {
+    std::deque<std::pair<moxygen::TrackNamespace, std::shared_ptr<NamespaceNode>>> queue;
+    queue.emplace_back(startNs, std::move(startNode));
+    while (!queue.empty()) {
+      auto [ns, node] = std::move(queue.front());
+      queue.pop_front();
+      fn(ns, node);
+      for (auto& [childKey, childNode] : node->children_) {
+        moxygen::TrackNamespace childNs(ns);
+        childNs.append(childKey);
+        queue.emplace_back(std::move(childNs), childNode);
+      }
+    }
+  }
+
+private:
+  // RAII guard that snapshots hasContent() at construction and calls
+  // notifyParentIfFirstContent + tryPruneSelf on destruction. Bracket any
+  // mutation of a node's content fields with this guard.
+  class NodeMutationGuard {
+  public:
+    NodeMutationGuard(NamespaceTree& tree, NamespaceNode& node, moxygen::TrackNamespace ns)
+        : tree_(tree), node_(node), ns_(std::move(ns)), hadContent_(node.hasContent()) {}
+    ~NodeMutationGuard() {
+      tree_.notifyParentIfFirstContent(node_, !hadContent_);
+      tree_.tryPruneSelf(node_, hadContent_, ns_);
+    }
+    NodeMutationGuard(const NodeMutationGuard&) = delete;
+    NodeMutationGuard& operator=(const NodeMutationGuard&) = delete;
+
+  private:
+    NamespaceTree& tree_;
+    NamespaceNode& node_;
+    moxygen::TrackNamespace ns_;
+    bool hadContent_;
+  };
+
+  void onNodeDone(const moxygen::TrackNamespace& ns) { cb_.onPublishNamespaceDone(ns); }
+
+  bool shouldKeep(const NamespaceNode& node) const {
+    return node.hasContent() || node.activeChildCount_ > 0;
+  }
+
+  // Called after content is added: increments parent's activeChildCount when
+  // node transitions from empty to non-empty.
+  void notifyParentIfFirstContent(NamespaceNode& node, bool wasEmpty);
+
+  // Called after content is removed: prunes node from its parent if now empty.
+  void tryPruneSelf(NamespaceNode& node, bool hadContent, const moxygen::TrackNamespace& ns);
+
+  void incrementActiveChildren(NamespaceNode& node);
+  void tryPruneChild(NamespaceNode& parentNode, const std::string& childKey);
+
+  Callback& cb_;
+  NamespaceNode root_{*this};
+};
+
+} // namespace openmoq::moqx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,17 @@ target_link_libraries(moqx_relay_test PRIVATE
 )
 gtest_discover_tests(moqx_relay_test)
 
+add_executable(moqx_namespace_tree_test
+  NamespaceTreeTest.cpp
+)
+target_link_libraries(moqx_namespace_tree_test PRIVATE
+  moqx_core
+  moqx_test_main
+  GTest::gmock
+  moxygen::moqtest_utils
+)
+gtest_discover_tests(moqx_namespace_tree_test)
+
 add_executable(moqx_config_test
   config/LoaderTest.cpp
 )

--- a/test/MoqxRelayTest.cpp
+++ b/test/MoqxRelayTest.cpp
@@ -434,429 +434,6 @@ TEST_F(MoQRelayTest, PublishSuccess) {
   removeSession(publisherSession);
 }
 
-// Test: Tree pruning when leaf node is removed
-// Scenario: test/A/B/C and test/A/D exist. Remove C should prune B but keep A
-// and D
-TEST_F(MoQRelayTest, PruneLeafKeepSiblings) {
-  auto publisherABC = createMockSession();
-  auto publisherAD = createMockSession();
-
-  // PublishNamespace test/A/B/C (don't add to state because we
-  // publishNamespaceDone manually)
-  TrackNamespace nsABC{{"test", "A", "B", "C"}};
-  auto handleABC = doPublishNamespace(publisherABC, nsABC, /*addToState=*/false);
-
-  // PublishNamespace test/A/D
-  TrackNamespace nsAD{{"test", "A", "D"}};
-  doPublishNamespace(publisherAD, nsAD);
-
-  // PublishNamespaceDone test/A/B/C - should prune B (and C) but keep A and D
-  withSessionContext(publisherABC, [&]() { handleABC->publishNamespaceDone(); });
-
-  // Verify test/A/D still exists using findPublishNamespaceSessions
-  auto sessions = relay_->findPublishNamespaceSessions(nsAD);
-  EXPECT_EQ(sessions.size(), 1);
-  EXPECT_EQ(sessions[0], publisherAD);
-
-  removeSession(publisherABC);
-  removeSession(publisherAD);
-}
-
-// Test: Tree pruning removes highest empty ancestor
-// Scenario: test/A/B/C only. Remove C should prune A (highest empty after test)
-TEST_F(MoQRelayTest, PruneHighestEmptyAncestor) {
-  auto publisher = createMockSession();
-
-  // PublishNamespace test/A/B/C (don't add to state because we
-  // publishNamespaceDone manually)
-  TrackNamespace nsABC{{"test", "A", "B", "C"}};
-  auto handle = doPublishNamespace(publisher, nsABC, /*addToState=*/false);
-
-  // PublishNamespaceDone test/A/B/C - should prune A (highest empty ancestor)
-  withSessionContext(publisher, [&]() { handle->publishNamespaceDone(); });
-
-  // Try to publishNamespace test/A/B/C again with a new session - should create
-  // fresh tree
-  auto publisher2 = createMockSession();
-  doPublishNamespace(publisher2, nsABC);
-
-  removeSession(publisher);
-  removeSession(publisher2);
-}
-
-// Test: Pruning happens automatically on removeSession
-TEST_F(MoQRelayTest, PruneOnRemoveSession) {
-  auto publisher = createMockSession();
-
-  // PublishNamespace deep tree test/A/B/C/D
-  TrackNamespace nsABCD{{"test", "A", "B", "C", "D"}};
-  doPublishNamespace(publisher, nsABCD);
-
-  // Remove session - should prune entire tree test/A/B/C/D
-  removeSession(publisher);
-
-  // Verify we can create test/A/B/C/D again (tree was pruned)
-  auto publisher2 = createMockSession();
-  doPublishNamespace(publisher2, nsABCD);
-
-  removeSession(publisher2);
-}
-
-// Test: No pruning when node still has content (multiple publishers)
-TEST_F(MoQRelayTest, NoPruneWhenNodeHasContent) {
-  auto publisher1 = createMockSession();
-  auto publisher2 = createMockSession();
-
-  // Both publishNamespace test/A/B
-  TrackNamespace nsAB{{"test", "A", "B"}};
-  auto handle1 = doPublishNamespace(publisher1, nsAB, /*addToState=*/false);
-  doPublishNamespace(publisher2, nsAB);
-
-  // PublishNamespaceDone from publisher1 - should NOT prune because publisher2
-  // still there
-  withSessionContext(publisher1, [&]() { handle1->publishNamespaceDone(); });
-
-  // Verify test/A/B still exists by publishing a track through publisher2
-  doPublish(publisher2, FullTrackName{nsAB, "track1"});
-
-  removeSession(publisher1);
-  removeSession(publisher2);
-}
-
-// Test: EXPOSES BUG - onPublishDone should trigger pruning but doesn't
-// This test FAILS because onPublishDone removes the publish from the map
-// but doesn't call tryPruneChild to clean up empty nodes
-TEST_F(MoQRelayTest, PruneOnPublishDoneBug) {
-  auto publisher = createMockSession();
-
-  // Create deep tree test/A/B/C with only a publish (no publishNamespace)
-  TrackNamespace nsABC{{"test", "A", "B", "C"}};
-
-  // First publishNamespace so we can publish
-  doPublishNamespace(publisher, nsABC);
-
-  // Publish a track
-  auto consumer = doPublish(publisher, FullTrackName{nsABC, "track1"});
-
-  // Verify publish exists in the tree
-  auto state = relay_->findPublishState(FullTrackName{nsABC, "track1"});
-  EXPECT_TRUE(state.nodeExists);
-  EXPECT_EQ(state.session, publisher);
-
-  // PublishNamespaceDone - node should stay because publish is still active
-  withSessionContext(publisher, [&]() {
-    getOrCreateMockState(publisher)->publishNamespaceHandles[0]->publishNamespaceDone();
-    getOrCreateMockState(publisher)->publishNamespaceHandles.clear();
-  });
-
-  // Publish should still be there, node still exists
-  state = relay_->findPublishState(FullTrackName{nsABC, "track1"});
-  EXPECT_TRUE(state.nodeExists);
-  EXPECT_EQ(state.session, publisher);
-
-  // End the publish - onPublishDone gets called
-  withSessionContext(publisher, [&]() {
-    consumer->publishDone(
-        {RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher done"}
-    );
-  });
-
-  // BUG EXPOSED: The publish is removed from the map but the node still exists
-  state = relay_->findPublishState(FullTrackName{nsABC, "track1"});
-  EXPECT_EQ(state.session, nullptr); // No session - PASS
-
-  // THIS FAILS: Node should have been pruned but still exists (memory leak)
-  EXPECT_FALSE(state.nodeExists
-  ) << "BUG: Node test/A/B/C still exists after publish ended and was the "
-       "only content. "
-       "onPublishDone should have called tryPruneChild to clean up empty "
-       "nodes.";
-
-  removeSession(publisher);
-}
-
-// Test: Mixed content types - node with publishNamespace + publish
-TEST_F(MoQRelayTest, MixedContentPublishNamespaceAndPublish) {
-  auto publisher = createMockSession();
-
-  // PublishNamespace test/A/B
-  TrackNamespace nsAB{{"test", "A", "B"}};
-  doPublishNamespace(publisher, nsAB);
-
-  // Publish a track in test/A/B
-  doPublish(publisher, FullTrackName{nsAB, "track1"});
-
-  // PublishNamespaceDone - should NOT prune because publish still exists
-  withSessionContext(publisher, [&]() {
-    getOrCreateMockState(publisher)->publishNamespaceHandles[0]->publishNamespaceDone();
-    getOrCreateMockState(publisher)->publishNamespaceHandles.clear();
-  });
-
-  // Verify node still exists by publishing another track
-  doPublish(publisher, FullTrackName{nsAB, "track2"});
-
-  removeSession(publisher);
-}
-
-// Test: Mixed content types - node with publishNamespace + sessions
-// (subscribers)
-TEST_F(MoQRelayTest, MixedContentPublishNamespaceAndSessions) {
-  auto publisher = createMockSession();
-  auto subscriber = createMockSession();
-
-  // PublishNamespace test/A/B
-  TrackNamespace nsAB{{"test", "A", "B"}};
-  doPublishNamespace(publisher, nsAB);
-
-  // Subscribe to namespace from another session
-  doSubscribeNamespace(subscriber, nsAB);
-
-  // PublishNamespaceDone from publisher - should NOT prune because subscriber
-  // still there
-  std::shared_ptr<Subscriber::PublishNamespaceHandle> handle =
-      getOrCreateMockState(publisher)->publishNamespaceHandles[0];
-  getOrCreateMockState(publisher)->publishNamespaceHandles.clear();
-  withSessionContext(publisher, [&]() { handle->publishNamespaceDone(); });
-
-  // PublishNamespace again from a different publisher - should work (node still
-  // exists)
-  auto publisher2 = createMockSession();
-  doPublishNamespace(publisher2, nsAB);
-
-  removeSession(publisher);
-  removeSession(publisher2);
-  removeSession(subscriber);
-}
-
-// Test: UnsubscribeNamespace triggers pruning
-TEST_F(MoQRelayTest, PruneOnUnsubscribeNamespace) {
-  auto subscriber = createMockSession();
-
-  // Subscribe to test/A/B/C namespace (creates tree without publishNamespace)
-  TrackNamespace nsABC{{"test", "A", "B", "C"}};
-  auto handle = doSubscribeNamespace(subscriber, nsABC, /*addToState=*/false);
-
-  // Unsubscribe - should prune the entire test/A/B/C tree
-  withSessionContext(subscriber, [&]() { handle->unsubscribeNamespace(); });
-
-  // Verify tree was pruned by subscribing again - should create fresh tree
-  doSubscribeNamespace(subscriber, nsABC);
-
-  removeSession(subscriber);
-}
-
-// Test: Middle empty nodes in deep tree
-// Scenario: test/A (has publishNamespace), test/A/B (empty), test/A/B/C (has
-// publish) Remove C should prune B but keep A
-TEST_F(MoQRelayTest, PruneMiddleEmptyNode) {
-  auto publisherA = createMockSession();
-  auto publisherC = createMockSession();
-
-  // PublishNamespace test/A
-  TrackNamespace nsA{{"test", "A"}};
-  doPublishNamespace(publisherA, nsA);
-
-  // PublishNamespace test/A/B/C (this creates B as empty intermediate node)
-  TrackNamespace nsABC{{"test", "A", "B", "C"}};
-  auto handleC = doPublishNamespace(publisherC, nsABC, /*addToState=*/false);
-
-  // PublishNamespaceDone test/A/B/C - should prune B and C but keep A
-  withSessionContext(publisherC, [&]() { handleC->publishNamespaceDone(); });
-
-  // Verify test/A still exists
-  auto sessionsA = relay_->findPublishNamespaceSessions(nsA);
-  EXPECT_EQ(sessionsA.size(), 1);
-  EXPECT_EQ(sessionsA[0], publisherA);
-
-  // Verify test/A/B/C was pruned - should be able to publishNamespace it again
-  auto publisherC2 = createMockSession();
-  doPublishNamespace(publisherC2, nsABC);
-
-  removeSession(publisherA);
-  removeSession(publisherC);
-  removeSession(publisherC2);
-}
-
-// Test: Double publishNamespaceDone doesn't crash or corrupt state
-TEST_F(MoQRelayTest, DoublePublishNamespaceDone) {
-  auto publisher = createMockSession();
-
-  // PublishNamespace test/A/B
-  TrackNamespace nsAB{{"test", "A", "B"}};
-  auto handle = doPublishNamespace(publisher, nsAB, /*addToState=*/false);
-
-  // PublishNamespaceDone once
-  withSessionContext(publisher, [&]() { handle->publishNamespaceDone(); });
-
-  // PublishNamespaceDone again - should not crash (code handles this
-  // gracefully)
-  withSessionContext(publisher, [&]() { handle->publishNamespaceDone(); });
-
-  // Verify we can still use the relay
-  auto publisher2 = createMockSession();
-  doPublishNamespace(publisher2, nsAB);
-
-  removeSession(publisher);
-  removeSession(publisher2);
-}
-
-// Test: Ownership check in publishNamespaceDone prevents non-owner from
-// clearing state When a session calls publishNamespaceDone but is not the owner
-// of the namespace, the publishNamespaceDone should be ignored and the real
-// owner should remain.
-TEST_F(MoQRelayTest, StalePublishNamespaceDoneDoesNotAffectNewOwner) {
-  auto publisher1 = createMockSession();
-  auto publisher2 = createMockSession();
-
-  // Publisher1 publishNamespaces test/A/B
-  TrackNamespace nsAB{{"test", "A", "B"}};
-  auto handle1 = doPublishNamespace(publisher1, nsAB, /*addToState=*/false);
-
-  // Publisher2 publishNamespaces a child namespace test/A/B/C
-  TrackNamespace nsABC{{"test", "A", "B", "C"}};
-  doPublishNamespace(publisher2, nsABC);
-
-  // Publisher2 tries to publishNamespaceDone Publisher1's namespace test/A/B
-  // using Publisher1's handle but with Publisher2's session context - should be
-  // ignored because publisher2 is not the owner of test/A/B
-  withSessionContext(publisher2, [&]() { handle1->publishNamespaceDone(); });
-
-  // Verify publisher1 is STILL the owner by checking
-  // findPublishNamespaceSessions returns publisher1 for the namespace. If the
-  // ownership check didn't work, sourceSession would be null and
-  // findPublishNamespaceSessions would return empty.
-  auto sessions = relay_->findPublishNamespaceSessions(nsAB);
-  EXPECT_EQ(sessions.size(), 1)
-      << "Ownership check failed: findPublishNamespaceSessions returned wrong count";
-  if (!sessions.empty()) {
-    EXPECT_EQ(sessions[0], publisher1) << "Ownership check failed: wrong session returned";
-  }
-
-  // Publisher1 should still be able to properly publishNamespaceDone its own
-  // namespace
-  withSessionContext(publisher1, [&]() { handle1->publishNamespaceDone(); });
-
-  // Clean up - should not crash
-  removeSession(publisher1);
-  removeSession(publisher2);
-}
-
-// Test: Pruning with multiple children at same level
-// Scenario: test/A has children B, C, D. Only B has content.
-// Remove B should prune B but keep A, C, D structure intact
-TEST_F(MoQRelayTest, PruneOneOfMultipleChildren) {
-  auto publisherB = createMockSession();
-  auto subscriberC = createMockSession();
-  auto subscriberD = createMockSession();
-
-  // PublishNamespace test/A/B
-  TrackNamespace nsAB{{"test", "A", "B"}};
-  auto handleB = doPublishNamespace(publisherB, nsAB, /*addToState=*/false);
-
-  // Subscribe to test/A/C (creates C as empty node with session)
-  TrackNamespace nsAC{{"test", "A", "C"}};
-  doSubscribeNamespace(subscriberC, nsAC);
-
-  // Subscribe to test/A/D
-  TrackNamespace nsAD{{"test", "A", "D"}};
-  doSubscribeNamespace(subscriberD, nsAD);
-
-  // PublishNamespaceDone test/A/B - should prune only B
-  withSessionContext(publisherB, [&]() { handleB->publishNamespaceDone(); });
-
-  // Verify test/A still exists (has children C and D)
-  // Try to publishNamespace at test/A
-  auto publisherA = createMockSession();
-  TrackNamespace nsA{{"test", "A"}};
-  doPublishNamespace(publisherA, nsA);
-
-  removeSession(publisherB);
-  removeSession(publisherA);
-  removeSession(subscriberC);
-  removeSession(subscriberD);
-}
-
-// Test: Empty namespace edge case
-TEST_F(MoQRelayTest, EmptyNamespacePublishNamespaceDone) {
-  auto publisher = createMockSession();
-
-  // Try to publishNamespace empty namespace (edge case)
-  TrackNamespace emptyNs{{}};
-
-  // This might fail or succeed depending on implementation
-  // Just verify it doesn't crash
-  PublishNamespace ann;
-  ann.trackNamespace = emptyNs;
-  withSessionContext(publisher, [&]() {
-    auto task = relay_->publishNamespace(std::move(ann), nullptr);
-    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
-    // Don't assert on success/failure, just verify no crash
-    if (res.hasValue()) {
-      getOrCreateMockState(publisher)->publishNamespaceHandles.push_back(res.value());
-    }
-  });
-
-  removeSession(publisher);
-}
-
-// Test: Verify activeChildCount consistency after complex operations
-TEST_F(MoQRelayTest, ActiveChildCountConsistency) {
-  auto pub1 = createMockSession();
-  auto pub2 = createMockSession();
-  auto sub1 = createMockSession();
-
-  // Build tree: test/A/B and test/A/C with different content types
-  TrackNamespace nsAB{{"test", "A", "B"}};
-  doPublishNamespace(pub1, nsAB);
-
-  TrackNamespace nsAC{{"test", "A", "C"}};
-  doSubscribeNamespace(sub1, nsAC);
-
-  // At this point, test/A should have activeChildCount_ == 2 (B and C)
-  // We can't directly access private members, but we can verify behavior
-
-  // Remove pub1 (which should remove B and decrement A's count)
-  removeSession(pub1);
-
-  // A should still exist (C is still active)
-  // Verify by announcing at test/A
-  TrackNamespace nsA{{"test", "A"}};
-  doPublishNamespace(pub2, nsA);
-
-  // Remove sub1 (which should remove C)
-  removeSession(sub1);
-
-  // A should still exist because pub2 published at A
-  auto sessions = relay_->findPublishNamespaceSessions(nsA);
-  EXPECT_EQ(sessions.size(), 1);
-  EXPECT_EQ(sessions[0], pub2);
-
-  removeSession(pub2);
-}
-
-// Test: Publish then publishNamespaceDone shouldn't prune while publish active
-TEST_F(MoQRelayTest, PublishKeepsNodeAliveAfterPublishNamespaceDone) {
-  auto publisher = createMockSession();
-
-  // PublishNamespace test/A/B
-  TrackNamespace nsAB{{"test", "A", "B"}};
-  doPublishNamespace(publisher, nsAB);
-
-  // Publish track
-  doPublish(publisher, FullTrackName{nsAB, "track1"});
-
-  // PublishNamespaceDone (but publish is still active)
-  std::shared_ptr<Subscriber::PublishNamespaceHandle> handle =
-      getOrCreateMockState(publisher)->publishNamespaceHandles[0];
-  getOrCreateMockState(publisher)->publishNamespaceHandles.clear();
-  withSessionContext(publisher, [&]() { handle->publishNamespaceDone(); });
-
-  // Try to publish another track - should work (node still exists)
-  doPublish(publisher, FullTrackName{nsAB, "track2"});
-
-  removeSession(publisher);
-}
-
 // Test: Verify that subgroups are only created at appropriate times
 // Sequence: publish, sub1 joins, beginSubgroup (->1), beginObject (->1),
 // sub2 joins, beginObject (->1,2), sub3 joins, objectPayload (->1,2),
@@ -3681,6 +3258,61 @@ TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeSuccessPathCrash) {
     );
   }
   relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2);
+}
+
+// the track was the only remaining content.  (Was a bug before unpublishTrack
+// gained a NodeMutationGuard; kept as a regression guard.)
+TEST_F(MoQRelayTest, PublishDonePrunesNamespaceTreeNode) {
+  auto publisher = createMockSession();
+
+  doPublishNamespace(publisher, kTestNamespace);
+  auto consumer = doPublish(publisher, kTestTrackName);
+
+  // Verify the publish is visible in the tree
+  auto state = relay_->findPublishState(kTestTrackName);
+  EXPECT_TRUE(state.nodeExists);
+  EXPECT_EQ(state.session, publisher);
+
+  // publishNamespaceDone — node stays alive because the track publish is still active
+  withSessionContext(publisher, [&]() {
+    getOrCreateMockState(publisher)->publishNamespaceHandles[0]->publishNamespaceDone();
+    getOrCreateMockState(publisher)->publishNamespaceHandles.clear();
+  });
+
+  state = relay_->findPublishState(kTestTrackName);
+  EXPECT_TRUE(state.nodeExists);
+  EXPECT_EQ(state.session, publisher);
+
+  // End the track publish — node should now be pruned
+  withSessionContext(publisher, [&]() {
+    consumer->publishDone(
+        {RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "publisher done"}
+    );
+  });
+
+  state = relay_->findPublishState(kTestTrackName);
+  EXPECT_EQ(state.session, nullptr);
+  EXPECT_FALSE(state.nodeExists) << "Node persists after publish ended; pruning did not run";
+
+  removeSession(publisher);
+}
+
+// Empty namespace: publishNamespace with an empty TrackNamespace must not crash.
+TEST_F(MoQRelayTest, EmptyNamespacePublishNamespaceDone) {
+  auto publisher = createMockSession();
+
+  TrackNamespace emptyNs{{}};
+  PublishNamespace ann;
+  ann.trackNamespace = emptyNs;
+  withSessionContext(publisher, [&]() {
+    auto task = relay_->publishNamespace(std::move(ann), nullptr);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    if (res.hasValue()) {
+      getOrCreateMockState(publisher)->publishNamespaceHandles.push_back(res.value());
+    }
+  });
+
+  removeSession(publisher);
 }
 
 } // namespace moxygen::test

--- a/test/NamespaceTreeTest.cpp
+++ b/test/NamespaceTreeTest.cpp
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Originally from github.com/facebookexperimental/moxygen.
+ * See deps/moxygen/LICENSE file in the root directory for license terms.
+ *
+ * Copyright (c) OpenMOQ contributors.
+ */
+
+#include "NamespaceTree.h"
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/test/MockMoQSession.h>
+
+using namespace testing;
+using namespace moxygen;
+
+namespace openmoq::moqx::test {
+
+class NamespaceTreeTest : public ::testing::Test {
+protected:
+  struct NullCallback : public NamespaceTree::Callback {
+    void onPublishNamespaceDone(const TrackNamespace&) override {}
+  };
+
+  NullCallback cb_;
+  NamespaceTree tree_{cb_};
+
+  std::shared_ptr<MoQSession> makeSession() {
+    return std::make_shared<NiceMock<moxygen::test::MockMoQSession>>();
+  }
+
+  std::shared_ptr<NamespaceTree::NamespaceNode>
+  publish(const TrackNamespace& ns, std::shared_ptr<MoQSession> session) {
+    return tree_.setPublisher(ns, session, nullptr, {}, RequestID(0)).node;
+  }
+
+  void unpublish(const TrackNamespace& ns, const std::shared_ptr<MoQSession>& session) {
+    tree_.unpublishNamespace(ns, session); // NodeNotFound / NotOwner are ignorable
+  }
+
+  void subscribe(const TrackNamespace& ns, std::shared_ptr<MoQSession> session) {
+    tree_.addNamespaceSubscriber(ns, std::move(session), {});
+  }
+
+  void unsubscribe(const TrackNamespace& ns, const std::shared_ptr<MoQSession>& session) {
+    tree_.removeNamespaceSubscriber(ns, session); // NotSubscribed is ignorable
+  }
+
+  void publishTrack(
+      const TrackNamespace& ns,
+      const std::string& trackName,
+      std::shared_ptr<MoQSession> session
+  ) {
+    tree_.addPublish({ns, trackName}, std::move(session), {});
+  }
+};
+
+// Test: Leaf pruning keeps siblings intact
+// Scenario: test/A/B/C and test/A/D both exist.
+// Removing B/C should prune B (and C) but keep A and D.
+TEST_F(NamespaceTreeTest, PruneLeafKeepSiblings) {
+  auto publisherABC = makeSession();
+  auto publisherAD = makeSession();
+
+  TrackNamespace nsABC{{"test", "A", "B", "C"}};
+  TrackNamespace nsAD{{"test", "A", "D"}};
+  publish(nsABC, publisherABC);
+  publish(nsAD, publisherAD);
+
+  // Removing B/C should prune B (and C) but keep A and D
+  unpublish(nsABC, publisherABC);
+
+  EXPECT_EQ(tree_.findPublisherSession(nsAD), publisherAD);
+}
+
+// Test: Tree pruning removes highest empty ancestor
+// Scenario: test/A/B/C only. Remove C should prune A (highest empty after test)
+TEST_F(NamespaceTreeTest, PruneHighestEmptyAncestor) {
+  auto publisher = makeSession();
+
+  TrackNamespace nsABC{{"test", "A", "B", "C"}};
+  publish(nsABC, publisher);
+  // Remove C — should prune A (highest empty ancestor below root)
+  unpublish(nsABC, publisher);
+
+  // The entire subtree under the top-level "test" component should be gone.
+  EXPECT_EQ(tree_.findNode(TrackNamespace{{"test"}}), nullptr);
+  EXPECT_EQ(tree_.findNode(nsABC), nullptr);
+
+  // Re-publishing must create fresh nodes without crashing.
+  auto publisher2 = makeSession();
+  auto node = publish(nsABC, publisher2);
+  EXPECT_NE(node, nullptr);
+}
+
+// Test: Pruning happens after explicit unpublish (simulating removeSession)
+TEST_F(NamespaceTreeTest, PruneOnUnpublish) {
+  auto publisher = makeSession();
+
+  TrackNamespace nsABCD{{"test", "A", "B", "C", "D"}};
+  publish(nsABCD, publisher);
+  unpublish(nsABCD, publisher);
+
+  EXPECT_EQ(tree_.findNode(nsABCD), nullptr);
+
+  // Re-publishing must work after pruning.
+  auto publisher2 = makeSession();
+  auto node = publish(nsABCD, publisher2);
+  EXPECT_NE(node, nullptr);
+}
+
+// Test: Unpublish from the non-owner is ignored; new owner remains
+TEST_F(NamespaceTreeTest, NonOwnerUnpublishIsIgnored) {
+  auto publisher1 = makeSession();
+  auto publisher2 = makeSession();
+
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  publish(nsAB, publisher1);
+  publish(nsAB, publisher2);   // replaces publisher1 as owner
+  unpublish(nsAB, publisher1); // NotOwner — should be ignored
+  EXPECT_EQ(tree_.findPublisherSession(nsAB), publisher2);
+}
+
+// Test: unpublishTrack prunes node when it was the only content
+TEST_F(NamespaceTreeTest, PublishDonePrunesNode) {
+  auto publisher = makeSession();
+
+  TrackNamespace nsABC{{"test", "A", "B", "C"}};
+  auto node = publish(nsABC, publisher);
+
+  // Simulate a track-level publish on the same node (as relay's publish() does)
+  publishTrack(nsABC, "track1", publisher);
+
+  // Unpublish namespace — node stays alive because the track publish is still active
+  unpublish(nsABC, publisher);
+  EXPECT_NE(tree_.findNode(nsABC), nullptr);
+
+  // Unpublish the track — node is now empty, so it should be pruned
+  tree_.unpublishTrack(nsABC, "track1");
+  EXPECT_EQ(tree_.findNode(nsABC), nullptr);
+}
+
+// Test: Mixed content types — node with publisher + active track publish
+TEST_F(NamespaceTreeTest, MixedContentPublishAndTrack) {
+  auto publisher = makeSession();
+
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  auto node = publish(nsAB, publisher);
+
+  publishTrack(nsAB, "track1", publisher);
+
+  // Unpublish namespace — node stays alive because track is still there
+  unpublish(nsAB, publisher);
+  EXPECT_NE(tree_.findNode(nsAB), nullptr);
+
+  // Adding another track still works
+  publishTrack(nsAB, "track2", publisher);
+  EXPECT_NE(tree_.findNode(nsAB), nullptr);
+}
+
+// Test: Mixed content types — node with publisher + namespace subscriber
+TEST_F(NamespaceTreeTest, MixedContentPublishAndSubscriber) {
+  auto publisher = makeSession();
+  auto subscriber = makeSession();
+
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  publish(nsAB, publisher);
+  subscribe(nsAB, subscriber); // SUBSCRIBE_NAMESPACE from another session
+
+  // Unpublish namespace — node stays alive because subscriber is still there
+  unpublish(nsAB, publisher);
+  EXPECT_NE(tree_.findNode(nsAB), nullptr);
+
+  // New publisher can take the namespace
+  auto publisher2 = makeSession();
+  publish(nsAB, publisher2);
+  EXPECT_EQ(tree_.findPublisherSession(nsAB), publisher2);
+}
+
+// Test: Unsubscribe triggers pruning when node has no other content
+TEST_F(NamespaceTreeTest, PruneOnUnsubscribeNamespace) {
+  auto subscriber = makeSession();
+
+  TrackNamespace nsABC{{"test", "A", "B", "C"}};
+  subscribe(nsABC, subscriber);
+  unsubscribe(nsABC, subscriber);
+
+  EXPECT_EQ(tree_.findNode(nsABC), nullptr);
+
+  // Re-subscribing creates a fresh tree without crash
+  subscribe(nsABC, subscriber);
+  EXPECT_NE(tree_.findNode(nsABC), nullptr);
+}
+
+// Test: Middle empty nodes in deep tree
+// Scenario: test/A (has publisher), test/A/B (empty), test/A/B/C (has
+// publisher). Remove C should prune B but keep A.
+TEST_F(NamespaceTreeTest, PruneMiddleEmptyNode) {
+  auto publisherA = makeSession();
+  auto publisherC = makeSession();
+
+  TrackNamespace nsA{{"test", "A"}};
+  TrackNamespace nsABC{{"test", "A", "B", "C"}};
+  publish(nsA, publisherA);
+  publish(nsABC, publisherC); // creates B as an empty intermediate node
+
+  // Removing C should prune B and C but keep A
+  unpublish(nsABC, publisherC);
+
+  EXPECT_EQ(tree_.findPublisherSession(nsA), publisherA);
+
+  // Re-publishing nsABC works — B and C were pruned so fresh nodes are created
+  auto publisherC2 = makeSession();
+  EXPECT_NE(publish(nsABC, publisherC2), nullptr);
+}
+
+// Test: Double unpublish doesn't crash or corrupt state
+TEST_F(NamespaceTreeTest, DoubleUnpublishNamespace) {
+  auto publisher = makeSession();
+
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  publish(nsAB, publisher);
+  unpublish(nsAB, publisher);
+
+  EXPECT_EQ(tree_.findNode(nsAB), nullptr);
+
+  unpublish(nsAB, publisher); // NodeNotFound — should not crash
+
+  auto publisher2 = makeSession();
+  EXPECT_NE(publish(nsAB, publisher2), nullptr);
+}
+
+// Test: Unpublish from an unrelated session (child publisher) is also ignored
+TEST_F(NamespaceTreeTest, UnrelatedSessionUnpublishIsIgnored) {
+  auto publisher1 = makeSession();
+  auto publisher2 = makeSession();
+
+  // publisher1 owns nsAB; publisher2 owns a child namespace
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  TrackNamespace nsABC{{"test", "A", "B", "C"}};
+  publish(nsAB, publisher1);
+  publish(nsABC, publisher2);
+
+  // publisher2 tries to unpublish nsAB — NotOwner, ignored
+  unpublish(nsAB, publisher2);
+
+  EXPECT_EQ(tree_.findPublisherSession(nsAB), publisher1)
+      << "Ownership check failed: wrong session returned after unrelated unpublish";
+}
+
+// Test: Pruning with multiple children at same level
+// Scenario: test/A has children B (publisher), C (subscriber), D (subscriber).
+// Remove B should prune B but keep A (with children C and D).
+TEST_F(NamespaceTreeTest, PruneOneOfMultipleChildren) {
+  auto publisherB = makeSession();
+  auto subscriberC = makeSession();
+  auto subscriberD = makeSession();
+
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  TrackNamespace nsAC{{"test", "A", "C"}};
+  TrackNamespace nsAD{{"test", "A", "D"}};
+  publish(nsAB, publisherB);
+  subscribe(nsAC, subscriberC); // creates C as a node with only a subscriber session
+  subscribe(nsAD, subscriberD); // creates D similarly
+
+  // Unpublish B — should prune B only, not A (which still has children C and D)
+  unpublish(nsAB, publisherB);
+
+  EXPECT_NE(tree_.findNode(nsAC), nullptr);
+  EXPECT_NE(tree_.findNode(nsAD), nullptr);
+}
+
+// Test: Empty namespace edge case — setPublisher with empty namespace must not crash
+TEST_F(NamespaceTreeTest, EmptyNamespacePublish) {
+  auto publisher = makeSession();
+
+  TrackNamespace emptyNs{{}};
+  auto result = tree_.setPublisher(emptyNs, publisher, nullptr, {}, RequestID(0));
+  EXPECT_NE(result.node, nullptr);
+
+  unpublish(emptyNs, publisher);
+}
+
+// Test: Verify activeChildCount consistency after complex operations
+TEST_F(NamespaceTreeTest, ActiveChildCountConsistency) {
+  auto pub1 = makeSession();
+  auto pub2 = makeSession();
+  auto sub1 = makeSession();
+
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  TrackNamespace nsAC{{"test", "A", "C"}};
+  TrackNamespace nsA{{"test", "A"}};
+
+  publish(nsAB, pub1);
+  subscribe(nsAC, sub1);
+
+  unpublish(nsAB, pub1); // removes B; A's activeChildCount drops to 1 (only C)
+
+  // A should still exist because C is still active; pub2 can publish at A
+  publish(nsA, pub2);
+
+  unsubscribe(nsAC, sub1); // removes C; A's activeChildCount drops to 0
+
+  // A itself has content (pub2's sourceSession), so it should not be pruned
+  EXPECT_EQ(tree_.findPublisherSession(nsA), pub2);
+}
+
+// Test: Track publish keeps node alive while namespace is still published
+TEST_F(NamespaceTreeTest, PublishKeepsNodeAliveAfterNamespaceDone) {
+  auto publisher = makeSession();
+
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  auto node = publish(nsAB, publisher);
+
+  publishTrack(nsAB, "track1", publisher);
+
+  // Unpublish namespace (track is still active)
+  unpublish(nsAB, publisher);
+  EXPECT_NE(tree_.findNode(nsAB), nullptr);
+
+  // Add a second track
+  publishTrack(nsAB, "track2", publisher);
+
+  tree_.unpublishTrack(nsAB, "track1");
+  EXPECT_NE(tree_.findNode(nsAB), nullptr); // track2 still alive
+
+  tree_.unpublishTrack(nsAB, "track2");
+  EXPECT_EQ(tree_.findNode(nsAB), nullptr); // fully pruned
+}
+
+} // namespace openmoq::moqx::test


### PR DESCRIPTION
Move the namespace tree out of MoqxRelay into src/NamespaceTree.h/.cpp. NamespaceNode content fields (publisherSession_, publishes_, subscribers_, etc.) are now private; MoqxRelay interacts through typed methods — setPublisher, unpublishNamespace, unpublishTrack, addPublish, addNamespaceSubscriber, removeNamespaceSubscriber — and typed result structs (SetPublisherResult, AddPublishResult, UnpublishNamespaceResult) with folly::Expected error returns.

Namespace tree unit tests move to test/NamespaceTreeTest.cpp, exercising pruning, mixed-content, and activeChildCount invariants directly without going through the full relay fixture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/253)
<!-- Reviewable:end -->
