### PR TITLE
hotfix: cron shift + version-release UX (norm, branch-aware default, prerelease, auto-latest)

### DIFF
--- a/.github/workflows/moxygen-sync.yml
+++ b/.github/workflows/moxygen-sync.yml
@@ -13,13 +13,13 @@ name: moxygen sync
 on:
   schedule:
     # Fourth (final) stage of the openmoq sync cron cascade (UTC; ET shifts under DST):
-    #   04:35  picoquic upstream-sync     (private-octopus → openmoq/picoquic)
-    #   05:35  moxygen  upstream-sync     (facebookexperimental → openmoq/moxygen)
-    #   05:45  moxygen  picoquic-pin sync (openmoq/picoquic → moxygen picoquic-rev.txt)
-    #   09:05  moqx     moxygen-submodule sync (this workflow — openmoq/moxygen → moqx deps/moxygen)
-    # The 3h20m gap before this stage gives moxygen sync PRs (upstream + picoquic-pin)
+    #   03:23  picoquic upstream-sync     (private-octopus → openmoq/picoquic)
+    #   04:23  moxygen  upstream-sync     (facebookexperimental → openmoq/moxygen)
+    #   04:37  moxygen  picoquic-pin sync (openmoq/picoquic → moxygen picoquic-rev.txt)
+    #   08:23  moqx     moxygen-submodule sync (this workflow — openmoq/moxygen → moqx deps/moxygen)
+    # The 3h46m gap before this stage gives moxygen sync PRs (upstream + picoquic-pin)
     # time to run CI and auto-merge into openmoq/moxygen main before we pull it.
-    - cron: '5 9 * * *'
+    - cron: '23 8 * * *'
   repository_dispatch:
     types: [moxygen-update]
   workflow_dispatch:

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -124,15 +124,44 @@ jobs:
           # Moxygen reference: explicit input or snapshot-latest fallback.
           MOX_REF="${{ inputs.moxygen_release }}"
           if [ -z "$MOX_REF" ]; then
-            MOX_REF="snapshot-latest"
-            echo "==> No moxygen_release input — defaulting to moxygen snapshot-latest"
+            # Branch-aware default: from main, use GitHub's "latest" tagged
+            # release (highest non-prerelease semver across all branches).
+            # From release/vM.m, use the latest non-prerelease v M.m.* tag —
+            # so a hotfix dispatch on a release line picks the matching
+            # moxygen patch line, not whatever's newest globally.
+            if [ "$BRANCH" = "main" ]; then
+              MOX_REF=$(gh release view --repo openmoq/moxygen --json tagName --jq .tagName 2>/dev/null || true)
+              if [ -z "$MOX_REF" ]; then
+                echo "Error: no tagged moxygen release found." >&2
+                exit 1
+              fi
+              echo "==> No moxygen_release input — defaulting to GitHub latest: $MOX_REF"
+            else
+              LABEL="${BRANCH#release/v}"
+              MOX_REF=$(gh release list --repo openmoq/moxygen --limit 50 \
+                --json tagName,isPrerelease \
+                --jq ".[] | select(.isPrerelease == false) | select(.tagName | startswith(\"v$LABEL.\")) | .tagName" \
+                | head -1)
+              if [ -z "$MOX_REF" ]; then
+                echo "Error: no v${LABEL}.* non-prerelease moxygen release found for this release branch line." >&2
+                exit 1
+              fi
+              echo "==> No moxygen_release input — defaulting to latest v${LABEL}.* tag: $MOX_REF"
+            fi
           else
