### PR TITLE
ci: add scheduled trigger to moxygen-sync (cascade stage 4)

### DIFF
--- a/.github/workflows/moxygen-sync.yml
+++ b/.github/workflows/moxygen-sync.yml
@@ -1,13 +1,25 @@
 name: moxygen sync
 
 # Updates deps/moxygen submodule to latest moxygen main, creates a PR.
-# Event-triggered by moxygen ci-main after successful release, or manual.
+# Schedule-driven (daily cron) plus workflow_dispatch for ad-hoc syncs.
+# repository_dispatch retained for non-sync flows (e.g., manual hand-merged
+# moxygen PRs that need immediate propagation); the routine cron-cascade
+# does not use it.
 # One PR at a time — blocks if one is pending.
 #
 # Branch naming: sync-moxygen/<short-sha>
 # Auto-merged by auto-merge-moxygen.yml after ci-pr passes.
 
 on:
+  schedule:
+    # Fourth (final) stage of the openmoq sync cron cascade (UTC; ET shifts under DST):
+    #   04:35  picoquic upstream-sync     (private-octopus → openmoq/picoquic)
+    #   05:35  moxygen  upstream-sync     (facebookexperimental → openmoq/moxygen)
+    #   05:45  moxygen  picoquic-pin sync (openmoq/picoquic → moxygen picoquic-rev.txt)
+    #   09:05  moqx     moxygen-submodule sync (this workflow — openmoq/moxygen → moqx deps/moxygen)
+    # The 3h20m gap before this stage gives moxygen sync PRs (upstream + picoquic-pin)
+    # time to run CI and auto-merge into openmoq/moxygen main before we pull it.
+    - cron: '5 9 * * *'
   repository_dispatch:
     types: [moxygen-update]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Add `cron: '5 9 * * *'` (09:05 UTC daily) to `moxygen-sync.yml`. This is the fourth and final stage of the openmoq sync cron cascade, replacing the per-merge `repository_dispatch` trigger that `openmoq/moxygen`'s `omoq-ci-main` previously fired on every successful main build.

## Sync cron cascade (UTC; ET shifts under DST)

| UTC | Repo | Workflow |
|---|---|---|
| 04:35 | picoquic | upstream-sync (private-octopus → openmoq/picoquic) |
| 05:35 | moxygen | upstream-sync (facebookexperimental → openmoq/moxygen) |
| 05:45 | moxygen | picoquic-pin sync (openmoq/picoquic → moxygen picoquic-rev.txt) |
| **09:05** | **moqx** | **moxygen-submodule sync (this PR — openmoq/moxygen → moqx deps/moxygen)** |

The 3h20m gap before this stage gives moxygen sync PRs (upstream + picoquic-pin) time to run CI and auto-merge into openmoq/moxygen main before moqx pulls it.

## Triggers retained

- `workflow_dispatch` — ad-hoc manual syncs.
- `repository_dispatch (types: moxygen-update)` — kept dormant for future non-sync flows (e.g., manual hand-merged moxygen PRs needing immediate propagation outside the routine cascade). Routine cascade does not use it.

## Test plan

- [ ] `workflow_dispatch` post-merge to verify the workflow still runs cleanly with the schedule trigger present
- [ ] Confirm next scheduled run fires at 09:05 UTC
- [ ] Verify the moxygen sibling PR removes the `omoq-ci-main` dispatch step (so the only trigger paths are now schedule + manual + the dormant repository_dispatch)

## Related

Sibling PRs (same cascade rearch):
- openmoq/picoquic#5 — schedule realignment to 04:35 UTC (cascade stage 1)
- openmoq/moxygen#195 — schedule realignment, picoquic-bump→sync rename, drop ci-main dispatch, manifest repoint (stages 2 & 3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/277)
<!-- Reviewable:end -->
