### PR TITLE
feat: add Privacy Pass relay auth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,174 +1,235 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(moqx VERSION 0.1.0 LANGUAGES CXX)
+    project(moqx VERSION 0.1.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+        set(CMAKE_CXX_STANDARD 20) set(CMAKE_CXX_STANDARD_REQUIRED ON) set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Default to RelWithDebInfo for reproducible dev builds.
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "" FORCE)
-endif()
+#Default to RelWithDebInfo for reproducible dev builds.
+            if (NOT CMAKE_BUILD_TYPE) set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "" FORCE
+            ) endif()
 
-option(MOQX_BUILD_TESTS "Build tests" ON)
-option(MOQX_ENABLE_SANITIZERS "Enable ASAN/UBSAN (non-Release)" OFF)
+                option(MOQX_BUILD_TESTS "Build tests" ON
+                ) option(MOQX_ENABLE_SANITIZERS "Enable ASAN/UBSAN (non-Release)" OFF)
 
-if(MOQX_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
-  add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
-  add_link_options(-fsanitize=address,undefined)
-endif()
+                    if (MOQX_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release") add_compile_options(
+                        -fsanitize = address,
+                        undefined - fno - omit - frame - pointer
+                    ) add_link_options(-fsanitize = address, undefined) endif()
 
-# Prefer static libraries for all transitive deps (from-release mode).
-# For from-source builds, build.sh overrides this to ON (system gflags is shared-only).
-set(GFLAGS_SHARED OFF CACHE BOOL "")
+#Prefer static libraries for all transitive deps(from - release mode).
+#For from - source builds, build.sh overrides this to ON(system gflags is shared - only).
+                        set(GFLAGS_SHARED OFF CACHE BOOL "")
 
-list(APPEND CMAKE_MODULE_PATH
-  "${PROJECT_SOURCE_DIR}/deps/moxygen/build/fbcode_builder/CMake"
-)
+                            list(APPEND CMAKE_MODULE_PATH
+                                 "${PROJECT_SOURCE_DIR}/deps/moxygen/build/fbcode_builder/CMake")
 
-# Folly's config calls FindBoost which was removed in CMake 3.30 (CMP0167).
-# Folly itself works fine with Boost's own config-mode package; silence the
-# policy warning until upstream fixes their config files.
-if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 OLD)
-endif()
+#Folly's config calls FindBoost which was removed in CMake 3.30 (CMP0167).
+#Folly itself works fine with Boost's own config-mode package; silence the
+#policy warning until upstream fixes their config files.
+                                if (POLICY CMP0167) cmake_policy(SET CMP0167 OLD) endif()
 
-find_package(moxygen REQUIRED)
+                                    find_package(moxygen REQUIRED) find_package(OpenSSL REQUIRED)
 
-# --- yaml-cpp (FetchContent) ---
+#-- - yaml - cpp(FetchContent) -- -
 
-include(FetchContent)
+                                        include(FetchContent)
 
-set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
-set(YAML_CPP_FORMAT_SOURCE OFF CACHE BOOL "" FORCE)
+                                            set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "" FORCE
+                                            ) set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "" FORCE
+                                            ) set(YAML_CPP_FORMAT_SOURCE OFF CACHE BOOL "" FORCE)
 
-# yaml-cpp 0.8.0 uses cmake_minimum_required(VERSION 3.0.2) which triggers a
-# deprecation warning on CMake ≥ 3.27. Suppress it for this dependency only.
-set(_moqx_save_warn_deprecated "${CMAKE_WARN_DEPRECATED}")
-set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
+#yaml - cpp 0.8.0 uses cmake_minimum_required(VERSION 3.0.2) which triggers a
+#deprecation warning on CMake ≥ 3.27. Suppress it for this dependency only.
+                                                set(_moqx_save_warn_deprecated
+                                                    "${CMAKE_WARN_DEPRECATED}"
+                                                ) set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 
-FetchContent_Declare(yaml-cpp
-  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-  GIT_TAG 0.8.0
-  SYSTEM
-)
-FetchContent_MakeAvailable(yaml-cpp)
+                                                    FetchContent_Declare(
+                                                        yaml - cpp GIT_REPOSITORY https
+                                                        : // github.com/jbeder/yaml-cpp.git
+                                                        GIT_TAG 0.8.0 SYSTEM
+                                                    ) FetchContent_MakeAvailable(yaml - cpp)
 
-set(CMAKE_WARN_DEPRECATED "${_moqx_save_warn_deprecated}" CACHE BOOL "" FORCE)
+                                                        set(CMAKE_WARN_DEPRECATED
+                                                            "${_moqx_save_warn_"
+                                                            "deprecated}" CACHE BOOL "" FORCE)
 
-# --- reflect-cpp (FetchContent, needs yaml-cpp available) ---
+#-- - reflect - cpp(FetchContent, needs yaml - cpp available) -- -
 
