### PR TITLE
stats: add EventBaseStatsCollector and wire into relay servers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ add_library(moqx_core STATIC
   src/stats/MoQStatsCollector.cpp
   src/stats/PicoQuicStatsCollector.cpp
   src/stats/QuicStatsCollector.cpp
+  src/stats/EventBaseStatsCollector.cpp
   src/UpstreamProvider.cpp
   src/relay/TopNFilter.cpp
   src/relay/PropertyRanking.cpp

--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -6,6 +6,7 @@
 
 #include "MoqxPicoRelayServer.h"
 
+#include "stats/EventBaseStatsCollector.h"
 #include "stats/PicoQuicStatsCollector.h"
 #include <folly/io/async/EventBase.h>
 #include <folly/logging/xlog.h>
@@ -94,7 +95,9 @@ MoqxPicoRelayServer::~MoqxPicoRelayServer() {
 
 void MoqxPicoRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
   context_->setStatsRegistry(registry);
-  auto collector = stats::PicoQuicStatsCollector::create(std::move(registry), evb_);
+  auto evbCollector = stats::EventBaseStatsCollector::create(registry, evb_);
+  auto collector =
+      stats::PicoQuicStatsCollector::create(std::move(registry), evb_, evbCollector.get());
   setPicoQuicStatsCallback(std::move(collector));
 }
 

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "MoqxRelayServer.h"
+#include "stats/EventBaseStatsCollector.h"
 #include "stats/QuicStatsCollector.h"
 #include <moxygen/MoQRelaySession.h>
 #include <moxygen/events/MoQFollyExecutorImpl.h>
@@ -107,6 +108,9 @@ MoqxRelayServer::~MoqxRelayServer() {
 
 void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
   context_->setStatsRegistry(registry);
+  for (auto& ka : ioExecutor_->getAllEventBases()) {
+    stats::EventBaseStatsCollector::create(registry, ka.get());
+  }
   setQuicStatsFactory(std::make_unique<stats::QuicStatsCollector::Factory>(std::move(registry)));
 }
 

--- a/src/stats/EventBaseStatsCollector.cpp
+++ b/src/stats/EventBaseStatsCollector.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "stats/EventBaseStatsCollector.h"
+
+namespace openmoq::moqx::stats {
+
+/* static */
+std::shared_ptr<EventBaseStatsCollector>
+EventBaseStatsCollector::create(std::shared_ptr<StatsRegistry> registry, folly::EventBase* evb) {
+  auto collector = std::shared_ptr<EventBaseStatsCollector>(new EventBaseStatsCollector(evb));
+  registry->registerEvbCollector(evb, collector);
+  evb->runImmediatelyOrRunInEventBaseThread([evb, collector] { evb->setObserver(collector); });
+  return collector;
+}
+
+EventBaseStatsCollector::EventBaseStatsCollector(folly::EventBase* evb) : evb_(evb) {}
+
+void EventBaseStatsCollector::addLoopObserver(std::function<void(int64_t, int64_t)> cb) {
+  evb_->runImmediatelyOrRunInEventBaseThread([this, cb = std::move(cb)]() mutable {
+    observers_.emplace_back(std::move(cb));
+  });
+}
+
+void EventBaseStatsCollector::loopSample(int64_t busyUs, int64_t idleUs) {
+  evbLoopBusy_.addValue(static_cast<uint64_t>(busyUs));
+  evbLoopIdle_.addValue(static_cast<uint64_t>(idleUs));
+
+  for (auto& cb : observers_) {
+    cb(busyUs, idleUs);
+  }
+}
+
+StatsSnapshot EventBaseStatsCollector::snapshot() const {
+  StatsSnapshot snap;
+
+#define COPY_HISTOGRAM(name, bounds, unit)                                                         \
+  name##_.fillCumulative(snap.name##Buckets);                                                      \
+  snap.name##Sum = name##_.sum;                                                                    \
+  snap.name##Count = name##_.count;
+  STATS_EVB_HISTOGRAM_FIELDS(COPY_HISTOGRAM)
+#undef COPY_HISTOGRAM
+
+  return snap;
+}
+
+folly::Executor* EventBaseStatsCollector::owningExecutor() const {
+  return evb_;
+}
+
+} // namespace openmoq::moqx::stats

--- a/src/stats/EventBaseStatsCollector.h
+++ b/src/stats/EventBaseStatsCollector.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include <folly/io/async/EventBase.h>
+
+#include "stats/BoundedHistogram.h"
+#include "stats/StatsRegistry.h"
+
+namespace openmoq::moqx::stats {
+
+/**
+ * Collects folly EventBase loop-time statistics for one IO thread.
+ *
+ * Implements folly::EventBaseObserver (samples every loop iteration) and
+ * StatsCollectorBase (registered with the StatsRegistry for aggregation).
+ *
+ * Other collectors may subscribe to loop samples via addLoopObserver().
+ * Subscribers MUST outlive this collector (i.e. outlive the EventBase).
+ *
+ * Ownership: shared_ptr held by both the StatsRegistry and the EventBase
+ * observer slot.  Call create() once per worker EventBase.
+ */
+class EventBaseStatsCollector : public StatsCollectorBase, public folly::EventBaseObserver {
+public:
+  static std::shared_ptr<EventBaseStatsCollector>
+  create(std::shared_ptr<StatsRegistry> registry, folly::EventBase* evb);
+
+  ~EventBaseStatsCollector() override = default;
+
+  // StatsCollectorBase
+  StatsSnapshot snapshot() const override;
+  folly::Executor* owningExecutor() const override;
+
+  // folly::EventBaseObserver — sample every loop iteration
+  uint32_t getSampleRate() const override { return 1; }
+  void loopSample(int64_t busyUs, int64_t idleUs) override;
+
+  // Subscribe to loop samples.  cb is invoked on the EVB thread each iteration.
+  // May be called from any thread; the subscription is installed asynchronously.
+  // The caller must ensure the objects captured by cb outlive this collector.
+  void addLoopObserver(std::function<void(int64_t, int64_t)> cb);
+
+private:
+  explicit EventBaseStatsCollector(folly::EventBase* evb);
+
+  folly::EventBase* evb_;
+
+  // Only accessed on evb_ thread.
+  std::vector<std::function<void(int64_t, int64_t)>> observers_;
+
+#define DEFINE_HISTOGRAM(name, bounds, unit) BoundedHistogram<bounds.size()> name##_{bounds};
+  STATS_EVB_HISTOGRAM_FIELDS(DEFINE_HISTOGRAM)
+#undef DEFINE_HISTOGRAM
+};
+
+} // namespace openmoq::moqx::stats

--- a/src/stats/PicoQuicStatsCollector.cpp
+++ b/src/stats/PicoQuicStatsCollector.cpp
@@ -6,13 +6,31 @@
 
 #include "stats/PicoQuicStatsCollector.h"
 
+#include <folly/tracing/StaticTracepoint.h>
+
 namespace openmoq::moqx::stats {
 
 /* static */
-std::shared_ptr<PicoQuicStatsCollector>
-PicoQuicStatsCollector::create(std::shared_ptr<StatsRegistry> registry, folly::EventBase* evb) {
+std::shared_ptr<PicoQuicStatsCollector> PicoQuicStatsCollector::create(
+    std::shared_ptr<StatsRegistry> registry,
+    folly::EventBase* evb,
+    EventBaseStatsCollector* evbCollector
+) {
   auto collector = std::shared_ptr<PicoQuicStatsCollector>(new PicoQuicStatsCollector(evb));
   registry->registerCollector(collector);
+  if (evbCollector) {
+    evbCollector->addLoopObserver([c = collector.get()](int64_t busyUs, int64_t /*idleUs*/) {
+      uint64_t sent = c->quicPacketsSent_;
+      uint64_t recv = c->quicPacketsReceived_;
+      uint64_t dSent = sent - c->prevLoopPktsSent_;
+      uint64_t dRecv = recv - c->prevLoopPktsRecv_;
+      c->evbPktsSentPerLoop_.addValue(dSent);
+      c->evbPktsRecvPerLoop_.addValue(dRecv);
+      c->prevLoopPktsSent_ = sent;
+      c->prevLoopPktsRecv_ = recv;
+      FOLLY_SDT(moqx, evb_loop_sample, busyUs, dSent, dRecv);
+    });
+  }
   return collector;
 }
 
@@ -40,8 +58,15 @@ void PicoQuicStatsCollector::onStreamReset() {
   ++quicStreamsReset_;
 }
 
+void PicoQuicStatsCollector::onPacketsSent(uint64_t n) {
+  quicPacketsSent_ += n;
+}
+
+void PicoQuicStatsCollector::onPacketsReceived(uint64_t n) {
+  quicPacketsReceived_ += n;
+}
+
 void PicoQuicStatsCollector::onPathQualityDelta(const PathQualityDelta& d) {
-  quicPacketsSent_ += d.packetsSent;
   quicPacketLoss_ += d.packetsLost;
   quicBytesWritten_ += d.bytesSent;
   quicBytesRead_ += d.bytesReceived;

--- a/src/stats/PicoQuicStatsCollector.h
+++ b/src/stats/PicoQuicStatsCollector.h
@@ -13,6 +13,7 @@
 #include <moxygen/openmoq/transport/pico/PicoQuicStatsCallback.h>
 
 #include "stats/BoundedHistogram.h"
+#include "stats/EventBaseStatsCollector.h"
 #include "stats/StatsRegistry.h"
 
 namespace openmoq::moqx::stats {
@@ -28,8 +29,13 @@ namespace openmoq::moqx::stats {
  */
 class PicoQuicStatsCollector : public StatsCollectorBase, public moxygen::PicoQuicStatsCallback {
 public:
-  static std::shared_ptr<PicoQuicStatsCollector>
-  create(std::shared_ptr<StatsRegistry> registry, folly::EventBase* evb);
+  // evbCollector is optional; if provided, registers a loop observer to
+  // populate evbPktsSentPerLoop/evbPktsRecvPerLoop from per-loop deltas.
+  static std::shared_ptr<PicoQuicStatsCollector> create(
+      std::shared_ptr<StatsRegistry> registry,
+      folly::EventBase* evb,
+      EventBaseStatsCollector* evbCollector = nullptr
+  );
 
   ~PicoQuicStatsCollector() override = default;
 
@@ -44,11 +50,16 @@ public:
   void onStreamClosed() override;
   void onStreamReset() override;
   void onPathQualityDelta(const PathQualityDelta& d) override;
+  void onPacketsSent(uint64_t n) override;
+  void onPacketsReceived(uint64_t n) override;
 
 private:
   PicoQuicStatsCollector(folly::EventBase* evb);
 
   folly::EventBase* evb_;
+
+  uint64_t prevLoopPktsSent_{0};
+  uint64_t prevLoopPktsRecv_{0};
 
   // Counters and gauges — all writes on evb_, no sync needed.
 #define DEFINE_FIELD(type, name) type name##_{0};

--- a/src/stats/QuicStatsCollector.cpp
+++ b/src/stats/QuicStatsCollector.cpp
@@ -7,6 +7,7 @@
 #include "stats/QuicStatsCollector.h"
 
 #include <folly/io/async/EventBaseManager.h>
+#include <folly/tracing/StaticTracepoint.h>
 #include <glog/logging.h>
 
 namespace openmoq::moqx::stats {
@@ -18,7 +19,7 @@ namespace openmoq::moqx::stats {
 class QuicStatsCollector::Callback : public quic::QuicTransportStatsCallback {
 public:
   explicit Callback(std::weak_ptr<StatsRegistry> registry)
-      : data_(std::shared_ptr<QuicStatsCollector>(new QuicStatsCollector())) {
+      : data_(std::shared_ptr<QuicStatsCollector>(new QuicStatsCollector())), registry_(registry) {
     if (auto reg = registry.lock()) {
       reg->registerCollector(data_);
     }
@@ -150,9 +151,26 @@ private:
     auto* evb = folly::EventBaseManager::get()->getExistingEventBase();
     CHECK(evb) << "QuicStatsCollector::Callback: first callback not on an EventBase thread";
     data_->owningEvb_.store(evb, std::memory_order_relaxed);
+
+    if (auto reg = registry_.lock()) {
+      if (auto evbColl = reg->findEvbCollector(evb).lock()) {
+        evbColl->addLoopObserver([d = data_.get()](int64_t busyUs, int64_t /*idleUs*/) {
+          uint64_t sent = d->quicPacketsSent_;
+          uint64_t recv = d->quicPacketsReceived_;
+          uint64_t dSent = sent - d->prevLoopPktsSent_;
+          uint64_t dRecv = recv - d->prevLoopPktsRecv_;
+          d->evbPktsSentPerLoop_.addValue(dSent);
+          d->evbPktsRecvPerLoop_.addValue(dRecv);
+          d->prevLoopPktsSent_ = sent;
+          d->prevLoopPktsRecv_ = recv;
+          FOLLY_SDT(moqx, evb_loop_sample, busyUs, dSent, dRecv);
+        });
+      }
+    }
   }
 
   std::shared_ptr<QuicStatsCollector> data_;
+  std::weak_ptr<StatsRegistry> registry_;
 };
 
 QuicStatsCollector::Factory::Factory(std::shared_ptr<StatsRegistry> registry)

--- a/src/stats/QuicStatsCollector.h
+++ b/src/stats/QuicStatsCollector.h
@@ -15,6 +15,7 @@
 #include <quic/state/QuicTransportStatsCallback.h>
 
 #include "stats/BoundedHistogram.h"
+#include "stats/EventBaseStatsCollector.h"
 #include "stats/StatsRegistry.h"
 
 namespace openmoq::moqx::stats {
@@ -56,6 +57,9 @@ private:
   QuicStatsCollector() = default;
 
   std::atomic<folly::EventBase*> owningEvb_{nullptr};
+
+  uint64_t prevLoopPktsSent_{0};
+  uint64_t prevLoopPktsRecv_{0};
 
   // Counters and gauges (no sync needed; all writes on the QUIC IO EventBase).
 #define DEFINE_FIELD(type, name) type name##_{0};

--- a/src/stats/StatsRegistry.cpp
+++ b/src/stats/StatsRegistry.cpp
@@ -6,6 +6,8 @@
 
 #include "stats/StatsRegistry.h"
 
+#include "stats/EventBaseStatsCollector.h"
+
 #include <algorithm>
 #include <folly/Conv.h>
 #include <folly/io/Cursor.h>
@@ -128,6 +130,26 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
 #undef EMIT_ERROR_COUNTER
 
   return queue.move();
+}
+
+void StatsRegistry::registerEvbCollector(
+    folly::EventBase* evb,
+    std::shared_ptr<EventBaseStatsCollector> collector
+) {
+  registerCollector(collector);
+  evb->runImmediatelyOrRunInEventBaseThread(
+      [this, evb, weak = std::weak_ptr<EventBaseStatsCollector>(collector)]() mutable {
+        evbCollectors_.emplace(*evb, std::move(weak));
+      }
+  );
+}
+
+std::weak_ptr<EventBaseStatsCollector> StatsRegistry::findEvbCollector(folly::EventBase* evb
+) const {
+  if (auto* ptr = evbCollectors_.get(*evb)) {
+    return *ptr;
+  }
+  return {};
 }
 
 void StatsRegistry::registerCollector(std::shared_ptr<StatsCollectorBase> collector) {

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -16,6 +16,7 @@
 #include <folly/coro/Task.h>
 #include <folly/executors/SequencedExecutor.h>
 #include <folly/io/IOBuf.h>
+#include <folly/io/async/EventBaseLocal.h>
 
 #include <moxygen/MoQTypes.h>
 
@@ -46,6 +47,14 @@ inline constexpr std::array<uint64_t, 10> kBandwidthBucketsBitsPerSec = {
 // Bytes-in-flight buckets in bytes (from onInflightBytesSample).
 inline constexpr std::array<uint64_t, 7> kInflightBytesBuckets =
     {4096, 65536, 262144, 1048576, 4194304, 16777216, 67108864};
+
+// EventBase loop time buckets in microseconds.
+inline constexpr std::array<uint64_t, 11> kEvbLoopBucketsUs =
+    {50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000};
+
+// Per-loop QUIC packet count buckets.
+inline constexpr std::array<uint64_t, 12> kEvbPktsPerLoopBuckets =
+    {0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024};
 
 // RequestErrorCode compact-index table
 // All *ErrorCode type aliases resolve to moxygen::RequestErrorCode. we maintain a
@@ -202,14 +211,23 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
   X(moqPublishNamespaceLatency, kLatencyBucketsUs, "microseconds")                                 \
   X(moqPublishLatency, kLatencyBucketsUs, "microseconds")
 
-// QUIC transport histograms — populated exclusively by QuicStatsCollector.
+// QUIC transport histograms — populated by QuicStatsCollector and PicoQuicStatsCollector.
+// Per-loop packet fields require an EventBaseStatsCollector loop observer to be wired up.
 #define STATS_QUIC_HISTOGRAM_FIELDS(X)                                                             \
   X(quicRttSample, kRttBucketsMs, "milliseconds")                                                  \
   X(quicBandwidthSample, kBandwidthBucketsBitsPerSec, "bits_per_second")                           \
   X(quicInflightBytesSample, kInflightBytesBuckets, "bytes")                                       \
-  X(quicCwndHintBytesSample, kInflightBytesBuckets, "bytes")
+  X(quicCwndHintBytesSample, kInflightBytesBuckets, "bytes")                                       \
+  X(evbPktsSentPerLoop, kEvbPktsPerLoopBuckets, "packets")                                         \
+  X(evbPktsRecvPerLoop, kEvbPktsPerLoopBuckets, "packets")
 
-#define STATS_HISTOGRAM_FIELDS(X) STATS_MOQ_HISTOGRAM_FIELDS(X) STATS_QUIC_HISTOGRAM_FIELDS(X)
+// EventBase loop time histograms — populated by EventBaseStatsCollector, one per IO thread.
+#define STATS_EVB_HISTOGRAM_FIELDS(X)                                                              \
+  X(evbLoopBusy, kEvbLoopBucketsUs, "microseconds")                                                \
+  X(evbLoopIdle, kEvbLoopBucketsUs, "microseconds")
+
+#define STATS_HISTOGRAM_FIELDS(X)                                                                  \
+  STATS_MOQ_HISTOGRAM_FIELDS(X) STATS_QUIC_HISTOGRAM_FIELDS(X) STATS_EVB_HISTOGRAM_FIELDS(X)
 
 // Error-code breakdowns: fields in STATS_MOQ_COUNTER_FIELDS whose callbacks receive
 // a RequestErrorCode argument.  Each expands to a
@@ -265,6 +283,8 @@ public:
   virtual folly::Executor* owningExecutor() const = 0;
 };
 
+class EventBaseStatsCollector;
+
 class StatsRegistry {
 public:
   StatsRegistry() = default;
@@ -272,11 +292,20 @@ public:
 
   void registerCollector(std::shared_ptr<StatsCollectorBase> collector);
 
+  // Registers the collector for aggregation and associates it with its EVB so
+  // QUIC collectors can subscribe to loop samples.  May be called from any
+  // thread; the EVB association is scheduled onto the EVB thread.
+  void
+  registerEvbCollector(folly::EventBase* evb, std::shared_ptr<EventBaseStatsCollector> collector);
+
+  // Must be called on the EVB thread.
+  std::weak_ptr<EventBaseStatsCollector> findEvbCollector(folly::EventBase* evb) const;
+
   folly::coro::Task<StatsSnapshot> aggregateAsync();
 
 private:
-  // Ownership stays with callers. aggregateAsync() prunes it lazily.
   std::vector<std::weak_ptr<StatsCollectorBase>> collectors_;
+  mutable folly::EventBaseLocal<std::weak_ptr<EventBaseStatsCollector>> evbCollectors_;
 };
 
 } // namespace openmoq::moqx::stats

--- a/test/stats/PicoQuicStatsCollectorTest.cpp
+++ b/test/stats/PicoQuicStatsCollectorTest.cpp
@@ -48,8 +48,12 @@ TEST_F(PicoQuicStatsCollectorTest, ConnectionLifecycle) {
 TEST_F(PicoQuicStatsCollectorTest, PathQualityDeltaAccumulation) {
   using Delta = moxygen::PicoQuicStatsCallback::PathQualityDelta;
 
+  // Packet sent/received counts come via onPacketsSent/onPacketsReceived
+  // (socket-level drain callbacks), not from PathQualityDelta.
+  collector_->onPacketsSent(10);
+  collector_->onPacketsReceived(7);
+
   Delta d1{};
-  d1.packetsSent = 10;
   d1.packetsLost = 1;
   d1.bytesSent = 1000;
   d1.bytesReceived = 800;
@@ -58,8 +62,10 @@ TEST_F(PicoQuicStatsCollectorTest, PathQualityDeltaAccumulation) {
   d1.cwndBlocked = false;
   collector_->onPathQualityDelta(d1);
 
+  collector_->onPacketsSent(5);
+  collector_->onPacketsReceived(3);
+
   Delta d2{};
-  d2.packetsSent = 5;
   d2.packetsLost = 0;
   d2.bytesSent = 500;
   d2.bytesReceived = 400;
@@ -70,6 +76,7 @@ TEST_F(PicoQuicStatsCollectorTest, PathQualityDeltaAccumulation) {
 
   auto snap = collector_->snapshot();
   EXPECT_EQ(snap.quicPacketsSent, 15);
+  EXPECT_EQ(snap.quicPacketsReceived, 10);
   EXPECT_EQ(snap.quicPacketLoss, 1);
   EXPECT_EQ(snap.quicBytesWritten, 1500);
   EXPECT_EQ(snap.quicBytesRead, 1200);

--- a/test/test_admin_metrics.sh
+++ b/test/test_admin_metrics.sh
@@ -97,6 +97,11 @@ EXPECTED_METRICS=(
   "moqx_moqPublishSuccess_total"
   "moqx_moqSubscribeLatency_microseconds"
   "moqx_moqFetchLatency_microseconds"
+  "moqx_quicPacketsSent_total"
+  "moqx_quicRttSample_milliseconds"
+  "moqx_evbPktsSentPerLoop_packets"
+  "moqx_evbLoopBusy_microseconds"
+  "moqx_evbLoopIdle_microseconds"
 )
 
 for metric in "${EXPECTED_METRICS[@]}"; do
@@ -119,6 +124,14 @@ fi
 
 if ! grep -q '_count ' <<<"$RESPONSE"; then
   echo "FAIL: no histogram _count lines found" >&2
+  exit 1
+fi
+
+# Validate that EVB loop samples were actually collected (the event loop runs
+# continuously, so count must be non-zero by the time /metrics is fetched).
+EVB_COUNT=$(grep '^moqx_evbLoopBusy_microseconds_count ' <<<"$RESPONSE" | awk '{print $2}' | head -1)
+if [[ -z "$EVB_COUNT" ]] || [[ "$EVB_COUNT" -eq 0 ]]; then
+  echo "FAIL: moqx_evbLoopBusy_microseconds_count is zero or missing (expected > 0)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Add EventBaseStatsCollector which implements folly::EventBaseObserver to sample busy/idle loop times per IO thread. Wire it into MoqxRelayServer (one collector per evb worker) and MoqxPicoRelayServer (single evb). Add kEvbLoopBucketsUs and STATS_EVB_HISTOGRAM_FIELDS to the shared StatsRegistry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/295)
<!-- Reviewable:end -->
