### PR TITLE
ci: auto-detect moxygen submodule on/off main for setup mode

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -93,14 +93,29 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           MOQX_PLATFORM: ${{ matrix.platform || '' }}
         run: |
-          # Release branches pin a specific moxygen release tag via
-          # .moxygen-release. Main uses snapshot-latest via --use-latest.
+          # Three-mode setup resolution:
+          # 1. .moxygen-release file (release branches): use pinned tag.
+          # 2. Submodule SHA reachable from moxygen main: tarball mode via
+          #    snapshot-latest. Robust to drift between moxygen merges and
+          #    moqx's daily moxygen-sync.
+          # 3. Submodule SHA NOT reachable from main (dev iterating against
+          #    an unreleased moxygen feature branch): source build. Slow
+          #    but supports cross-repo iteration without requiring a
+          #    published moxygen tarball.
           if [ -f .moxygen-release ]; then
             export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
-            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            echo "==> Pinned moxygen tag: $MOQX_MOXYGEN_RELEASE_TAG"
             bash scripts/build.sh setup --no-fallback
           else
-            bash scripts/build.sh setup --use-latest
+            SUB_SHA=$(git -C deps/moxygen rev-parse HEAD)
+            AHEAD=$(gh api "repos/openmoq/moxygen/compare/main...$SUB_SHA" --jq .ahead_by 2>/dev/null || echo "1")
+            if [ "$AHEAD" = "0" ]; then
+              echo "==> moxygen submodule $SUB_SHA on main → snapshot tarball"
+              bash scripts/build.sh setup --use-latest --no-fallback
+            else
+              echo "==> moxygen submodule $SUB_SHA $AHEAD commits diverged from main → source build"
+              bash scripts/build.sh setup
+            fi
           fi
 
       - name: Build
@@ -179,7 +194,23 @@ jobs:
       - name: Setup dependencies
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: bash scripts/build.sh setup --use-latest --no-fallback
+        run: |
+          # Three-mode setup resolution (matches build job).
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "==> Pinned moxygen tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            bash scripts/build.sh setup --no-fallback
+          else
+            SUB_SHA=$(git -C deps/moxygen rev-parse HEAD)
+            AHEAD=$(gh api "repos/openmoq/moxygen/compare/main...$SUB_SHA" --jq .ahead_by 2>/dev/null || echo "1")
+            if [ "$AHEAD" = "0" ]; then
+              echo "==> moxygen submodule $SUB_SHA on main → snapshot tarball"
+              bash scripts/build.sh setup --use-latest --no-fallback
+            else
+              echo "==> moxygen submodule $SUB_SHA $AHEAD commits diverged from main → source build"
+              bash scripts/build.sh setup
+            fi
+          fi
 
       - name: Build
         run: bash scripts/build.sh

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -70,17 +70,32 @@ jobs:
 
       - name: Setup dependencies
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MOQX_PLATFORM: ${{ matrix.platform || '' }}
         run: |
-          # Release branches pin a specific moxygen release tag via
-          # .moxygen-release. Main uses snapshot-latest via --use-latest.
+          # Three-mode setup resolution:
+          # 1. .moxygen-release file (release branches): use pinned tag.
+          # 2. Submodule SHA reachable from moxygen main: tarball mode via
+          #    snapshot-latest. Robust to drift between moxygen merges and
+          #    moqx's daily moxygen-sync.
+          # 3. Submodule SHA NOT reachable from main (dev iterating against
+          #    an unreleased moxygen feature branch): source build. Slow
+          #    but supports cross-repo iteration without requiring a
+          #    published moxygen tarball.
           if [ -f .moxygen-release ]; then
             export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
-            echo "Using pinned moxygen release tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            echo "==> Pinned moxygen tag: $MOQX_MOXYGEN_RELEASE_TAG"
             bash scripts/build.sh setup --no-fallback
           else
-            bash scripts/build.sh setup --use-latest
+            SUB_SHA=$(git -C deps/moxygen rev-parse HEAD)
+            AHEAD=$(gh api "repos/openmoq/moxygen/compare/main...$SUB_SHA" --jq .ahead_by 2>/dev/null || echo "1")
+            if [ "$AHEAD" = "0" ]; then
+              echo "==> moxygen submodule $SUB_SHA on main → snapshot tarball"
+              bash scripts/build.sh setup --use-latest --no-fallback
+            else
+              echo "==> moxygen submodule $SUB_SHA $AHEAD commits diverged from main → source build"
+              bash scripts/build.sh setup
+            fi
           fi
 
       - name: Build
