### PR TITLE
docs+build: single Quick Start, fail-fast prereqs, portable cmake guidance

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,10 @@
 # Building moqx
 
+The Quick Start is in the top-level [README](README.md#quick-start). This
+document is the detailed build reference: the procedure annotated with
+what each step does, plus prereqs, dependency modes, profiles, Docker,
+formatting, and CI.
+
 ## Supported Platforms
 
 | Platform | Status | Notes |
@@ -9,16 +14,70 @@
 | Fedora / RHEL | TBD | `install-system-deps.sh` has dnf support; not yet CI-tested |
 | macOS (Homebrew) | TBD | `install-system-deps.sh` has brew support; not yet CI-tested |
 
+## Build Procedure
+
+Six steps. Each links to its detail section.
+
+1. **Clone and init the moxygen submodule.**
+   `git clone … && cd moqx && git submodule update --init` —
+   the submodule pins the exact moxygen commit the build will use
+   (see [Dependency Modes](#dependency-modes)).
+2. **Ensure CMake 3.25+** is on `PATH`. moqx top-level `CMakeLists.txt`
+   requires it; `build.sh` aborts early otherwise. On Jammy follow
+   [Installing CMake 3.25+](#installing-cmake-325-ubuntudebian).
+3. **Install system libraries.** Required in *both* dependency modes —
+   see the system-libraries bullet in [Prerequisites](#prerequisites)
+   for why. One-liner:
+   `sudo deps/moxygen/standalone/install-system-deps.sh`.
+4. **Stage moxygen.** `./scripts/build.sh setup` — defaults to
+   `--from-release` (downloads the prebuilt tarball, ~1 min); falls back
+   to source build if unavailable. See [Dependency Modes](#dependency-modes)
+   for `--from-source`, `--moxygen-dir`, SHA pinning, etc.
+5. **Build moqx.** `./scripts/build.sh` — configures and builds.
+   See [Build Profiles](#build-profiles) for `default` vs `san`.
+6. **Run tests.** `./scripts/build.sh test` — 77 tests, sub-second.
+
+If you'd rather build in a clean container, skip to
+[Building from a Fresh Ubuntu Docker](#building-from-a-fresh-ubuntu-docker-reproducible-build).
+
 ## Prerequisites
 
-- CMake 3.25+
-- Ninja, C++20 compiler (GCC 11+ / Clang 14+)
-- `gh` CLI (authenticated, for downloading release artifacts)
-- System libraries -- `build.sh setup` checks and reports what's missing
+- **CMake 3.25+** — required by moqx top-level `CMakeLists.txt`. Ubuntu 22.04
+  ships 3.22 (too old); install from Kitware (see below). Ubuntu 24.04+ and
+  recent macOS Homebrew ship a new-enough version. `build.sh` enforces this
+  and aborts early with install instructions if cmake is missing or too old
+  (override with `MOQX_SKIP_CMAKE_CHECK=1`).
+- Ninja, C++20 compiler (GCC 11+ / Clang 14+).
+- `curl` for downloading the moxygen release tarball
+  ([`setup-deps-tarball.sh`](scripts/setup-deps-tarball.sh)). No `gh` CLI is
+  required. Set `GITHUB_TOKEN`/`GH_TOKEN` only if you hit api.github.com's
+  unauthenticated rate limit.
+- **System libraries** — required in **both** dependency modes:
+  libssl, libfmt, libglog, libgflags, libdouble-conversion, libevent,
+  libsodium, libzstd, libboost, c-ares, libunwind, zlib, gperf. The
+  release tarball ships folly/fizz/wangle/mvfst/proxygen statically, but
+  moxygen's CMake config does `find_dependency(fmt, Glog, ...)` and folly
+  itself transitively wants OpenSSL/Boost. Install all with:
+  ```bash
+  sudo deps/moxygen/standalone/install-system-deps.sh
+  ```
+  (`build.sh setup`'s system-dep check only fires when falling back to a
+  source build — it does not preempt the build-step failure if libs are
+  missing.)
 
-### Installing CMake 3.25+ (Ubuntu/Debian)
+### Installing CMake 3.25+
 
-Ubuntu 22.04 ships cmake 3.22 which is too old. Install from the Kitware APT repo:
+moqx requires CMake 3.25+. By platform:
+
+**Ubuntu 24.04+ / Debian 12+** — distro packages are new enough:
+
+```bash
+sudo apt-get install -y cmake
+cmake --version   # should show 3.25+
+```
+
+**Ubuntu 22.04 (Jammy)** — distro ships 3.22, too old. Install from the
+Kitware APT repo:
 
 ```bash
 # Remove distro cmake if installed
@@ -36,7 +95,12 @@ sudo apt-get install -y cmake
 cmake --version   # should show 3.25+
 ```
 
-Ubuntu 24.04+ ships cmake 3.28 -- no extra steps needed.
+**macOS (Homebrew)** — Homebrew currently ships cmake 3.30+:
+
+```bash
+brew install cmake     # or `brew upgrade cmake` if already present
+cmake --version
+```
 
 ### Installing System Dependencies
 
@@ -53,26 +117,14 @@ who don't want to install deps on their host:
 docker run --rm -it -v "$PWD":/src -w /src ubuntu:22.04 bash
 
 # Inside the container:
-apt-get update && apt-get install -y gpg wget lsb-release sudo git gh
+apt-get update && apt-get install -y gpg wget lsb-release sudo git curl ca-certificates
 # Install cmake 3.25+ from Kitware (see above)
 # Then:
 git submodule update --init
 sudo deps/moxygen/standalone/install-system-deps.sh
-./scripts/build.sh setup --from-source   # no gh auth = build from source
+./scripts/build.sh setup --from-source   # build from source (no release artifacts available offline)
 ./scripts/build.sh
 ./scripts/build.sh test
-```
-
-## Quick Start
-
-```bash
-git clone https://github.com/openmoq/moqx.git && cd moqx
-git submodule update --init
-sudo deps/moxygen/standalone/install-system-deps.sh
-
-./scripts/build.sh setup      # download prebuilt moxygen deps (~1 min)
-./scripts/build.sh            # configure + build
-./scripts/build.sh test       # run tests (77 tests, <1s)
 ```
 
 ## Dependency Modes

--- a/README.md
+++ b/README.md
@@ -40,18 +40,34 @@ handler and create `MoQRelaySession` instances for incoming connections.
 
 ## Quick Start
 
+> **Prerequisite: CMake 3.25+ is required.** Ubuntu 22.04 (Jammy) ships
+> CMake 3.22, which is too old — the moqx top-level `CMakeLists.txt` will
+> reject it at configure. `build.sh` aborts early with install instructions
+> if it sees a missing or old cmake (override with `MOQX_SKIP_CMAKE_CHECK=1`
+> if you know what you're doing). Ubuntu 24.04+ and recent macOS Homebrew
+> ship a new-enough version out of the box. Verify with `cmake --version`.
+> Per-platform install instructions:
+> [BUILD.md → Installing CMake 3.25+](BUILD.md#installing-cmake-325).
+
 ```bash
 git clone https://github.com/openmoq/moqx.git && cd moqx
 git submodule update --init
-sudo deps/moxygen/standalone/install-system-deps.sh
+sudo deps/moxygen/standalone/install-system-deps.sh   # system libs (both modes)
 
 ./scripts/build.sh setup     # download prebuilt deps (~1 min)
 ./scripts/build.sh           # build
 ./scripts/build.sh test      # test
 ```
 
-See [BUILD.md](BUILD.md) for build and test instructions, and
-[RUNNING.md](RUNNING.md) for Docker deployment and relay operations.
+System libraries are needed in **both** dependency modes — the moxygen
+tarball ships folly/fizz/mvfst/proxygen statically, but its CMake config
+still does `find_dependency(fmt, Glog, ...)` and folly itself transitively
+needs OpenSSL/Boost. `build.sh setup`'s system-dep check only fires when
+falling back to source, but the build step needs the libs regardless.
+
+See [BUILD.md](BUILD.md) for full build and test instructions (dependency
+modes, sanitizer profiles, Docker), and [RUNNING.md](RUNNING.md) for relay
+operations.
 
 ## License
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,12 +10,8 @@
 #   ./scripts/build.sh [--profile NAME] [--build-dir DIR]
 #   ./scripts/build.sh test [--build-dir DIR] [-- CTEST_ARGS...]
 #
-# First time:
-#   git submodule update --init
-#   sudo deps/moxygen/standalone/install-system-deps.sh   # or see check output
-#   ./scripts/build.sh setup
-#   ./scripts/build.sh
-#   ./scripts/build.sh test
+# First-time setup: see README "Quick Start" and BUILD.md "Prerequisites"
+# (CMake 3.25+, system libs).
 #
 # Incremental (after source changes):
 #   ./scripts/build.sh          # rebuilds only what changed
@@ -37,6 +33,60 @@ DEPS_MODE_FILE="${SCRATCH}/deps-mode"
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 die() { echo "Error: $*" >&2; exit 1; }
+
+# ── CMake version precheck ───────────────────────────────────────────────────
+# moqx top-level CMakeLists.txt requires cmake_minimum_required(VERSION 3.25).
+# Ubuntu 22.04 (Jammy) ships 3.22, which fails at configure. Detect early so
+# users see actionable install instructions instead of a buried cmake error
+# 30 seconds into the build. Override with MOQX_SKIP_CMAKE_CHECK=1 if you're
+# building in an environment that satisfies the requirement another way.
+require_cmake_version() {
+  [[ "${MOQX_SKIP_CMAKE_CHECK:-}" == "1" ]] && return 0
+
+  if ! command -v cmake >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: cmake not found in PATH.
+moqx requires CMake 3.25+. Install:
+  Ubuntu 24.04+ / Debian 12+:  sudo apt-get install cmake
+  Ubuntu 22.04 (Jammy):        cmake 3.22 in apt is too old; install from Kitware:
+                               see BUILD.md "Installing CMake 3.25+"
+  macOS:                       brew install cmake
+
+To bypass this check (advanced): export MOQX_SKIP_CMAKE_CHECK=1
+EOF
+    exit 1
+  fi
+
+  local ver major minor
+  ver=$(cmake --version | head -1 | sed 's/[^0-9]*\([0-9]*\.[0-9]*\).*/\1/')
+  major=$(echo "$ver" | cut -d. -f1)
+  minor=$(echo "$ver" | cut -d. -f2)
+  if (( major < 3 || (major == 3 && minor < 25) )); then
+    cat >&2 <<EOF
+Error: CMake $ver is too old. moqx requires 3.25+ (top-level CMakeLists.txt).
+
+  $(command -v cmake) — $(cmake --version | head -1)
+
+The moqx configure step will fail with this version. To install 3.25+:
+
+  Ubuntu 22.04 (Jammy):
+    sudo apt-get remove --purge cmake
+    sudo apt-get install -y gpg wget
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \\
+      | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ \$(lsb_release -cs) main" \\
+      | sudo tee /etc/apt/sources.list.d/kitware.list
+    sudo apt-get update && sudo apt-get install -y cmake
+
+  Ubuntu 24.04+:  sudo apt-get install cmake
+  macOS:          brew install cmake
+
+To bypass this check (e.g. you have a 3.25+ cmake on a non-default path
+and have set CMAKE in your environment): export MOQX_SKIP_CMAKE_CHECK=1
+EOF
+    exit 1
+  fi
+}
 
 usage() {
   cat <<'EOF'
@@ -114,17 +164,9 @@ check_system_deps() {
     fi
   fi
 
-  # CMake version check (need 3.25+)
-  if command -v cmake >/dev/null 2>&1; then
-    local ver
-    ver=$(cmake --version | head -1 | sed 's/[^0-9]*\([0-9]*\.[0-9]*\).*/\1/')
-    local major minor
-    major=$(echo "$ver" | cut -d. -f1)
-    minor=$(echo "$ver" | cut -d. -f2)
-    if (( major < 3 || (major == 3 && minor < 25) )); then
-      missing+=("cmake 3.25+ (found $ver)")
-    fi
-  fi
+  # NOTE: CMake version is enforced by require_cmake_version() — kept separate
+  # because the install instructions differ from a plain apt-get (Kitware repo
+  # required on Ubuntu 22.04).
 
   for w in "${warnings[@]+"${warnings[@]}"}"; do
     echo "  Warning: $w"
@@ -171,6 +213,21 @@ check_system_deps() {
   return 0
 }
 
+# ── System-dep precheck wrapper ──────────────────────────────────────────────
+# System libraries are needed in BOTH dependency modes — the from-release
+# tarball ships folly/fizz/wangle/mvfst/proxygen statically, but moxygen's
+# CMake config does find_dependency(fmt, Glog, ...) and folly transitively
+# wants OpenSSL/Boost. So fail fast at setup AND build time, before users
+# hit an opaque cmake error several seconds in. Override with
+# MOQX_SKIP_DEPS_CHECK=1 if you have these on a non-default path.
+require_system_deps() {
+  [[ "${MOQX_SKIP_DEPS_CHECK:-}" == "1" ]] && return 0
+  if ! check_system_deps; then
+    die "Install missing dependencies and re-run.
+  Quick fix: sudo deps/moxygen/standalone/install-system-deps.sh"
+  fi
+}
+
 # ── Submodule check ──────────────────────────────────────────────────────────
 
 check_submodule() {
@@ -192,6 +249,8 @@ checkout_submodule() {
 # ── Setup command ────────────────────────────────────────────────────────────
 
 cmd_setup() {
+  require_cmake_version
+  require_system_deps
   local mode="from-release"
   local profile="default"
   local no_fallback=false
@@ -278,11 +337,6 @@ cmd_setup() {
   fi
 
   if [[ "$mode" == "from-source" ]]; then
-    echo "Checking system dependencies..."
-    if ! check_system_deps; then
-      die "Install missing dependencies and re-run."
-    fi
-    echo "  All system dependencies found."
     echo ""
     echo "==> Setting up dependencies (from source)..."
     bash "$SCRIPT_DIR/setup-deps-standalone.sh" --profile "$profile"
@@ -297,6 +351,8 @@ cmd_setup() {
 # ── Build command (default) ──────────────────────────────────────────────────
 
 cmd_build() {
+  require_cmake_version
+  require_system_deps
   local profile="default"
   local build_dir=""
 


### PR DESCRIPTION
Trying to build moqx fresh on Ubuntu 22.04 surfaced a few rough edges in the docs and `build.sh`. This consolidates them.

## Problems

- Quick Start was duplicated across README, BUILD.md, and the `build.sh` header — drift risk.
- BUILD.md listed `gh` CLI as a prerequisite; no script invokes it (`setup-deps-tarball.sh` uses `curl`).
- README didn't mention CMake 3.25+. Ubuntu 22.04 ships 3.22 → opaque configure failure for first-timers.
- `build.sh setup`'s system-dep check was gated to `--from-source` only. On the default `--from-release` path, missing libs only surface as a cmake error during the build step — not actionable. (Same libs are needed in both modes: the tarball ships folly/fizz/wangle/mvfst/proxygen statically, but moxygen's CMake config does `find_dependency(fmt, Glog, ...)` and folly transitively wants OpenSSL/Boost.)
- "Installing CMake 3.25+" was Ubuntu/Debian-only despite Homebrew being a common dev environment.

## Fix

- **README** = sole Quick Start, with a CMake 3.25+ callout and a one-line note on why `install-system-deps.sh` is needed in both modes.
- **BUILD.md** = detailed build reference. Lead paragraph points to README. New annotated **Build Procedure** section near the top with intra-doc links. \`gh\` dropped, \`curl\` added. **Installing CMake 3.25+** split into Ubuntu 24.04+/Debian 12+ (apt), Ubuntu 22.04 (Kitware), macOS (Homebrew).
- **scripts/build.sh**: new \`require_cmake_version\` (fail-fast with platform-specific install snippets, override via \`MOQX_SKIP_CMAKE_CHECK=1\`) and \`require_system_deps\` wrapper, both called at the top of \`cmd_setup\` and \`cmd_build\` (override via \`MOQX_SKIP_DEPS_CHECK=1\`). Removed the redundant cmake check inside \`check_system_deps\` — its install advice was wrong on Jammy (\`apt-get install cmake\` re-installs 3.22).

## Verified

Smoke-tested on Ubuntu 22.04 / cmake 3.22.1: \`./scripts/build.sh setup\` aborts with the Kitware install snippet; \`MOQX_SKIP_CMAKE_CHECK=1 ./scripts/build.sh setup\` proceeds and downloads the moxygen tarball. \`--help\` short-circuits both checks.

Out of scope: a CI job that runs the README Quick Start verbatim in clean \`ubuntu:22.04\` (worth a follow-up to keep docs honest).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/260)
<!-- Reviewable:end -->