-set(REFLECTCPP_YAML ON CACHE BOOL "" FORCE)
-set(REFLECTCPP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+                                                            set(REFLECTCPP_YAML ON CACHE BOOL
+                                                                "" FORCE
+                                                            ) set(REFLECTCPP_BUILD_TESTS OFF
+                                                                      CACHE BOOL "" FORCE)
 
-FetchContent_Declare(reflectcpp
-  GIT_REPOSITORY https://github.com/getml/reflect-cpp.git
-  GIT_TAG v0.18.0
-  SYSTEM
-)
-FetchContent_MakeAvailable(reflectcpp)
+                                                                FetchContent_Declare(
+                                                                    reflectcpp GIT_REPOSITORY https
+                                                                    : // github.com/getml/reflect-cpp.git
+                                                                    GIT_TAG v0 .18.0 SYSTEM
+                                                                ) FetchContent_MakeAvailable(reflectcpp
+                                                                )
 
-# --- Core library ---
+#-- - Core library -- -
 
-add_library(moqx_core STATIC
-  src/NamespaceTree.cpp
-  src/MoqxRelay.cpp
-  src/MoqxRelayContext.cpp
-  src/MoqxRelayServer.cpp
-  src/MoqxPicoRelayServer.cpp
-  src/ServiceMatcher.cpp
-  src/admin/AdminServer.cpp
-  src/admin/BuiltinRoutes.cpp
-  src/admin/CachePurgeHandler.cpp
-  src/admin/MetricsHandler.cpp
-  src/admin/StateHandler.cpp
-  src/stats/StatsRegistry.cpp
-  src/stats/MoQStatsCollector.cpp
-  src/stats/PicoQuicStatsCollector.cpp
-  src/stats/QuicStatsCollector.cpp
-  src/UpstreamProvider.cpp
-  src/relay/TopNFilter.cpp
-  src/relay/PropertyRanking.cpp
-)
+                                                                    add_library(
+                                                                        moqx_core STATIC src /
+                                                                        NamespaceTree.cpp src /
+                                                                        auth / PrivacyPass.cpp src /
+                                                                        MoqxRelay.cpp src /
+                                                                        MoqxRelayContext.cpp src /
+                                                                        MoqxRelayServer.cpp src /
+                                                                        MoqxPicoRelayServer
+                                                                            .cpp src /
+                                                                        ServiceMatcher.cpp src /
+                                                                        admin /
+                                                                        AdminServer.cpp src /
+                                                                        admin /
+                                                                        BuiltinRoutes.cpp src /
+                                                                        admin /
+                                                                        CachePurgeHandler.cpp src /
+                                                                        admin /
+                                                                        MetricsHandler.cpp src /
+                                                                        admin /
+                                                                        StateHandler.cpp src /
+                                                                        stats /
+                                                                        StatsRegistry.cpp src /
+                                                                        stats /
+                                                                        MoQStatsCollector.cpp src /
+                                                                        stats /
+                                                                        PicoQuicStatsCollector
+                                                                            .cpp src /
+                                                                        stats /
+                                                                        QuicStatsCollector.cpp src /
+                                                                        UpstreamProvider.cpp src /
+                                                                        relay / TopNFilter.cpp src /
+                                                                        relay / PropertyRanking.cpp
+                                                                    )
 
-target_include_directories(moqx_core
-  PUBLIC
-    ${PROJECT_SOURCE_DIR}/src
-)
+                                                                        target_include_directories(
+                                                                            moqx_core PUBLIC ${
+                                                                                PROJECT_SOURCE_DIR
+                                                                            } /
+                                                                            src
+                                                                        )
 
-target_link_libraries(moqx_core PUBLIC
-  moxygen::moxygen_relay_moq_forwarder
-  moxygen::moxygen_relay_moq_cache
-  moxygen::moxygen_moq_relay_session
-  moxygen::moxygen_moq_server
-  moxygen::openmoq_pico_evb_server_transport
-  proxygen::proxygenhttpserver
-  # Workaround: wangle::wangle_acceptor_acceptor_core uses AsyncFdSocket from
-  # FizzAcceptorHandshakeHelper but omits this dep from its cmake config.
-  Folly::folly_io_async_fdsock_async_fd_socket
-  moxygen::moxygen_moqclient
-)
+                                                                            target_link_libraries(
+                                                                                moqx_core PUBLIC moxygen::moxygen_relay_moq_forwarder
+                                                                                    moxygen::moxygen_relay_moq_cache
+                                                                                        moxygen::moxygen_moq_relay_session
+                                                                                            moxygen::moxygen_moq_server
+                                                                                                moxygen::openmoq_pico_evb_server_transport
+                                                                                                    proxygen::proxygenhttpserver
+                                                                                                        OpenSSL::Crypto
+#Workaround : wangle::wangle_acceptor_acceptor_core uses AsyncFdSocket from
+#FizzAcceptorHandshakeHelper but omits this dep from its cmake config.
+                                                                                                            Folly::folly_io_async_fdsock_async_fd_socket
+                                                                                                                moxygen::
+                                                                                                                    moxygen_moqclient
+                                                                            )
 
-target_compile_options(moqx_core PRIVATE -Wall -Wextra -Wpedantic)
-target_compile_definitions(moqx_core PRIVATE MOQX_VERSION="${PROJECT_VERSION}")
+                                                                                target_compile_options(
+                                                                                    moqx_core
+                                                                                        PRIVATE -
+                                                                                    Wall - Wextra -
+                                                                                    Wpedantic
+                                                                                ) target_compile_definitions(moqx_core PRIVATE MOQX_VERSION = "${PROJECT_VERSION}")
 
-# --- Config types (resolved Config structs, header-only, no rfl dependency) ---
-# Library consumers that only need the Config API link this.
+#-- - Config types(resolved Config structs, header - only, no rfl dependency) -- -
+#Library consumers that only need the Config API link this.
 
-add_library(moqx_config INTERFACE)
+                                                                                    add_library(
+                                                                                        moqx_config
+                                                                                            INTERFACE
+                                                                                    )
 
-target_include_directories(moqx_config
-  INTERFACE
-    ${PROJECT_SOURCE_DIR}/src
-)
+                                                                                        target_include_directories(
+                                                                                            moqx_config INTERFACE
+                                                                                                ${PROJECT_SOURCE_DIR
+                                                                                                } /
+                                                                                            src
+                                                                                        )
 
-target_link_libraries(moqx_config INTERFACE
-  Folly::folly_network_address
-  Folly::folly_container_detail_f14_hash_detail
-)
+                                                                                            target_link_libraries(
+                                                                                                moqx_config INTERFACE
+                                                                                                    Folly::folly_network_address
+                                                                                                        Folly::
+                                                                                                            folly_container_detail_f14_hash_detail
+                                                                                            )
 
-# --- Config loader (YAML parsing + validation + resolution + init) ---
-# Application-level: ParsedConfig rfl structs, loadConfig(), resolveConfig(),
-# handleConfigSubcommand(). Links rfl/yaml-cpp; consumers that only need
-# resolved Config types can depend on moqx_config alone.
+#-- - Config loader(YAML parsing + validation + resolution + init) -- -
+#Application - level : ParsedConfig rfl structs, loadConfig(), resolveConfig(),
+#handleConfigSubcommand().Links rfl / yaml - cpp; consumers that only need
+#resolved Config types can depend on moqx_config alone.
 
-add_library(moqx_config_loader STATIC
-  src/config/Loader.cpp
-  src/config/ConfigResolver.cpp
-  src/config/ConfigInit.cpp
-)
+                                                                                                add_library(
+                                                                                                    moqx_config_loader
+                                                                                                        STATIC
+                                                                                                            src /
+                                                                                                    config /
+                                                                                                    Loader
+                                                                                                        .cpp
+                                                                                                            src /
+                                                                                                    config /
+                                                                                                    ConfigResolver
+                                                                                                        .cpp
+                                                                                                            src /
+                                                                                                    config /
+                                                                                                    ConfigInit
+                                                                                                        .cpp
+                                                                                                )
 
-target_include_directories(moqx_config_loader
-  PUBLIC
-    ${PROJECT_SOURCE_DIR}/src
-)
+                                                                                                    target_include_directories(
+                                                                                                        moqx_config_loader PUBLIC
+                                                                                                            ${PROJECT_SOURCE_DIR
+                                                                                                            } /
+                                                                                                        src
+                                                                                                    )
 
-target_link_libraries(moqx_config_loader PUBLIC
-  moqx_config
-  reflectcpp
-  yaml-cpp
-  Folly::folly_file_util
-)
+                                                                                                        target_link_libraries(
+                                                                                                            moqx_config_loader
+                                                                                                                PUBLIC moqx_config
+                                                                                                                    reflectcpp
+                                                                                                                        yaml -
+                                                                                                            cpp Folly::
+                                                                                                                folly_file_util
+                                                                                                        )
 
-target_compile_options(moqx_config_loader PRIVATE -Wall -Wextra -Wpedantic)
+                                                                                                            target_compile_options(
+                                                                                                                moqx_config_loader
+                                                                                                                    PRIVATE -
+                                                                                                                Wall -
+                                                                                                                Wextra -
+                                                                                                                Wpedantic
+                                                                                                            )
 
-# --- Main executable ---
+#-- - Main executable -- -
 
-add_executable(moqx
-  src/main.cpp
-)
+                                                                                                                add_executable(
+                                                                                                                    moqx
+                                                                                                                        src /
+                                                                                                                    main.cpp
+                                                                                                                )
 
-target_link_libraries(moqx PRIVATE moqx_core moqx_config_loader)
+                                                                                                                    target_link_libraries(
+                                                                                                                        moqx PRIVATE
+                                                                                                                            moqx_core
+                                                                                                                                moqx_config_loader
+                                                                                                                    )
 
-# --- Tests ---
+#-- - Tests -- -
 
-if(MOQX_BUILD_TESTS)
-  enable_testing()
-  add_subdirectory(test)
-endif()
+                                                                                                                        if (MOQX_BUILD_TESTS) enable_testing(
+                                                                                                                        ) add_subdirectory(test
+                                                                                                                        ) endif()
 
-include(${PROJECT_SOURCE_DIR}/cmake/Lint.cmake)
+                                                                                                                            include(
+                                                                                                                                ${PROJECT_SOURCE_DIR
+                                                                                                                                } /
+                                                                                                                                cmake /
+                                                                                                                                Lint.cmake
+                                                                                                                            )
 
-install(TARGETS moqx moqx_core moqx_config_loader)
+                                                                                                                                install(
+                                                                                                                                    TARGETS moqx
+                                                                                                                                        moqx_core
+                                                                                                                                            moqx_config_loader
+                                                                                                                                )

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -55,6 +55,15 @@ services:
     #   tls:
     #     insecure: false         # true = skip cert verification (dev only)
     #     # ca_cert: /path/to/ca.pem  # Custom CA cert (mutually exclusive with insecure: true)
+    # auth:                       # Optional: Privacy Pass authorization
+    #   enabled: true
+    #   audience: "moqx-relay"
+    #   issuer_keys:
+    #     - id: "issuer-1"
+    #       public_key_pem: |-
+    #         -----BEGIN PUBLIC KEY-----
+    #         ...
+    #         -----END PUBLIC KEY-----
 
   testing:
     match:

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,6 +36,7 @@ services:                  # required; at least one
     match: [ ... ]
     cache: { ... }
     upstream: { ... }
+    auth: { ... }
 
 admin:                     # optional; omit to disable the admin server
   { ... }
@@ -102,7 +103,7 @@ Set under `listener_defaults.quic` (global defaults) or `listeners[n].quic`
 
 Services define how incoming connections are routed and can match MOQT
 sessions arriving on any listener. Each service has one or more match rules,
-optional cache settings, and an optional upstream.
+optional cache settings, an optional upstream, and optional Privacy Pass auth.
 
 ```yaml
 services:
@@ -136,6 +137,26 @@ authority and path rules both match.
 any path
 
 Duplicate (authority, path) combinations across all services are rejected.
+
+### Privacy Pass Auth
+
+Set `services.<name>.auth` to enable Privacy Pass authorization for a service.
+The relay verifies redemption tokens against the listed issuer public keys and
+checks that the token audience matches the configured value.
+
+```yaml
+auth:
+  enabled: true
+  audience: "moqx-relay"
+  issuer_keys:
+    - id: "issuer-1"
+      public_key_pem: |
+        -----BEGIN PUBLIC KEY-----
+        ...
+        -----END PUBLIC KEY-----
+```
+
+When `auth.enabled` is false or omitted, the service behaves as it does today.
 
 **picoquic limitation:** Only exact path matches work reliably with
 picoquic. Prefix path rules will generate a warning and connections may fail to

--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -113,7 +113,7 @@ void MoqxPicoRelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession
 }
 
 void MoqxPicoRelayServer::terminateClientSession(std::shared_ptr<MoQSession> session) {
-  context_->onSessionEnd();
+  context_->onSessionEnd(session);
   MoQPicoQuicEventBaseServer::terminateClientSession(std::move(session));
 }
 

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -14,6 +14,11 @@
 namespace {
 constexpr uint8_t kDefaultUpstreamPriority = 128;
 constexpr std::chrono::seconds kUpstreamConnectWaitTimeout(5);
+
+moxygen::RequestErrorCode toRequestErrorCode(openmoq::moqx::auth::AuthError error) {
+  (void)error;
+  return moxygen::RequestErrorCode::UNAUTHORIZED;
+}
 } // namespace
 
 using namespace moxygen;
@@ -93,6 +98,124 @@ folly::coro::Task<void> MoqxRelay::onUpstreamConnect(std::shared_ptr<MoQSession>
 
 void MoqxRelay::onUpstreamDisconnect() {
   upstreamSubNsHandle_.reset();
+}
+
+bool MoqxRelay::isPeerSession(MoQSession* session) const {
+  return session && peerSubNsHandles_.find(session) != peerSubNsHandles_.end();
+}
+
+std::optional<auth::Claims> MoqxRelay::getSessionAuth(MoQSession* session) const {
+  auto it = sessionAuth_.find(session);
+  if (it == sessionAuth_.end()) {
+    return std::nullopt;
+  }
+  return it->second.claims;
+}
+
+bool MoqxRelay::isSessionAuthValid(const auth::Claims& claims) {
+  const auto now = std::chrono::system_clock::now();
+  if (now < claims.issuedAt || now >= claims.expiresAt) {
+    return false;
+  }
+  if (claims.revalidateAfter) {
+    const auto revalidateAt = claims.issuedAt + *claims.revalidateAfter;
+    if (now >= revalidateAt) {
+      return false;
+    }
+  }
+  return true;
+}
+
+folly::Expected<folly::Unit, auth::AuthError>
+MoqxRelay::authenticateSession(const SetupParameters& params, std::shared_ptr<MoQSession> session) {
+  if (!auth_) {
+    return folly::unit;
+  }
+
+  bool sawPrivacyPassToken = false;
+  std::optional<auth::Claims> acceptedClaims;
+  for (const auto& param : params) {
+    if (param.key != folly::to_underlying(SetupKey::AUTHORIZATION_TOKEN)) {
+      continue;
+    }
+    sawPrivacyPassToken = true;
+    auto claims = auth_->verify(param.asAuthToken);
+    if (!claims.hasValue()) {
+      if (claims.error() == auth::AuthError::WrongTokenType) {
+        continue;
+      }
+      return folly::makeUnexpected(claims.error());
+    }
+    if (!auth_->allows(*claims, auth::Action::ClientSetup, {})) {
+      return folly::makeUnexpected(auth::AuthError::Forbidden);
+    }
+    acceptedClaims = std::move(*claims);
+    break;
+  }
+
+  if (acceptedClaims) {
+    sessionAuth_.insert_or_assign(session.get(), SessionAuthState{std::move(*acceptedClaims)});
+  } else if (!sawPrivacyPassToken) {
+    sessionAuth_.erase(session.get());
+  }
+
+  return folly::unit;
+}
+
+folly::Expected<folly::Unit, auth::AuthError> MoqxRelay::authorizeRequest(
+    const Parameters& params,
+    auth::Action action,
+    const TrackNamespace& namespaceValue,
+    std::string_view trackValue
+) const {
+  if (!auth_) {
+    return folly::unit;
+  }
+
+  auto session = MoQSession::getRequestSession();
+  if (session && isPeerSession(session.get())) {
+    return folly::unit;
+  }
+
+  const auto namespaceStr = namespaceValue.describe();
+  bool sawPrivacyPassToken = false;
+  std::optional<auth::AuthError> requestError;
+  for (const auto& param : params) {
+    if (param.key != folly::to_underlying(TrackRequestParamKey::AUTHORIZATION_TOKEN)) {
+      continue;
+    }
+    sawPrivacyPassToken = true;
+    auto claims = auth_->verify(param.asAuthToken);
+    if (!claims.hasValue()) {
+      if (claims.error() == auth::AuthError::WrongTokenType) {
+        continue;
+      }
+      requestError = claims.error();
+      continue;
+    }
+    if (auth_->allows(*claims, action, namespaceStr, trackValue)) {
+      return folly::unit;
+    }
+    sawPrivacyPassToken = true;
+  }
+
+  if (session) {
+    auto sessionClaims = getSessionAuth(session.get());
+    if (sessionClaims && isSessionAuthValid(*sessionClaims) &&
+        auth_->allows(*sessionClaims, action, namespaceStr, trackValue)) {
+      return folly::unit;
+    }
+    if (sessionClaims && !isSessionAuthValid(*sessionClaims) && !requestError) {
+      requestError = auth::AuthError::Expired;
+    }
+  }
+
+  if (requestError) {
+    return folly::makeUnexpected(*requestError);
+  }
+  return folly::makeUnexpected(
+      sawPrivacyPassToken ? auth::AuthError::Forbidden : auth::AuthError::Missing
+  );
 }
 
 // Sends SUBSCRIBE_UPDATE to update forwarding state. Called from:
@@ -192,6 +315,22 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespac
 ) {
   // TODO: store auth for forwarding on future SubscribeNamespace?
   auto session = MoQSession::getRequestSession();
+  if (!pubNs.trackNamespace.startsWith(allowedNamespacePrefix_)) {
+    co_return folly::makeUnexpected(PublishNamespaceError{
+        pubNs.requestID,
+        PublishNamespaceErrorCode::UNINTERESTED,
+        "bad namespace"
+    });
+  }
+  auto authRes =
+      authorizeRequest(pubNs.params, auth::Action::PublishNamespace, pubNs.trackNamespace, "");
+  if (authRes.hasError()) {
+    co_return folly::makeUnexpected(PublishNamespaceError{
+        pubNs.requestID,
+        toRequestErrorCode(authRes.error()),
+        auth::toString(authRes.error())
+    });
+  }
   auto requestID = pubNs.requestID;
   auto result = doPublishNamespace(std::move(pubNs), session, std::move(callback));
   if (!result) {
@@ -295,6 +434,20 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
     return folly::makeUnexpected(
         PublishError({pub.requestID, PublishErrorCode::INTERNAL_ERROR, "namespace required"})
     );
+  }
+
+  auto authRes = authorizeRequest(
+      pub.params,
+      auth::Action::Publish,
+      pub.fullTrackName.trackNamespace,
+      pub.fullTrackName.trackName
+  );
+  if (authRes.hasError()) {
+    return folly::makeUnexpected(PublishError{
+        pub.requestID,
+        toRequestErrorCode(authRes.error()),
+        auth::toString(authRes.error())
+    });
   }
 
   auto session = MoQSession::getRequestSession();
@@ -582,7 +735,22 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   auto maybeNegotiatedVersion = session->getNegotiatedVersion();
   CHECK(maybeNegotiatedVersion.has_value());
 
-  // check auth
+  if (incomingPeerID.empty()) {
+    auto authRes = authorizeRequest(
+        subNs.params,
+        auth::Action::SubscribeNamespace,
+        subNs.trackNamespacePrefix,
+        ""
+    );
+    if (authRes.hasError()) {
+      co_return folly::makeUnexpected(SubscribeNamespaceError{
+          subNs.requestID,
+          toRequestErrorCode(authRes.error()),
+          auth::toString(authRes.error())
+      });
+    }
+  }
+
   // Allow empty namespace prefix only for draft-16 and above.
   if (subNs.trackNamespacePrefix.empty() && getDraftMajorVersion(*maybeNegotiatedVersion) < 16) {
     co_return folly::makeUnexpected(SubscribeNamespaceError{
@@ -753,6 +921,19 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
       co_return folly::makeUnexpected(SubscribeError(
           {subReq.requestID, SubscribeErrorCode::TRACK_NOT_EXIST, "no such namespace or track"}
       ));
+    }
+    auto authRes = authorizeRequest(
+        subReq.params,
+        auth::Action::Subscribe,
+        subReq.fullTrackName.trackNamespace,
+        subReq.fullTrackName.trackName
+    );
+    if (authRes.hasError()) {
+      co_return folly::makeUnexpected(SubscribeError{
+          subReq.requestID,
+          toRequestErrorCode(authRes.error()),
+          auth::toString(authRes.error())
+      });
     }
     subReq.priority = kDefaultUpstreamPriority;
     subReq.groupOrder = GroupOrder::Default;
@@ -942,6 +1123,19 @@ MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
       );
     }
   }
+  auto authRes = authorizeRequest(
+      fetch.params,
+      auth::Action::Fetch,
+      fetch.fullTrackName.trackNamespace,
+      fetch.fullTrackName.trackName
+  );
+  if (authRes.hasError()) {
+    co_return folly::makeUnexpected(FetchError{
+        fetch.requestID,
+        toRequestErrorCode(authRes.error()),
+        auth::toString(authRes.error())
+    });
+  }
   if (session.get() == upstreamSession.get()) {
     co_return folly::makeUnexpected(
         FetchError({fetch.requestID, FetchErrorCode::INTERNAL_ERROR, "self fetch"})
@@ -968,6 +1162,20 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatus(TrackStat
     co_return folly::makeUnexpected(TrackStatusError(
         {trackStatus.requestID, TrackStatusErrorCode::TRACK_NOT_EXIST, "namespace required"}
     ));
+  }
+
+  auto authRes = authorizeRequest(
+      trackStatus.params,
+      auth::Action::TrackStatus,
+      trackStatus.fullTrackName.trackNamespace,
+      trackStatus.fullTrackName.trackName
+  );
+  if (authRes.hasError()) {
+    co_return folly::makeUnexpected(TrackStatusError{
+        trackStatus.requestID,
+        toRequestErrorCode(authRes.error()),
+        auth::toString(authRes.error())
+    });
   }
 
   auto subscriptionIt = subscriptions_.find(trackStatus.fullTrackName);

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -10,6 +10,7 @@
 
 #include "NamespaceTree.h"
 #include "UpstreamProvider.h"
+#include "auth/PrivacyPass.h"
 #include "config/Config.h"
 #include "relay/PropertyRanking.h"
 #include "relay/TopNFilter.h"
@@ -103,7 +104,8 @@ public:
       std::string relayID = {},
       uint64_t maxDeselected = kDefaultMaxDeselected,
       std::chrono::milliseconds idleTimeout = kDefaultIdleTimeout,
-      std::chrono::milliseconds activityThreshold = kDefaultActivityThreshold
+      std::chrono::milliseconds activityThreshold = kDefaultActivityThreshold,
+      std::optional<config::AuthConfig> auth = std::nullopt
   )
       : relayID_(std::move(relayID)), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
         activityThreshold_(activityThreshold) {
@@ -115,6 +117,9 @@ public:
       cache_->setDefaultMaxCacheDuration(cache.defaultMaxCacheDuration);
       // TODO: wire cache.maxCacheDuration once MoQCache supports clamping
       // publisher-set track durations.
+    }
+    if (auth && auth->enabled) {
+      auth_ = std::make_unique<auth::PrivacyPassVerifier>(*auth);
     }
   }
 
@@ -128,6 +133,17 @@ public:
   void setUpstreamProvider(std::shared_ptr<UpstreamProvider> upstream) {
     upstream_ = std::move(upstream);
   }
+
+  void setSessionAuth(std::shared_ptr<moxygen::MoQSession> session, auth::Claims claims) {
+    sessionAuth_.insert_or_assign(session.get(), SessionAuthState{std::move(claims)});
+  }
+
+  void clearSessionAuth(moxygen::MoQSession* session) { sessionAuth_.erase(session); }
+
+  folly::Expected<folly::Unit, auth::AuthError> authenticateSession(
+      const moxygen::SetupParameters& params,
+      std::shared_ptr<moxygen::MoQSession> session
+  );
 
   // Force-evicts a specific track unconditionally. Not thread-safe.
   size_t purge(const moxygen::FullTrackName& ftn) { return cache_ ? cache_->purge(ftn) : 0; }
@@ -350,6 +366,12 @@ private:
   folly::F14NodeMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
       subscriptions_;
 
+  struct SessionAuthState {
+    auth::Claims claims;
+  };
+  folly::F14FastMap<moxygen::MoQSession*, SessionAuthState> sessionAuth_;
+  std::unique_ptr<auth::PrivacyPassVerifier> auth_;
+
   std::shared_ptr<moxygen::TrackConsumer> getSubscribeWriteback(
       const moxygen::FullTrackName& ftn,
       std::shared_ptr<moxygen::TrackConsumer> consumer
@@ -361,6 +383,17 @@ private:
   static constexpr std::chrono::milliseconds kDefaultActivityThreshold{2'000};
   std::chrono::milliseconds idleTimeout_{kDefaultIdleTimeout};
   std::chrono::milliseconds activityThreshold_{kDefaultActivityThreshold};
+
+  folly::Expected<folly::Unit, auth::AuthError> authorizeRequest(
+      const moxygen::Parameters& params,
+      auth::Action action,
+      const moxygen::TrackNamespace& namespaceValue,
+      std::string_view trackValue = {}
+  ) const;
+
+  std::optional<auth::Claims> getSessionAuth(moxygen::MoQSession* session) const;
+  static bool isSessionAuthValid(const auth::Claims& claims);
+  bool isPeerSession(moxygen::MoQSession* session) const;
 };
 
 // Creates a NamespacePublishHandle that bridges NAMESPACE/NAMESPACE_DONE

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -16,13 +16,45 @@ using namespace moxygen;
 
 namespace openmoq::moqx {
 
+namespace {
+
+SessionCloseErrorCode toSessionCloseError(auth::AuthError error) {
+  switch (error) {
+  case auth::AuthError::Malformed:
+  case auth::AuthError::BadSignature:
+  case auth::AuthError::WrongTokenType:
+    return SessionCloseErrorCode::MALFORMED_AUTH_TOKEN;
+  case auth::AuthError::Expired:
+    return SessionCloseErrorCode::EXPIRED_AUTH_TOKEN;
+  case auth::AuthError::Missing:
+  case auth::AuthError::Forbidden:
+    return SessionCloseErrorCode::UNAUTHORIZED;
+  }
+  return SessionCloseErrorCode::INTERNAL_ERROR;
+}
+
+} // namespace
+
 MoqxRelayContext::MoqxRelayContext(
     const folly::F14FastMap<std::string, config::ServiceConfig>& services,
     const std::string& relayID
 )
     : serviceMatcher_(services), relayID_(relayID) {
   for (const auto& [name, svc] : services) {
-    services_.emplace(name, ServiceEntry{svc, std::make_shared<MoqxRelay>(svc.cache, relayID)});
+    services_.emplace(
+        name,
+        ServiceEntry{
+            svc,
+            std::make_shared<MoqxRelay>(
+                svc.cache,
+                relayID,
+                MoqxRelay::kDefaultMaxDeselected,
+                std::chrono::milliseconds{},
+                std::chrono::milliseconds{},
+                svc.auth
+            )
+        }
+    );
   }
 }
 
@@ -138,14 +170,20 @@ void MoqxRelayContext::onNewSession(std::shared_ptr<MoQSession> clientSession) {
   }
 }
 
-void MoqxRelayContext::onSessionEnd() {
+void MoqxRelayContext::onSessionEnd(std::shared_ptr<MoQSession> session) {
   if (statsCollector_) {
     statsCollector_->onSessionEnd();
+  }
+  if (!session) {
+    return;
+  }
+  for (auto& [name, entry] : services_) {
+    entry.relay->clearSessionAuth(session.get());
   }
 }
 
 folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayContext::validateAuthority(
-    const ClientSetup& /*clientSetup*/,
+    const ClientSetup& clientSetup,
     uint64_t /*negotiatedVersion*/,
     std::shared_ptr<MoQSession> session
 ) {
@@ -163,6 +201,12 @@ folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayContext::validateAu
   CHECK(it != services_.end()) << "Service '" << *matchedName << "' matched but no entry found";
   session->setPublishHandler(it->second.relay);
   session->setSubscribeHandler(it->second.relay);
+  auto authRes = it->second.relay->authenticateSession(clientSetup.params, session);
+  if (!authRes.hasValue()) {
+    XLOG(ERR) << "Privacy Pass setup auth failed for service '" << *matchedName
+              << "' err=" << auth::toString(authRes.error());
+    return folly::makeUnexpected(toSessionCloseError(authRes.error()));
+  }
   return folly::unit;
 }
 

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -99,7 +99,7 @@ public:
   // --- Delegation targets for MoqxRelayServer virtual overrides ---
 
   void onNewSession(std::shared_ptr<moxygen::MoQSession> session);
-  void onSessionEnd();
+  void onSessionEnd(std::shared_ptr<moxygen::MoQSession> session);
 
   folly::Expected<folly::Unit, moxygen::SessionCloseErrorCode> validateAuthority(
       const moxygen::ClientSetup& clientSetup,

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -129,7 +129,7 @@ void MoqxRelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
 }
 
 void MoqxRelayServer::terminateClientSession(std::shared_ptr<MoQSession> session) {
-  context_->onSessionEnd();
+  context_->onSessionEnd(session);
   MoQServer::terminateClientSession(std::move(session));
 }
 

--- a/src/auth/PrivacyPass.cpp
+++ b/src/auth/PrivacyPass.cpp
@@ -1,0 +1,522 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "auth/PrivacyPass.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+
+#include <folly/Conv.h>
+#include <folly/logging/xlog.h>
+
+namespace openmoq::moqx::auth {
+
+namespace {
+
+using Clock = std::chrono::system_clock;
+using Seconds = std::chrono::seconds;
+
+constexpr size_t kMinUnsignedTokenSize = 4 + 2 + 8 + 8 + 8 + 2 + 2 + 2;
+constexpr uint16_t kMaxStringLen = 0xFFFF;
+constexpr uint16_t kMaxScopes = 0xFFFF;
+constexpr std::string_view kPrivacyPassMagic = "PPv1";
+
+struct PkeyDeleter {
+  void operator()(EVP_PKEY* pkey) const { EVP_PKEY_free(pkey); }
+};
+
+using PkeyPtr = std::unique_ptr<EVP_PKEY, PkeyDeleter>;
+
+struct MdCtxDeleter {
+  void operator()(EVP_MD_CTX* ctx) const { EVP_MD_CTX_free(ctx); }
+};
+
+using MdCtxPtr = std::unique_ptr<EVP_MD_CTX, MdCtxDeleter>;
+
+struct BioDeleter {
+  void operator()(BIO* bio) const { BIO_free(bio); }
+};
+
+using BioPtr = std::unique_ptr<BIO, BioDeleter>;
+
+template <class T> void appendInteger(std::string& out, T value) {
+  for (int i = sizeof(T) - 1; i >= 0; --i) {
+    out.push_back(static_cast<char>((static_cast<uint64_t>(value) >> (i * 8)) & 0xFF));
+  }
+}
+
+template <class T> bool readInteger(std::string_view& in, T& value) {
+  if (in.size() < sizeof(T)) {
+    return false;
+  }
+  uint64_t out = 0;
+  for (size_t i = 0; i < sizeof(T); ++i) {
+    out = (out << 8) | static_cast<unsigned char>(in[i]);
+  }
+  in.remove_prefix(sizeof(T));
+  value = static_cast<T>(out);
+  return true;
+}
+
+bool appendString(std::string& out, std::string_view value) {
+  if (value.size() > kMaxStringLen) {
+    return false;
+  }
+  appendInteger<uint16_t>(out, static_cast<uint16_t>(value.size()));
+  out.append(value.data(), value.size());
+  return true;
+}
+
+bool readString(std::string_view& in, std::string& value) {
+  uint16_t size = 0;
+  if (!readInteger(in, size) || in.size() < size) {
+    return false;
+  }
+  value.assign(in.substr(0, size));
+  in.remove_prefix(size);
+  return true;
+}
+
+bool readStringView(std::string_view& in, std::string_view& value) {
+  uint16_t size = 0;
+  if (!readInteger(in, size) || in.size() < size) {
+    return false;
+  }
+  value = in.substr(0, size);
+  in.remove_prefix(size);
+  return true;
+}
+
+bool writeMatchSpec(std::string& out, const MatchSpec& spec) {
+  out.push_back(static_cast<char>(spec.kind));
+  return appendString(out, spec.value);
+}
+
+bool readMatchSpec(std::string_view& in, MatchSpec& spec) {
+  if (in.empty()) {
+    return false;
+  }
+  spec.kind = static_cast<MatchKind>(static_cast<unsigned char>(in.front()));
+  in.remove_prefix(1);
+  std::string_view value;
+  if (!readStringView(in, value)) {
+    return false;
+  }
+  spec.value.assign(value.data(), value.size());
+  return true;
+}
+
+std::string encodeClaimsPayload(const Claims& claims) {
+  std::string out;
+  out.reserve(256);
+  appendInteger<uint64_t>(
+      out,
+      static_cast<uint64_t>(claims.issuedAt.time_since_epoch() / Seconds(1))
+  );
+  appendInteger<uint64_t>(
+      out,
+      static_cast<uint64_t>(claims.expiresAt.time_since_epoch() / Seconds(1))
+  );
+  appendInteger<uint64_t>(
+      out,
+      static_cast<uint64_t>(claims.revalidateAfter ? claims.revalidateAfter->count() : 0)
+  );
+  if (!appendString(out, claims.audience)) {
+    throw std::runtime_error("audience too large");
+  }
+  if (claims.scopes.size() > kMaxScopes) {
+    throw std::runtime_error("too many scopes");
+  }
+  appendInteger<uint16_t>(out, static_cast<uint16_t>(claims.scopes.size()));
+  for (const auto& scope : claims.scopes) {
+    if (scope.actions.size() > 255) {
+      throw std::runtime_error("too many actions");
+    }
+    out.push_back(static_cast<char>(scope.actions.size()));
+    for (auto action : scope.actions) {
+      out.push_back(static_cast<char>(action));
+    }
+    if (!writeMatchSpec(out, scope.namespaceMatch) || !writeMatchSpec(out, scope.trackMatch)) {
+      throw std::runtime_error("match value too large");
+    }
+  }
+  return out;
+}
+
+bool decodeClaimsPayload(std::string_view payload, Claims& claims) {
+  uint64_t iat = 0;
+  uint64_t exp = 0;
+  uint64_t reval = 0;
+  if (!readInteger(payload, iat) || !readInteger(payload, exp) || !readInteger(payload, reval)) {
+    return false;
+  }
+  claims.issuedAt = Clock::time_point(Seconds(iat));
+  claims.expiresAt = Clock::time_point(Seconds(exp));
+  if (reval > 0) {
+    claims.revalidateAfter = Seconds(reval);
+  } else {
+    claims.revalidateAfter = std::nullopt;
+  }
+  if (!readString(payload, claims.audience)) {
+    return false;
+  }
+  uint16_t scopeCount = 0;
+  if (!readInteger(payload, scopeCount)) {
+    return false;
+  }
+  claims.scopes.clear();
+  claims.scopes.reserve(scopeCount);
+  for (uint16_t i = 0; i < scopeCount; ++i) {
+    if (payload.empty()) {
+      return false;
+    }
+    const auto actionCount = static_cast<unsigned char>(payload.front());
+    payload.remove_prefix(1);
+    Scope scope;
+    scope.actions.reserve(actionCount);
+    for (unsigned char j = 0; j < actionCount; ++j) {
+      if (payload.empty()) {
+        return false;
+      }
+      scope.actions.push_back(static_cast<Action>(static_cast<unsigned char>(payload.front())));
+      payload.remove_prefix(1);
+    }
+    if (!readMatchSpec(payload, scope.namespaceMatch) ||
+        !readMatchSpec(payload, scope.trackMatch)) {
+      return false;
+    }
+    claims.scopes.push_back(std::move(scope));
+  }
+  return payload.empty();
+}
+
+PkeyPtr loadPublicKey(const std::string& pem) {
+  BioPtr bio(BIO_new_mem_buf(pem.data(), static_cast<int>(pem.size())));
+  if (!bio) {
+    return nullptr;
+  }
+  return PkeyPtr(PEM_read_bio_PUBKEY(bio.get(), nullptr, nullptr, nullptr));
+}
+
+PkeyPtr loadPrivateKey(const std::string& pem) {
+  BioPtr bio(BIO_new_mem_buf(pem.data(), static_cast<int>(pem.size())));
+  if (!bio) {
+    return nullptr;
+  }
+  return PkeyPtr(PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
+}
+
+std::string signPayload(const std::string& payload, EVP_PKEY* key) {
+  auto md = MdCtxPtr(EVP_MD_CTX_new());
+  if (!md) {
+    throw std::runtime_error("EVP_MD_CTX_new failed");
+  }
+  if (EVP_DigestSignInit(md.get(), nullptr, nullptr, nullptr, key) != 1) {
+    throw std::runtime_error("EVP_DigestSignInit failed");
+  }
+  size_t sigLen = 0;
+  if (EVP_DigestSign(
+          md.get(),
+          nullptr,
+          &sigLen,
+          reinterpret_cast<const unsigned char*>(payload.data()),
+          payload.size()
+      ) != 1) {
+    throw std::runtime_error("EVP_DigestSign(size) failed");
+  }
+  std::string sig(sigLen, '\0');
+  if (EVP_DigestSign(
+          md.get(),
+          reinterpret_cast<unsigned char*>(sig.data()),
+          &sigLen,
+          reinterpret_cast<const unsigned char*>(payload.data()),
+          payload.size()
+      ) != 1) {
+    throw std::runtime_error("EVP_DigestSign failed");
+  }
+  sig.resize(sigLen);
+  return sig;
+}
+
+bool verifyPayload(const std::string& payload, std::string_view signature, EVP_PKEY* key) {
+  auto md = MdCtxPtr(EVP_MD_CTX_new());
+  if (!md) {
+    return false;
+  }
+  if (EVP_DigestVerifyInit(md.get(), nullptr, nullptr, nullptr, key) != 1) {
+    return false;
+  }
+  return EVP_DigestVerify(
+             md.get(),
+             reinterpret_cast<const unsigned char*>(signature.data()),
+             signature.size(),
+             reinterpret_cast<const unsigned char*>(payload.data()),
+             payload.size()
+         ) == 1;
+}
+
+std::string makeTokenWireFormat(
+    const config::AuthIssuerKey& issuerKey,
+    std::string_view privateKeyPem,
+    const Claims& claims
+) {
+  const auto claimsPayload = encodeClaimsPayload(claims);
+  std::string signedPortion;
+  signedPortion.reserve(4 + 2 + issuerKey.id.size() + claimsPayload.size());
+  signedPortion.append(kPrivacyPassMagic.data(), kPrivacyPassMagic.size());
+  if (!appendString(signedPortion, issuerKey.id)) {
+    throw std::runtime_error("issuer key id too large");
+  }
+  appendInteger<uint16_t>(signedPortion, static_cast<uint16_t>(claimsPayload.size()));
+  signedPortion.append(claimsPayload);
+  auto key = loadPrivateKey(std::string(privateKeyPem));
+  if (!key) {
+    throw std::runtime_error("failed to load private key");
+  }
+  auto signature = signPayload(signedPortion, key.get());
+
+  std::string token = signedPortion;
+  appendInteger<uint16_t>(token, static_cast<uint16_t>(signature.size()));
+  token.append(signature);
+  return token;
+}
+
+std::optional<std::string_view> maybePrivacyPassTokenValue(const moxygen::AuthToken& token) {
+  if (token.tokenValue.size() < kPrivacyPassMagic.size() ||
+      token.tokenValue.compare(0, kPrivacyPassMagic.size(), kPrivacyPassMagic) != 0) {
+    return std::nullopt;
+  }
+  return std::string_view(token.tokenValue);
+}
+
+} // namespace
+
+bool MatchSpec::matches(std::string_view target) const {
+  switch (kind) {
+  case MatchKind::Any:
+    return true;
+  case MatchKind::Exact:
+    return target == value;
+  case MatchKind::Prefix:
+    return target.size() >= value.size() && target.substr(0, value.size()) == value;
+  case MatchKind::Suffix:
+    return target.size() >= value.size() &&
+           target.substr(target.size() - value.size(), value.size()) == value;
+  case MatchKind::Contains:
+    return target.find(value) != std::string_view::npos;
+  }
+  return false;
+}
+
+std::string toString(AuthError error) {
+  switch (error) {
+  case AuthError::Missing:
+    return "missing";
+  case AuthError::Malformed:
+    return "malformed";
+  case AuthError::BadSignature:
+    return "bad signature";
+  case AuthError::Expired:
+    return "expired";
+  case AuthError::Forbidden:
+    return "forbidden";
+  case AuthError::WrongTokenType:
+    return "wrong token type";
+  }
+  return "unknown";
+}
+
+std::string signTokenForTest(
+    const config::AuthIssuerKey& issuerKey,
+    std::string_view privateKeyPem,
+    const Claims& claims
+) {
+  return makeTokenWireFormat(issuerKey, privateKeyPem, claims);
+}
+
+PrivacyPassVerifier::PrivacyPassVerifier(config::AuthConfig config) : config_(std::move(config)) {
+  issuerKeys_ = config_.issuerKeys;
+}
+
+folly::Expected<Claims, AuthError>
+PrivacyPassVerifier::tryVerifyToken(const moxygen::AuthToken& token) const {
+  auto wire = maybePrivacyPassTokenValue(token);
+  if (!wire) {
+    return folly::makeUnexpected(AuthError::WrongTokenType);
+  }
+
+  std::string_view view = *wire;
+  if (view.size() < kMinUnsignedTokenSize ||
+      view.substr(0, kPrivacyPassMagic.size()) != kPrivacyPassMagic) {
+    return folly::makeUnexpected(AuthError::WrongTokenType);
+  }
+  view.remove_prefix(kPrivacyPassMagic.size());
+
+  std::string issuerId;
+  if (!readString(view, issuerId) || view.size() < sizeof(uint16_t)) {
+    return folly::makeUnexpected(AuthError::Malformed);
+  }
+  uint16_t claimsSize = 0;
+  if (!readInteger(view, claimsSize) || view.size() < claimsSize + sizeof(uint16_t)) {
+    return folly::makeUnexpected(AuthError::Malformed);
+  }
+  std::string claimsPayload(view.substr(0, claimsSize));
+  view.remove_prefix(claimsSize);
+
+  uint16_t signatureSize = 0;
+  if (!readInteger(view, signatureSize) || view.size() != signatureSize) {
+    return folly::makeUnexpected(AuthError::Malformed);
+  }
+  std::string_view signature = view;
+
+  const auto keyIt = std::find_if(issuerKeys_.begin(), issuerKeys_.end(), [&](const auto& key) {
+    return key.id == issuerId;
+  });
+  if (keyIt == issuerKeys_.end()) {
+    return folly::makeUnexpected(AuthError::WrongTokenType);
+  }
+  const auto signedLen = wire->size() - signatureSize - sizeof(uint16_t);
+  auto key = loadPublicKey(keyIt->publicKeyPem);
+  if (!key) {
+    return folly::makeUnexpected(AuthError::Malformed);
+  }
+  if (!verifyPayload(std::string(wire->substr(0, signedLen)), signature, key.get())) {
+    return folly::makeUnexpected(AuthError::BadSignature);
+  }
+
+  Claims claims;
+  if (!decodeClaimsPayload(claimsPayload, claims)) {
+    return folly::makeUnexpected(AuthError::Malformed);
+  }
+  claims.issuerId = issuerId;
+  return claims;
+}
+
+folly::Expected<Claims, AuthError> PrivacyPassVerifier::verify(const moxygen::AuthToken& token
+) const {
+  if (!config_.enabled) {
+    return folly::makeUnexpected(AuthError::WrongTokenType);
+  }
+  auto claims = tryVerifyToken(token);
+  if (!claims.hasValue()) {
+    return folly::makeUnexpected(claims.error());
+  }
+
+  const auto now = Clock::now();
+  if (claims->audience != config_.audience) {
+    return folly::makeUnexpected(AuthError::Forbidden);
+  }
+  if (now < claims->issuedAt || now >= claims->expiresAt) {
+    return folly::makeUnexpected(AuthError::Expired);
+  }
+  if (claims->revalidateAfter) {
+    auto revalidateAt = claims->issuedAt + *claims->revalidateAfter;
+    if (now >= revalidateAt) {
+      return folly::makeUnexpected(AuthError::Expired);
+    }
+  }
+  return *claims;
+}
+
+bool PrivacyPassVerifier::allows(
+    const Claims& claims,
+    Action action,
+    std::string_view namespaceValue,
+    std::string_view trackValue
+) const {
+  const bool isSetupAction = action == Action::ClientSetup || action == Action::ServerSetup;
+  const bool isNamespaceAction =
+      action == Action::PublishNamespace || action == Action::SubscribeNamespace;
+  const bool isTrackAction = !isSetupAction && !isNamespaceAction;
+
+  for (const auto& scope : claims.scopes) {
+    if (std::find(scope.actions.begin(), scope.actions.end(), action) == scope.actions.end()) {
+      continue;
+    }
+    if (!isSetupAction) {
+      if (!scope.namespaceMatch.matches(namespaceValue)) {
+        continue;
+      }
+      if (isTrackAction && !scope.trackMatch.matches(trackValue)) {
+        continue;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+folly::Expected<folly::Unit, AuthError> PrivacyPassVerifier::authorize(
+    const moxygen::Parameters& params,
+    Action action,
+    std::string_view namespaceValue,
+    std::string_view trackValue
+) const {
+  if (!config_.enabled) {
+    return folly::unit;
+  }
+
+  bool sawPrivacyPassToken = false;
+  for (const auto& param : params) {
+    if (param.key != folly::to_underlying(moxygen::TrackRequestParamKey::AUTHORIZATION_TOKEN) &&
+        param.key != folly::to_underlying(moxygen::SetupKey::AUTHORIZATION_TOKEN)) {
+      continue;
+    }
+    sawPrivacyPassToken = true;
+    auto claims = verify(param.asAuthToken);
+    if (!claims.hasValue()) {
+      if (claims.error() == AuthError::WrongTokenType) {
+        continue;
+      }
+      return folly::makeUnexpected(claims.error());
+    }
+    if (allows(*claims, action, namespaceValue, trackValue)) {
+      return folly::unit;
+    }
+  }
+
+  if (!sawPrivacyPassToken) {
+    return folly::makeUnexpected(AuthError::Missing);
+  }
+  return folly::makeUnexpected(AuthError::Forbidden);
+}
+
+folly::Expected<folly::Unit, AuthError>
+PrivacyPassVerifier::authorizeSetup(const moxygen::SetupParameters& params) const {
+  if (!config_.enabled) {
+    return folly::unit;
+  }
+  bool sawPrivacyPassToken = false;
+  for (const auto& param : params) {
+    if (param.key != folly::to_underlying(moxygen::SetupKey::AUTHORIZATION_TOKEN)) {
+      continue;
+    }
+    sawPrivacyPassToken = true;
+    auto claims = verify(param.asAuthToken);
+    if (!claims.hasValue()) {
+      if (claims.error() == AuthError::WrongTokenType) {
+        continue;
+      }
+      return folly::makeUnexpected(claims.error());
+    }
+    if (allows(*claims, Action::ClientSetup, {})) {
+      return folly::unit;
+    }
+  }
+  if (!sawPrivacyPassToken) {
+    return folly::unit;
+  }
+  return folly::makeUnexpected(AuthError::Forbidden);
+}
+
+} // namespace openmoq::moqx::auth

--- a/src/auth/PrivacyPass.h
+++ b/src/auth/PrivacyPass.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <folly/Expected.h>
+
+#include <moxygen/MoQTypes.h>
+
+#include "config/Config.h"
+
+namespace openmoq::moqx::auth {
+
+enum class Action : uint8_t {
+  ClientSetup = 0,
+  ServerSetup = 1,
+  PublishNamespace = 2,
+  SubscribeNamespace = 3,
+  Subscribe = 4,
+  SubscribeUpdate = 5,
+  Publish = 6,
+  Fetch = 7,
+  TrackStatus = 8,
+};
+
+enum class MatchKind : uint8_t {
+  Any = 0,
+  Exact = 1,
+  Prefix = 2,
+  Suffix = 3,
+  Contains = 4,
+};
+
+struct MatchSpec {
+  MatchKind kind{MatchKind::Any};
+  std::string value;
+
+  bool matches(std::string_view target) const;
+};
+
+struct Scope {
+  std::vector<Action> actions;
+  MatchSpec namespaceMatch;
+  MatchSpec trackMatch;
+};
+
+struct Claims {
+  std::string issuerId;
+  std::string audience;
+  std::chrono::system_clock::time_point issuedAt;
+  std::chrono::system_clock::time_point expiresAt;
+  std::optional<std::chrono::seconds> revalidateAfter;
+  std::vector<Scope> scopes;
+};
+
+enum class AuthError {
+  Missing,
+  Malformed,
+  BadSignature,
+  Expired,
+  Forbidden,
+  WrongTokenType,
+};
+
+std::string toString(AuthError error);
+
+// Helper for tests and for external issuer-side fixtures.
+std::string signTokenForTest(
+    const config::AuthIssuerKey& issuerKey,
+    std::string_view privateKeyPem,
+    const Claims& claims
+);
+
+class PrivacyPassVerifier {
+public:
+  explicit PrivacyPassVerifier(config::AuthConfig config);
+
+  bool enabled() const { return config_.enabled; }
+
+  const std::string& audience() const { return config_.audience; }
+
+  folly::Expected<Claims, AuthError> verify(const moxygen::AuthToken& token) const;
+
+  bool allows(
+      const Claims& claims,
+      Action action,
+      std::string_view namespaceValue,
+      std::string_view trackValue = {}
+  ) const;
+
+  folly::Expected<folly::Unit, AuthError> authorize(
+      const moxygen::Parameters& params,
+      Action action,
+      std::string_view namespaceValue,
+      std::string_view trackValue = {}
+  ) const;
+
+  folly::Expected<folly::Unit, AuthError> authorizeSetup(const moxygen::SetupParameters& params
+  ) const;
+
+private:
+  static constexpr std::string_view kMagic = "PPv1";
+
+  folly::Expected<Claims, AuthError> tryVerifyToken(const moxygen::AuthToken& token) const;
+
+  config::AuthConfig config_;
+  std::vector<config::AuthIssuerKey> issuerKeys_;
+};
+
+} // namespace openmoq::moqx::auth

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -79,6 +79,17 @@ struct UpstreamConfig {
   std::chrono::milliseconds idleTimeout{5000};
 };
 
+struct AuthIssuerKey {
+  std::string id;
+  std::string publicKeyPem;
+};
+
+struct AuthConfig {
+  bool enabled{false};
+  std::string audience;
+  std::vector<AuthIssuerKey> issuerKeys;
+};
+
 struct ServiceConfig {
   struct MatchEntry {
     struct ExactAuthority {
@@ -103,6 +114,7 @@ struct ServiceConfig {
 
   std::vector<MatchEntry> match;
   CacheConfig cache;
+  std::optional<AuthConfig> auth;
   std::optional<UpstreamConfig> upstream; // set if this service chains to an upstream relay
 };
 

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -312,6 +312,22 @@ UpstreamConfig resolveUpstream(const ParsedUpstreamConfig& upstream) {
   };
 }
 
+AuthConfig resolveAuth(const ParsedAuthConfig& auth) {
+  std::vector<AuthIssuerKey> issuerKeys;
+  issuerKeys.reserve(auth.issuer_keys.value().size());
+  for (const auto& key : auth.issuer_keys.value()) {
+    issuerKeys.push_back(AuthIssuerKey{
+        .id = key.id.value(),
+        .publicKeyPem = key.public_key_pem.value(),
+    });
+  }
+  return AuthConfig{
+      .enabled = auth.enabled.value(),
+      .audience = auth.audience.value(),
+      .issuerKeys = std::move(issuerKeys),
+  };
+}
+
 // --- Service validation ---
 
 void validateService(
@@ -387,6 +403,34 @@ void validateService(
   }
 
   mergedCaches.emplace(name, std::move(merged));
+
+  if (svc.auth.value().has_value()) {
+    if (svc.auth.value()->enabled.value()) {
+      if (svc.auth.value()->audience.value().empty()) {
+        errors.push_back("Service '" + name + "': auth.audience must be non-empty when enabled");
+      }
+      if (svc.auth.value()->issuer_keys.value().empty()) {
+        errors.push_back("Service '" + name + "': auth.issuer_keys must not be empty when enabled");
+      }
+      std::unordered_set<std::string> ids;
+      for (const auto& key : svc.auth.value()->issuer_keys.value()) {
+        if (key.id.value().empty()) {
+          errors.push_back("Service '" + name + "': auth.issuer_keys[].id must be non-empty");
+          continue;
+        }
+        if (!ids.insert(key.id.value()).second) {
+          errors.push_back(
+              "Service '" + name + "': duplicate auth.issuer_keys[].id '" + key.id.value() + "'"
+          );
+        }
+        if (key.public_key_pem.value().empty()) {
+          errors.push_back(
+              "Service '" + name + "': auth.issuer_keys[].public_key_pem must be non-empty"
+          );
+        }
+      }
+    }
+  }
 
   // Validate per-service upstream if present.
   if (svc.upstream.value().has_value()) {
@@ -602,9 +646,14 @@ ServiceConfig resolveService(const ParsedServiceConfig& svc, const ParsedCacheCo
   if (svc.upstream.value().has_value()) {
     upstream = resolveUpstream(*svc.upstream.value());
   }
+  std::optional<AuthConfig> auth;
+  if (svc.auth.value().has_value()) {
+    auth = resolveAuth(*svc.auth.value());
+  }
   return ServiceConfig{
       .match = std::move(entries),
       .cache = resolveCacheConfig(cache),
+      .auth = std::move(auth),
       .upstream = std::move(upstream),
   };
 }

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -157,6 +157,17 @@ struct ParsedUpstreamConfig {
       idle_timeout_ms;
 };
 
+struct ParsedAuthIssuerKey {
+  rfl::Description<"Issuer key identifier", std::string> id;
+  rfl::Description<"Issuer public key PEM", std::string> public_key_pem;
+};
+
+struct ParsedAuthConfig {
+  rfl::Description<"Enable Privacy Pass authorization for this service", bool> enabled;
+  rfl::Description<"Expected audience / redemption context", std::string> audience;
+  rfl::Description<"Accepted issuer public keys", std::vector<ParsedAuthIssuerKey>> issuer_keys;
+};
+
 struct ParsedServiceConfig {
   struct MatchRule {
     struct ExactAuthority {
@@ -202,6 +213,10 @@ struct ParsedServiceConfig {
       "Upstream MoQ server for this service (optional; enables relay chaining)",
       std::optional<ParsedUpstreamConfig>>
       upstream;
+  rfl::Description<
+      "Privacy Pass authorization settings for this service",
+      std::optional<ParsedAuthConfig>>
+      auth;
 };
 
 struct ParsedListenerDefaultsConfig {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,238 +1,255 @@
-find_package(GTest REQUIRED CONFIG)
-include(GoogleTest)
+find_package(GTest REQUIRED CONFIG) include(GoogleTest)
 
-add_library(moqx_test_utils STATIC
-  TestUtils.cpp
-)
-target_include_directories(moqx_test_utils PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
-)
-target_link_libraries(moqx_test_utils PUBLIC
-  Folly::folly_io_iobuf
-  Folly::folly_random
-)
+    add_library(moqx_test_utils STATIC TestUtils.cpp
+    ) target_include_directories(moqx_test_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    ) target_link_libraries(moqx_test_utils PUBLIC Folly::folly_io_iobuf Folly::folly_random)
 
-add_library(moqx_test_main STATIC
-  TestMain.cpp
-)
-target_link_libraries(moqx_test_main PUBLIC
-  Folly::folly_init_init
-  GTest::gtest
-)
+        add_library(moqx_test_main STATIC TestMain.cpp
+        ) target_link_libraries(moqx_test_main PUBLIC Folly::folly_init_init GTest::gtest)
 
-add_executable(moqx_relay_test
-  MoqxRelayTest.cpp
-)
-target_link_libraries(moqx_relay_test PRIVATE
-  moqx_core
-  moqx_test_utils
-  moqx_test_main
-  GTest::gmock
-  moxygen::moxygen_events_moq_folly_executor_impl
-)
-gtest_discover_tests(moqx_relay_test)
+            add_executable(moqx_relay_test MoqxRelayTest.cpp
+            ) target_link_libraries(moqx_relay_test PRIVATE moqx_core moqx_test_utils moqx_test_main
+                                        GTest::gmock moxygen::moxygen_events_moq_folly_executor_impl
+            ) gtest_discover_tests(moqx_relay_test)
 
-add_executable(moqx_namespace_tree_test
-  NamespaceTreeTest.cpp
-)
-target_link_libraries(moqx_namespace_tree_test PRIVATE
-  moqx_core
-  moqx_test_main
-  GTest::gmock
-  moxygen::moqtest_utils
-)
-gtest_discover_tests(moqx_namespace_tree_test)
+                add_executable(moqx_namespace_tree_test NamespaceTreeTest.cpp
+                ) target_link_libraries(moqx_namespace_tree_test PRIVATE moqx_core moqx_test_main
+                                            GTest::gmock moxygen::moqtest_utils
+                ) gtest_discover_tests(moqx_namespace_tree_test)
 
-add_executable(moqx_config_test
-  config/LoaderTest.cpp
-)
-target_link_libraries(moqx_config_test PRIVATE
-  moqx_config_loader
-  GTest::gtest_main
-  GTest::gmock
-)
-target_compile_definitions(moqx_config_test PRIVATE
-  CONFIG_EXAMPLE_PATH="${PROJECT_SOURCE_DIR}/config.example.yaml"
-)
-if(NOT GFLAGS_SHARED)
-  target_link_libraries(moqx_config_test PRIVATE
-    "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
-  )
-  set_property(TARGET moqx_config_test PROPERTY
-    LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
-  )
-endif()
-gtest_discover_tests(moqx_config_test)
+                    add_executable(moqx_config_test config / LoaderTest.cpp) target_link_libraries(
+                        moqx_config_test PRIVATE moqx_config_loader GTest::gtest_main GTest::gmock
+                    )
+                        target_compile_definitions(
+                            moqx_config_test PRIVATE CONFIG_EXAMPLE_PATH =
+                                "${PROJECT_SOURCE_DIR}/config.example.yaml"
+                        ) if (NOT GFLAGS_SHARED) target_link_libraries(moqx_config_test PRIVATE
+                                                                       "$<LINK_LIBRARY:WHOLE_"
+                                                                       "ARCHIVE,gflags_nothreads_"
+                                                                       "static>"
+                        ) set_property(TARGET moqx_config_test PROPERTY LINK_LIBRARY_OVERRIDE
+                                       "WHOLE_ARCHIVE,gflags_nothreads_static"
+                        ) endif() gtest_discover_tests(moqx_config_test)
 
-add_executable(moqx_config_resolver_test
-  config/ConfigResolverTest.cpp
-)
-target_link_libraries(moqx_config_resolver_test PRIVATE
-  moqx_config_loader
-  GTest::gtest_main
-  GTest::gmock
-)
-if(NOT GFLAGS_SHARED)
-  target_link_libraries(moqx_config_resolver_test PRIVATE
-    "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
-  )
-  set_property(TARGET moqx_config_resolver_test PROPERTY
-    LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
-  )
-endif()
-gtest_discover_tests(moqx_config_resolver_test)
+                            add_executable(
+                                moqx_config_resolver_test config / ConfigResolverTest.cpp
+                            ) target_link_libraries(moqx_config_resolver_test PRIVATE
+                                                        moqx_config_loader
+                                                            GTest::gtest_main GTest::gmock
+                            ) if (NOT GFLAGS_SHARED) target_link_libraries(moqx_config_resolver_test PRIVATE
+                                                                           "$<LINK_LIBRARY:WHOLE_"
+                                                                           "ARCHIVE,gflags_"
+                                                                           "nothreads_static>"
+                            ) set_property(TARGET moqx_config_resolver_test
+                                               PROPERTY LINK_LIBRARY_OVERRIDE
+                                           "WHOLE_ARCHIVE,gflags_nothreads_static"
+                            ) endif() gtest_discover_tests(moqx_config_resolver_test)
 
-add_executable(moqx_bounded_histogram_test
-  stats/BoundedHistogramTest.cpp
-)
-target_include_directories(moqx_bounded_histogram_test PRIVATE
-  ${PROJECT_SOURCE_DIR}/src
-)
-target_link_libraries(moqx_bounded_histogram_test PRIVATE
-  GTest::gtest_main
-  GTest::gmock
-)
-gtest_discover_tests(moqx_bounded_histogram_test)
+                                add_executable(moqx_privacy_pass_test PrivacyPassTest.cpp
+                                ) target_link_libraries(moqx_privacy_pass_test PRIVATE moqx_core
+                                                            GTest::gtest_main GTest::gmock
+                                ) gtest_discover_tests(moqx_privacy_pass_test)
 
-add_executable(moqx_pico_quic_stats_test
-  stats/PicoQuicStatsCollectorTest.cpp
-)
-target_include_directories(moqx_pico_quic_stats_test PRIVATE
-  ${PROJECT_SOURCE_DIR}/src
-)
-target_link_libraries(moqx_pico_quic_stats_test PRIVATE
-  moqx_core
-  GTest::gtest_main
-  GTest::gmock
-)
-gtest_discover_tests(moqx_pico_quic_stats_test)
+                                    add_executable(
+                                        moqx_bounded_histogram_test stats / BoundedHistogramTest.cpp
+                                    )
+                                        target_include_directories(
+                                            moqx_bounded_histogram_test PRIVATE ${PROJECT_SOURCE_DIR
+                                            } /
+                                            src
+                                        ) target_link_libraries(moqx_bounded_histogram_test PRIVATE
+                                                                    GTest::gtest_main GTest::gmock
+                                        ) gtest_discover_tests(moqx_bounded_histogram_test)
 
-add_executable(moqx_service_matcher_test
-  ServiceMatcherTest.cpp
-)
-target_link_libraries(moqx_service_matcher_test PRIVATE
-  moqx_core
-  moqx_config
-  GTest::gtest_main
-  GTest::gmock
-)
-gtest_discover_tests(moqx_service_matcher_test)
+                                            add_executable(
+                                                moqx_pico_quic_stats_test stats /
+                                                PicoQuicStatsCollectorTest.cpp
+                                            )
+                                                target_include_directories(
+                                                    moqx_pico_quic_stats_test PRIVATE
+                                                        ${PROJECT_SOURCE_DIR} /
+                                                    src
+                                                ) target_link_libraries(moqx_pico_quic_stats_test
+                                                                            PRIVATE moqx_core
+                                                                                GTest::gtest_main
+                                                                                    GTest::gmock
+                                                ) gtest_discover_tests(moqx_pico_quic_stats_test)
 
-add_executable(moqx_relay_context_test
-  MoqxRelayContextTest.cpp
-)
-target_link_libraries(moqx_relay_context_test PRIVATE
-  moqx_core
-  moqx_test_utils
-  moqx_test_main
-  GTest::gmock
-  moxygen::moxygen_events_moq_folly_executor_impl
-)
-gtest_discover_tests(moqx_relay_context_test)
+                                                    add_executable(moqx_service_matcher_test
+                                                                       ServiceMatcherTest.cpp
+                                                    ) target_link_libraries(moqx_service_matcher_test
+                                                                                PRIVATE moqx_core
+                                                                                    moqx_config GTest::
+                                                                                        gtest_main
+                                                                                            GTest::
+                                                                                                gmock
+                                                    ) gtest_discover_tests(moqx_service_matcher_test
+                                                    )
 
-add_test(
-  NAME relay_chain
-  COMMAND bash ${PROJECT_SOURCE_DIR}/test/test_relay_chain.sh $<TARGET_FILE:moqx>
-)
-set_tests_properties(relay_chain PROPERTIES
-  TIMEOUT 120
-  ENVIRONMENT "MOQBIN=${PROJECT_SOURCE_DIR}/.scratch/moxygen-install/bin"
-)
+                                                        add_executable(moqx_relay_context_test
+                                                                           MoqxRelayContextTest.cpp)
+                                                            target_link_libraries(
+                                                                moqx_relay_context_test PRIVATE
+                                                                    moqx_core moqx_test_utils
+                                                                        moqx_test_main
+                                                                            GTest::gmock moxygen::
+                                                                                moxygen_events_moq_folly_executor_impl
+                                                            ) gtest_discover_tests(moqx_relay_context_test
+                                                            )
 
-add_test(
-  NAME admin_info_endpoint
-  COMMAND bash ${PROJECT_SOURCE_DIR}/test/test_admin_info.sh $<TARGET_FILE:moqx>
-)
-add_test(
-  NAME admin_tls_endpoint
-  COMMAND bash ${PROJECT_SOURCE_DIR}/test/test_admin_tls.sh $<TARGET_FILE:moqx>
-)
-add_test(
-  NAME admin_metrics_endpoint
-  COMMAND bash ${PROJECT_SOURCE_DIR}/test/test_admin_metrics.sh $<TARGET_FILE:moqx>
-)
-add_test(
-  NAME admin_cache_purge_endpoint
-  COMMAND bash ${PROJECT_SOURCE_DIR}/test/test_admin_cache_purge.sh $<TARGET_FILE:moqx>
-)
-add_test(
-  NAME admin_cache_purge_concurrency_test
-  COMMAND bash ${PROJECT_SOURCE_DIR}/test/test_admin_cache_purge_race.sh $<TARGET_FILE:moqx>
-)
+                                                                add_test(
+                                                                    NAME relay_chain COMMAND
+                                                                                bash ${
+                                                                                    PROJECT_SOURCE_DIR
+                                                                                } /
+                                                                            test /
+                                                                            test_relay_chain.sh $ <
+                                                                        TARGET_FILE
+                                                                    : moqx >
+                                                                ) set_tests_properties(relay_chain
+                                                                                           PROPERTIES TIMEOUT 120 ENVIRONMENT
+                                                                                       "MOQBIN=${"
+                                                                                       "PROJECT_"
+                                                                                       "SOURCE_DIR}"
+                                                                                       "/.scratch/"
+                                                                                       "moxygen-"
+                                                                                       "install/bin"
+                                                                )
 
-add_executable(moqx_upstream_provider_test
-  UpstreamProviderTest.cpp
-)
-target_link_libraries(moqx_upstream_provider_test PRIVATE
-  moqx_core
-  moqx_test_utils
-  moqx_test_main
-  moxygen::moqtest_utils
-  moxygen::moxygen_events_moq_folly_executor_impl
-  moxygen::moxygen_moqclient
-  GTest::gmock
-)
-gtest_discover_tests(moqx_upstream_provider_test)
+                                                                    add_test(NAME admin_info_endpoint COMMAND
+                                                                                         bash ${
+                                                                                             PROJECT_SOURCE_DIR
+                                                                                         } /
+                                                                                     test /
+                                                                                     test_admin_info
+                                                                                         .sh $ <
+                                                                                 TARGET_FILE
+                                                                             : moqx >
+                                                                    ) add_test(NAME admin_tls_endpoint COMMAND bash
+                                                                                           ${PROJECT_SOURCE_DIR
+                                                                                           } /
+                                                                                       test /
+                                                                                       test_admin_tls
+                                                                                           .sh $ <
+                                                                                   TARGET_FILE
+                                                                               : moqx >
+                                                                    ) add_test(NAME admin_metrics_endpoint COMMAND bash
+                                                                                           ${PROJECT_SOURCE_DIR
+                                                                                           } /
+                                                                                       test /
+                                                                                       test_admin_metrics
+                                                                                           .sh $ <
+                                                                                   TARGET_FILE
+                                                                               : moqx >
+                                                                    ) add_test(NAME admin_cache_purge_endpoint COMMAND bash
+                                                                                           ${PROJECT_SOURCE_DIR
+                                                                                           } /
+                                                                                       test /
+                                                                                       test_admin_cache_purge
+                                                                                           .sh $ <
+                                                                                   TARGET_FILE
+                                                                               : moqx >
+                                                                    ) add_test(NAME admin_cache_purge_concurrency_test COMMAND bash
+                                                                                           ${PROJECT_SOURCE_DIR
+                                                                                           } /
+                                                                                       test /
+                                                                                       test_admin_cache_purge_race
+                                                                                           .sh $ <
+                                                                                   TARGET_FILE
+                                                                               : moqx >)
 
-# TopNFilter unit tests
-add_executable(moqx_topn_filter_test
-  TopNFilterTest.cpp
-)
-target_link_libraries(moqx_topn_filter_test PRIVATE
-  moqx_core
-  GTest::gtest_main
-  GTest::gmock
-)
-gtest_discover_tests(moqx_topn_filter_test)
+                                                                        add_executable(
+                                                                            moqx_upstream_provider_test
+                                                                                UpstreamProviderTest.cpp
+                                                                        )
+                                                                            target_link_libraries(
+                                                                                moqx_upstream_provider_test
+                                                                                    PRIVATE
+                                                                                        moqx_core moqx_test_utils moqx_test_main
+                                                                                            moxygen::moqtest_utils
+                                                                                                moxygen::moxygen_events_moq_folly_executor_impl
+                                                                                                    moxygen::moxygen_moqclient
+                                                                                                        GTest::
+                                                                                                            gmock
+                                                                            ) gtest_discover_tests(moqx_upstream_provider_test
+                                                                            )
 
-# PropertyRanking base unit tests (no self-exclusion)
-add_executable(moqx_property_ranking_base_test
-  PropertyRankingBaseTest.cpp
-)
-target_link_libraries(moqx_property_ranking_base_test PRIVATE
-  moqx_core
-  GTest::gtest_main
-  GTest::gmock
-)
-gtest_discover_tests(moqx_property_ranking_base_test)
+#TopNFilter unit tests
+                                                                                add_executable(
+                                                                                    moqx_topn_filter_test
+                                                                                        TopNFilterTest
+                                                                                            .cpp
+                                                                                )
+                                                                                    target_link_libraries(
+                                                                                        moqx_topn_filter_test
+                                                                                            PRIVATE moqx_core
+                                                                                                GTest::gtest_main
+                                                                                                    GTest::
+                                                                                                        gmock
+                                                                                    ) gtest_discover_tests(moqx_topn_filter_test
+                                                                                    )
 
-# PropertyRanking self-exclusion / waterline unit tests
-add_executable(moqx_property_ranking_self_exclusion_test
-  PropertyRankingSelfExclusionTest.cpp
-)
-target_link_libraries(moqx_property_ranking_self_exclusion_test PRIVATE
-  moqx_core
-  GTest::gtest_main
-  GTest::gmock
-)
-gtest_discover_tests(moqx_property_ranking_self_exclusion_test)
+#PropertyRanking base unit tests(no self - exclusion)
+                                                                                        add_executable(
+                                                                                            moqx_property_ranking_base_test
+                                                                                                PropertyRankingBaseTest
+                                                                                                    .cpp
+                                                                                        )
+                                                                                            target_link_libraries(
+                                                                                                moqx_property_ranking_base_test
+                                                                                                    PRIVATE moqx_core
+                                                                                                        GTest::gtest_main
+                                                                                                            GTest::
+                                                                                                                gmock
+                                                                                            ) gtest_discover_tests(moqx_property_ranking_base_test
+                                                                                            )
 
-# TRACK_FILTER integration tests (in-process relay, no live server)
-add_executable(moqx_track_filter_test
-  MoqxTrackFilterTest.cpp
-)
-target_link_libraries(moqx_track_filter_test PRIVATE
-  moqx_core
-  moqx_test_main
-  GTest::gmock
-  moxygen::moxygen_events_moq_folly_executor_impl
-)
-gtest_discover_tests(moqx_track_filter_test)
+#PropertyRanking self - exclusion / waterline unit tests
+                                                                                                add_executable(
+                                                                                                    moqx_property_ranking_self_exclusion_test
+                                                                                                        PropertyRankingSelfExclusionTest
+                                                                                                            .cpp
+                                                                                                )
+                                                                                                    target_link_libraries(
+                                                                                                        moqx_property_ranking_self_exclusion_test
+                                                                                                            PRIVATE moqx_core
+                                                                                                                GTest::gtest_main
+                                                                                                                    GTest::
+                                                                                                                        gmock
+                                                                                                    ) gtest_discover_tests(moqx_property_ranking_self_exclusion_test
+                                                                                                    )
 
-# TrackFilterLoadTest: requires a live relay process.
-# Run manually: ./track_filter_load_test --relay_url=https://localhost:9668/moq-relay
-# Not registered with gtest_discover_tests — excluded from automated ctest.
-add_executable(track_filter_load_test
-  TrackFilterLoadTest.cpp
-)
-target_link_libraries(track_filter_load_test PRIVATE
-  moqx_core
-  Folly::folly_init_init
-  moxygen::moxygen_events_moq_folly_executor_impl
-  moxygen::moxygen_moqclient
-  moxygen::moxygen_moq_webtransport_client
-  moxygen::moxygen_relay_moq_relay_client
-  moxygen::moxygen_relay_moq_forwarder
-  moxygen::moxygen_moq_relay_session
-  moxygen::moxygen_util_insecure_verifier_dangerous_do_not_use_in_production
-)
+#TRACK_FILTER integration tests(in - process relay, no live server)
+                                                                                                        add_executable(
+                                                                                                            moqx_track_filter_test
+                                                                                                                MoqxTrackFilterTest
+                                                                                                                    .cpp
+                                                                                                        )
+                                                                                                            target_link_libraries(
+                                                                                                                moqx_track_filter_test
+                                                                                                                    PRIVATE moqx_core moqx_test_main
+                                                                                                                        GTest::gmock
+                                                                                                                            moxygen::
+                                                                                                                                moxygen_events_moq_folly_executor_impl
+                                                                                                            ) gtest_discover_tests(moqx_track_filter_test
+                                                                                                            )
+
+#TrackFilterLoadTest : requires a live relay process.
+#Run manually :./ track_filter_load_test-- relay_url = https: // localhost:9668/moq-relay
+#Not registered with gtest_discover_tests — excluded from automated ctest.
+                                                                                                                add_executable(
+                                                                                                                    track_filter_load_test
+                                                                                                                        TrackFilterLoadTest
+                                                                                                                            .cpp
+                                                                                                                )
+                                                                                                                    target_link_libraries(
+                                                                                                                        track_filter_load_test PRIVATE moqx_core
+                                                                                                                            Folly::folly_init_init moxygen::moxygen_events_moq_folly_executor_impl
+                                                                                                                                moxygen::moxygen_moqclient
+                                                                                                                                    moxygen::moxygen_moq_webtransport_client
+                                                                                                                                        moxygen::moxygen_relay_moq_relay_client
+                                                                                                                                            moxygen::moxygen_relay_moq_forwarder
+                                                                                                                                                moxygen::moxygen_moq_relay_session
+                                                                                                                                                    moxygen::
+                                                                                                                                                        moxygen_util_insecure_verifier_dangerous_do_not_use_in_production
+                                                                                                                    )

--- a/test/PrivacyPassTest.cpp
+++ b/test/PrivacyPassTest.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "auth/PrivacyPass.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace openmoq::moqx::auth {
+namespace {
+
+using ::testing::HasSubstr;
+
+constexpr char kPrivateKeyPem[] = R"(-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIErhyiUzUJWurF+fXkkoWw6nF3jHicKlTV7RY8klhNaH
+-----END PRIVATE KEY-----)";
+
+constexpr char kPublicKeyPem[] = R"(-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAgV7mddBzR6UIIyGl/GEgWgSkImWT4bbV+LEDL2XPQnE=
+-----END PUBLIC KEY-----)";
+
+config::AuthConfig makeConfig() {
+  config::AuthConfig cfg;
+  cfg.enabled = true;
+  cfg.audience = "moqx-test";
+  cfg.issuerKeys.push_back(config::AuthIssuerKey{
+      .id = "issuer-1",
+      .publicKeyPem = kPublicKeyPem,
+  });
+  return cfg;
+}
+
+Claims makeClaims() {
+  Claims claims;
+  claims.issuerId = "issuer-1";
+  claims.audience = "moqx-test";
+  claims.issuedAt = std::chrono::system_clock::now() - std::chrono::minutes(1);
+  claims.expiresAt = std::chrono::system_clock::now() + std::chrono::minutes(10);
+  Scope scope;
+  scope.actions = {Action::Subscribe, Action::Fetch};
+  scope.namespaceMatch = MatchSpec{MatchKind::Prefix, "/live/"};
+  scope.trackMatch = MatchSpec{MatchKind::Prefix, "track/"};
+  claims.scopes.push_back(std::move(scope));
+  return claims;
+}
+
+moxygen::AuthToken makeToken(const std::string& value) {
+  return moxygen::AuthToken{
+      .tokenType = 0,
+      .tokenValue = value,
+      .alias = moxygen::AuthToken::DontRegister,
+  };
+}
+
+} // namespace
+
+TEST(PrivacyPass, VerifiesAndAuthorizesValidToken) {
+  auto config = makeConfig();
+  auto verifier = PrivacyPassVerifier(config);
+  auto claims = makeClaims();
+  auto token = makeToken(signTokenForTest(config.issuerKeys.front(), kPrivateKeyPem, claims));
+
+  auto verified = verifier.verify(token);
+  ASSERT_TRUE(verified.hasValue());
+  EXPECT_EQ(verified.value().issuerId, claims.issuerId);
+  EXPECT_TRUE(verifier.allows(verified.value(), Action::Subscribe, "/live/room", "track/123"));
+  EXPECT_FALSE(verifier.allows(verified.value(), Action::Publish, "/live/room", "track/123"));
+}
+
+TEST(PrivacyPass, RejectsExpiredToken) {
+  auto config = makeConfig();
+  PrivacyPassVerifier verifier(config);
+  auto claims = makeClaims();
+  claims.expiresAt = std::chrono::system_clock::now() - std::chrono::seconds(1);
+  auto token = makeToken(signTokenForTest(config.issuerKeys.front(), kPrivateKeyPem, claims));
+
+  auto verified = verifier.verify(token);
+  ASSERT_TRUE(verified.hasError());
+  EXPECT_EQ(verified.error(), AuthError::Expired);
+}
+
+TEST(PrivacyPass, RejectsWrongAudience) {
+  auto config = makeConfig();
+  PrivacyPassVerifier verifier(config);
+  auto claims = makeClaims();
+  claims.audience = "other";
+  auto token = makeToken(signTokenForTest(config.issuerKeys.front(), kPrivateKeyPem, claims));
+
+  auto verified = verifier.verify(token);
+  ASSERT_TRUE(verified.hasError());
+  EXPECT_EQ(verified.error(), AuthError::Forbidden);
+}
+
+TEST(PrivacyPass, RejectsBadSignature) {
+  auto config = makeConfig();
+  PrivacyPassVerifier verifier(config);
+  auto claims = makeClaims();
+  auto tokenValue = signTokenForTest(config.issuerKeys.front(), kPrivateKeyPem, claims);
+  tokenValue.back() ^= 0x01;
+  auto token = makeToken(tokenValue);
+
+  auto verified = verifier.verify(token);
+  ASSERT_TRUE(verified.hasError());
+  EXPECT_EQ(verified.error(), AuthError::BadSignature);
+}
+
+TEST(PrivacyPass, AuthorizeSetupAllowsMissingToken) {
+  PrivacyPassVerifier verifier(makeConfig());
+  moxygen::SetupParameters params{moxygen::FrameType::CLIENT_SETUP};
+
+  auto res = verifier.authorizeSetup(params);
+  ASSERT_TRUE(res.hasValue());
+}
+
+TEST(PrivacyPass, AuthorizeRequestUsesToken) {
+  auto config = makeConfig();
+  PrivacyPassVerifier verifier(config);
+  auto claims = makeClaims();
+  auto token = signTokenForTest(config.issuerKeys.front(), kPrivateKeyPem, claims);
+
+  moxygen::Parameters params{moxygen::FrameType::SUBSCRIBE};
+  ASSERT_TRUE(params
+                  .insertParam(moxygen::Parameter{
+                      static_cast<uint64_t>(moxygen::TrackRequestParamKey::AUTHORIZATION_TOKEN),
+                      makeToken(token)
+                  })
+                  .hasValue());
+
+  auto res = verifier.authorize(params, Action::Subscribe, "/live/room", "track/123");
+  ASSERT_TRUE(res.hasValue());
+}
+
+} // namespace openmoq::moqx::auth

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -61,6 +61,17 @@ ParsedServiceConfig makeDefaultService() {
   return svc;
 }
 
+ParsedAuthConfig makeDefaultAuth() {
+  ParsedAuthConfig auth;
+  auth.enabled = true;
+  auth.audience = "moqx-test";
+  ParsedAuthIssuerKey key;
+  key.id = "issuer-1";
+  key.public_key_pem = "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n";
+  auth.issuer_keys.value().push_back(std::move(key));
+  return auth;
+}
+
 // Build a minimal valid insecure config with one any-authority service and admin.
 ParsedConfig makeMinimalInsecureConfig(std::string name = "test") {
   ParsedConfig cfg;
@@ -658,6 +669,44 @@ TEST(ResolveConfig, ResolvePrefixPath) {
   ASSERT_EQ(entries.size(), 1);
   ASSERT_TRUE(std::holds_alternative<ServiceConfig::MatchEntry::PrefixPath>(entries[0].path));
   EXPECT_EQ(std::get<ServiceConfig::MatchEntry::PrefixPath>(entries[0].path).value, "/live/");
+}
+
+TEST(ResolveConfig, ResolveAuth) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.services.value().clear();
+
+  ParsedServiceConfig svc;
+  svc.match.value().push_back(makeAnyAuthorityMatch());
+  svc.cache = makeDefaultCache();
+  svc.auth = makeDefaultAuth();
+  cfg.services.value().emplace("authed", std::move(svc));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& auth = result.value().config.services.at("authed").auth;
+  ASSERT_TRUE(auth.has_value());
+  EXPECT_TRUE(auth->enabled);
+  EXPECT_EQ(auth->audience, "moqx-test");
+  ASSERT_EQ(auth->issuerKeys.size(), 1u);
+  EXPECT_EQ(auth->issuerKeys[0].id, "issuer-1");
+}
+
+TEST(ResolveConfig, AuthEnabledRequiresIssuerKeys) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.services.value().clear();
+
+  ParsedServiceConfig svc;
+  svc.match.value().push_back(makeAnyAuthorityMatch());
+  svc.cache = makeDefaultCache();
+  ParsedAuthConfig auth;
+  auth.enabled = true;
+  auth.audience = "moqx-test";
+  svc.auth = auth;
+  cfg.services.value().emplace("authed", std::move(svc));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("auth.issuer_keys must not be empty"));
 }
 
 TEST(ResolveConfig, VersionsEmpty) {


### PR DESCRIPTION
Implements opt-in Privacy Pass authorization for relay services.

What changed:
- Added per-service auth config with audience and issuer public keys.
- Verified setup tokens and cached session auth state.
- Enforced request-time authorization for publish namespace, subscribe namespace, subscribe, fetch, track status, and publish.
- Kept peer relay peering and disabled-auth behavior unchanged.
- Added config/docs updates and unit coverage for token verification and config resolution.

Verification:
- ./scripts/docker-build.sh moqx-auth-verify

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/266)
<!-- Reviewable:end -->