@@ -162,7 +177,23 @@ jobs:
       - name: Setup dependencies
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: bash scripts/build.sh setup --use-latest --no-fallback
+        run: |
+          # Three-mode setup resolution (matches build job).
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "==> Pinned moxygen tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            bash scripts/build.sh setup --no-fallback
+          else
+            SUB_SHA=$(git -C deps/moxygen rev-parse HEAD)
+            AHEAD=$(gh api "repos/openmoq/moxygen/compare/main...$SUB_SHA" --jq .ahead_by 2>/dev/null || echo "1")
+            if [ "$AHEAD" = "0" ]; then
+              echo "==> moxygen submodule $SUB_SHA on main → snapshot tarball"
+              bash scripts/build.sh setup --use-latest --no-fallback
+            else
+              echo "==> moxygen submodule $SUB_SHA $AHEAD commits diverged from main → source build"
+              bash scripts/build.sh setup
+            fi
+          fi
 
       - name: Build
         run: bash scripts/build.sh


### PR DESCRIPTION
## Summary

Three-mode setup resolution for moqx CI's deps fetch — applied uniformly across `build` and `conformance` jobs in both `ci-main.yml` and `ci-pr.yml`:

1. **`.moxygen-release` file present** → use the pinned moxygen tag
2. **Submodule SHA reachable from moxygen `main`** → snapshot tarball via `--use-latest --no-fallback`
3. **Submodule SHA NOT reachable from main** → source build (developer iterating against an unreleased moxygen)

## Behavior

| Context | Setup mode | Result |
|---|---|---|
| Developer local build (`bash scripts/build.sh setup`) | script default | strict SHA match against snapshot-latest, source-build fallback if mismatch |
| Developer local with `--use-latest` | script default | snapshot tarball, accepts drift |
| PR CI build / conformance | three-mode | pin file → moxygen tag; submodule on main → snapshot tarball; submodule off main → **source build** *(new)* |
| Main CI build / conformance | mode 2 in practice | snapshot tarball (main's submodule is always on moxygen main) |
| Release branch (`release/vM.m`) build | mode 1 | pinned moxygen tag from `.moxygen-release` |
| Release branch (`release/vM.m`) conformance | mode 1 *(new)* | pinned moxygen tag from `.moxygen-release` (previously ignored the file) |
| `moxygen-sync.yml` | n/a | doesn't build; only bumps submodule pointer and opens PR |
| `version-release.yml` dispatch | n/a | downloads moxygen tarball directly via `moxygen_release` input |
| `publish` docker build | n/a | uses moxygen tarball, no source compile of moxygen |

## Detection

```bash
SUB_SHA=$(git -C deps/moxygen rev-parse HEAD)
AHEAD=$(gh api "repos/openmoq/moxygen/compare/main...$SUB_SHA" --jq .ahead_by 2>/dev/null || echo "1")
if [ "$AHEAD" = "0" ]; then
  # SUB on main → fast tarball path
else
  # SUB diverged → source build
fi
```

`compare/main...SUB`'s `ahead_by` field is exactly "commits in SUB not in main." Zero means SUB is reachable from main; non-zero means SUB has diverged. Defensive `|| echo "1"` handles rare API failures (treat as "diverged" → source build, safe fallback).

## Sites changed

| File | Job | Site |
|---|---|---|
| `ci-main.yml` | build | line ~91 |
| `ci-main.yml` | conformance | line ~179 |
| `ci-pr.yml` | build | line ~71 |
| `ci-pr.yml` | conformance | line ~162 |

Build and conformance now use the **same** logic — important because building moxygen from source in conformance but a different moxygen for build would cross-link mismatched moxygen artifacts across the two jobs.

## Test plan

- [ ] PR's own CI passes (submodule on main → snapshot tarball, fast)
- [ ] Manual test of dev iteration: bump submodule to a non-main moxygen SHA, push to a temp PR — observe both build and conformance go to source-build path. Run completes (slow but green).
- [ ] After merge, monitor next moxygen sync drift event — conformance should still use tarball (because submodule SHA, even when lagging main HEAD, is still reachable from main as an ancestor).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/292)
<!-- Reviewable:end -->
