### PR TITLE
refactor: extract SubscriptionRegistry from MoqxRelay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ FetchContent_MakeAvailable(reflectcpp)
 
 add_library(moqx_core STATIC
   src/NamespaceTree.cpp
+  src/SubscriptionRegistry.cpp
   src/MoqxRelay.cpp
   src/MoqxRelayContext.cpp
   src/MoqxRelayServer.cpp

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -156,15 +156,13 @@ std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespac
     XLOG(WARNING) << "PublishNamespace: Existing session (" << replacedSession.get()
                   << ") has already published trackNamespace=" << pubNs.trackNamespace;
     // Remove ongoing subscriptions for the replaced publisher.
-    for (auto it = subscriptions_.begin(); it != subscriptions_.end();) {
-      if (it->first.trackNamespace.startsWith(pubNs.trackNamespace) &&
-          it->second.upstream == replacedSession) {
-        XLOG(DBG4) << "Erasing subscription to " << it->first;
-        it = subscriptions_.erase(it);
-      } else {
-        ++it;
+    registry_.removeIf([&](const FullTrackName& ftn, const SubscriptionRegistry::EntryView& e) {
+      if (ftn.trackNamespace.startsWith(pubNs.trackNamespace) && e.upstream == replacedSession) {
+        XLOG(DBG4) << "Erasing subscription to " << ftn;
+        return true;
       }
-    }
+      return false;
+    });
   }
   for (auto& [outSession, info] : sessions) {
     if (outSession != session && (info.options == SubscribeNamespaceOptions::NAMESPACE ||
@@ -260,24 +258,15 @@ void MoqxRelay::onPublishNamespaceDone(const TrackNamespace& trackNamespace) {
 void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
   XLOG(DBG1) << __func__ << " ftn=" << ftn;
 
-  auto it = subscriptions_.find(ftn);
-  if (it != subscriptions_.end()) {
-    if (it->second.isPublish) {
-      namespaceTree_.unpublishTrack(ftn.trackNamespace, ftn.trackName);
-    }
+  auto upstreamView = registry_.getUpstreamView(ftn);
+  if (upstreamView && upstreamView->isPublish) {
+    namespaceTree_.unpublishTrack(ftn.trackNamespace, ftn.trackName);
+  }
 
-    // Clear the handle and upstream - this signals publisher is done
-    // Clearing upstream is important to break circular reference:
-    // session holds FilterConsumer, relay holds session in upstream
-    it->second.handle.reset();
-    it->second.upstream.reset();
-
-    // If forwarder has no subscribers, clean up immediately
-    // Otherwise onEmpty will be called when last subscriber leaves
-    if (it->second.forwarder->empty()) {
-      XLOG(DBG1) << "Publisher terminated with no subscribers, cleaning up " << ftn;
-      subscriptions_.erase(it);
-    }
+  // Clears handle + upstream; erases if no subscribers remain.
+  auto forwarder = registry_.onPublisherTerminated(ftn);
+  if (!forwarder) {
+    XLOG(DBG1) << "Publisher terminated with no subscribers, cleaning up " << ftn;
   }
 }
 
@@ -310,16 +299,24 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   // subgroups).  onPublishDone() already reset handle and drained the
   // forwarder, so skip both calls to avoid a null deref and a double
   // publishDone.
-  auto it = subscriptions_.find(pub.fullTrackName);
-  if (it != subscriptions_.end()) {
+  auto forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
+  forwarder->setExtensions(pub.extensions);
+
+  auto publishEntry = registry_.createFromPublish(
+      pub.fullTrackName,
+      forwarder,
+      session,
+      pub.requestID,
+      std::move(handle),
+      [&](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(pub.fullTrackName, f); }
+  );
+
+  if (publishEntry.evicted) {
     XLOG(DBG1) << "New publisher for existing subscription";
-    auto oldHandle = std::move(it->second.handle);
-    auto oldForwarder = std::move(it->second.forwarder);
-    XLOG(DBG4) << "Erasing subscription to " << it->first;
-    subscriptions_.erase(it);
-    if (oldHandle) {
-      oldHandle->unsubscribe();
-      oldForwarder->publishDone(
+    auto& evicted = *publishEntry.evicted;
+    if (evicted.handle) {
+      evicted.handle->unsubscribe();
+      evicted.forwarder->publishDone(
           {RequestID(0),
            PublishDoneStatusCode::SUBSCRIPTION_ENDED,
            0, // filled in by session
@@ -328,29 +325,7 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
     }
   }
 
-  // Create Forwarder for this publish
-  auto forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
-  forwarder->setExtensions(pub.extensions);
-
-  auto subRes = subscriptions_.emplace(
-      std::piecewise_construct,
-      std::forward_as_tuple(pub.fullTrackName),
-      std::forward_as_tuple(forwarder, session)
-  );
-  auto& rsub = subRes.first->second;
-  rsub.promise.setValue(folly::unit);
-  rsub.requestID = pub.requestID;
-  rsub.handle = std::move(handle);
-  rsub.isPublish = true;
-
-  // Build filter chain using shared helper (TopNFilter → TerminationFilter → Forwarder).
-  auto [filterConsumer, topNFilter] = buildFilterChain(pub.fullTrackName, forwarder);
-  rsub.topNFilter = topNFilter;
-
-  // Wire activity tracking: TopNFilter writes lastObjectTime on every object,
-  // and fires onActivity callbacks (throttled) for idle sweep triggering.
-  topNFilter->setActivityTarget(&rsub.lastObjectTime);
-  topNFilter->setActivityThreshold(activityThreshold_);
+  auto topNFilter = registry_.getTopNView(pub.fullTrackName)->topNFilter;
 
   // Register in the namespace tree. The ranking callback fires once per
   // PropertyRanking on the path from this node to the root — registering the
@@ -397,7 +372,7 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   bool shouldForward = (nSubscribers > 0) || hasTrackFilterSub;
 
   return PublishConsumerAndReplyTask{
-      filterConsumer,
+      publishEntry.consumer,
       folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(PublishOk{
           pub.requestID,
           /*forward=*/shouldForward,
@@ -523,12 +498,12 @@ std::shared_ptr<TrackConsumer> MoqxRelay::getSubscribeWriteback(
 ) {
   auto baseConsumer =
       cache_ ? cache_->getSubscribeWriteback(ftn, std::move(consumer)) : std::move(consumer);
-  auto filterConsumer =
+  auto termFilter =
       std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(baseConsumer));
-  return std::static_pointer_cast<TrackConsumer>(filterConsumer);
+  return std::static_pointer_cast<TrackConsumer>(termFilter);
 }
 
-MoqxRelay::FilterChainResult
+SubscriptionRegistry::FilterChainResult
 MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForwarder> forwarder) {
   // Build chain: TopNFilter → TerminationFilter → (cache?) → Forwarder
   // This ensures property values are observed in both PUBLISH and SUBSCRIBE paths.
@@ -538,8 +513,9 @@ MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForward
       std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(baseConsumer));
   auto topNFilter =
       std::make_shared<TopNFilter>(ftn, std::static_pointer_cast<TrackConsumer>(terminationFilter));
+  topNFilter->setActivityThreshold(activityThreshold_);
 
-  return FilterChainResult{
+  return SubscriptionRegistry::FilterChainResult{
       .consumer = std::static_pointer_cast<TrackConsumer>(topNFilter),
       .topNFilter = topNFilter
   };
@@ -654,12 +630,11 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
         node->forEachPublish([&](const std::string& trackName,
                                  const std::shared_ptr<MoQSession>& publishSession) {
           FullTrackName ftn{prefix, trackName};
-          auto subscriptionIt = subscriptions_.find(ftn);
-          if (subscriptionIt == subscriptions_.end()) {
+          auto forwarder = registry_.getForwarder(ftn);
+          if (!forwarder) {
             XLOG(ERR) << "Invalid state, no subscription for publish ftn=" << ftn;
             return;
           }
-          auto& forwarder = subscriptionIt->second.forwarder;
           auto maybeNegotiatedVersion = session->getNegotiatedVersion();
           CHECK(maybeNegotiatedVersion.has_value());
 
@@ -723,78 +698,42 @@ MoqxRelay::PublishState MoqxRelay::findPublishState(const FullTrackName& ftn) {
 folly::coro::Task<Publisher::SubscribeResult>
 MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
-  auto subscriptionIt = subscriptions_.find(subReq.fullTrackName);
-  // TOCTOU fix: if we might be the first subscriber, wait for the upstream
-  // connection before branching.  waitForConnected() is a suspension point —
-  // a concurrent coroutine may emplace this subscription while we are
-  // suspended.  Re-checking subscriptionIt afterwards ensures we take the
-  // second-subscriber path if that happened, avoiding a double
-  // promise.setValue() crash (folly::PromiseAlreadySatisfied → std::terminate).
-  if (subscriptionIt == subscriptions_.end() && upstream_) {
-    if (!namespaceTree_.findPublisherSession(subReq.fullTrackName.trackNamespace)) {
-      co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
-      subscriptionIt = subscriptions_.find(subReq.fullTrackName);
-    }
-  }
-  if (subscriptionIt == subscriptions_.end()) {
-    // first subscriber
+  const auto& ftn = subReq.fullTrackName;
 
-    // check auth
-    // get trackNamespace
-    if (subReq.fullTrackName.trackNamespace.empty()) {
-      // message error?
-      co_return folly::makeUnexpected(SubscribeError(
-          {subReq.requestID, SubscribeErrorCode::TRACK_NOT_EXIST, "namespace required"}
-      ));
-    }
-    auto upstreamSession = namespaceTree_.findPublisherSession(subReq.fullTrackName.trackNamespace);
+  if (ftn.trackNamespace.empty()) {
+    co_return folly::makeUnexpected(SubscribeError(
+        {subReq.requestID, SubscribeErrorCode::TRACK_NOT_EXIST, "namespace required"}
+    ));
+  }
+
+  // TOCTOU fix: if we might be the first subscriber, wait for the upstream
+  // connection before branching. A concurrent coroutine may emplace the entry
+  // while we are suspended, so we re-check inside getOrCreateFromSubscribe.
+  if (!registry_.exists(ftn) && upstream_ &&
+      !namespaceTree_.findPublisherSession(ftn.trackNamespace)) {
+    co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
+  }
+
+  auto firstOrSubsequent = registry_.getOrCreateFromSubscribe(
+      ftn,
+      shared_from_this(),
+      [this, &ftn](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(ftn, std::move(f)); }
+  );
+
+  if (auto* first = std::get_if<SubscriptionRegistry::FirstSubscriber>(&firstOrSubsequent)) {
+    auto upstreamSession = namespaceTree_.findPublisherSession(ftn.trackNamespace);
     if (!upstreamSession) {
-      // no such namespace has been published
       co_return folly::makeUnexpected(SubscribeError(
           {subReq.requestID, SubscribeErrorCode::TRACK_NOT_EXIST, "no such namespace or track"}
       ));
-    }
-    subReq.priority = kDefaultUpstreamPriority;
-    subReq.groupOrder = GroupOrder::Default;
-    // We only subscribe upstream with LargestObject. This is to satisfy other
-    // subscribers that join with narrower filters
-    subReq.locType = LocationType::LargestObject;
-    auto forwarder = std::make_shared<MoQForwarder>(subReq.fullTrackName, std::nullopt);
-    forwarder->setCallback(shared_from_this());
+    } // pending destructor fires on early return above
 
-    // Build filter chain using shared helper (TopNFilter → TerminationFilter → Forwarder).
-    // This ensures property values are observed even for SUBSCRIBE-path tracks,
-    // so TRACK_FILTER subscribers who join later see correct rankings.
-    auto [filterConsumer, topNFilter] = buildFilterChain(subReq.fullTrackName, forwarder);
-
-    auto emplaceRes = subscriptions_.emplace(
-        std::piecewise_construct,
-        std::forward_as_tuple(subReq.fullTrackName),
-        std::forward_as_tuple(forwarder, upstreamSession)
-    );
-    emplaceRes.first->second.topNFilter = topNFilter;
-    // The iterator returned from emplace does not survive across coroutine
-    // resumption, so both the guard and updating the RelaySubscription below
-    // require another lookup in the subscriptions_ map.
-    // Capture forwarder identity: a reconnecting publisher may replace this
-    // entry before we resume, leaving a new entry with a satisfied promise.
-    auto g = folly::makeGuard(
-        [this, trackName = subReq.fullTrackName, weakForwarder = std::weak_ptr(forwarder)] {
-          auto it = subscriptions_.find(trackName);
-          if (it != subscriptions_.end() && it->second.forwarder == weakForwarder.lock()) {
-            it->second.promise.setException(std::runtime_error("failed"));
-            XLOG(DBG4) << "Erasing subscription to " << it->first;
-            subscriptions_.erase(it);
-          } else {
-            // Entry was replaced by a reconnecting publisher; don't touch it.
-            XLOG(DBG4) << "Skipping stale guard for " << trackName;
-          }
-        }
-    );
-    // Add subscriber first in case objects come before subscribe OK.
-    auto subscriber = forwarder->addSubscriber(std::move(session), subReq, std::move(consumer));
+    // Add subscriber first (with the client's original request) in case objects
+    // arrive before subscribe OK.
+    auto subscriber =
+        first->forwarder->addSubscriber(std::move(session), subReq, std::move(consumer));
     if (!subscriber) {
-      XLOG(ERR) << "addSubscriber returned null (draining?) for " << subReq.fullTrackName
+      XLOG(ERR) << "addSubscriber returned null (draining?) for " << ftn
                 << " reqID=" << subReq.requestID;
       co_return folly::makeUnexpected(SubscribeError{
           subReq.requestID,
@@ -802,80 +741,68 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
           "failed to add subscriber"
       });
     }
-    XLOG(DBG4) << "added subscriber for ftn=" << subReq.fullTrackName;
-    // As per the spec, we must set forward = true in the subscribe request
-    // to the upstream.
-    // But should we if this is forward=0?
-    subReq.forward = forwarder->numForwardingSubscribers() > 0;
+    XLOG(DBG4) << "added subscriber for ftn=" << ftn;
 
-    emplaceRes.first->second.requestID = upstreamSession->peekNextRequestID();
-    auto subRes = co_await upstreamSession->subscribe(subReq, filterConsumer);
+    // Override fields for the upstream subscribe: always request from latest,
+    // upstream priority, and default group order.
+    const auto clientRequestID = subReq.requestID;
+    subReq.priority = kDefaultUpstreamPriority;
+    subReq.groupOrder = GroupOrder::Default;
+    subReq.locType = LocationType::LargestObject;
+    // Per the spec, we're supposed to always forward=1 upstream
+    subReq.forward = first->forwarder->numForwardingSubscribers() > 0;
+    subReq.requestID = upstreamSession->peekNextRequestID();
+
+    auto subRes = co_await upstreamSession->subscribe(subReq, first->consumer);
     if (subRes.hasError()) {
       co_return folly::makeUnexpected(SubscribeError(
-          {subReq.requestID,
+          {clientRequestID,
            subRes.error().errorCode,
            folly::to<std::string>("upstream subscribe failed: ", subRes.error().reasonPhrase)}
       ));
-    }
-    // is it more correct to co_await folly::coro::co_safe_point here?
-    g.dismiss();
+    } // pending destructor fires on error
+
     auto largest = subRes.value()->subscribeOk().largest;
     if (largest) {
-      forwarder->updateLargest(largest->group, largest->object);
+      first->forwarder->updateLargest(largest->group, largest->object);
       subscriber->updateLargest(*largest);
     }
-    // Save upstream extensions to forwarder (and existing subscribers) and
-    // cache
     auto& upstreamExtensions = subRes.value()->subscribeOk().extensions;
-    forwarder->setExtensions(upstreamExtensions);
+    first->forwarder->setExtensions(upstreamExtensions);
     if (cache_) {
-      cache_->setTrackExtensions(subReq.fullTrackName, upstreamExtensions);
+      cache_->setTrackExtensions(ftn, upstreamExtensions);
     }
 
-    auto it = subscriptions_.find(subReq.fullTrackName);
-    // There are cases that remove the subscription like failing to
-    // publish a datagram that was received before the subscribeOK
-    // and then gets flushed.  Also guard against a reconnecting publisher
-    // replacing the entry while we were suspended.
-    if (it == subscriptions_.end()) {
-      XLOG(ERR) << "Subscription is GONE, returning exception";
-      co_yield folly::coro::co_error(std::runtime_error("subscription is gone"));
-    }
-    if (it->second.forwarder != forwarder) {
-      XLOG(ERR) << "Subscription replaced by reconnecting publisher: " << subReq.fullTrackName;
+    // Record NGR as outstanding (no fire — it rides the outgoing SUBSCRIBE).
+    first->forwarder->tryProcessNewGroupRequest(subReq.params, /*fire=*/false);
+
+    auto requestID = subRes.value()->subscribeOk().requestID;
+    if (!first->pending.complete(std::move(subRes.value()), requestID, upstreamSession)) {
+      XLOG(ERR) << "Subscription replaced by reconnecting publisher: " << ftn;
       co_return folly::makeUnexpected(SubscribeError{
-          subReq.requestID,
+          clientRequestID,
           SubscribeErrorCode::INTERNAL_ERROR,
           "publisher reconnected during subscribe"
       });
     }
-    auto& rsub = it->second;
-    rsub.requestID = subRes.value()->subscribeOk().requestID;
-    rsub.handle = std::move(subRes.value());
-    // Record NGR as outstanding (no fire — it rides the outgoing SUBSCRIBE).
-    forwarder->tryProcessNewGroupRequest(subReq.params, /*fire=*/false);
-    rsub.promise.setValue(folly::unit);
     co_return subscriber;
+
   } else {
-    if (!subscriptionIt->second.promise.isFulfilled()) {
-      // this will throw if the dependent subscribe failed, which is good
-      // because subscriptionIt will be invalid
-      co_await subscriptionIt->second.promise.getFuture();
-    }
-    auto& forwarder = subscriptionIt->second.forwarder;
-    if (forwarder->largest() && subReq.locType == LocationType::AbsoluteRange &&
-        subReq.endGroup < forwarder->largest()->group) {
+    auto sub = co_await std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
+        std::move(firstOrSubsequent)
+    );
+    // sub.forwarder is valid: promise was fulfilled by first subscriber
+    if (sub.forwarder->largest() && subReq.locType == LocationType::AbsoluteRange &&
+        subReq.endGroup < sub.forwarder->largest()->group) {
       co_return folly::makeUnexpected(SubscribeError{
           subReq.requestID,
           SubscribeErrorCode::INVALID_RANGE,
           "Range in the past, use FETCH"
       });
-      // start may be in the past, it will get adjusted forward to largest
     }
-    auto subscriber = subscriptionIt->second.forwarder
-                          ->addSubscriber(std::move(session), subReq, std::move(consumer));
+    auto subscriber = sub.forwarder->addSubscriber(std::move(session), subReq, std::move(consumer));
     if (!subscriber) {
-      XLOG(ERR) << "addSubscriber returned null (draining?) for " << subReq.fullTrackName
+      XLOG(ERR) << "addSubscriber returned null (draining?) for " << ftn
                 << " reqID=" << subReq.requestID;
       co_return folly::makeUnexpected(SubscribeError{
           subReq.requestID,
@@ -883,10 +810,8 @@ MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> con
           "failed to add subscriber"
       });
     }
-    XLOG(DBG4) << "added subscriber for ftn=" << subReq.fullTrackName;
-    // forward updates handled by forwardChanged() via addForwardingSubscriber()
-
-    forwarder->tryProcessNewGroupRequest(subReq.params);
+    XLOG(DBG4) << "added subscriber for ftn=" << ftn;
+    sub.forwarder->tryProcessNewGroupRequest(subReq.params);
     co_return subscriber;
   }
 }
@@ -905,15 +830,14 @@ MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
 
   auto [standalone, joining] = fetchType(fetch);
   if (joining) {
-    auto subscriptionIt = subscriptions_.find(fetch.fullTrackName);
-    if (subscriptionIt == subscriptions_.end()) {
+    auto fetchView = registry_.getFetchView(fetch.fullTrackName);
+    if (!fetchView) {
       XLOG(ERR) << "No subscription for joining fetch";
-      // message error
       co_return folly::makeUnexpected(FetchError(
           {fetch.requestID, FetchErrorCode::TRACK_NOT_EXIST, "No subscription for joining fetch"}
       ));
-    } else if (subscriptionIt->second.promise.isFulfilled()) {
-      auto res = subscriptionIt->second.forwarder->resolveJoiningFetch(session, *joining);
+    } else if (fetchView->isReady) {
+      auto res = fetchView->forwarder->resolveJoiningFetch(session, *joining);
       if (res.hasError()) {
         co_return folly::makeUnexpected(res.error());
       }
@@ -921,7 +845,7 @@ MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
       joining = nullptr;
     } else {
       // Upstream is resolving the subscribe, forward joining fetch
-      joining->joiningRequestID = subscriptionIt->second.requestID;
+      joining->joiningRequestID = fetchView->requestID;
     }
   }
 
@@ -932,9 +856,8 @@ MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   }
   if (!upstreamSession) {
     // Attempt to find matching upstream subscription (from publish)
-    auto subscriptionIt = subscriptions_.find(fetch.fullTrackName);
-    if (subscriptionIt != subscriptions_.end()) {
-      upstreamSession = subscriptionIt->second.upstream;
+    if (auto fetchView = registry_.getFetchView(fetch.fullTrackName)) {
+      upstreamSession = fetchView->upstream;
     }
     if (!upstreamSession) {
       co_return folly::makeUnexpected(
@@ -970,20 +893,18 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatus(TrackStat
     ));
   }
 
-  auto subscriptionIt = subscriptions_.find(trackStatus.fullTrackName);
-  if (subscriptionIt != subscriptions_.end() &&
-      subscriptionIt->second.forwarder->numForwardingSubscribers() > 0) {
+  auto upstreamView = registry_.getUpstreamView(trackStatus.fullTrackName);
+  if (upstreamView && upstreamView->forwarder->numForwardingSubscribers() > 0) {
     // We have active subscription - answer directly from local forwarder state
-    auto& subscription = subscriptionIt->second;
-    auto& forwarder = subscription.forwarder;
+    auto& forwarder = upstreamView->forwarder;
 
     TrackStatusCode statusCode = TrackStatusCode::TRACK_NOT_STARTED;
     // forwarder->largest() being set means: we have actually
     // received at least one object for this track.
-    // subscription.handle being non-null means: the relay still has a
+    // upstreamView->handle being non-null means: the relay still has a
     // live upstream Publisher::SubscriptionHandle for this track
     if (forwarder->largest()) {
-      if (subscription.handle) {
+      if (upstreamView->handle) {
         statusCode = TrackStatusCode::IN_PROGRESS;
       } else {
         statusCode = TrackStatusCode::UNKNOWN;
@@ -1031,57 +952,56 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatus(TrackStat
 }
 
 void MoqxRelay::onEmpty(MoQForwarder* forwarder) {
-  auto subscriptionIt = subscriptions_.find(forwarder->fullTrackName());
-  if (subscriptionIt == subscriptions_.end()) {
+  const auto& ftn = forwarder->fullTrackName();
+  auto upstreamView = registry_.getUpstreamView(ftn);
+  if (!upstreamView) {
     return;
   }
-  auto& subscription = subscriptionIt->second;
 
-  if (!subscription.handle) {
+  if (!upstreamView->handle) {
     // Handle is null - publisher terminated via FilterConsumer
-    XLOG(INFO) << "Publisher terminated for " << subscriptionIt->first;
-    subscriptions_.erase(subscriptionIt);
+    XLOG(INFO) << "Publisher terminated for " << ftn;
+    registry_.remove(ftn);
     return;
   }
 
   // Handle exists - just last subscriber left
-  XLOG(INFO) << "Last subscriber removed for " << subscriptionIt->first;
-  if (subscription.isPublish) {
+  XLOG(INFO) << "Last subscriber removed for " << ftn;
+  if (upstreamView->isPublish) {
     // if it's publish, don't unsubscribe, just subscribeUpdate forward=false
     XLOG(DBG1) << "Updating upstream subscription forward=false";
-    auto exec = subscription.upstream->getExecutor();
-    co_withExecutor(exec, doSubscribeUpdate(subscription.handle, /*forward=*/false)).start();
+    auto exec = upstreamView->upstream->getExecutor();
+    co_withExecutor(exec, doSubscribeUpdate(upstreamView->handle, /*forward=*/false)).start();
   } else {
-    subscription.handle->unsubscribe();
-    XLOG(DBG4) << "Erasing subscription to " << subscriptionIt->first;
-    subscriptions_.erase(subscriptionIt);
+    upstreamView->handle->unsubscribe();
+    XLOG(DBG4) << "Erasing subscription to " << ftn;
+    registry_.remove(ftn);
   }
 }
 
 void MoqxRelay::forwardChanged(MoQForwarder* forwarder) {
-  auto subscriptionIt = subscriptions_.find(forwarder->fullTrackName());
-  if (subscriptionIt == subscriptions_.end()) {
+  const auto& ftn = forwarder->fullTrackName();
+  auto upstreamView = registry_.getUpstreamView(ftn);
+  if (!upstreamView) {
     return;
   }
-  auto& subscription = subscriptionIt->second;
-  if (!subscription.promise.isFulfilled()) {
+  if (!upstreamView->isReady) {
     // Ignore: it's the first subscriber, forward update not needed
     return;
   }
-  if (!subscription.handle) {
+  if (!upstreamView->handle) {
     // Publisher terminated (onPublishDone cleared handle/upstream)
-    XLOG(DBG4) << "Ignoring forward change for " << subscriptionIt->first
-               << " - publisher terminated";
+    XLOG(DBG4) << "Ignoring forward change for " << ftn << " - publisher terminated";
     return;
   }
-  XLOG(INFO) << "Updating forward for " << subscriptionIt->first
+  XLOG(INFO) << "Updating forward for " << ftn
              << " numForwardingSubs=" << forwarder->numForwardingSubscribers();
 
-  auto exec = subscription.upstream->getExecutor();
+  auto exec = upstreamView->upstream->getExecutor();
   co_withExecutor(
       exec,
       doSubscribeUpdate(
-          subscription.handle,
+          upstreamView->handle,
           /*forward=*/forwarder->numForwardingSubscribers() > 0
       )
   )
@@ -1089,21 +1009,17 @@ void MoqxRelay::forwardChanged(MoQForwarder* forwarder) {
 }
 
 void MoqxRelay::newGroupRequested(MoQForwarder* forwarder, uint64_t group) {
-  auto subscriptionIt = subscriptions_.find(forwarder->fullTrackName());
-  if (subscriptionIt == subscriptions_.end()) {
-    return;
-  }
-  auto& subscription = subscriptionIt->second;
+  const auto& ftn = forwarder->fullTrackName();
+  auto upstreamView = registry_.getUpstreamView(ftn);
   // Check if handle is still valid (publisher may have terminated)
-  if (!subscription.handle) {
-    XLOG(DBG4) << "Ignoring NEW_GROUP_REQUEST for " << subscriptionIt->first
-               << " - publisher terminated";
+  if (!upstreamView || !upstreamView->handle) {
+    XLOG(DBG4) << "Ignoring NEW_GROUP_REQUEST for " << ftn << " - publisher terminated";
     return;
   }
-  XLOG(INFO) << "New group request detected for " << subscriptionIt->first;
+  XLOG(INFO) << "New group request detected for " << ftn;
 
-  auto exec = subscription.upstream->getExecutor();
-  auto handle = subscription.handle;
+  auto exec = upstreamView->upstream->getExecutor();
+  auto handle = upstreamView->handle;
   co_withExecutor(exec, doNewGroupRequestUpdate(std::move(handle), group)).start();
 }
 
@@ -1122,11 +1038,8 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
         idleTimeout_,
         std::chrono::milliseconds(0), // sweepThrottle wired in subsequent commit
         [this](const FullTrackName& ftn) -> std::chrono::steady_clock::time_point {
-          auto it = subscriptions_.find(ftn);
-          if (it == subscriptions_.end()) {
-            return std::chrono::steady_clock::time_point{};
-          }
-          return it->second.lastObjectTime;
+          auto view = registry_.getTopNView(ftn);
+          return view ? view->lastObjectTime : std::chrono::steady_clock::time_point{};
         },
         // Batch callback: called once per track-selected event with all sessions
         [this](
@@ -1172,15 +1085,15 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
             FullTrackName ftn{prefix, trackName};
             std::optional<uint64_t> initialPropertyValue;
             std::chrono::steady_clock::time_point lastObjectTime{};
-            auto subIt = subscriptions_.find(ftn);
-            if (subIt != subscriptions_.end()) {
-              lastObjectTime = subIt->second.lastObjectTime;
+            auto topNView = registry_.getTopNView(ftn);
+            if (topNView) {
+              lastObjectTime = topNView->lastObjectTime;
               initialPropertyValue =
-                  subIt->second.forwarder->extensions().getIntExtension(propertyType);
+                  topNView->forwarder->extensions().getIntExtension(propertyType);
               // Wire value-change, track-ended, and activity observers on the existing TopNFilter.
-              if (subIt->second.topNFilter) {
+              if (topNView->topNFilter) {
                 auto rankingPtr = ranking;
-                subIt->second.topNFilter->registerObserver(
+                topNView->topNFilter->registerObserver(
                     propertyType,
                     PropertyObserver{
                         .onValueChanged = [rankingPtr, ftn](uint64_t value
@@ -1227,8 +1140,8 @@ void MoqxRelay::onTrackSelected(
     return;
   }
 
-  auto subIt = subscriptions_.find(ftn);
-  if (subIt == subscriptions_.end() || !subIt->second.forwarder) {
+  auto trackForwarder = registry_.getForwarder(ftn);
+  if (!trackForwarder) {
     XLOG(DBG4) << "onTrackSelected: no subscription/forwarder for " << ftn;
     return;
   }
@@ -1240,7 +1153,7 @@ void MoqxRelay::onTrackSelected(
   // when multiple tracks are selected for the same session in a single ranking update.
   co_withExecutor(
       exec,
-      publishToSession(session, subIt->second.forwarder, forward, /*trackFilterSubscriber=*/true)
+      publishToSession(session, trackForwarder, forward, /*trackFilterSubscriber=*/true)
   )
       .start();
 }
@@ -1253,15 +1166,10 @@ void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSess
     return;
   }
 
-  auto subIt = subscriptions_.find(ftn);
-  if (subIt == subscriptions_.end()) {
+  auto forwarder = registry_.getForwarder(ftn);
+  if (!forwarder) {
     return;
   }
-
-  if (!subIt->second.forwarder) {
-    return;
-  }
-  auto& forwarder = subIt->second.forwarder;
   auto sub = forwarder->getSubscriber(session.get());
   if (!sub || sub->isPinned()) {
     XLOG(DBG4) << "onTrackEvicted: pinned subscriber, skipping";
@@ -1285,23 +1193,23 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
   visitor.onPeersEnd();
 
   visitor.onSubscriptionsBegin();
-  for (const auto& [ftn, sub] : subscriptions_) {
+  registry_.forEach([&](const SubscriptionRegistry::EntryView& e) {
     std::string sourceAddr;
-    if (sub.upstream) {
-      sourceAddr = sub.upstream->getPeerAddress().describe();
+    if (e.upstream) {
+      sourceAddr = e.upstream->getPeerAddress().describe();
     }
     RelayStateVisitor::SubscriptionInfo info{
-        .ftn = ftn,
-        .isPublish = sub.isPublish,
-        .subscribers = sub.forwarder->subscriberCount(),
-        .forwardingSubscribers = sub.forwarder->numForwardingSubscribers(),
-        .largest = sub.forwarder->largest(),
-        .totalGroupsReceived = sub.forwarder->totalGroupsReceived(),
-        .totalObjectsReceived = sub.forwarder->totalObjectsReceived(),
+        .ftn = e.ftn,
+        .isPublish = e.isPublish,
+        .subscribers = e.forwarder->subscriberCount(),
+        .forwardingSubscribers = e.forwarder->numForwardingSubscribers(),
+        .largest = e.forwarder->largest(),
+        .totalGroupsReceived = e.forwarder->totalGroupsReceived(),
+        .totalObjectsReceived = e.forwarder->totalObjectsReceived(),
         .sourceAddress = sourceAddr,
     };
     visitor.onSubscription(info);
-  }
+  });
   visitor.onSubscriptionsEnd();
 
   visitor.onNamespaceTreeBegin();

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -9,11 +9,10 @@
 #pragma once
 
 #include "NamespaceTree.h"
+#include "SubscriptionRegistry.h"
 #include "UpstreamProvider.h"
 #include "config/Config.h"
 #include "relay/PropertyRanking.h"
-#include "relay/TopNFilter.h"
-#include <folly/coro/SharedPromise.h>
 #include <moxygen/MoQSession.h>
 #include <moxygen/relay/MoQCache.h>
 #include <moxygen/relay/MoQForwarder.h>
@@ -246,30 +245,6 @@ private:
 
   NamespaceTree namespaceTree_{*this};
 
-  struct RelaySubscription {
-    RelaySubscription(
-        std::shared_ptr<moxygen::MoQForwarder> f,
-        std::shared_ptr<moxygen::MoQSession> u
-    )
-        : forwarder(std::move(f)), upstream(std::move(u)),
-          lastObjectTime(std::chrono::steady_clock::now()) {}
-
-    std::shared_ptr<moxygen::MoQForwarder> forwarder;
-    std::shared_ptr<moxygen::MoQSession> upstream;
-    moxygen::RequestID requestID{0};
-    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle;
-    folly::coro::SharedPromise<folly::Unit> promise;
-    bool isPublish{false};
-
-    // TopNFilter installed in the publisher's filter chain for property observation
-    std::shared_ptr<TopNFilter> topNFilter;
-
-    // Written by TopNFilter on every object arrival; read by PropertyRanking::sweepIdle
-    // via the getLastActivity_ callback. Initialized to now() so newly registered tracks
-    // are not immediately eligible for idle eviction.
-    std::chrono::steady_clock::time_point lastObjectTime;
-  };
-
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
   void forwardChanged(moxygen::MoQForwarder* forwarder) override;
   void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override;
@@ -297,16 +272,9 @@ private:
 
   // TRACK_FILTER support
 
-  // Result of buildFilterChain - contains both the consumer to pass upstream
-  // and the TopNFilter pointer to store for later observer wiring.
-  struct FilterChainResult {
-    std::shared_ptr<moxygen::TrackConsumer> consumer;
-    std::shared_ptr<TopNFilter> topNFilter;
-  };
-
   // Build the filter chain for a track subscription: TopNFilter → TerminationFilter → (cache) →
   // forwarder. Used by both publish() and subscribe() paths to ensure consistent filter chain.
-  FilterChainResult buildFilterChain(
+  SubscriptionRegistry::FilterChainResult buildFilterChain(
       const moxygen::FullTrackName& ftn,
       std::shared_ptr<moxygen::MoQForwarder> forwarder
   );
@@ -347,8 +315,7 @@ private:
   // connected to us. Kept alive so the subscription is not immediately
   // cancelled. Keyed by raw session pointer (valid for session lifetime).
   folly::F14FastMap<moxygen::MoQSession*, PeerInfo> peerSubNsHandles_;
-  folly::F14NodeMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
-      subscriptions_;
+  SubscriptionRegistry registry_;
 
   std::shared_ptr<moxygen::TrackConsumer> getSubscribeWriteback(
       const moxygen::FullTrackName& ftn,

--- a/src/SubscriptionRegistry.cpp
+++ b/src/SubscriptionRegistry.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ */
+
+#include "SubscriptionRegistry.h"
+
+#include <folly/logging/xlog.h>
+
+namespace openmoq::moqx {
+
+// === UpstreamSubscribePending ===
+
+bool SubscriptionRegistry::UpstreamSubscribePending::complete(
+    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+    moxygen::RequestID requestID,
+    std::shared_ptr<moxygen::MoQSession> upstreamSession
+) {
+  active_ = false;
+  return registry_->completeSubscription(
+      ftn_,
+      weakForwarder_,
+      std::move(handle),
+      requestID,
+      std::move(upstreamSession)
+  );
+}
+
+SubscriptionRegistry::UpstreamSubscribePending::~UpstreamSubscribePending() {
+  if (active_) {
+    registry_->failAndRemove(ftn_, weakForwarder_);
+  }
+}
+
+// === SubscriptionRegistry ===
+
+std::variant<
+    SubscriptionRegistry::FirstSubscriber,
+    folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>
+SubscriptionRegistry::getOrCreateFromSubscribe(
+    const moxygen::FullTrackName& ftn,
+    std::shared_ptr<moxygen::MoQForwarder::Callback> callback,
+    folly::FunctionRef<FilterChainResult(std::shared_ptr<moxygen::MoQForwarder>)> chainBuilder,
+    std::optional<moxygen::AbsoluteLocation> largest
+) {
+  auto it = subscriptions_.find(ftn);
+  if (it == subscriptions_.end()) {
+    auto forwarder = std::make_shared<moxygen::MoQForwarder>(ftn, largest);
+    forwarder->setCallback(std::move(callback));
+    auto [consumer, topNFilter] = chainBuilder(forwarder);
+    auto [emplaceIt, inserted] = subscriptions_.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(ftn),
+        std::forward_as_tuple(forwarder, nullptr)
+    );
+    emplaceIt->second.topNFilter = topNFilter;
+    return FirstSubscriber{
+        forwarder,
+        std::move(consumer),
+        UpstreamSubscribePending{this, ftn, forwarder}
+    };
+  }
+
+  // Subsequent subscriber: await in a proper coroutine function (not a lambda)
+  // so the parameters live in the heap-allocated coroutine frame, not on the
+  // stack of getOrCreateFromSubscribe.
+  return awaitSubsequent(this, ftn, it->second.promise.getFuture());
+}
+
+folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber> SubscriptionRegistry::awaitSubsequent(
+    SubscriptionRegistry* registry,
+    moxygen::FullTrackName ftn,
+    folly::coro::Future<folly::Unit> future
+) {
+  co_await std::move(future);                    // throws on first-subscriber failure
+  auto sit = registry->subscriptions_.find(ftn); // MUST re-find after suspension
+  if (sit == registry->subscriptions_.end()) {
+    XLOG(ERR) << "Subscription is GONE for " << ftn;
+    co_yield folly::coro::co_error(std::runtime_error("subscription gone"));
+  }
+  co_return SubsequentSubscriber{sit->second.forwarder};
+}
+
+bool SubscriptionRegistry::completeSubscription(
+    const moxygen::FullTrackName& ftn,
+    std::weak_ptr<moxygen::MoQForwarder> weakForwarder,
+    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+    moxygen::RequestID requestID,
+    std::shared_ptr<moxygen::MoQSession> upstreamSession
+) {
+  auto it = subscriptions_.find(ftn);
+  if (it == subscriptions_.end() || it->second.forwarder != weakForwarder.lock()) {
+    return false;
+  }
+  auto& rsub = it->second;
+  rsub.handle = std::move(handle);
+  rsub.requestID = requestID;
+  rsub.upstream = std::move(upstreamSession);
+  rsub.promise.setValue(folly::unit);
+  return true;
+}
+
+void SubscriptionRegistry::failAndRemove(
+    const moxygen::FullTrackName& ftn,
+    std::weak_ptr<moxygen::MoQForwarder> weakForwarder
+) {
+  auto it = subscriptions_.find(ftn);
+  if (it != subscriptions_.end() && it->second.forwarder == weakForwarder.lock()) {
+    it->second.promise.setException(std::runtime_error("upstream subscribe failed"));
+    subscriptions_.erase(it);
+  }
+}
+
+SubscriptionRegistry::PublishEntry SubscriptionRegistry::createFromPublish(
+    const moxygen::FullTrackName& ftn,
+    std::shared_ptr<moxygen::MoQForwarder> forwarder,
+    std::shared_ptr<moxygen::MoQSession> session,
+    moxygen::RequestID requestID,
+    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+    folly::FunctionRef<FilterChainResult(std::shared_ptr<moxygen::MoQForwarder>)> chainBuilder
+) {
+  std::optional<Evicted> evicted;
+
+  // Move out forwarder+handle before erasing to avoid use-after-free:
+  // publishDone → onEmpty may fire during the erase.
+  auto it = subscriptions_.find(ftn);
+  if (it != subscriptions_.end()) {
+    evicted = Evicted{std::move(it->second.forwarder), std::move(it->second.handle)};
+    subscriptions_.erase(it);
+  }
+
+  auto [emplaceIt, inserted] = subscriptions_.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(ftn),
+      std::forward_as_tuple(forwarder, session)
+  );
+  auto& rsub = emplaceIt->second;
+  rsub.promise.setValue(folly::unit);
+  rsub.requestID = requestID;
+  rsub.handle = std::move(handle);
+  rsub.isPublish = true;
+
+  auto [consumer, topNFilter] = chainBuilder(forwarder);
+  rsub.topNFilter = topNFilter;
+  topNFilter->setActivityTarget(&rsub.lastObjectTime);
+
+  return PublishEntry{std::move(consumer), std::move(evicted)};
+}
+
+bool SubscriptionRegistry::exists(const moxygen::FullTrackName& ftn) const {
+  return subscriptions_.find(ftn) != subscriptions_.end();
+}
+
+std::shared_ptr<moxygen::MoQForwarder>
+SubscriptionRegistry::getForwarder(const moxygen::FullTrackName& ftn) const {
+  auto it = subscriptions_.find(ftn);
+  return it != subscriptions_.end() ? it->second.forwarder : nullptr;
+}
+
+std::optional<SubscriptionRegistry::TopNView>
+SubscriptionRegistry::getTopNView(const moxygen::FullTrackName& ftn) const {
+  auto it = subscriptions_.find(ftn);
+  if (it == subscriptions_.end()) {
+    return std::nullopt;
+  }
+  return TopNView{it->second.forwarder, it->second.topNFilter, it->second.lastObjectTime};
+}
+
+std::optional<SubscriptionRegistry::UpstreamView>
+SubscriptionRegistry::getUpstreamView(const moxygen::FullTrackName& ftn) const {
+  auto it = subscriptions_.find(ftn);
+  if (it == subscriptions_.end()) {
+    return std::nullopt;
+  }
+  const auto& rsub = it->second;
+  return UpstreamView{
+      rsub.forwarder,
+      rsub.upstream,
+      rsub.handle,
+      rsub.requestID,
+      rsub.isPublish,
+      rsub.promise.isFulfilled()
+  };
+}
+
+std::optional<SubscriptionRegistry::FetchView>
+SubscriptionRegistry::getFetchView(const moxygen::FullTrackName& ftn) const {
+  auto it = subscriptions_.find(ftn);
+  if (it == subscriptions_.end()) {
+    return std::nullopt;
+  }
+  const auto& rsub = it->second;
+  return FetchView{rsub.forwarder, rsub.upstream, rsub.requestID, rsub.promise.isFulfilled()};
+}
+
+std::shared_ptr<moxygen::MoQForwarder>
+SubscriptionRegistry::onPublisherTerminated(const moxygen::FullTrackName& ftn) {
+  auto it = subscriptions_.find(ftn);
+  if (it == subscriptions_.end()) {
+    return nullptr;
+  }
+  auto& rsub = it->second;
+  rsub.handle.reset();
+  rsub.upstream.reset();
+  if (rsub.forwarder->empty()) {
+    subscriptions_.erase(it);
+    return nullptr;
+  }
+  return rsub.forwarder;
+}
+
+void SubscriptionRegistry::remove(const moxygen::FullTrackName& ftn) {
+  subscriptions_.erase(ftn);
+}
+
+void SubscriptionRegistry::removeIf(
+    folly::FunctionRef<bool(const moxygen::FullTrackName&, const EntryView&)> predicate
+) {
+  for (auto it = subscriptions_.begin(); it != subscriptions_.end();) {
+    EntryView view{
+        it->first,
+        it->second.forwarder,
+        it->second.upstream,
+        it->second.isPublish,
+        it->second.lastObjectTime
+    };
+    if (predicate(it->first, view)) {
+      it = subscriptions_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void SubscriptionRegistry::forEach(folly::FunctionRef<void(const EntryView&)> fn) const {
+  for (const auto& [ftn, rsub] : subscriptions_) {
+    fn(EntryView{ftn, rsub.forwarder, rsub.upstream, rsub.isPublish, rsub.lastObjectTime});
+  }
+}
+
+} // namespace openmoq::moqx

--- a/src/SubscriptionRegistry.h
+++ b/src/SubscriptionRegistry.h
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ */
+
+#pragma once
+
+#include "relay/TopNFilter.h"
+#include <folly/Function.h>
+#include <folly/container/F14Map.h>
+#include <folly/coro/SharedPromise.h>
+#include <folly/coro/Task.h>
+#include <moxygen/MoQSession.h>
+#include <moxygen/relay/MoQForwarder.h>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <variant>
+
+namespace openmoq::moqx {
+
+class SubscriptionRegistry {
+public:
+  struct FilterChainResult {
+    std::shared_ptr<moxygen::TrackConsumer> consumer;
+    std::shared_ptr<TopNFilter> topNFilter;
+  };
+
+  // === Subscribe path ===
+
+  // Represents the window between emplacing a new subscription entry and the
+  // upstream subscribe completing. complete() closes it on success; the destructor
+  // closes it on failure (sets exception on promise, erases entry).
+  // Does NOT undo addSubscriber() — only cleans up the registry entry.
+  class UpstreamSubscribePending {
+  public:
+    UpstreamSubscribePending(
+        SubscriptionRegistry* registry,
+        moxygen::FullTrackName ftn,
+        std::weak_ptr<moxygen::MoQForwarder> weakForwarder
+    )
+        : registry_(registry), ftn_(std::move(ftn)), weakForwarder_(std::move(weakForwarder)) {}
+
+    UpstreamSubscribePending(UpstreamSubscribePending&& o) noexcept
+        : registry_(o.registry_), ftn_(std::move(o.ftn_)),
+          weakForwarder_(std::move(o.weakForwarder_)), active_(o.active_) {
+      o.active_ = false;
+    }
+
+    UpstreamSubscribePending& operator=(UpstreamSubscribePending&&) = delete;
+    UpstreamSubscribePending(const UpstreamSubscribePending&) = delete;
+    UpstreamSubscribePending& operator=(const UpstreamSubscribePending&) = delete;
+
+    // Identity-checked success path. Re-finds by ftn; checks forwarder identity
+    // to detect a reconnecting publisher that replaced the entry during the
+    // caller's co_await suspension. Sets handle, requestID, upstreamSession;
+    // fulfills promise. Returns false if entry is gone or replaced.
+    bool complete(
+        std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+        moxygen::RequestID requestID,
+        std::shared_ptr<moxygen::MoQSession> upstreamSession
+    );
+
+    ~UpstreamSubscribePending();
+
+  private:
+    SubscriptionRegistry* registry_;
+    moxygen::FullTrackName ftn_;
+    std::weak_ptr<moxygen::MoQForwarder> weakForwarder_;
+    bool active_{true};
+  };
+
+  struct FirstSubscriber {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    std::shared_ptr<moxygen::TrackConsumer> consumer;
+    UpstreamSubscribePending pending;
+  };
+
+  struct SubsequentSubscriber {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+  };
+
+  // Synchronous. First path: creates entry, calls chainBuilder, returns
+  // FirstSubscriber immediately. Subsequent path: returns a Task that
+  // co_awaits the promise then re-finds (throws on first-subscriber failure).
+  std::variant<FirstSubscriber, folly::coro::Task<SubsequentSubscriber>> getOrCreateFromSubscribe(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQForwarder::Callback> callback,
+      folly::FunctionRef<FilterChainResult(std::shared_ptr<moxygen::MoQForwarder>)> chainBuilder,
+      std::optional<moxygen::AbsoluteLocation> largest = std::nullopt
+  );
+
+  // === Publish path ===
+
+  struct Evicted {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle; // may be null
+  };
+
+  struct PublishEntry {
+    std::shared_ptr<moxygen::TrackConsumer> consumer;
+    std::optional<Evicted> evicted;
+  };
+
+  // Creates entry, pre-fulfills promise, wires activity tracking.
+  // Evicts any prior entry before emplacing — caller must call
+  // publishDone/unsubscribe on evicted data.
+  PublishEntry createFromPublish(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQForwarder> forwarder,
+      std::shared_ptr<moxygen::MoQSession> session,
+      moxygen::RequestID requestID,
+      std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+      folly::FunctionRef<FilterChainResult(std::shared_ptr<moxygen::MoQForwarder>)> chainBuilder
+  );
+
+  // === Lookup ===
+
+  bool exists(const moxygen::FullTrackName& ftn) const;
+  std::shared_ptr<moxygen::MoQForwarder> getForwarder(const moxygen::FullTrackName& ftn) const;
+
+  struct TopNView {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    std::shared_ptr<TopNFilter> topNFilter; // may be null for subscribe-path tracks
+    std::chrono::steady_clock::time_point lastObjectTime;
+  };
+  std::optional<TopNView> getTopNView(const moxygen::FullTrackName& ftn) const;
+
+  // For onEmpty / forwardChanged / newGroupRequested
+  struct UpstreamView {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    std::shared_ptr<moxygen::MoQSession> upstream;
+    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle;
+    moxygen::RequestID requestID;
+    bool isPublish;
+    bool isReady; // promise fulfilled
+  };
+  std::optional<UpstreamView> getUpstreamView(const moxygen::FullTrackName& ftn) const;
+
+  // For fetch()
+  struct FetchView {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    std::shared_ptr<moxygen::MoQSession> upstream;
+    moxygen::RequestID requestID;
+    bool isReady;
+  };
+  std::optional<FetchView> getFetchView(const moxygen::FullTrackName& ftn) const;
+
+  // === Lifecycle transitions ===
+
+  // Clears handle + upstream. Erases if no subscribers remain (returns null).
+  // If subscribers remain, entry persists; caller must call remove() from onEmpty.
+  std::shared_ptr<moxygen::MoQForwarder> onPublisherTerminated(const moxygen::FullTrackName& ftn);
+
+  // Called from onEmpty after handle->unsubscribe() (subscribe-mode), or after
+  // a publisher-terminated entry's forwarder goes empty.
+  void remove(const moxygen::FullTrackName& ftn);
+
+  // === Iteration ===
+
+  struct EntryView {
+    const moxygen::FullTrackName& ftn;
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    std::shared_ptr<moxygen::MoQSession> upstream;
+    bool isPublish;
+    std::chrono::steady_clock::time_point lastObjectTime;
+  };
+
+  void removeIf(folly::FunctionRef<bool(const moxygen::FullTrackName&, const EntryView&)> predicate
+  );
+
+  void forEach(folly::FunctionRef<void(const EntryView&)> fn) const;
+
+private:
+  struct RelaySubscription {
+    RelaySubscription(
+        std::shared_ptr<moxygen::MoQForwarder> f,
+        std::shared_ptr<moxygen::MoQSession> u
+    )
+        : forwarder(std::move(f)), upstream(std::move(u)),
+          lastObjectTime(std::chrono::steady_clock::now()) {}
+
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    std::shared_ptr<moxygen::MoQSession> upstream;
+    moxygen::RequestID requestID{0};
+    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle;
+    folly::coro::SharedPromise<folly::Unit> promise;
+    bool isPublish{false};
+    std::shared_ptr<TopNFilter> topNFilter;
+    std::chrono::steady_clock::time_point lastObjectTime;
+  };
+
+  // Called by UpstreamSubscribePending::complete().
+  bool completeSubscription(
+      const moxygen::FullTrackName& ftn,
+      std::weak_ptr<moxygen::MoQForwarder> weakForwarder,
+      std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+      moxygen::RequestID requestID,
+      std::shared_ptr<moxygen::MoQSession> upstreamSession
+  );
+
+  // Called by UpstreamSubscribePending destructor on failure.
+  void failAndRemove(
+      const moxygen::FullTrackName& ftn,
+      std::weak_ptr<moxygen::MoQForwarder> weakForwarder
+  );
+
+  // Standalone coroutine for the subsequent-subscriber path. Parameters are
+  // passed by value so they live in the heap-allocated coroutine frame rather
+  // than in a lambda closure on the caller's stack.
+  static folly::coro::Task<SubsequentSubscriber> awaitSubsequent(
+      SubscriptionRegistry* registry,
+      moxygen::FullTrackName ftn,
+      folly::coro::Future<folly::Unit> future
+  );
+
+  folly::F14NodeMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
+      subscriptions_;
+};
+
+} // namespace openmoq::moqx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,6 +174,17 @@ target_link_libraries(moqx_upstream_provider_test PRIVATE
 )
 gtest_discover_tests(moqx_upstream_provider_test)
 
+# SubscriptionRegistry unit tests
+add_executable(moqx_subscription_registry_test
+  SubscriptionRegistryTest.cpp
+)
+target_link_libraries(moqx_subscription_registry_test PRIVATE
+  moqx_core
+  moqx_test_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_subscription_registry_test)
+
 # TopNFilter unit tests
 add_executable(moqx_topn_filter_test
   TopNFilterTest.cpp

--- a/test/SubscriptionRegistryTest.cpp
+++ b/test/SubscriptionRegistryTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ */
+
+#include "SubscriptionRegistry.h"
+#include "relay/TopNFilter.h"
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/io/async/EventBase.h>
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/relay/MoQForwarder.h>
+
+using namespace testing;
+using namespace moxygen;
+using namespace openmoq::moqx;
+
+namespace {
+
+const TrackNamespace kTestNs{{"test", "namespace"}};
+const FullTrackName kFtn{kTestNs, "track1"};
+
+// Minimal chain for subscribe-path tests (no TopNFilter needed).
+SubscriptionRegistry::FilterChainResult subscribeChain(std::shared_ptr<MoQForwarder> f) {
+  return {std::static_pointer_cast<TrackConsumer>(f), nullptr};
+}
+
+// Chain for publish-path tests: createFromPublish dereferences topNFilter.
+SubscriptionRegistry::FilterChainResult publishChain(std::shared_ptr<MoQForwarder> f) {
+  auto filter = std::make_shared<TopNFilter>(kFtn, nullptr);
+  return {std::static_pointer_cast<TrackConsumer>(f), filter};
+}
+
+} // namespace
+
+// === Subscribe path ===
+
+TEST(SubscriptionRegistryTest, AwaitSubsequentSucceeds) {
+  SubscriptionRegistry registry;
+  auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+  );
+  auto task = std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+  );
+
+  EXPECT_TRUE(first.pending.complete(nullptr, RequestID(0), nullptr));
+
+  folly::EventBase evb;
+  auto sub = folly::coro::blockingWait(std::move(task), &evb);
+  EXPECT_EQ(sub.forwarder, first.forwarder);
+}
+
+// === UpstreamSubscribePending ===
+
+TEST(SubscriptionRegistryTest, PendingDestructorRemovesEntry) {
+  SubscriptionRegistry registry;
+  {
+    auto result = registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain);
+    ASSERT_TRUE(std::holds_alternative<SubscriptionRegistry::FirstSubscriber>(result));
+    // drops result without calling complete() → destructor calls failAndRemove
+  }
+  EXPECT_FALSE(registry.exists(kFtn));
+}
+
+TEST(SubscriptionRegistryTest, PendingDestructorFailsSubsequentSubscriber) {
+  SubscriptionRegistry registry;
+  auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+  );
+  auto task = std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+  );
+
+  // Move pending out and drop it — destructor fires failAndRemove, sets exception on promise.
+  {
+    auto drop = std::move(first.pending);
+  }
+
+  folly::EventBase evb;
+  EXPECT_THROW(folly::coro::blockingWait(std::move(task), &evb), std::runtime_error);
+}
+
+TEST(SubscriptionRegistryTest, PendingCompleteReturnsFalseWhenEntryGone) {
+  SubscriptionRegistry registry;
+  auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+  );
+
+  registry.remove(kFtn); // simulate publisher replacing the entry mid-subscribe
+
+  EXPECT_FALSE(first.pending.complete(nullptr, RequestID(0), nullptr));
+}
+
+// Regression: awaitSubsequent must re-find after suspension; erased entry throws.
+TEST(SubscriptionRegistryTest, AwaitSubsequentHandlesErasedEntry) {
+  SubscriptionRegistry registry;
+
+  auto token1 = registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain);
+  ASSERT_TRUE(std::holds_alternative<SubscriptionRegistry::FirstSubscriber>(token1));
+  auto& first = std::get<SubscriptionRegistry::FirstSubscriber>(token1);
+
+  auto token2 = registry.getOrCreateFromSubscribe(
+      kFtn,
+      /*callback=*/nullptr,
+      [](std::shared_ptr<MoQForwarder>) -> SubscriptionRegistry::FilterChainResult {
+        return {nullptr, nullptr};
+      }
+  );
+  ASSERT_TRUE(
+      std::holds_alternative<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(token2)
+  );
+  auto subsequentTask =
+      std::move(std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(token2));
+
+  // Upstream subscribe succeeds — fulfills the promise.
+  EXPECT_TRUE(first.pending.complete(nullptr, RequestID(0), nullptr));
+
+  // Entry is erased before the subsequent coroutine resumes.
+  registry.remove(kFtn);
+
+  folly::EventBase evb;
+  EXPECT_THROW(folly::coro::blockingWait(std::move(subsequentTask), &evb), std::runtime_error);
+}
+
+// === Publish path ===
+
+TEST(SubscriptionRegistryTest, CreateFromPublishEvictsSubscribeEntry) {
+  SubscriptionRegistry registry;
+  auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+  );
+  auto originalForwarder = first.forwarder;
+  first.pending.complete(nullptr, RequestID(0), nullptr);
+
+  auto newForwarder = std::make_shared<MoQForwarder>(kFtn, std::nullopt);
+  auto entry =
+      registry.createFromPublish(kFtn, newForwarder, nullptr, RequestID(1), nullptr, publishChain);
+
+  ASSERT_TRUE(entry.evicted.has_value());
+  EXPECT_EQ(entry.evicted->forwarder, originalForwarder);
+  EXPECT_EQ(registry.getForwarder(kFtn), newForwarder);
+}
+
+// === onPublisherTerminated ===
+
+TEST(SubscriptionRegistryTest, OnPublisherTerminatedErasesEmptyEntry) {
+  SubscriptionRegistry registry;
+  auto forwarder = std::make_shared<MoQForwarder>(kFtn, std::nullopt);
+  registry.createFromPublish(kFtn, forwarder, nullptr, RequestID(0), nullptr, publishChain);
+
+  auto result = registry.onPublisherTerminated(kFtn);
+  EXPECT_EQ(result, nullptr);
+  EXPECT_FALSE(registry.exists(kFtn));
+}


### PR DESCRIPTION
Encapsulates subscriptions_ behind a SubscriptionRegistry class with verb-centric APIs (getOrCreateFromSubscribe, createFromPublish, getUpstreamView, getFetchView, getTopNView, onPublisherTerminated, etc.) so that MoqxRelay no longer touches RelaySubscription fields directly.

Key design points:
- UpstreamSubscribePending RAII guards the window between entry creation and upstream subscribe completion; its destructor fires the failure path (promise.setException + erase) if complete() was never called
- getOrCreateFromSubscribe is synchronous on the first path and returns a Task<SubsequentSubscriber> on the subsequent path; the task is implemented as a proper coroutine function (not a lambda) so its parameters live in the heap-allocated coroutine frame rather than on the caller's stack
- Upstream-specific subReq overrides (locType=LargestObject, upstream priority/group order) are now applied after addSubscriber so the downstream subscriber's range reflects the client's original request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/267)
<!-- Reviewable:end -->