+            # Accept bare semver (0.1.4) or v-prefixed (v0.1.4); normalize.
+            if [[ "$MOX_REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+              MOX_REF="v$MOX_REF"
+              echo "==> Normalized bare semver to $MOX_REF"
+            fi
             echo "==> Pinning to moxygen release: $MOX_REF"
           fi
 
-          # Verify moxygen reference exists.
+          # Verify moxygen reference exists; on failure, list recent releases.
           if ! gh release view "$MOX_REF" --repo openmoq/moxygen >/dev/null 2>&1; then
             echo "Error: moxygen release $MOX_REF does not exist on openmoq/moxygen" >&2
+            echo "Available recent releases:" >&2
+            gh release list --repo openmoq/moxygen --limit 10 --json tagName --jq '.[].tagName' | sed 's/^/  /' >&2
             exit 1
           fi
 
@@ -196,9 +225,17 @@ jobs:
             PORTABLE_NOTE="_Portable Linux tarballs not produced for this release: moxygen \`${MOX_REF}\` does not include the required portable assets._"
           fi
 
+          # Mark prereleases (1.2.3-rc1) as such so GitHub's "latest"
+          # algorithm correctly excludes them.
+          PRERELEASE_FLAG=()
+          if [[ "$VERSION" == *-* ]]; then
+            PRERELEASE_FLAG=(--prerelease)
+          fi
+
           gh release create "$TAG" \
             --target "$SNAPSHOT_SHA" \
             --title "moqx $VERSION" \
+            "${PRERELEASE_FLAG[@]}" \
             --notes "$(cat <<EOF
           **Version:** \`${VERSION}\`
           **Commit:** \`${SNAPSHOT_SHA}\`
@@ -437,11 +474,15 @@ jobs:
           app-id: ${{ secrets.OMOQ_APP_ID }}
           private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
 
-      - name: Mark release as latest
+      - name: Confirm release published
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          gh release edit "$TAG" --repo "$REPO" --latest
+          # No --latest flag here. Let GitHub's auto-latest algorithm
+          # pick the highest non-prerelease semver tag. Forcing --latest
+          # would mark a hotfix patch from a release/vM.m branch as
+          # latest even when a newer vM.(m+1) line exists.
           echo "Released: $TAG"
+          gh release view "$TAG" --repo "$REPO" --json isLatest,isPrerelease,name --jq '"isLatest=\(.isLatest) isPrerelease=\(.isPrerelease) name=\(.name)"'


### PR DESCRIPTION
## Summary

Two related fixes to the release/sync infrastructure.

### 1. Cron cascade shift (1h earlier, on :23 / :37)

GitHub Actions schedule triggers were firing ~2-3h late under load. Shifting off the top-of-hour and 1 hour earlier should improve reliability:

| Stage | Was | Now |
|---|---|---|
| picoquic upstream-sync | 04:35 | 03:23 |
| moxygen upstream-sync | 05:35 | 04:23 |
| moxygen picoquic-pin sync | 05:45 | 04:37 |
| moqx moxygen-submodule sync (this repo) | 09:05 | **08:23** |

Inter-stage spacing preserved (gap before final stage is now 3h46m).

### 2. version-release UX

Five fixes triggered by today's failed dispatch (`moxygen_release=0.1.4` → "does not exist"):

- **Input normalization**: accept bare semver (\`0.1.4\`) or v-prefixed (\`v0.1.4\`).
- **Branch-aware empty-input default**: dispatching from main with no \`moxygen_release\` → GitHub's "latest" tagged moxygen release. From \`release/vM.m\` → latest non-prerelease \`vM.m.*\` tag, so hotfix dispatches stay on their line.
- **Helpful error**: failed lookup lists the 10 most recent moxygen releases.
- **Prerelease detection**: \`1.2.3-rc1\` semver gets \`--prerelease\` flag, so GitHub's "latest" auto-excludes it.
- **Drop forced --latest**: finalize no longer hard-sets the new release as Latest. Lets GitHub auto-determine based on highest non-prerelease semver — correct behavior for hotfix patches on older release lines.

## Companion PRs

- openmoq/moxygen — cron shift + same prerelease/auto-latest fixes
- openmoq/picoquic — cron shift only

## Test plan

- [ ] Manual \`workflow_dispatch\` of \`version release\` from main with empty \`moxygen_release\` → uses latest moxygen tagged.
- [ ] Same with \`moxygen_release=0.1.4\` → normalized to \`v0.1.4\`, succeeds.
- [ ] Same with \`moxygen_release=v0.0.1-portabletest\` → still works (test release tag).
- [ ] Same with bogus \`moxygen_release=v999.0.0\` → fails with the 10-recent-releases listing in the error.
- [ ] \`version=0.1.0-rc1\` produces release marked \`isPrerelease=true\` and not Latest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/279)
<!-- Reviewable:end -->
