### PR TITLE
docs: add banner and badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<div align="center">
+  <img src="docs/banner.png" alt="moqx — Media Over QUIC Relay" />
+</div>
+
+<div align="center">
+
+[![ci main](https://github.com/openmoq/moqx/actions/workflows/ci-main.yml/badge.svg)](https://github.com/openmoq/moqx/actions/workflows/ci-main.yml)
+[![ci pr](https://github.com/openmoq/moqx/actions/workflows/ci-pr.yml/badge.svg)](https://github.com/openmoq/moqx/actions/workflows/ci-pr.yml)
+[![Latest release](https://img.shields.io/github/v/release/openmoq/moqx?display_name=tag&sort=semver&logo=github)](https://github.com/openmoq/moqx/releases/latest)
+[![License](https://img.shields.io/github/license/openmoq/moqx)](LICENSE)
+[![Last commit](https://img.shields.io/github/last-commit/openmoq/moqx)](https://github.com/openmoq/moqx/commits/main)
+[![Open issues](https://img.shields.io/github/issues/openmoq/moqx)](https://github.com/openmoq/moqx/issues)
+[![Open PRs](https://img.shields.io/github/issues-pr/openmoq/moqx)](https://github.com/openmoq/moqx/pulls)
+[![MOQT](https://img.shields.io/badge/MOQT-draft--16-blue)](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/)
+
+</div>
+
 # moqx
 
 The OpenMOQ Relay — a MoQT relay server based on


### PR DESCRIPTION
## Summary

Adds the OpenMOQ moqx banner image at the top of the README, plus a row of badges with at-a-glance project status.

## Banner

\`docs/banner.png\` — referenced via relative HTML \`<img>\` so it renders centered on github.com and most repo mirrors.

## Badges

| Badge | What it shows |
|---|---|
| ci main / ci pr | Workflow status, links to Actions |
| Latest release | Highest non-prerelease semver tag (auto from GitHub) |
| License | Detected from LICENSE file (Apache 2.0) |
| Last commit | Freshness indicator |
| Open issues / Open PRs | Project activity at a glance |
| MOQT | IETF MOQT draft version we target — static badge, hand-bumped when draft changes (rare, every few months) |

## Deferred

A **conformance** badge will be added once \`openmoq/moq-interop-runner\` (forking englishm/moq-interop-runner) is up and publishing a results JSON via gh-pages. Tracked separately.

## Test plan

- [ ] Check README renders correctly on GitHub UI — banner centered, badges in a row, no broken images.
- [ ] Click each badge link — goes to the correct workflow / release page / issues / etc.
- [ ] Verify shields.io renders all auto-detected badges (latest release, license, last commit, issues, PRs) without errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/280)
<!-- Reviewable:end -->
