### PR TITLE
stats: add QUIC transport histograms for RTT, bandwidth, and inflight bytes

### DIFF
--- a/src/stats/PicoQuicStatsCollector.cpp
+++ b/src/stats/PicoQuicStatsCollector.cpp
@@ -51,6 +51,15 @@ void PicoQuicStatsCollector::onPathQualityDelta(const PathQualityDelta& d) {
   if (d.cwndBlocked) {
     ++quicCwndBlocked_;
   }
+  if (d.smoothedRttUs > 0) {
+    quicRttSample_.addValue(d.smoothedRttUs / 1000);
+  }
+  if (d.receiveBytesPerSec > 0) {
+    quicBandwidthSample_.addValue(d.receiveBytesPerSec * 8);
+  }
+  if (d.bytesInTransit > 0) {
+    quicInflightBytesSample_.addValue(d.bytesInTransit);
+  }
 }
 
 StatsSnapshot PicoQuicStatsCollector::snapshot() const {
@@ -60,6 +69,13 @@ StatsSnapshot PicoQuicStatsCollector::snapshot() const {
   STATS_QUIC_COUNTER_FIELDS(COPY_FIELD)
   STATS_QUIC_GAUGE_FIELDS(COPY_FIELD)
 #undef COPY_FIELD
+
+#define COPY_HISTOGRAM(name, bounds, unit)                                                         \
+  name##_.fillCumulative(snap.name##Buckets);                                                      \
+  snap.name##Sum = name##_.sum;                                                                    \
+  snap.name##Count = name##_.count;
+  STATS_QUIC_HISTOGRAM_FIELDS(COPY_HISTOGRAM)
+#undef COPY_HISTOGRAM
 
   return snap;
 }

--- a/src/stats/PicoQuicStatsCollector.h
+++ b/src/stats/PicoQuicStatsCollector.h
@@ -12,6 +12,7 @@
 #include <folly/io/async/EventBase.h>
 #include <moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h>
 
+#include "stats/BoundedHistogram.h"
 #include "stats/StatsRegistry.h"
 
 namespace openmoq::moqx::stats {
@@ -54,6 +55,10 @@ private:
   STATS_QUIC_COUNTER_FIELDS(DEFINE_FIELD)
   STATS_QUIC_GAUGE_FIELDS(DEFINE_FIELD)
 #undef DEFINE_FIELD
+
+#define DEFINE_HISTOGRAM(name, bounds, unit) BoundedHistogram<bounds.size()> name##_{bounds};
+  STATS_QUIC_HISTOGRAM_FIELDS(DEFINE_HISTOGRAM)
+#undef DEFINE_HISTOGRAM
 };
 
 } // namespace openmoq::moqx::stats

--- a/src/stats/QuicStatsCollector.cpp
+++ b/src/stats/QuicStatsCollector.cpp
@@ -81,6 +81,14 @@ public:
   void onConnectionWritableBytesLimited() override { ++data_->quicConnectionWritableBytesLimited_; }
   void onConnectionRateLimited() override { ++data_->quicConnectionRateLimited_; }
   void onPacerTimerLagged() override { ++data_->quicPacerTimerLagged_; }
+  void onRttSample(uint64_t ms) override { data_->quicRttSample_.addValue(ms); }
+  void onBandwidthSample(uint64_t bps) override { data_->quicBandwidthSample_.addValue(bps); }
+  void onInflightBytesSample(uint64_t bytes) override {
+    data_->quicInflightBytesSample_.addValue(bytes);
+  }
+  void onCwndHintBytesSample(uint64_t bytes) override {
+    data_->quicCwndHintBytesSample_.addValue(bytes);
+  }
 
   // --- Untracked callbacks (no-op) ---
   void onRxDelaySample(uint64_t) override {}
@@ -102,10 +110,6 @@ public:
   void onConnFlowControlUpdate() override {}
   void onStatelessReset() override {}
   void onStreamFlowControlUpdate() override {}
