### PR TITLE
stats: track additional QUIC counter events

### DIFF
--- a/src/stats/PicoQuicStatsCollector.cpp
+++ b/src/stats/PicoQuicStatsCollector.cpp
@@ -45,7 +45,9 @@ void PicoQuicStatsCollector::onPathQualityDelta(const PathQualityDelta& d) {
   quicPacketLoss_ += d.packetsLost;
   quicBytesWritten_ += d.bytesSent;
   quicBytesRead_ += d.bytesReceived;
-  quicPacketRetransmissions_ += d.timerLosses + d.spuriousLosses;
+  quicPacketRetransmissions_ += d.timerLosses;
+  quicPTO_ += d.timerLosses;
+  quicPacketSpuriousLoss_ += d.spuriousLosses;
   if (d.cwndBlocked) {
     ++quicCwndBlocked_;
   }

--- a/src/stats/QuicStatsCollector.cpp
+++ b/src/stats/QuicStatsCollector.cpp
@@ -74,21 +74,23 @@ public:
   void onPeerMaxBidiStreamsLimitSaturated() override {
     ++data_->quicPeerMaxBidiStreamsLimitSaturated_;
   }
+  void onPacketProcessed() override { ++data_->quicPacketsProcessed_; }
+  void onPTO() override { ++data_->quicPTO_; }
+  void onPacketSpuriousLoss() override { ++data_->quicPacketSpuriousLoss_; }
+  void onPersistentCongestion() override { ++data_->quicPersistentCongestion_; }
+  void onConnectionWritableBytesLimited() override { ++data_->quicConnectionWritableBytesLimited_; }
+  void onConnectionRateLimited() override { ++data_->quicConnectionRateLimited_; }
+  void onPacerTimerLagged() override { ++data_->quicPacerTimerLagged_; }
 
   // --- Untracked callbacks (no-op) ---
   void onRxDelaySample(uint64_t) override {}
   void onDuplicatedPacketReceived() override {}
   void onOutOfOrderPacketReceived() override {}
-  void onPacketProcessed() override {}
-  void onPacketSpuriousLoss() override {}
-  void onPersistentCongestion() override {}
   void onPacketForwarded() override {}
   void onPacketDroppedByEgressPolicer() override {}
   void onForwardedPacketReceived() override {}
   void onForwardedPacketProcessed() override {}
   void onClientInitialReceived(quic::QuicVersion) override {}
-  void onConnectionRateLimited() override {}
-  void onConnectionWritableBytesLimited() override {}
   void onNewTokenReceived() override {}
   void onNewTokenIssued() override {}
   void onTokenDecryptFailure() override {}
@@ -106,8 +108,15 @@ public:
   void onCwndHintBytesSample(uint64_t) override {}
   void onCongestionControllerResumed() override {}
   void onNewCongestionController(quic::CongestionControlType) override {}
-  void onPTO() override {}
-  void onUDPSocketWriteError(SocketErrorType) override {}
+  void onUDPSocketWriteError(SocketErrorType errorType) override {
+    if (errorType == SocketErrorType::AGAIN) {
+      ++data_->quicSocketWriteAgain_;
+    } else if (errorType == SocketErrorType::NOBUFS) {
+      ++data_->quicSocketWriteNobufs_;
+    } else {
+      ++data_->quicSocketWriteOther_;
+    }
+  }
   void onTransportKnobApplied(quic::TransportKnobParamId) override {}
   void onTransportKnobError(quic::TransportKnobParamId) override {}
   void onTransportKnobOutOfOrder(quic::TransportKnobParamId) override {}
@@ -121,7 +130,6 @@ public:
   void onDatagramRead(size_t) override {}
   void onDatagramWrite(size_t) override {}
   void onShortHeaderPadding(size_t) override {}
-  void onPacerTimerLagged() override {}
   void onConnectionIdCreated(size_t) override {}
   void onKeyUpdateAttemptInitiated() override {}
   void onKeyUpdateAttemptReceived() override {}

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -133,7 +133,17 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
   X(uint64_t, quicDatagramsDroppedOnWrite)                                                         \
   X(uint64_t, quicDatagramsDroppedOnRead)                                                          \
   X(uint64_t, quicPeerMaxUniStreamsLimitSaturated)                                                 \
-  X(uint64_t, quicPeerMaxBidiStreamsLimitSaturated)
+  X(uint64_t, quicPeerMaxBidiStreamsLimitSaturated)                                                \
+  X(uint64_t, quicSocketWriteAgain)                                                                \
+  X(uint64_t, quicSocketWriteNobufs)                                                               \
+  X(uint64_t, quicSocketWriteOther)                                                                \
+  X(uint64_t, quicPacketsProcessed)                                                                \
+  X(uint64_t, quicPTO)                                                                             \
+  X(uint64_t, quicPacketSpuriousLoss)                                                              \
+  X(uint64_t, quicPersistentCongestion)                                                            \
+  X(uint64_t, quicConnectionWritableBytesLimited)                                                  \
+  X(uint64_t, quicConnectionRateLimited)                                                           \
+  X(uint64_t, quicPacerTimerLagged)
 
 // Combined convenience macro to iterate all counter fields
 #define STATS_COUNTER_FIELDS(X) STATS_MOQ_COUNTER_FIELDS(X) STATS_QUIC_COUNTER_FIELDS(X)

--- a/test/stats/PicoQuicStatsCollectorTest.cpp
+++ b/test/stats/PicoQuicStatsCollectorTest.cpp
@@ -73,7 +73,9 @@ TEST_F(PicoQuicStatsCollectorTest, PathQualityDeltaAccumulation) {
   EXPECT_EQ(snap.quicPacketLoss, 1);
   EXPECT_EQ(snap.quicBytesWritten, 1500);
   EXPECT_EQ(snap.quicBytesRead, 1200);
-  EXPECT_EQ(snap.quicPacketRetransmissions, 2); // timerLosses + spuriousLosses
+  EXPECT_EQ(snap.quicPacketRetransmissions, 1); // timerLosses only
+  EXPECT_EQ(snap.quicPTO, 1);
+  EXPECT_EQ(snap.quicPacketSpuriousLoss, 1);
   EXPECT_EQ(snap.quicCwndBlocked, 1);
 }
 


### PR DESCRIPTION
Wire onPacketProcessed, onPTO, onPacketSpuriousLoss, onPersistentCongestion, onConnectionWritableBytesLimited, onConnectionRateLimited, onPacerTimerLagged, and onUDPSocketWriteError into the stats data structures instead of no-opping. Split quicPacketRetransmissions into timerLosses/spuriousLosses in pico path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/283)
<!-- Reviewable:end -->
