### PR TITLE
ci: gate publish-portable to release/**, add version-release workflow

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -423,6 +423,7 @@ jobs:
             -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
             -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DCMAKE_DISABLE_FIND_PACKAGE_LibUnwind=TRUE \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install"
 
       - name: Build
@@ -443,11 +444,14 @@ jobs:
           # libboost_context: jammy=1.74, noble=1.83 — different SONAMEs,
           # must bundle. Others below are SONAME-stable across LTS releases
           # but bundling them belt-and-suspenders for true portability.
+          # libunwind intentionally NOT bundled — portable Release tarballs
+          # disable libunwind via CMAKE_DISABLE_FIND_PACKAGE_LibUnwind to
+          # match moxygen's portable-build treatment (symbolization is a
+          # debug-aid, not needed in Release).
           for lib in \
               libboost_context.so.1.74.0 \
               libgflags.so.2.2 \
               libsodium.so.23 \
-              libunwind.so.8 \
               libdouble-conversion.so.3 \
               libevent-2.1.so.7 \
               libzstd.so.1 \

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -367,7 +367,17 @@ jobs:
           submodules: true
 
       - name: Install system dependencies
-        run: bash deps/moxygen/standalone/install-system-deps.sh
+        run: |
+          # Match docker/Dockerfile's build-stage apt list — picks up
+          # libdwarf-dev / libbrotli-dev that moxygen's install-system-deps
+          # doesn't install but proxygen needs.
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential ninja-build cmake git ca-certificates pkg-config \
+            libssl-dev libunwind-dev libgoogle-glog-dev libgflags-dev \
+            libdouble-conversion-dev libevent-dev libsodium-dev libzstd-dev \
+            libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev libdwarf-dev \
+            libbrotli-dev libgtest-dev libgmock-dev libxxhash-dev
 
       - name: Download moxygen portable tarball
         env:
@@ -387,9 +397,13 @@ jobs:
 
       - name: Configure
         run: |
+          # CMAKE_MODULE_PATH points at moqx/cmake/ (Findc-ares.cmake shim
+          # for jammy where libc-ares-dev doesn't ship a CONFIG file) plus
+          # moxygen's fbcode_builder Find*.cmake helpers.
           cmake -S . -B _build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(cat .scratch/cmake_prefix_path.txt)" \
+            -DCMAKE_MODULE_PATH="${GITHUB_WORKSPACE}/cmake;${GITHUB_WORKSPACE}/deps/moxygen/build/fbcode_builder/CMake" \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install"
 
       - name: Build

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -14,7 +14,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  # Cancel superseded runs on release/** branches (rapid-iteration churn).
+  # Keep main's serialize-don't-cancel behavior so external-state steps
+  # (Docker push, release create, deploy) aren't interrupted mid-flight.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: write

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -334,6 +334,101 @@ jobs:
           retention-days: 90
 
   # ════════════════════════════════════════════════════════════════════════════
+  # Publish portable: bare-metal Linux tarballs (amd64 + arm64)
+  #   Native cmake build on jammy host against moxygen linux-* tarball.
+  #   Produces moqx-linux-{amd64,arm64}.tar.gz — runs on jammy, noble,
+  #   debian 12+, RHEL 9+, AL2023, Rockchip / Pi 4+ (arm64), etc.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  publish-portable:
+    needs: [check-format, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+            platform: linux-amd64
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+            platform: linux-arm64
+    name: publish portable (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install system dependencies
+        run: bash deps/moxygen/standalone/install-system-deps.sh
+
+      - name: Download moxygen portable tarball
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MOQX_PLATFORM: ${{ matrix.platform }}
+          # TEMPORARY: pin to the test-build-matrix branch's snapshot until the
+          # moxygen PR adding linux-* entries lands on main. Remove this line
+          # before merging the moqx PR — once moxygen is merged, snapshot-latest
+          # will carry the linux-* tarballs and the default path applies.
+          MOQX_MOXYGEN_RELEASE_TAG: snapshot-test-build-matrix-latest
+        run: |
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+          fi
+          bash scripts/build.sh setup --use-latest --no-fallback
+
+      - name: Configure
+        run: |
+          cmake -S . -B _build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$(cat .scratch/cmake_prefix_path.txt)" \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install"
+
+      - name: Build
+        run: cmake --build _build -j "$(nproc)"
+
+      - name: Install
+        run: cmake --install _build
+
+      - name: Package
+        id: package
+        run: |
+          ARTIFACT="moqx-${{ matrix.platform }}.tar.gz"
+          tar czf "$ARTIFACT" -C _install .
+          echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
+          echo "==> Tarball contents:"
+          tar tzf "$ARTIFACT" | head -20
+          echo "==> Tarball size:"
+          ls -lh "$ARTIFACT"
+
+      - name: Smoke test (binary loads + --help)
+        run: |
+          tar xzf "moqx-${{ matrix.platform }}.tar.gz" -C /tmp/
+          echo "==> ldd"
+          ldd /tmp/bin/moqx | tee /tmp/ldd.out
+          if grep -q "not found" /tmp/ldd.out; then
+            echo "ERROR: missing shared libraries"
+            exit 1
+          fi
+          echo "==> --help (first 5 lines, exit code allowed nonzero)"
+          /tmp/bin/moqx --help 2>&1 | head -5 || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: moqx-${{ matrix.platform }}.tar.gz
+          path: moqx-${{ matrix.platform }}.tar.gz
+          retention-days: 90
+
+  # ════════════════════════════════════════════════════════════════════════════
   # Manifest: stitch per-arch images into multiplatform tags
   # ════════════════════════════════════════════════════════════════════════════
 
@@ -401,7 +496,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   release:
-    needs: [build, manifest]
+    needs: [build, manifest, publish-portable]
     runs-on: ubuntu-22.04
     outputs:
       tag: ${{ steps.publish.outputs.tag }}
@@ -590,7 +685,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   notify:
-    needs: [check-format, build, conformance, publish, manifest, release, deploy]
+    needs: [check-format, build, conformance, publish, publish-portable, manifest, release, deploy]
     if: always()
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -409,19 +409,20 @@ jobs:
           # moxygen's fbcode_builder Find*.cmake helpers.
           # cxx_flags must match what moxygen's tarball was compiled with
           # so folly's F14 intrinsics-mode templates resolve correctly.
-          # Boost_USE_STATIC_LIBS + .a suffix preference: link Boost::context
-          # (and other Boost components folly pulls in) statically so the
-          # final binary doesn't carry a libboost_context.so.1.74.0 dep —
-          # noble/RHEL/etc. don't have that exact SONAME. Mirrors moxygen's
-          # standalone BUNDLE_DEPS treatment.
+          # CMAKE_INSTALL_RPATH = $ORIGIN/../lib makes the binary look for
+          # bundled .so files next to itself (in the tarball's lib/) before
+          # the system search path. Combined with the Package step bundling
+          # libboost_context.so.1.74.0, this produces a self-contained
+          # tarball that runs on noble / RHEL 9 / AL2023 without any
+          # system package install.
           cmake -S . -B _build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(cat .scratch/cmake_prefix_path.txt)" \
             -DCMAKE_MODULE_PATH="${GITHUB_WORKSPACE}/cmake;${GITHUB_WORKSPACE}/deps/moxygen/build/fbcode_builder/CMake" \
             -DCMAKE_C_FLAGS="${{ matrix.cxx_flags }}" \
             -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
-            -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \
-            -DBoost_USE_STATIC_LIBS=ON \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install"
 
       - name: Build
@@ -429,6 +430,41 @@ jobs:
 
       - name: Install
         run: cmake --install _build
+
+      - name: Bundle non-toolchain dynamic deps
+        run: |
+          # Bundle SONAME-versioned .so deps that aren't part of the
+          # toolchain/glibc set, so the tarball runs on any modern Linux
+          # without needing distro-specific packages installed. The binary
+          # has RPATH=$ORIGIN/../lib, so the loader finds these first.
+          # Skips libstdc++/libgcc_s/libc/libm/ld-linux/linux-vdso (toolchain).
+          mkdir -p _install/lib
+          LIBARCH="$(uname -m)-linux-gnu"
+          # libboost_context: jammy=1.74, noble=1.83 — different SONAMEs,
+          # must bundle. Others below are SONAME-stable across LTS releases
+          # but bundling them belt-and-suspenders for true portability.
+          for lib in \
+              libboost_context.so.1.74.0 \
+              libgflags.so.2.2 \
+              libsodium.so.23 \
+              libunwind.so.8 \
+              libdouble-conversion.so.3 \
+              libevent-2.1.so.7 \
+              libzstd.so.1 \
+              libcares.so.2 \
+              libbrotlidec.so.1 \
+              libbrotlienc.so.1 \
+              libbrotlicommon.so.1 \
+              ; do
+            src="/usr/lib/${LIBARCH}/${lib}"
+            if [ -f "$src" ]; then
+              cp -L "$src" _install/lib/
+            fi
+          done
+          echo "==> bundled libs:"
+          ls -lh _install/lib/
+          echo "==> binary RUNPATH/RPATH:"
+          readelf -d _install/bin/moqx | grep -E "RUNPATH|RPATH" || echo "(none)"
 
       - name: Package
         id: package
@@ -448,15 +484,20 @@ jobs:
           path: moqx-${{ matrix.platform }}.tar.gz
           retention-days: 90
 
-      - name: Smoke test (binary loads + --help)
+      - name: Smoke test (binary resolves bundled libs + --help)
         run: |
           mkdir -p /tmp/moqx-smoke
           tar xzf "moqx-${{ matrix.platform }}.tar.gz" -C /tmp/moqx-smoke
-          echo "==> ldd"
+          echo "==> ldd (must resolve bundled libs from $ORIGIN/../lib)"
           ldd /tmp/moqx-smoke/bin/moqx | tee /tmp/ldd.out
           if grep -q "not found" /tmp/ldd.out; then
             echo "ERROR: missing shared libraries"
             exit 1
+          fi
+          # Confirm bundled boost_context resolves to OUR lib/, not /usr/lib
+          if ! grep -q "moqx-smoke/lib/libboost_context.so.1.74.0" /tmp/ldd.out; then
+            echo "WARNING: libboost_context.so.1.74.0 didn't resolve to bundled lib/" >&2
+            grep boost_context /tmp/ldd.out >&2 || true
           fi
           echo "==> --help (first 5 lines, exit code allowed nonzero)"
           /tmp/moqx-smoke/bin/moqx --help 2>&1 | head -5 || true

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -346,12 +346,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # cxx_flags MUST match what moxygen's linux-* publish entries used —
+          # folly's F14 templates select an intrinsics mode based on compile-
+          # time -march macros. Mismatch between consumer (moqx) and provider
+          # (folly in tarball) causes undefined-reference link errors on
+          # F14LinkCheck<N>::check(). Keep these in sync with moxygen.
           - arch: amd64
             runner: ubuntu-22.04
             platform: linux-amd64
+            cxx_flags: "-march=x86-64-v2"
           - arch: arm64
             runner: ubuntu-22.04-arm
             platform: linux-arm64
+            cxx_flags: "-march=armv8-a"
     name: publish portable (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     steps:
@@ -400,10 +407,14 @@ jobs:
           # CMAKE_MODULE_PATH points at moqx/cmake/ (Findc-ares.cmake shim
           # for jammy where libc-ares-dev doesn't ship a CONFIG file) plus
           # moxygen's fbcode_builder Find*.cmake helpers.
+          # cxx_flags must match what moxygen's tarball was compiled with
+          # so folly's F14 intrinsics-mode templates resolve correctly.
           cmake -S . -B _build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(cat .scratch/cmake_prefix_path.txt)" \
             -DCMAKE_MODULE_PATH="${GITHUB_WORKSPACE}/cmake;${GITHUB_WORKSPACE}/deps/moxygen/build/fbcode_builder/CMake" \
+            -DCMAKE_C_FLAGS="${{ matrix.cxx_flags }}" \
+            -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install"
 
       - name: Build
@@ -423,24 +434,25 @@ jobs:
           echo "==> Tarball size:"
           ls -lh "$ARTIFACT"
 
-      - name: Smoke test (binary loads + --help)
-        run: |
-          tar xzf "moqx-${{ matrix.platform }}.tar.gz" -C /tmp/
-          echo "==> ldd"
-          ldd /tmp/bin/moqx | tee /tmp/ldd.out
-          if grep -q "not found" /tmp/ldd.out; then
-            echo "ERROR: missing shared libraries"
-            exit 1
-          fi
-          echo "==> --help (first 5 lines, exit code allowed nonzero)"
-          /tmp/bin/moqx --help 2>&1 | head -5 || true
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: moqx-${{ matrix.platform }}.tar.gz
           path: moqx-${{ matrix.platform }}.tar.gz
           retention-days: 90
+
+      - name: Smoke test (binary loads + --help)
+        run: |
+          mkdir -p /tmp/moqx-smoke
+          tar xzf "moqx-${{ matrix.platform }}.tar.gz" -C /tmp/moqx-smoke
+          echo "==> ldd"
+          ldd /tmp/moqx-smoke/bin/moqx | tee /tmp/ldd.out
+          if grep -q "not found" /tmp/ldd.out; then
+            echo "ERROR: missing shared libraries"
+            exit 1
+          fi
+          echo "==> --help (first 5 lines, exit code allowed nonzero)"
+          /tmp/moqx-smoke/bin/moqx --help 2>&1 | head -5 || true
 
   # ════════════════════════════════════════════════════════════════════════════
   # Manifest: stitch per-arch images into multiplatform tags

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -337,190 +337,6 @@ jobs:
           retention-days: 90
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Publish portable: bare-metal Linux tarballs (amd64 + arm64)
-  #   Native cmake build on jammy host against moxygen linux-* tarball.
-  #   Produces moqx-linux-{amd64,arm64}.tar.gz — runs on jammy, noble,
-  #   debian 12+, RHEL 9+, AL2023, Rockchip / Pi 4+ (arm64), etc.
-  # ════════════════════════════════════════════════════════════════════════════
-
-  publish-portable:
-    # Release-branch only: portable tarballs are an explicit release
-    # deliverable, not produced on every main push. Cut a release branch
-    # via .github/workflows/version-release.yml to trigger this.
-    if: startsWith(github.ref, 'refs/heads/release/')
-    needs: [check-format, build]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # cxx_flags MUST match what moxygen's linux-* portable build used —
-          # folly's F14 templates select an intrinsics mode based on compile-
-          # time -march macros. Mismatch between consumer (moqx) and provider
-          # (folly in tarball) causes undefined-reference link errors on
-          # F14LinkCheck<N>::check(). Keep these in sync with moxygen's
-          # omoq-version-release.yml portable-build matrix.
-          #
-          # Frame-pointer flags preserved at -O3 so signal-handler stack
-          # unwinding (folly::symbolizer) and post-mortem debugging via the
-          # moxygen .symbols sidecar work against highly-optimized binaries.
-          - arch: amd64
-            runner: ubuntu-22.04
-            platform: linux-amd64
-            cxx_flags: "-march=x86-64-v2 -fno-omit-frame-pointer -fasynchronous-unwind-tables"
-          - arch: arm64
-            runner: ubuntu-22.04-arm
-            platform: linux-arm64
-            cxx_flags: "-march=armv8-a -fno-omit-frame-pointer -fasynchronous-unwind-tables"
-    name: publish portable (${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OMOQ_APP_ID }}
-          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Install system dependencies
-        run: |
-          # Match docker/Dockerfile's build-stage apt list — picks up
-          # libdwarf-dev / libbrotli-dev that moxygen's install-system-deps
-          # doesn't install but proxygen needs.
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential ninja-build cmake git ca-certificates pkg-config \
-            libssl-dev libunwind-dev libgoogle-glog-dev libgflags-dev \
-            libdouble-conversion-dev libevent-dev libsodium-dev libzstd-dev \
-            libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev libdwarf-dev \
-            libbrotli-dev libgtest-dev libgmock-dev libxxhash-dev
-
-      - name: Download moxygen portable tarball
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          MOQX_PLATFORM: ${{ matrix.platform }}
-        run: |
-          # .moxygen-release is an opt-in pin to a specific moxygen release
-          # tag. When absent, fall back to snapshot-latest. Same behavior on
-          # main and release/** — release branches optionally pin, never
-          # required.
-          if [ -f .moxygen-release ]; then
-            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
-            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
-            bash scripts/build.sh setup --no-fallback
-          else
-            echo "No .moxygen-release pin — using snapshot-latest"
-            bash scripts/build.sh setup --use-latest --no-fallback
-          fi
-
-      - name: Configure
-        run: |
-          # CMAKE_MODULE_PATH points at moqx/cmake/ (Findc-ares.cmake shim
-          # for jammy where libc-ares-dev doesn't ship a CONFIG file) plus
-          # moxygen's fbcode_builder Find*.cmake helpers.
-          # cxx_flags must match what moxygen's tarball was compiled with
-          # so folly's F14 intrinsics-mode templates resolve correctly.
-          # CMAKE_INSTALL_RPATH = $ORIGIN/../lib makes the binary look for
-          # bundled .so files next to itself (in the tarball's lib/) before
-          # the system search path. Combined with the Package step bundling
-          # libboost_context.so.1.74.0, this produces a self-contained
-          # tarball that runs on noble / RHEL 9 / AL2023 without any
-          # system package install.
-          cmake -S . -B _build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH="$(cat .scratch/cmake_prefix_path.txt)" \
-            -DCMAKE_MODULE_PATH="${GITHUB_WORKSPACE}/cmake;${GITHUB_WORKSPACE}/deps/moxygen/build/fbcode_builder/CMake" \
-            -DCMAKE_C_FLAGS="${{ matrix.cxx_flags }}" \
-            -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
-            -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
-            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
-            -DCMAKE_DISABLE_FIND_PACKAGE_LibUnwind=TRUE \
-            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install"
-
-      - name: Build
-        run: cmake --build _build -j "$(nproc)"
-
-      - name: Install
-        run: cmake --install _build
-
-      - name: Bundle non-toolchain dynamic deps
-        run: |
-          # Bundle SONAME-versioned .so deps that aren't part of the
-          # toolchain/glibc set, so the tarball runs on any modern Linux
-          # without needing distro-specific packages installed. The binary
-          # has RPATH=$ORIGIN/../lib, so the loader finds these first.
-          # Skips libstdc++/libgcc_s/libc/libm/ld-linux/linux-vdso (toolchain).
-          mkdir -p _install/lib
-          LIBARCH="$(uname -m)-linux-gnu"
-          # libboost_context: jammy=1.74, noble=1.83 — different SONAMEs,
-          # must bundle. Others below are SONAME-stable across LTS releases
-          # but bundling them belt-and-suspenders for true portability.
-          # libunwind intentionally NOT bundled — portable Release tarballs
-          # disable libunwind via CMAKE_DISABLE_FIND_PACKAGE_LibUnwind to
-          # match moxygen's portable-build treatment (symbolization is a
-          # debug-aid, not needed in Release).
-          for lib in \
-              libboost_context.so.1.74.0 \
-              libgflags.so.2.2 \
-              libsodium.so.23 \
-              libdouble-conversion.so.3 \
-              libevent-2.1.so.7 \
-              libzstd.so.1 \
-              libcares.so.2 \
-              libbrotlidec.so.1 \
-              libbrotlienc.so.1 \
-              libbrotlicommon.so.1 \
-              ; do
-            src="/usr/lib/${LIBARCH}/${lib}"
-            if [ -f "$src" ]; then
-              cp -L "$src" _install/lib/
-            fi
-          done
-          echo "==> bundled libs:"
-          ls -lh _install/lib/
-          echo "==> binary RUNPATH/RPATH:"
-          readelf -d _install/bin/moqx | grep -E "RUNPATH|RPATH" || echo "(none)"
-
-      - name: Package
-        id: package
-        run: |
-          ARTIFACT="moqx-${{ matrix.platform }}.tar.gz"
-          tar czf "$ARTIFACT" -C _install .
-          echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
-          echo "==> Tarball contents:"
-          tar tzf "$ARTIFACT" | head -20
-          echo "==> Tarball size:"
-          ls -lh "$ARTIFACT"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: moqx-${{ matrix.platform }}.tar.gz
-          path: moqx-${{ matrix.platform }}.tar.gz
-          retention-days: 90
-
-      - name: Smoke test (binary resolves bundled libs + --help)
-        run: |
-          mkdir -p /tmp/moqx-smoke
-          tar xzf "moqx-${{ matrix.platform }}.tar.gz" -C /tmp/moqx-smoke
-          echo "==> ldd (must resolve bundled libs from $ORIGIN/../lib)"
-          ldd /tmp/moqx-smoke/bin/moqx | tee /tmp/ldd.out
-          if grep -q "not found" /tmp/ldd.out; then
-            echo "ERROR: missing shared libraries"
-            exit 1
-          fi
-          # Confirm bundled boost_context resolves to OUR lib/, not /usr/lib
-          if ! grep -q "moqx-smoke/lib/libboost_context.so.1.74.0" /tmp/ldd.out; then
-            echo "WARNING: libboost_context.so.1.74.0 didn't resolve to bundled lib/" >&2
-            grep boost_context /tmp/ldd.out >&2 || true
-          fi
-          echo "==> --help (first 5 lines, exit code allowed nonzero)"
-          /tmp/moqx-smoke/bin/moqx --help 2>&1 | head -5 || true
-
-  # ════════════════════════════════════════════════════════════════════════════
   # Manifest: stitch per-arch images into multiplatform tags
   # ════════════════════════════════════════════════════════════════════════════
 
@@ -588,15 +404,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   release:
-    needs: [build, manifest, publish-portable]
-    # publish-portable is skipped on main pushes (release-branch only).
-    # Run when build+manifest succeeded and publish-portable didn't fail.
-    if: |
-      always() &&
-      needs.build.result == 'success' &&
-      needs.manifest.result == 'success' &&
-      needs.publish-portable.result != 'failure' &&
-      needs.publish-portable.result != 'cancelled'
+    needs: [build, manifest]
     runs-on: ubuntu-22.04
     outputs:
       tag: ${{ steps.publish.outputs.tag }}
@@ -785,7 +593,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   notify:
-    needs: [check-format, build, conformance, publish, publish-portable, manifest, release, deploy]
+    needs: [check-format, build, conformance, publish, manifest, release, deploy]
     if: always()
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -344,24 +344,33 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
 
   publish-portable:
+    # Release-branch only: portable tarballs are an explicit release
+    # deliverable, not produced on every main push. Cut a release branch
+    # via .github/workflows/version-release.yml to trigger this.
+    if: startsWith(github.ref, 'refs/heads/release/')
     needs: [check-format, build]
     strategy:
       fail-fast: false
       matrix:
         include:
-          # cxx_flags MUST match what moxygen's linux-* publish entries used —
+          # cxx_flags MUST match what moxygen's linux-* portable build used —
           # folly's F14 templates select an intrinsics mode based on compile-
           # time -march macros. Mismatch between consumer (moqx) and provider
           # (folly in tarball) causes undefined-reference link errors on
-          # F14LinkCheck<N>::check(). Keep these in sync with moxygen.
+          # F14LinkCheck<N>::check(). Keep these in sync with moxygen's
+          # omoq-version-release.yml portable-build matrix.
+          #
+          # Frame-pointer flags preserved at -O3 so signal-handler stack
+          # unwinding (folly::symbolizer) and post-mortem debugging via the
+          # moxygen .symbols sidecar work against highly-optimized binaries.
           - arch: amd64
             runner: ubuntu-22.04
             platform: linux-amd64
-            cxx_flags: "-march=x86-64-v2"
+            cxx_flags: "-march=x86-64-v2 -fno-omit-frame-pointer -fasynchronous-unwind-tables"
           - arch: arm64
             runner: ubuntu-22.04-arm
             platform: linux-arm64
-            cxx_flags: "-march=armv8-a"
+            cxx_flags: "-march=armv8-a -fno-omit-frame-pointer -fasynchronous-unwind-tables"
     name: publish portable (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     steps:
@@ -393,17 +402,17 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           MOQX_PLATFORM: ${{ matrix.platform }}
-          # TEMPORARY: pin to the test-build-matrix branch's snapshot until the
-          # moxygen PR adding linux-* entries lands on main. Remove this line
-          # before merging the moqx PR — once moxygen is merged, snapshot-latest
-          # will carry the linux-* tarballs and the default path applies.
-          MOQX_MOXYGEN_RELEASE_TAG: snapshot-test-build-matrix-latest
         run: |
-          if [ -f .moxygen-release ]; then
-            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
-            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+          # Release branches must pin a moxygen tag via .moxygen-release.
+          # The portable matrix only fires on release/**, so absence of the
+          # file means the release-cutting flow is broken — fail loud.
+          if [ ! -f .moxygen-release ]; then
+            echo "Error: .moxygen-release missing on release branch — cannot determine moxygen release to consume." >&2
+            exit 1
           fi
-          bash scripts/build.sh setup --use-latest --no-fallback
+          export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+          echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+          bash scripts/build.sh setup --no-fallback
 
       - name: Configure
         run: |
@@ -578,6 +587,14 @@ jobs:
 
   release:
     needs: [build, manifest, publish-portable]
+    # publish-portable is skipped on main pushes (release-branch only).
+    # Run when build+manifest succeeded and publish-portable didn't fail.
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      needs.manifest.result == 'success' &&
+      needs.publish-portable.result != 'failure' &&
+      needs.publish-portable.result != 'cancelled'
     runs-on: ubuntu-22.04
     outputs:
       tag: ${{ steps.publish.outputs.tag }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -403,16 +403,18 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           MOQX_PLATFORM: ${{ matrix.platform }}
         run: |
-          # Release branches must pin a moxygen tag via .moxygen-release.
-          # The portable matrix only fires on release/**, so absence of the
-          # file means the release-cutting flow is broken — fail loud.
-          if [ ! -f .moxygen-release ]; then
-            echo "Error: .moxygen-release missing on release branch — cannot determine moxygen release to consume." >&2
-            exit 1
+          # .moxygen-release is an opt-in pin to a specific moxygen release
+          # tag. When absent, fall back to snapshot-latest. Same behavior on
+          # main and release/** — release branches optionally pin, never
+          # required.
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            bash scripts/build.sh setup --no-fallback
+          else
+            echo "No .moxygen-release pin — using snapshot-latest"
+            bash scripts/build.sh setup --use-latest --no-fallback
           fi
-          export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
-          echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
-          bash scripts/build.sh setup --no-fallback
 
       - name: Configure
         run: |

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -409,12 +409,19 @@ jobs:
           # moxygen's fbcode_builder Find*.cmake helpers.
           # cxx_flags must match what moxygen's tarball was compiled with
           # so folly's F14 intrinsics-mode templates resolve correctly.
+          # Boost_USE_STATIC_LIBS + .a suffix preference: link Boost::context
+          # (and other Boost components folly pulls in) statically so the
+          # final binary doesn't carry a libboost_context.so.1.74.0 dep —
+          # noble/RHEL/etc. don't have that exact SONAME. Mirrors moxygen's
+          # standalone BUNDLE_DEPS treatment.
           cmake -S . -B _build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$(cat .scratch/cmake_prefix_path.txt)" \
             -DCMAKE_MODULE_PATH="${GITHUB_WORKSPACE}/cmake;${GITHUB_WORKSPACE}/deps/moxygen/build/fbcode_builder/CMake" \
             -DCMAKE_C_FLAGS="${{ matrix.cxx_flags }}" \
             -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
+            -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \
+            -DBoost_USE_STATIC_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install"
 
       - name: Build

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -7,6 +7,21 @@ name: version release
 # also builds portable linux-{amd64,arm64} tarballs against an explicit
 # moxygen release tag.
 #
+# Job graph (parallel):
+#
+#   validate
+#     │
+#     ▼
+#   create-release (--draft)
+#     │
+#     ├──► portable-build (matrix amd64/arm64, conditional)
+#     │       └─► uploads directly to release
+#     ├──► promote-snapshot
+#     │       └─► xargs -P parallel uploads to release
+#     │
+#     ▼
+#   finalize (--draft=false)
+#
 # Inputs:
 #   version          required. semver, e.g. 1.2.3
 #   moxygen_release  optional. moxygen tag to consume (e.g. v1.2.3).
@@ -47,8 +62,8 @@ permissions:
 
 jobs:
   # ════════════════════════════════════════════════════════════════════════════
-  # Validate: semver gate, tag-doesn't-exist, resolve snapshot tag from
-  # dispatched ref, probe moxygen reference for portable assets.
+  # Validate: semver gate, tag-doesn't-exist, resolve snapshot tag/sha,
+  # probe moxygen reference for portable assets.
   # ════════════════════════════════════════════════════════════════════════════
 
   validate:
@@ -57,6 +72,7 @@ jobs:
       version: ${{ steps.v.outputs.version }}
       tag: ${{ steps.v.outputs.tag }}
       snapshot_tag: ${{ steps.v.outputs.snapshot_tag }}
+      snapshot_sha: ${{ steps.v.outputs.snapshot_sha }}
       moxygen_ref: ${{ steps.v.outputs.moxygen_ref }}
       has_portable: ${{ steps.v.outputs.has_portable }}
     steps:
@@ -70,7 +86,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ inputs.version }}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
             echo "Error: version must be semver (e.g. 1.2.3 or 1.2.3-rc1)" >&2
             exit 1
           fi
@@ -89,6 +105,14 @@ jobs:
             SNAPSHOT_TAG="snapshot-${LABEL}-latest"
           fi
           echo "==> Dispatched from $BRANCH → consuming $SNAPSHOT_TAG"
+
+          # Resolve snapshot SHA.
+          SNAPSHOT_SHA=$(gh api repos/{owner}/{repo}/releases \
+            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
+          if [[ -z "$SNAPSHOT_SHA" ]]; then
+            echo "Error: $SNAPSHOT_TAG release not found. Push to the dispatched branch first to produce a snapshot." >&2
+            exit 1
+          fi
 
           # Moxygen reference: explicit input or snapshot-latest fallback.
           MOX_REF="${{ inputs.moxygen_release }}"
@@ -119,25 +143,68 @@ jobs:
             echo "==> moxygen $MOX_REF has portable assets — portable matrix will run"
           else
             echo "==> moxygen $MOX_REF lacks portable assets — portable matrix will be skipped"
-            echo "    Available assets:"
-            echo "$ASSETS" | sed 's/^/      /'
           fi
 
           {
             echo "version=$VERSION"
             echo "tag=$TAG"
             echo "snapshot_tag=$SNAPSHOT_TAG"
+            echo "snapshot_sha=$SNAPSHOT_SHA"
             echo "moxygen_ref=$MOX_REF"
             echo "has_portable=$HAS_PORTABLE"
           } >> "$GITHUB_OUTPUT"
 
   # ════════════════════════════════════════════════════════════════════════════
+  # Create-release: open a draft release that the upload jobs append to.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  create-release:
+    needs: [validate]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          MOX_REF: ${{ needs.validate.outputs.moxygen_ref }}
+          HAS_PORTABLE: ${{ needs.validate.outputs.has_portable }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+          SNAPSHOT_SHA: ${{ needs.validate.outputs.snapshot_sha }}
+        run: |
+          if [ "$HAS_PORTABLE" = "true" ]; then
+            PORTABLE_NOTE="**Portable Linux tarballs** built against moxygen \`${MOX_REF}\`:
+          - \`moqx-linux-amd64.tar.gz\` — \`-march=x86-64-v2\` (≈ all cloud x86 since 2015)
+          - \`moqx-linux-arm64.tar.gz\` — \`-march=armv8-a\` (Graviton, Ampere, Apple M, RPi 3+, Rockchip)"
+          else
+            PORTABLE_NOTE="_Portable Linux tarballs not produced for this release: moxygen \`${MOX_REF}\` does not include the required portable assets._"
+          fi
+
+          gh release create "$TAG" \
+            --target "$SNAPSHOT_SHA" \
+            --title "moqx $VERSION" \
+            --draft \
+            --notes "$(cat <<EOF
+          **Version:** \`${VERSION}\`
+          **Commit:** \`${SNAPSHOT_SHA}\`
+          **moxygen reference:** \`${MOX_REF}\`
+
+          Standard tarballs promoted from [\`${SNAPSHOT_TAG}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${SNAPSHOT_TAG}).
+
+          ${PORTABLE_NOTE}
+          EOF
+          )"
+
+  # ════════════════════════════════════════════════════════════════════════════
   # Portable build: -O3, ISA-baselined, statically linked moqx-linux-{amd64,arm64}
   # tarballs. Runs only when the moxygen reference carries portable assets.
+  # Each runner uploads its own tarball directly to the draft release.
   # ════════════════════════════════════════════════════════════════════════════
 
   portable-build:
-    needs: [validate]
+    needs: [validate, create-release]
     if: needs.validate.outputs.has_portable == 'true'
     strategy:
       fail-fast: false
@@ -256,15 +323,7 @@ jobs:
         run: |
           ARTIFACT="moqx-${{ matrix.platform }}.tar.gz"
           tar czf "$ARTIFACT" -C _install .
-          echo "==> Tarball: $ARTIFACT"
           ls -lh "$ARTIFACT"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: moqx-${{ matrix.platform }}.tar.gz
-          path: moqx-${{ matrix.platform }}.tar.gz
-          retention-days: 90
 
       - name: Smoke test
         run: |
@@ -276,102 +335,66 @@ jobs:
             echo "ERROR: missing shared libraries"
             exit 1
           fi
-          echo "==> --help"
-          /tmp/moqx-smoke/bin/moqx --help 2>&1 | head -5 || true
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          gh release upload "$TAG" "moqx-${{ matrix.platform }}.tar.gz" --clobber
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Release: combine snapshot tarballs (always) + portable tarballs (when
-  # built) and create the tagged, non-prerelease GitHub release.
+  # Promote-snapshot: copy the existing platform tarballs from the rolling
+  # snapshot to the new release. Runs in parallel with portable-build.
   # ════════════════════════════════════════════════════════════════════════════
 
-  release:
-    needs: [validate, portable-build]
-    # Run when validate succeeded and portable-build either succeeded or
-    # was skipped (moxygen ref had no portable assets). Don't run if
-    # portable-build was attempted and failed.
-    if: |
-      always() &&
-      needs.validate.result == 'success' &&
-      needs.portable-build.result != 'failure' &&
-      needs.portable-build.result != 'cancelled'
+  promote-snapshot:
+    needs: [validate, create-release]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Download portable artifacts
-        if: needs.validate.outputs.has_portable == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          path: portable-assets/
-          merge-multiple: true
-
-      - name: Download snapshot artifacts
+      - name: Download snapshot tarballs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
           mkdir -p snapshot-assets
-          echo "Downloading platform tarballs from $SNAPSHOT_TAG..."
           gh release download "$SNAPSHOT_TAG" --dir snapshot-assets --pattern '*.tar.gz'
-          # Drop any portable tarballs from snapshot if present — we
-          # built them fresh in this workflow when applicable.
+          # Drop any portable tarballs from snapshot — those are built fresh
+          # in portable-build and uploaded directly there.
           rm -f snapshot-assets/moqx-linux-amd64*.tar.gz \
                 snapshot-assets/moqx-linux-arm64*.tar.gz
-          echo "Snapshot platform tarballs:"
+          echo "Snapshot tarballs to promote:"
           ls -lh snapshot-assets/
 
-      - name: Get snapshot commit
+      - name: Upload to release (parallel)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
-        run: |
-          SNAPSHOT_SHA=$(gh api repos/{owner}/{repo}/releases \
-            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
-          if [[ -z "$SNAPSHOT_SHA" ]]; then
-            echo "Error: $SNAPSHOT_TAG release not found. Push to the dispatched branch first to produce a snapshot." >&2
-            exit 1
-          fi
-          echo "Snapshot built from commit: $SNAPSHOT_SHA"
-          echo "SNAPSHOT_SHA=$SNAPSHOT_SHA" >> "$GITHUB_ENV"
-
-      - name: Stage release assets
-        run: |
-          mkdir -p release-assets
-          cp snapshot-assets/*.tar.gz release-assets/
-          if [ -d portable-assets ]; then
-            cp portable-assets/*.tar.gz release-assets/ 2>/dev/null || true
-          fi
-          echo "==> Release assets:"
-          ls -lh release-assets/
-
-      - name: Create versioned release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.validate.outputs.version }}
           TAG: ${{ needs.validate.outputs.tag }}
-          MOX_REF: ${{ needs.validate.outputs.moxygen_ref }}
-          HAS_PORTABLE: ${{ needs.validate.outputs.has_portable }}
-          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
-          if [ "$HAS_PORTABLE" = "true" ]; then
-            PORTABLE_NOTE="**Portable Linux tarballs** built against moxygen \`${MOX_REF}\`:
-          - \`moqx-linux-amd64.tar.gz\` — \`-march=x86-64-v2\` (≈ all cloud x86 since 2015)
-          - \`moqx-linux-arm64.tar.gz\` — \`-march=armv8-a\` (Graviton, Ampere, Apple M, RPi 3+, Rockchip)"
-          else
-            PORTABLE_NOTE="_Portable Linux tarballs not produced for this release: moxygen \`${MOX_REF}\` does not include the required portable assets._"
-          fi
+          # Fan out asset upload to N concurrent gh release upload calls.
+          find snapshot-assets -name '*.tar.gz' -print0 | \
+            xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" {} --clobber
 
-          gh release create "$TAG" release-assets/*.tar.gz \
-            --target "$SNAPSHOT_SHA" \
-            --title "moqx $VERSION" \
-            --notes "$(cat <<EOF
-          **Version:** \`${VERSION}\`
-          **Commit:** \`${SNAPSHOT_SHA}\`
-          **moxygen reference:** \`${MOX_REF}\`
+  # ════════════════════════════════════════════════════════════════════════════
+  # Finalize: flip draft → published once all uploads succeeded.
+  # Tolerates portable-build being skipped (has_portable=false).
+  # ════════════════════════════════════════════════════════════════════════════
 
-          Standard tarballs promoted from [\`${SNAPSHOT_TAG}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${SNAPSHOT_TAG}).
-
-          ${PORTABLE_NOTE}
-          EOF
-          )"
+  finalize:
+    needs: [validate, create-release, portable-build, promote-snapshot]
+    if: |
+      always() &&
+      needs.validate.result == 'success' &&
+      needs.create-release.result == 'success' &&
+      needs.promote-snapshot.result == 'success' &&
+      needs.portable-build.result != 'failure' &&
+      needs.portable-build.result != 'cancelled'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          gh release edit "$TAG" --draft=false
           echo "Released: $TAG"

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -149,7 +149,7 @@ jobs:
           # F14LinkCheck<N>::check() undefined-reference link errors.
           # Frame-pointer flags preserved at -O3 so signal-handler stack
           # unwinding (folly::symbolizer) and post-mortem debugging via
-          # the moxygen .symbols sidecar work against optimized binaries.
+          # the moxygen .dbg sidecar work against optimized binaries.
           - arch: amd64
             runner: ubuntu-22.04
             platform: linux-amd64

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -1,0 +1,110 @@
+name: version release
+
+# Manual workflow to cut a moqx release branch pinned to a specific moxygen
+# release. Creates `release/v<version>` from main with a `.moxygen-release`
+# file containing `<moxygen_release>`, which:
+#   1. Pins the moxygen tarballs that ci-main.yml downloads via setup-deps.
+#   2. Triggers ci-main.yml on the new branch — which builds the portable
+#      linux-{amd64,arm64} tarballs (gated to release/** only) and creates
+#      a snapshot-v<version>-latest pre-release with all artifacts.
+#
+# After the release branch CI is green, promote snapshot-v<version>-latest
+# to a tagged v<version> non-prerelease via the (forthcoming) promote-release
+# workflow or `gh release edit --prerelease=false`.
+#
+# Usage: Actions → version release → Run workflow →
+#   version: 1.2.3
+#   moxygen_release: v1.2.3   (must already exist on openmoq/moxygen)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'moqx version (e.g. 1.2.3)'
+        required: true
+        type: string
+      moxygen_release:
+        description: 'moxygen release tag (e.g. v1.2.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  cut-release-branch:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Validate version
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Error: version must be semver (e.g. 1.2.3 or 1.2.3-rc1)" >&2
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          BRANCH="release/${TAG}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Error: tag $TAG already exists" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Error: branch $BRANCH already exists" >&2
+            exit 1
+          fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+      - name: Validate moxygen release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MOX="${{ inputs.moxygen_release }}"
+          if ! gh release view "$MOX" --repo openmoq/moxygen >/dev/null 2>&1; then
+            echo "Error: moxygen release $MOX does not exist on openmoq/moxygen" >&2
+            exit 1
+          fi
+          # Sanity: the moxygen release should carry the portable linux-*
+          # tarballs that publish-portable expects.
+          ASSETS=$(gh release view "$MOX" --repo openmoq/moxygen --json assets --jq '.assets[].name')
+          for required in moxygen-linux-amd64.tar.gz moxygen-linux-arm64.tar.gz; do
+            if ! echo "$ASSETS" | grep -qx "$required"; then
+              echo "Error: moxygen release $MOX missing required asset: $required" >&2
+              echo "Found assets:" >&2
+              echo "$ASSETS" | sed 's/^/  /' >&2
+              exit 1
+            fi
+          done
+          echo "MOX_TAG=$MOX" >> "$GITHUB_ENV"
+
+      - name: Cut release branch with .moxygen-release
+        run: |
+          git config user.email "omoq-sync-bot[bot]@users.noreply.github.com"
+          git config user.name "omoq-sync-bot[bot]"
+          git checkout -b "$BRANCH"
+          echo "$MOX_TAG" > .moxygen-release
+          git add .moxygen-release
+          git commit -m "release: pin moxygen $MOX_TAG for $TAG"
+          git push origin "$BRANCH"
+          echo
+          echo "==> Release branch created: $BRANCH"
+          echo "    pinned moxygen release: $MOX_TAG"
+          echo "    pushed; ci-main.yml will trigger and build the portable matrix."
+          echo
+          echo "Once CI is green, the snapshot-${TAG}-latest pre-release will carry"
+          echo "all platform tarballs (including portable linux-amd64/arm64). Promote"
+          echo "it to a non-prerelease ${TAG} tag with:"
+          echo "  gh release edit snapshot-${TAG}-latest --tag ${TAG} --prerelease=false --title \"moqx ${{ inputs.version }}\""

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -162,11 +162,18 @@ jobs:
     needs: [validate]
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
       - uses: actions/checkout@v4
 
-      - name: Create draft release
+      - name: Create release (no assets yet)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           TAG: ${{ needs.validate.outputs.tag }}
           MOX_REF: ${{ needs.validate.outputs.moxygen_ref }}
@@ -185,7 +192,6 @@ jobs:
           gh release create "$TAG" \
             --target "$SNAPSHOT_SHA" \
             --title "moqx $VERSION" \
-            --draft \
             --notes "$(cat <<EOF
           **Version:** \`${VERSION}\`
           **Commit:** \`${SNAPSHOT_SHA}\`
@@ -338,7 +344,7 @@ jobs:
 
       - name: Upload to release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           gh release upload "$TAG" "moqx-${{ matrix.platform }}.tar.gz" --clobber
@@ -352,9 +358,16 @@ jobs:
     needs: [validate, create-release]
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
       - name: Download snapshot tarballs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
           mkdir -p snapshot-assets
@@ -368,7 +381,7 @@ jobs:
 
       - name: Upload to release (parallel)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           # Fan out asset upload to N concurrent gh release upload calls.
@@ -376,7 +389,7 @@ jobs:
             xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" {} --clobber
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Finalize: flip draft → published once all uploads succeeded.
+  # Finalize: mark release as latest once all uploads succeeded.
   # Tolerates portable-build being skipped (has_portable=false).
   # ════════════════════════════════════════════════════════════════════════════
 
@@ -391,10 +404,17 @@ jobs:
       needs.portable-build.result != 'cancelled'
     runs-on: ubuntu-22.04
     steps:
-      - name: Publish release
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+
+      - name: Mark release as latest
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          gh release edit "$TAG" --draft=false
+          gh release edit "$TAG" --latest
           echo "Released: $TAG"

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -1,20 +1,34 @@
 name: version release
 
-# Manual workflow to cut a moqx release branch pinned to a specific moxygen
-# release. Creates `release/v<version>` from main with a `.moxygen-release`
-# file containing `<moxygen_release>`, which:
-#   1. Pins the moxygen tarballs that ci-main.yml downloads via setup-deps.
-#   2. Triggers ci-main.yml on the new branch — which builds the portable
-#      linux-{amd64,arm64} tarballs (gated to release/** only) and creates
-#      a snapshot-v<version>-latest pre-release with all artifacts.
+# Manual workflow_dispatch to cut a moqx tagged release.
 #
-# After the release branch CI is green, promote snapshot-v<version>-latest
-# to a tagged v<version> non-prerelease via the (forthcoming) promote-release
-# workflow or `gh release edit --prerelease=false`.
+# Tags vM.m.p on the dispatched ref (main or release/vM.m). Promotes the
+# corresponding rolling snapshot pre-release tarballs and, when feasible,
+# also builds portable linux-{amd64,arm64} tarballs against an explicit
+# moxygen release tag.
 #
-# Usage: Actions → version release → Run workflow →
-#   version: 1.2.3
-#   moxygen_release: v1.2.3   (must already exist on openmoq/moxygen)
+# Inputs:
+#   version          required. semver, e.g. 1.2.3
+#   moxygen_release  optional. moxygen tag to consume (e.g. v1.2.3).
+#                    When absent, falls back to moxygen `snapshot-latest`.
+#                    The fallback is fine for everyday tagging but won't
+#                    produce portable tarballs (snapshot-latest doesn't
+#                    carry them — portable only ships in tagged moxygen
+#                    releases).
+#
+# Behavior matrix:
+#   moxygen_release present + has portable assets  → portable matrix runs
+#   moxygen_release present + no portable assets   → portable skipped (no failure)
+#   moxygen_release absent                         → portable skipped (no failure)
+#
+# Snapshot source — derived from dispatched ref:
+#   dispatched on main         → consume snapshot-latest
+#   dispatched on release/vM.m → consume snapshot-vM.m-latest
+#
+# Release branch creation is independent of this workflow. To maintain a
+# patch line, devops cuts release/vM.m manually
+# (`git checkout -b release/vM.m main && git push`); this workflow is
+# then dispatched on that branch to tag vM.m.p.
 
 on:
   workflow_dispatch:
@@ -24,16 +38,128 @@ on:
         required: true
         type: string
       moxygen_release:
-        description: 'moxygen release tag (e.g. v1.2.3)'
-        required: true
+        description: 'moxygen release tag (optional, e.g. v1.2.3). Default: moxygen snapshot-latest.'
+        required: false
         type: string
 
 permissions:
   contents: write
 
 jobs:
-  cut-release-branch:
+  # ════════════════════════════════════════════════════════════════════════════
+  # Validate: semver gate, tag-doesn't-exist, resolve snapshot tag from
+  # dispatched ref, probe moxygen reference for portable assets.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  validate:
     runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      tag: ${{ steps.v.outputs.tag }}
+      snapshot_tag: ${{ steps.v.outputs.snapshot_tag }}
+      moxygen_ref: ${{ steps.v.outputs.moxygen_ref }}
+      has_portable: ${{ steps.v.outputs.has_portable }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate inputs and resolve refs
+        id: v
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Error: version must be semver (e.g. 1.2.3 or 1.2.3-rc1)" >&2
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Error: tag $TAG already exists" >&2
+            exit 1
+          fi
+
+          # Snapshot source from dispatched ref.
+          BRANCH="${{ github.ref_name }}"
+          if [ "$BRANCH" = "main" ]; then
+            SNAPSHOT_TAG="snapshot-latest"
+          else
+            LABEL="${BRANCH#release/}"
+            SNAPSHOT_TAG="snapshot-${LABEL}-latest"
+          fi
+          echo "==> Dispatched from $BRANCH → consuming $SNAPSHOT_TAG"
+
+          # Moxygen reference: explicit input or snapshot-latest fallback.
+          MOX_REF="${{ inputs.moxygen_release }}"
+          if [ -z "$MOX_REF" ]; then
+            MOX_REF="snapshot-latest"
+            echo "==> No moxygen_release input — defaulting to moxygen snapshot-latest"
+          else
+            echo "==> Pinning to moxygen release: $MOX_REF"
+          fi
+
+          # Verify moxygen reference exists.
+          if ! gh release view "$MOX_REF" --repo openmoq/moxygen >/dev/null 2>&1; then
+            echo "Error: moxygen release $MOX_REF does not exist on openmoq/moxygen" >&2
+            exit 1
+          fi
+
+          # Probe portable assets.
+          ASSETS=$(gh release view "$MOX_REF" --repo openmoq/moxygen --json assets --jq '.assets[].name')
+          HAS_PORTABLE=true
+          for required in moxygen-linux-amd64.tar.gz moxygen-linux-arm64.tar.gz; do
+            if ! echo "$ASSETS" | grep -qx "$required"; then
+              HAS_PORTABLE=false
+              break
+            fi
+          done
+
+          if [ "$HAS_PORTABLE" = "true" ]; then
+            echo "==> moxygen $MOX_REF has portable assets — portable matrix will run"
+          else
+            echo "==> moxygen $MOX_REF lacks portable assets — portable matrix will be skipped"
+            echo "    Available assets:"
+            echo "$ASSETS" | sed 's/^/      /'
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "tag=$TAG"
+            echo "snapshot_tag=$SNAPSHOT_TAG"
+            echo "moxygen_ref=$MOX_REF"
+            echo "has_portable=$HAS_PORTABLE"
+          } >> "$GITHUB_OUTPUT"
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Portable build: -O3, ISA-baselined, statically linked moqx-linux-{amd64,arm64}
+  # tarballs. Runs only when the moxygen reference carries portable assets.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  portable-build:
+    needs: [validate]
+    if: needs.validate.outputs.has_portable == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # cxx_flags MUST match what moxygen's portable build used —
+          # folly's F14 templates select an intrinsics mode based on
+          # compile-time -march macros. Mismatch causes
+          # F14LinkCheck<N>::check() undefined-reference link errors.
+          # Frame-pointer flags preserved at -O3 so signal-handler stack
+          # unwinding (folly::symbolizer) and post-mortem debugging via
+          # the moxygen .symbols sidecar work against optimized binaries.
+          - arch: amd64
+            runner: ubuntu-22.04
+            platform: linux-amd64
+            cxx_flags: "-march=x86-64-v2 -fno-omit-frame-pointer -fasynchronous-unwind-tables"
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+            platform: linux-arm64
+            cxx_flags: "-march=armv8-a -fno-omit-frame-pointer -fasynchronous-unwind-tables"
+    name: portable (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Generate app token
         id: app-token
@@ -44,67 +170,208 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: main
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
+          submodules: true
 
-      - name: Validate version
+      - name: Install system dependencies
         run: |
-          VERSION="${{ inputs.version }}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "Error: version must be semver (e.g. 1.2.3 or 1.2.3-rc1)" >&2
-            exit 1
-          fi
-          TAG="v${VERSION}"
-          BRANCH="release/${TAG}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Error: tag $TAG already exists" >&2
-            exit 1
-          fi
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "Error: branch $BRANCH already exists" >&2
-            exit 1
-          fi
-          echo "TAG=$TAG" >> "$GITHUB_ENV"
-          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          # Match docker/Dockerfile's build-stage apt list — picks up
+          # libdwarf-dev / libbrotli-dev that moxygen's install-system-deps
+          # doesn't install but proxygen needs.
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential ninja-build cmake git ca-certificates pkg-config \
+            libssl-dev libunwind-dev libgoogle-glog-dev libgflags-dev \
+            libdouble-conversion-dev libevent-dev libsodium-dev libzstd-dev \
+            libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev libdwarf-dev \
+            libbrotli-dev libgtest-dev libgmock-dev libxxhash-dev
 
-      - name: Validate moxygen release exists
+      - name: Download moxygen portable tarball
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MOQX_PLATFORM: ${{ matrix.platform }}
+          MOX_REF: ${{ needs.validate.outputs.moxygen_ref }}
         run: |
-          MOX="${{ inputs.moxygen_release }}"
-          if ! gh release view "$MOX" --repo openmoq/moxygen >/dev/null 2>&1; then
-            echo "Error: moxygen release $MOX does not exist on openmoq/moxygen" >&2
-            exit 1
+          if [ "$MOX_REF" = "snapshot-latest" ]; then
+            bash scripts/build.sh setup --use-latest --no-fallback
+          else
+            export MOQX_MOXYGEN_RELEASE_TAG="$MOX_REF"
+            bash scripts/build.sh setup --no-fallback
           fi
-          # Sanity: the moxygen release should carry the portable linux-*
-          # tarballs that publish-portable expects.
-          ASSETS=$(gh release view "$MOX" --repo openmoq/moxygen --json assets --jq '.assets[].name')
-          for required in moxygen-linux-amd64.tar.gz moxygen-linux-arm64.tar.gz; do
-            if ! echo "$ASSETS" | grep -qx "$required"; then
-              echo "Error: moxygen release $MOX missing required asset: $required" >&2
-              echo "Found assets:" >&2
-              echo "$ASSETS" | sed 's/^/  /' >&2
-              exit 1
+
+      - name: Configure
+        run: |
+          # CMAKE_INSTALL_RPATH = $ORIGIN/../lib makes the binary look
+          # for bundled .so files next to itself before the system search
+          # path. Combined with the bundle step below this produces a
+          # self-contained tarball that runs on noble / RHEL 9 / AL2023
+          # without needing distro-specific packages installed.
+          cmake -S . -B _build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$(cat .scratch/cmake_prefix_path.txt)" \
+            -DCMAKE_MODULE_PATH="${GITHUB_WORKSPACE}/cmake;${GITHUB_WORKSPACE}/deps/moxygen/build/fbcode_builder/CMake" \
+            -DCMAKE_C_FLAGS="${{ matrix.cxx_flags }}" \
+            -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DCMAKE_DISABLE_FIND_PACKAGE_LibUnwind=TRUE \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/_install"
+
+      - name: Build
+        run: cmake --build _build -j "$(nproc)"
+
+      - name: Install
+        run: cmake --install _build
+
+      - name: Bundle non-toolchain dynamic deps
+        run: |
+          # Bundle SONAME-versioned .so deps so the tarball runs on any
+          # modern Linux without distro-specific packages installed.
+          # Skips libstdc++/libgcc_s/libc/libm/ld-linux/linux-vdso (toolchain).
+          mkdir -p _install/lib
+          LIBARCH="$(uname -m)-linux-gnu"
+          # libboost_context: jammy=1.74, noble=1.83 — must bundle.
+          # libunwind intentionally NOT bundled — disabled via
+          # CMAKE_DISABLE_FIND_PACKAGE_LibUnwind to match moxygen portable.
+          for lib in \
+              libboost_context.so.1.74.0 \
+              libgflags.so.2.2 \
+              libsodium.so.23 \
+              libdouble-conversion.so.3 \
+              libevent-2.1.so.7 \
+              libzstd.so.1 \
+              libcares.so.2 \
+              libbrotlidec.so.1 \
+              libbrotlienc.so.1 \
+              libbrotlicommon.so.1 \
+              ; do
+            src="/usr/lib/${LIBARCH}/${lib}"
+            if [ -f "$src" ]; then
+              cp -L "$src" _install/lib/
             fi
           done
-          echo "MOX_TAG=$MOX" >> "$GITHUB_ENV"
+          echo "==> bundled libs:"
+          ls -lh _install/lib/
 
-      - name: Cut release branch with .moxygen-release
+      - name: Package
         run: |
-          git config user.email "omoq-sync-bot[bot]@users.noreply.github.com"
-          git config user.name "omoq-sync-bot[bot]"
-          git checkout -b "$BRANCH"
-          echo "$MOX_TAG" > .moxygen-release
-          git add .moxygen-release
-          git commit -m "release: pin moxygen $MOX_TAG for $TAG"
-          git push origin "$BRANCH"
-          echo
-          echo "==> Release branch created: $BRANCH"
-          echo "    pinned moxygen release: $MOX_TAG"
-          echo "    pushed; ci-main.yml will trigger and build the portable matrix."
-          echo
-          echo "Once CI is green, the snapshot-${TAG}-latest pre-release will carry"
-          echo "all platform tarballs (including portable linux-amd64/arm64). Promote"
-          echo "it to a non-prerelease ${TAG} tag with:"
-          echo "  gh release edit snapshot-${TAG}-latest --tag ${TAG} --prerelease=false --title \"moqx ${{ inputs.version }}\""
+          ARTIFACT="moqx-${{ matrix.platform }}.tar.gz"
+          tar czf "$ARTIFACT" -C _install .
+          echo "==> Tarball: $ARTIFACT"
+          ls -lh "$ARTIFACT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: moqx-${{ matrix.platform }}.tar.gz
+          path: moqx-${{ matrix.platform }}.tar.gz
+          retention-days: 90
+
+      - name: Smoke test
+        run: |
+          mkdir -p /tmp/moqx-smoke
+          tar xzf "moqx-${{ matrix.platform }}.tar.gz" -C /tmp/moqx-smoke
+          echo "==> ldd"
+          ldd /tmp/moqx-smoke/bin/moqx | tee /tmp/ldd.out
+          if grep -q "not found" /tmp/ldd.out; then
+            echo "ERROR: missing shared libraries"
+            exit 1
+          fi
+          echo "==> --help"
+          /tmp/moqx-smoke/bin/moqx --help 2>&1 | head -5 || true
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Release: combine snapshot tarballs (always) + portable tarballs (when
+  # built) and create the tagged, non-prerelease GitHub release.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  release:
+    needs: [validate, portable-build]
+    # Run when validate succeeded and portable-build either succeeded or
+    # was skipped (moxygen ref had no portable assets). Don't run if
+    # portable-build was attempted and failed.
+    if: |
+      always() &&
+      needs.validate.result == 'success' &&
+      needs.portable-build.result != 'failure' &&
+      needs.portable-build.result != 'cancelled'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download portable artifacts
+        if: needs.validate.outputs.has_portable == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: portable-assets/
+          merge-multiple: true
+
+      - name: Download snapshot artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+        run: |
+          mkdir -p snapshot-assets
+          echo "Downloading platform tarballs from $SNAPSHOT_TAG..."
+          gh release download "$SNAPSHOT_TAG" --dir snapshot-assets --pattern '*.tar.gz'
+          # Drop any portable tarballs from snapshot if present — we
+          # built them fresh in this workflow when applicable.
+          rm -f snapshot-assets/moqx-linux-amd64*.tar.gz \
+                snapshot-assets/moqx-linux-arm64*.tar.gz
+          echo "Snapshot platform tarballs:"
+          ls -lh snapshot-assets/
+
+      - name: Get snapshot commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+        run: |
+          SNAPSHOT_SHA=$(gh api repos/{owner}/{repo}/releases \
+            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
+          if [[ -z "$SNAPSHOT_SHA" ]]; then
+            echo "Error: $SNAPSHOT_TAG release not found. Push to the dispatched branch first to produce a snapshot." >&2
+            exit 1
+          fi
+          echo "Snapshot built from commit: $SNAPSHOT_SHA"
+          echo "SNAPSHOT_SHA=$SNAPSHOT_SHA" >> "$GITHUB_ENV"
+
+      - name: Stage release assets
+        run: |
+          mkdir -p release-assets
+          cp snapshot-assets/*.tar.gz release-assets/
+          if [ -d portable-assets ]; then
+            cp portable-assets/*.tar.gz release-assets/ 2>/dev/null || true
+          fi
+          echo "==> Release assets:"
+          ls -lh release-assets/
+
+      - name: Create versioned release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          MOX_REF: ${{ needs.validate.outputs.moxygen_ref }}
+          HAS_PORTABLE: ${{ needs.validate.outputs.has_portable }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+        run: |
+          if [ "$HAS_PORTABLE" = "true" ]; then
+            PORTABLE_NOTE="**Portable Linux tarballs** built against moxygen \`${MOX_REF}\`:
+          - \`moqx-linux-amd64.tar.gz\` — \`-march=x86-64-v2\` (≈ all cloud x86 since 2015)
+          - \`moqx-linux-arm64.tar.gz\` — \`-march=armv8-a\` (Graviton, Ampere, Apple M, RPi 3+, Rockchip)"
+          else
+            PORTABLE_NOTE="_Portable Linux tarballs not produced for this release: moxygen \`${MOX_REF}\` does not include the required portable assets._"
+          fi
+
+          gh release create "$TAG" release-assets/*.tar.gz \
+            --target "$SNAPSHOT_SHA" \
+            --title "moqx $VERSION" \
+            --notes "$(cat <<EOF
+          **Version:** \`${VERSION}\`
+          **Commit:** \`${SNAPSHOT_SHA}\`
+          **moxygen reference:** \`${MOX_REF}\`
+
+          Standard tarballs promoted from [\`${SNAPSHOT_TAG}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${SNAPSHOT_TAG}).
+
+          ${PORTABLE_NOTE}
+          EOF
+          )"
+          echo "Released: $TAG"

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -57,6 +57,13 @@ on:
         required: false
         type: string
 
+# Serialize per-version dispatches: prevents two runs with the same
+# version from both passing validate's tag-doesn't-exist check and
+# then racing on create-release.
+concurrency:
+  group: version-release-${{ inputs.version }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -365,13 +372,31 @@ jobs:
           app-id: ${{ secrets.OMOQ_APP_ID }}
           private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
 
+      - name: Verify snapshot hasn't been replaced mid-flight
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
+          EXPECTED_SHA: ${{ needs.validate.outputs.snapshot_sha }}
+        run: |
+          CURRENT_SHA=$(gh api "repos/$REPO/releases" \
+            --jq ".[] | select(.tag_name == \"$SNAPSHOT_TAG\") | .target_commitish")
+          if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
+            echo "Error: $SNAPSHOT_TAG was replaced mid-release." >&2
+            echo "  expected: $EXPECTED_SHA" >&2
+            echo "  current:  $CURRENT_SHA" >&2
+            echo "Retry the dispatch — ci-main published a new snapshot during this run." >&2
+            exit 1
+          fi
+
       - name: Download snapshot tarballs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
           SNAPSHOT_TAG: ${{ needs.validate.outputs.snapshot_tag }}
         run: |
           mkdir -p snapshot-assets
-          gh release download "$SNAPSHOT_TAG" --dir snapshot-assets --pattern '*.tar.gz'
+          gh release download "$SNAPSHOT_TAG" --repo "$REPO" --dir snapshot-assets --pattern '*.tar.gz'
           # Drop any portable tarballs from snapshot — those are built fresh
           # in portable-build and uploaded directly there.
           rm -f snapshot-assets/moqx-linux-amd64*.tar.gz \
@@ -382,11 +407,12 @@ jobs:
       - name: Upload to release (parallel)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           # Fan out asset upload to N concurrent gh release upload calls.
           find snapshot-assets -name '*.tar.gz' -print0 | \
-            xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" {} --clobber
+            xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" --repo "$REPO" {} --clobber
 
   # ════════════════════════════════════════════════════════════════════════════
   # Finalize: mark release as latest once all uploads succeeded.
@@ -414,7 +440,8 @@ jobs:
       - name: Mark release as latest
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          gh release edit "$TAG" --latest
+          gh release edit "$TAG" --repo "$REPO" --latest
           echo "Released: $TAG"

--- a/docker/moqx-run.sh
+++ b/docker/moqx-run.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Local moqx CLI launcher. Honors docker/.env for DOMAIN / MOQX_* / GLOG_*.
+# CLI flags win over .env. .env wins over script defaults.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── CLI parsing ──────────────────────────────────────────────────────────
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options] [-- <extra args to moqx>]
+
+Logging (override .env/defaults):
+  -v, --verbose N           GLOG_v (0=off, 1-4 increasing detail)
+  -L, --log-level N         GLOG_minloglevel (0=INFO 1=WARN 2=ERR 3=FATAL)
+  -m, --vmodule SPEC        GLOG_vmodule (e.g. MoQSession=4,MoQForwarder=3)
+  -x, --xlog SPEC           folly XLOG config (passed as --logging=SPEC)
+                            Bare LEVEL sets root: -x DBG6 = everything
+                            CSV for category-specific:
+                              -x moxygen=DBG6,quic=INFO
+                            Levels: DBG0..DBG9, INFO, WARN, ERR, FATAL
+                            (moxygen uses folly XLOG; GLOG_* doesn't apply)
+
+Targeting:
+      --subcmd CMD          moqx subcommand (default: serve)
+      --config FILE         config YAML template (default: docker/config.production.yaml)
+      --env FILE            alternate .env file (default: docker/.env)
+      --bin FILE            moqx binary path (default: <project>/build/moqx)
+
+Execution:
+      --no-sudo             run without sudo (cert files must be user-readable)
+  -n, --dry-run             print resolved env + command, don't exec
+  -h, --help                this help
+
+Environment overrides (via .env or shell):
+  MOQX_BIN, MOQX_CONFIG, MOQX_ENV_FILE, MOQX_SUBCMD, MOQX_USE_SUDO
+  MOQX_VERBOSE, MOQX_LOG_LEVEL, GLOG_vmodule, DOMAIN
+
+Examples:
+  $0                                       # serve with .env + defaults
+  $0 -v 4                                  # GLOG_v=4
+  $0 -m MoQSession=5,StreamPublisherImpl=5 # targeted trace
+  $0 --subcmd validate-config --no-sudo    # just validate the config
+  $0 -n                                    # show what would run
+EOF
+}
+
+CLI_VERBOSE=""
+CLI_LOG_LEVEL=""
+CLI_VMODULE=""
+CLI_XLOG=""
+CLI_SUBCMD=""
+CLI_CONFIG=""
+CLI_ENV_FILE=""
+CLI_BIN=""
+CLI_USE_SUDO=""    # "" = unset; "0"/"1" set
+DRY_RUN=0
+PASSTHRU=()
+
+while (($#)); do
+  case "$1" in
+    -v|--verbose)    CLI_VERBOSE="$2"; shift 2 ;;
+    -L|--log-level)  CLI_LOG_LEVEL="$2"; shift 2 ;;
+    -m|--vmodule)    CLI_VMODULE="$2"; shift 2 ;;
+    -x|--xlog)       CLI_XLOG="$2"; shift 2 ;;
+    --subcmd)        CLI_SUBCMD="$2"; shift 2 ;;
+    --config)        CLI_CONFIG="$2"; shift 2 ;;
+    --env)           CLI_ENV_FILE="$2"; shift 2 ;;
+    --bin)           CLI_BIN="$2"; shift 2 ;;
+    --no-sudo)       CLI_USE_SUDO=0; shift ;;
+    -n|--dry-run)    DRY_RUN=1; shift ;;
+    -h|--help)       usage; exit 0 ;;
+    --)              shift; PASSTHRU+=("$@"); break ;;
+    *)               echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# ── Folly XLOG passthrough ────────────────────────────────────────────────
+# moxygen uses folly::XLOG (not glog VLOG), which ignores GLOG_*. folly
+# is initialized via folly::Init in moqx main.cpp and respects the
+# --logging=<config> gflag. Bare -x LEVEL sets the ROOT category — all
+# XLOGs at that level or higher fire. Pass `cat=LEVEL[,cat=LEVEL...]`
+# (a string containing `=`) for category-specific levels.
+#   -x DBG6                       → --logging=DBG6           (everything)
+#   -x moxygen=DBG6               → --logging=moxygen=DBG6   (one category)
+#   -x moxygen=DBG6,quic=INFO     → --logging=moxygen=DBG6,quic=INFO
+if [[ -n "$CLI_XLOG" ]]; then
+  PASSTHRU+=("--logging=$CLI_XLOG")
+fi
+
+# ── Source .env if present ───────────────────────────────────────────────
+# set -a exports every KEY=VALUE it parses (shell-compatible .env format).
+ENV_FILE="${CLI_ENV_FILE:-${MOQX_ENV_FILE:-$SCRIPT_DIR/.env}}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+# ── Paths (CLI > env > defaults) ─────────────────────────────────────────
+MOQX_BIN="${CLI_BIN:-${MOQX_BIN:-$PROJECT_ROOT/build/moqx}}"
+CONFIG_TEMPLATE="${CLI_CONFIG:-${MOQX_CONFIG:-$SCRIPT_DIR/config.production.yaml}}"
+
+[[ -x "$MOQX_BIN" ]]        || { echo "moqx binary not found: $MOQX_BIN" >&2; exit 1; }
+[[ -f "$CONFIG_TEMPLATE" ]] || { echo "config not found: $CONFIG_TEMPLATE" >&2; exit 1; }
+command -v envsubst >/dev/null || { echo "envsubst missing (apt install gettext-base)" >&2; exit 1; }
+
+# ── Resolve ${…} placeholders (DOMAIN, ports, etc.) into a temp config ──
+RESOLVED_CONFIG=/tmp/moqx-resolved.yaml
+envsubst < "$CONFIG_TEMPLATE" > "$RESOLVED_CONFIG"
+
+# ── GLOG — map MOQX_* → GLOG_* (matches docker/entrypoint.sh convention) ─
+# Precedence: CLI flag > .env/shell env > fallback default.
+export GLOG_logtostderr=1
+export GLOG_colorlogtostderr=1
+export GLOG_minloglevel="${CLI_LOG_LEVEL:-${MOQX_LOG_LEVEL:-0}}"
+export GLOG_v="${CLI_VERBOSE:-${MOQX_VERBOSE:-0}}"
+export GLOG_vmodule="${CLI_VMODULE:-${GLOG_vmodule:-MoqxRelay=3,MoQSession=3,MoQForwarder=3,MoQCache=2}}"
+
+# ── Run ──────────────────────────────────────────────────────────────────
+SUBCMD="${CLI_SUBCMD:-${MOQX_SUBCMD:-serve}}"
+USE_SUDO="${CLI_USE_SUDO:-${MOQX_USE_SUDO:-1}}"
+
+CMD=("$MOQX_BIN" "$SUBCMD" --config "$RESOLVED_CONFIG" "${PASSTHRU[@]}")
+
+if (( DRY_RUN )); then
+  echo "# resolved env"
+  echo "GLOG_minloglevel=$GLOG_minloglevel"
+  echo "GLOG_v=$GLOG_v"
+  echo "GLOG_vmodule=$GLOG_vmodule"
+  echo "# resolved config: $RESOLVED_CONFIG (from $CONFIG_TEMPLATE)"
+  echo "# command"
+  if (( USE_SUDO )); then
+    printf '  sudo'
+    printf ' %s=%q' \
+      GLOG_v "$GLOG_v" \
+      GLOG_vmodule "$GLOG_vmodule" \
+      GLOG_minloglevel "$GLOG_minloglevel" \
+      GLOG_logtostderr "$GLOG_logtostderr" \
+      GLOG_colorlogtostderr "$GLOG_colorlogtostderr"
+  fi
+  printf ' %q' "${CMD[@]}"
+  printf '\n'
+  exit 0
+fi
+
+if (( USE_SUDO )); then
+  # Pass GLOG_* explicitly: `sudo -E` is unreliable because sudoers
+  # env_reset (default on most distros) strips vars not listed in
+  # env_keep, and GLOG_* never is. Explicit name=value on the sudo
+  # command line bypasses env_reset entirely.
+  exec sudo \
+    GLOG_v="$GLOG_v" \
+    GLOG_vmodule="$GLOG_vmodule" \
+    GLOG_minloglevel="$GLOG_minloglevel" \
+    GLOG_logtostderr="$GLOG_logtostderr" \
+    GLOG_colorlogtostderr="$GLOG_colorlogtostderr" \
+    "${CMD[@]}"
+else
+  exec "${CMD[@]}"
+fi


### PR DESCRIPTION
## Summary

Reshape the moqx portable tarball flow to match moxygen's principled approach (openmoq/moxygen#194):

- **`publish-portable` is now release-branch only** — gated with `if: startsWith(github.ref, 'refs/heads/release/')`. Main pushes no longer pay the expensive -O3 portable build cost on every commit.
- **New `version-release.yml`** — \`workflow_dispatch\` with \`version\` and \`moxygen_release\` inputs. Validates the moxygen release exists with the required \`moxygen-linux-{amd64,arm64}.tar.gz\` assets, then cuts \`release/v<version>\` from main with \`.moxygen-release\` containing the moxygen tag. Push triggers \`ci-main\` on the release branch which fires \`publish-portable\` against the pinned moxygen.
- **Frame-pointer flags added** — \`-fno-omit-frame-pointer -fasynchronous-unwind-tables\` so optimized portable binaries are still debuggable (folly::symbolizer can unwind against the moxygen \`.symbols\` sidecar, even at -O3).
- **\`.moxygen-release\` is now load-bearing on release branches** — its absence is a fatal error in publish-portable (the cutting flow guarantees it's present). Dropped the temporary \`snapshot-test-build-matrix-latest\` pin.
- **\`release\` job tolerates skipped \`publish-portable\`** — \`if: always() && needs.build.result == 'success' && needs.manifest.result == 'success' && needs.publish-portable.result != 'failure' && needs.publish-portable.result != 'cancelled'\`.

## Dependency

Depends on openmoq/moxygen#194 landing first — \`version-release.yml\` validates the moxygen release contains \`moxygen-linux-{amd64,arm64}.tar.gz\` assets, which only exist after the moxygen portable matrix ships. Don't merge until moxygen #194 has landed and at least one moxygen release has been cut from the new flow.

## Lifecycle

\`\`\`
[Cut release on moxygen]
  Actions → version release (moxygen)
  → input: 1.2.3
  → produces: openmoq/moxygen v1.2.3 with portable linux-{amd64,arm64} tarballs

[Cut release on moqx]
  Actions → version release (moqx)
  → inputs: version=1.2.3, moxygen_release=v1.2.3
  → creates release/v1.2.3 branch with .moxygen-release="v1.2.3"
  → ci-main fires on release/v1.2.3
  → publish-portable builds moqx-linux-{amd64,arm64}.tar.gz against moxygen v1.2.3
  → snapshot-v1.2.3-latest pre-release published with all artifacts

[Promote moqx pre-release to tagged release]
  gh release edit snapshot-v1.2.3-latest --tag v1.2.3 --prerelease=false --title "moqx 1.2.3"
\`\`\`

(A future workflow can wrap that promotion step.)

## Test plan

After moxygen #194 lands and a moxygen release is cut:

- [x] Run version-release with \`version=0.1.0-rc1\`, \`moxygen_release=<test moxygen tag>\`. Verify branch \`release/v0.1.0-rc1\` exists with \`.moxygen-release\` correctly populated.
- [x] CI on \`release/v0.1.0-rc1\` runs publish-portable (linux-amd64, linux-arm64). Verify both portable jobs succeed and \`moqx-linux-{amd64,arm64}.tar.gz\` artifacts are uploaded.
- [x] CI on a main push runs without publish-portable (skipped) and \`release\` still creates \`snapshot-latest\`.
- [ ] Smoke test the moqx portable tarball on a non-jammy distro (RHEL 9 or noble) — bundled libs resolve via RPATH, binary runs.
- [ ] Verify the moqx portable binary's \`.note.gnu.build-id\` matches a corresponding moxygen \`.symbols\` sidecar entry — symbolization works end to end.
- [ ] Delete the test branch + tag after validation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/259)
<!-- Reviewable:end -->