-  void onInflightBytesSample(uint64_t) override {}
-  void onRttSample(uint64_t) override {}
-  void onBandwidthSample(uint64_t) override {}
-  void onCwndHintBytesSample(uint64_t) override {}
   void onCongestionControllerResumed() override {}
   void onNewCongestionController(quic::CongestionControlType) override {}
   void onUDPSocketWriteError(SocketErrorType errorType) override {
@@ -166,6 +170,13 @@ StatsSnapshot QuicStatsCollector::snapshot() const {
   STATS_QUIC_COUNTER_FIELDS(COPY_FIELD)
   STATS_QUIC_GAUGE_FIELDS(COPY_FIELD)
 #undef COPY_FIELD
+
+#define COPY_HISTOGRAM(name, bounds, unit)                                                         \
+  name##_.fillCumulative(snap.name##Buckets);                                                      \
+  snap.name##Sum = name##_.sum;                                                                    \
+  snap.name##Count = name##_.count;
+  STATS_QUIC_HISTOGRAM_FIELDS(COPY_HISTOGRAM)
+#undef COPY_HISTOGRAM
 
   return snap;
 }

--- a/src/stats/QuicStatsCollector.h
+++ b/src/stats/QuicStatsCollector.h
@@ -14,6 +14,7 @@
 #include <folly/io/async/EventBase.h>
 #include <quic/state/QuicTransportStatsCallback.h>
 
+#include "stats/BoundedHistogram.h"
 #include "stats/StatsRegistry.h"
 
 namespace openmoq::moqx::stats {
@@ -61,6 +62,10 @@ private:
   STATS_QUIC_COUNTER_FIELDS(DEFINE_FIELD)
   STATS_QUIC_GAUGE_FIELDS(DEFINE_FIELD)
 #undef DEFINE_FIELD
+
+#define DEFINE_HISTOGRAM(name, bounds, unit) BoundedHistogram<bounds.size()> name##_{bounds};
+  STATS_QUIC_HISTOGRAM_FIELDS(DEFINE_HISTOGRAM)
+#undef DEFINE_HISTOGRAM
 };
 
 } // namespace openmoq::moqx::stats

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -25,6 +25,28 @@ namespace openmoq::moqx::stats {
 inline constexpr std::array<uint64_t, 11> kLatencyBucketsUs =
     {10, 50, 100, 250, 500, 1000, 2000, 5000, 10000, 50000, 100000};
 
+// RTT buckets in milliseconds (from onRttSample).
+inline constexpr std::array<uint64_t, 10> kRttBucketsMs =
+    {1, 5, 10, 25, 50, 100, 250, 500, 1000, 5000};
+
+// Bandwidth buckets in bits/second (from onBandwidthSample).
+inline constexpr std::array<uint64_t, 10> kBandwidthBucketsBitsPerSec = {
+    1000000,
+    5000000,
+    10000000,
+    25000000,
+    50000000,
+    100000000,
+    250000000,
+    500000000,
+    1000000000,
+    10000000000ULL
+};
+
+// Bytes-in-flight buckets in bytes (from onInflightBytesSample).
+inline constexpr std::array<uint64_t, 7> kInflightBytesBuckets =
+    {4096, 65536, 262144, 1048576, 4194304, 16777216, 67108864};
+
 // RequestErrorCode compact-index table
 // All *ErrorCode type aliases resolve to moxygen::RequestErrorCode. we maintain a
 // small ordered lookup table and a constexpr mapping function.  Unknown codes
@@ -180,7 +202,14 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
   X(moqPublishNamespaceLatency, kLatencyBucketsUs, "microseconds")                                 \
   X(moqPublishLatency, kLatencyBucketsUs, "microseconds")
 
-#define STATS_HISTOGRAM_FIELDS(X) STATS_MOQ_HISTOGRAM_FIELDS(X)
+// QUIC transport histograms — populated exclusively by QuicStatsCollector.
+#define STATS_QUIC_HISTOGRAM_FIELDS(X)                                                             \
+  X(quicRttSample, kRttBucketsMs, "milliseconds")                                                  \
+  X(quicBandwidthSample, kBandwidthBucketsBitsPerSec, "bits_per_second")                           \
+  X(quicInflightBytesSample, kInflightBytesBuckets, "bytes")                                       \
+  X(quicCwndHintBytesSample, kInflightBytesBuckets, "bytes")
+
+#define STATS_HISTOGRAM_FIELDS(X) STATS_MOQ_HISTOGRAM_FIELDS(X) STATS_QUIC_HISTOGRAM_FIELDS(X)
 
 // Error-code breakdowns: fields in STATS_MOQ_COUNTER_FIELDS whose callbacks receive
 // a RequestErrorCode argument.  Each expands to a


### PR DESCRIPTION
Add bucket arrays (kRttBucketsMs, kBandwidthBucketsBitsPerSec, kInflightBytesBuckets), STATS_QUIC_HISTOGRAM_FIELDS macro, and BoundedHistogram members to QuicStatsCollector and PicoQuicStatsCollector. Wire onRttSample/onBandwidthSample/onInflightBytesSample/ onCwndHintBytesSample callbacks and include them in each collector's snapshot().

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/294)
<!-- Reviewable:end -->
