### PR TITLE
stats: add unit suffix to histogram X macro

### DIFF
--- a/src/stats/MoQStatsCollector.cpp
+++ b/src/stats/MoQStatsCollector.cpp
@@ -43,11 +43,11 @@ StatsSnapshot MoQStatsCollector::snapshot() const {
   STATS_GAUGE_FIELDS(COPY_FIELD)
 #undef COPY_FIELD
 
-#define COPY_HISTOGRAM(name, bounds)                                                               \
+#define COPY_HISTOGRAM(name, bounds, unit)                                                         \
   name##_.fillCumulative(snap.name##Buckets);                                                      \
   snap.name##Sum = name##_.sum;                                                                    \
   snap.name##Count = name##_.count;
-  STATS_HISTOGRAM_FIELDS(COPY_HISTOGRAM)
+  STATS_MOQ_HISTOGRAM_FIELDS(COPY_HISTOGRAM)
 #undef COPY_HISTOGRAM
 
 #define COPY_ERROR_ARRAY(name)                                                                     \

--- a/src/stats/MoQStatsCollector.h
+++ b/src/stats/MoQStatsCollector.h
@@ -141,8 +141,8 @@ private:
   STATS_GAUGE_FIELDS(DEFINE_FIELD)
 #undef DEFINE_FIELD
 
-#define DEFINE_HISTOGRAM(name, bounds) BoundedHistogram<bounds.size()> name##_{bounds};
-  STATS_HISTOGRAM_FIELDS(DEFINE_HISTOGRAM)
+#define DEFINE_HISTOGRAM(name, bounds, unit) BoundedHistogram<bounds.size()> name##_{bounds};
+  STATS_MOQ_HISTOGRAM_FIELDS(DEFINE_HISTOGRAM)
 #undef DEFINE_HISTOGRAM
 
   // Per-RequestErrorCode breakdown arrays (parallel to the aggregate counters).

--- a/src/stats/StatsRegistry.cpp
+++ b/src/stats/StatsRegistry.cpp
@@ -24,7 +24,7 @@ StatsSnapshot& StatsSnapshot::operator+=(const StatsSnapshot& o) {
   STATS_GAUGE_FIELDS(ADD_FIELD)
 #undef ADD_FIELD
 
-#define ADD_HISTOGRAM(name, bounds)                                                                \
+#define ADD_HISTOGRAM(name, bounds, unit)                                                          \
   for (size_t i = 0; i < name##Buckets.size(); ++i) {                                              \
     name##Buckets[i] += o.name##Buckets[i];                                                        \
   }                                                                                                \
@@ -83,27 +83,27 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
 #undef EMIT_GAUGE
 
   // --- Histograms ---
-#define EMIT_HISTOGRAM(name, bounds)                                                               \
-  app("# HELP moqx_" #name "_microseconds\n"                                                       \
-      "# TYPE moqx_" #name "_microseconds histogram\n");                                           \
+#define EMIT_HISTOGRAM(name, bounds, unit)                                                         \
+  app("# HELP moqx_" #name "_" unit "\n"                                                           \
+      "# TYPE moqx_" #name "_" unit " histogram\n");                                               \
   {                                                                                                \
     const auto& bvals = (bounds);                                                                  \
     const auto& bcounts = snap.name##Buckets;                                                      \
     for (size_t i = 0; i < bvals.size(); ++i) {                                                    \
-      app("moqx_" #name "_microseconds_bucket{le=\"");                                             \
+      app("moqx_" #name "_" unit "_bucket{le=\"");                                                 \
       appNum(bvals[i]);                                                                            \
       app("\"} ");                                                                                 \
       appNum(bcounts[i]);                                                                          \
       app("\n");                                                                                   \
     }                                                                                              \
-    app("moqx_" #name "_microseconds_bucket{le=\"+Inf\"} ");                                       \
+    app("moqx_" #name "_" unit "_bucket{le=\"+Inf\"} ");                                           \
     appNum(bcounts.back());                                                                        \
     app("\n");                                                                                     \
   }                                                                                                \
-  app("moqx_" #name "_microseconds_sum ");                                                         \
+  app("moqx_" #name "_" unit "_sum ");                                                             \
   appNum(snap.name##Sum);                                                                          \
   app("\n"                                                                                         \
-      "moqx_" #name "_microseconds_count ");                                                       \
+      "moqx_" #name "_" unit "_count ");                                                           \
   appNum(snap.name##Count);                                                                        \
   app("\n\n");
   STATS_HISTOGRAM_FIELDS(EMIT_HISTOGRAM)

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -160,14 +160,17 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
 // Combined convenience macro to iterate all gauge fields
 #define STATS_GAUGE_FIELDS(X) STATS_QUIC_GAUGE_FIELDS(X) STATS_MOQ_GAUGE_FIELDS(X)
 
-// Histograms: (name, constexpr_bounds_ref)
+// Histograms: X(name, constexpr_bounds_ref, unit_suffix)
+// unit_suffix is a string literal appended to the Prometheus metric name.
 // Each expands to: name##Buckets[] (len = bounds.size()+1 for +Inf),
 //                  name##Sum, name##Count
-#define STATS_HISTOGRAM_FIELDS(X)                                                                  \
-  X(moqSubscribeLatency, kLatencyBucketsUs)                                                        \
-  X(moqFetchLatency, kLatencyBucketsUs)                                                            \
-  X(moqPublishNamespaceLatency, kLatencyBucketsUs)                                                 \
-  X(moqPublishLatency, kLatencyBucketsUs)
+#define STATS_MOQ_HISTOGRAM_FIELDS(X)                                                              \
+  X(moqSubscribeLatency, kLatencyBucketsUs, "microseconds")                                        \
+  X(moqFetchLatency, kLatencyBucketsUs, "microseconds")                                            \
+  X(moqPublishNamespaceLatency, kLatencyBucketsUs, "microseconds")                                 \
+  X(moqPublishLatency, kLatencyBucketsUs, "microseconds")
+
+#define STATS_HISTOGRAM_FIELDS(X) STATS_MOQ_HISTOGRAM_FIELDS(X)
 
 // Error-code breakdowns: fields in STATS_MOQ_COUNTER_FIELDS whose callbacks receive
 // a RequestErrorCode argument.  Each expands to a
@@ -192,7 +195,7 @@ struct StatsSnapshot {
 #undef DEFINE_FIELD
 
   // --- Histogram fields ---
-#define DEFINE_HISTOGRAM(name, bounds)                                                             \
+#define DEFINE_HISTOGRAM(name, bounds, unit)                                                       \
   std::array<uint64_t, std::tuple_size_v<decltype(bounds)> + 1> name##Buckets{};                   \
   uint64_t name##Sum{0};                                                                           \
   uint64_t name##Count{0};


### PR DESCRIPTION
Rename STATS_HISTOGRAM_FIELDS to STATS_MOQ_HISTOGRAM_FIELDS and extend the X macro signature with a unit_suffix argument (e.g. "microseconds") that is appended to the Prometheus metric name.  STATS_HISTOGRAM_FIELDS is kept as a delegating wrapper so existing call sites are unaffected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/282)
<!-- Reviewable:end -->
