### PR TITLE
hotfix: conformance uses --use-latest --no-fallback like build job

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Setup dependencies
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: bash scripts/build.sh setup
+        run: bash scripts/build.sh setup --use-latest --no-fallback
 
       - name: Build
         run: bash scripts/build.sh

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Setup dependencies
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: bash scripts/build.sh setup
+        run: bash scripts/build.sh setup --use-latest --no-fallback
 
       - name: Build
         run: bash scripts/build.sh


### PR DESCRIPTION
## Problem

Conformance jobs intermittently took ~33 min instead of ~6 min, depending on whether the moqx \`deps/moxygen\` submodule SHA happened to match moxygen's \`snapshot-latest\` SHA at run time. When mismatched, \`bash scripts/build.sh setup\` silently fell back to a 27-min from-source build of folly+fizz+wangle+mvfst+proxygen+picoquic.

Today's main run (15:30 UTC):
- Submodule SHA: \`abe04a2\` (yesterday's moxygen-sync)
- snapshot-latest SHA: \`3b66924\` (advanced after PR #198 merged earlier today)
- Mismatch → 27-min source build

Earlier today's PR run (12:08 UTC):
- Submodule SHA: \`abe04a2\`
- snapshot-latest SHA: \`abe04a2\` (still aligned at that moment)
- Match → 4-second tarball download → fast (~6 min total)

## Fix

Match the build job's invocation:

\`\`\`diff
- run: bash scripts/build.sh setup
+ run: bash scripts/build.sh setup --use-latest --no-fallback
\`\`\`

- \`--use-latest\` — accept whatever's in \`snapshot-latest\` regardless of submodule SHA. Build job already does this.
- \`--no-fallback\` — fail loud if tarball download genuinely fails, instead of silently triggering a 27-min source rebuild.

## Impact

| | Before | After |
|---|---|---|
| Conformance setup-deps step | 4s (lucky) – 27 min (unlucky) | always ~5-30s |
| Conformance per-variant total | ~6 min – ~33 min | always ~6 min |

## Why now

Pre-existing flaw exposed by today's moxygen merge volume — multiple PRs merged in succession (#194, #196, #198, …), each advancing snapshot-latest faster than moqx's daily \`moxygen-sync\` cron. Same drift would have hit any time moxygen merged 2+ PRs in one day.

## Test plan

- [ ] PR's own \`ci pr\` runs at expected fast pace (~6 min per conformance variant).
- [ ] On merge, main's \`ci main\` similarly fast.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/281)
<!-- Reviewable:end -->
