### PR TITLE
hotfix: drop cmake_minimum_required to 3.22 (closes #296)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -22,9 +22,9 @@ Six steps. Each links to its detail section.
    `git clone … && cd moqx && git submodule update --init` —
    the submodule pins the exact moxygen commit the build will use
    (see [Dependency Modes](#dependency-modes)).
-2. **Ensure CMake 3.25+** is on `PATH`. moqx top-level `CMakeLists.txt`
-   requires it; `build.sh` aborts early otherwise. On Jammy follow
-   [Installing CMake 3.25+](#installing-cmake-325-ubuntudebian).
+2. **Ensure CMake 3.22+** is on `PATH`. All current targets ship a
+   new-enough version: Ubuntu 22.04+, Debian 12+, recent macOS Homebrew.
+   `build.sh` aborts early if cmake is missing or too old.
 3. **Install system libraries.** Required in *both* dependency modes —
    see the system-libraries bullet in [Prerequisites](#prerequisites)
    for why. One-liner:
@@ -42,11 +42,11 @@ If you'd rather build in a clean container, skip to
 
 ## Prerequisites
 
-- **CMake 3.25+** — required by moqx top-level `CMakeLists.txt`. Ubuntu 22.04
-  ships 3.22 (too old); install from Kitware (see below). Ubuntu 24.04+ and
-  recent macOS Homebrew ship a new-enough version. `build.sh` enforces this
-  and aborts early with install instructions if cmake is missing or too old
-  (override with `MOQX_SKIP_CMAKE_CHECK=1`).
+- **CMake 3.22+** — required by moqx top-level `CMakeLists.txt`. All
+  current targets ship a new-enough version out of the box: Ubuntu
+  22.04+, Debian 12+, recent macOS Homebrew. `build.sh` enforces this
+  and aborts early if cmake is missing or too old (override with
+  `MOQX_SKIP_CMAKE_CHECK=1`).
 - Ninja, C++20 compiler (GCC 11+ / Clang 14+).
 - `curl` for downloading the moxygen release tarball
   ([`setup-deps-tarball.sh`](scripts/setup-deps-tarball.sh)). No `gh` CLI is
@@ -65,37 +65,19 @@ If you'd rather build in a clean container, skip to
   source build — it does not preempt the build-step failure if libs are
   missing.)
 
-### Installing CMake 3.25+
+### Installing CMake
 
-moqx requires CMake 3.25+. By platform:
+moqx requires CMake 3.22+. All current targets ship a new-enough version
+out of the box:
 
-**Ubuntu 24.04+ / Debian 12+** — distro packages are new enough:
+**Ubuntu 22.04+ / Debian 12+:**
 
 ```bash
 sudo apt-get install -y cmake
-cmake --version   # should show 3.25+
+cmake --version   # should show 3.22+
 ```
 
-**Ubuntu 22.04 (Jammy)** — distro ships 3.22, too old. Install from the
-Kitware APT repo:
-
-```bash
-# Remove distro cmake if installed
-sudo apt-get remove --purge cmake
-
-# Add Kitware signing key and repo
-sudo apt-get install -y gpg wget
-wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
-  | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
-  | sudo tee /etc/apt/sources.list.d/kitware.list
-
-sudo apt-get update
-sudo apt-get install -y cmake
-cmake --version   # should show 3.25+
-```
-
-**macOS (Homebrew)** — Homebrew currently ships cmake 3.30+:
+**macOS (Homebrew):**
 
 ```bash
 brew install cmake     # or `brew upgrade cmake` if already present
@@ -117,9 +99,7 @@ who don't want to install deps on their host:
 docker run --rm -it -v "$PWD":/src -w /src ubuntu:22.04 bash
 
 # Inside the container:
-apt-get update && apt-get install -y gpg wget lsb-release sudo git curl ca-certificates
-# Install cmake 3.25+ from Kitware (see above)
-# Then:
+apt-get update && apt-get install -y cmake ninja-build sudo git curl ca-certificates
 git submodule update --init
 sudo deps/moxygen/standalone/install-system-deps.sh
 ./scripts/build.sh setup --from-source   # build from source (no release artifacts available offline)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.22)
 
 project(moqx VERSION 0.1.0 LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,11 @@ handler and create `MoQRelaySession` instances for incoming connections.
 
 ## Quick Start
 
-> **Prerequisite: CMake 3.25+ is required.** Ubuntu 22.04 (Jammy) ships
-> CMake 3.22, which is too old — the moqx top-level `CMakeLists.txt` will
-> reject it at configure. `build.sh` aborts early with install instructions
-> if it sees a missing or old cmake (override with `MOQX_SKIP_CMAKE_CHECK=1`
-> if you know what you're doing). Ubuntu 24.04+ and recent macOS Homebrew
-> ship a new-enough version out of the box. Verify with `cmake --version`.
-> Per-platform install instructions:
-> [BUILD.md → Installing CMake 3.25+](BUILD.md#installing-cmake-325).
+> **Prerequisite: CMake 3.22+ is required.** All current targets ship a
+> new-enough version out of the box: Ubuntu 22.04+, Debian 12+, recent
+> macOS Homebrew. Verify with `cmake --version`. `build.sh` aborts early
+> if cmake is missing or too old (override with `MOQX_SKIP_CMAKE_CHECK=1`
+> if you know what you're doing).
 
 ```bash
 git clone https://github.com/openmoq/moqx.git && cd moqx

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,7 @@
 #   ./scripts/build.sh test [--build-dir DIR] [-- CTEST_ARGS...]
 #
 # First-time setup: see README "Quick Start" and BUILD.md "Prerequisites"
-# (CMake 3.25+, system libs).
+# (CMake 3.22+, system libs).
 #
 # Incremental (after source changes):
 #   ./scripts/build.sh          # rebuilds only what changed
@@ -35,21 +35,18 @@ DEPS_MODE_FILE="${SCRATCH}/deps-mode"
 die() { echo "Error: $*" >&2; exit 1; }
 
 # ── CMake version precheck ───────────────────────────────────────────────────
-# moqx top-level CMakeLists.txt requires cmake_minimum_required(VERSION 3.25).
-# Ubuntu 22.04 (Jammy) ships 3.22, which fails at configure. Detect early so
-# users see actionable install instructions instead of a buried cmake error
-# 30 seconds into the build. Override with MOQX_SKIP_CMAKE_CHECK=1 if you're
-# building in an environment that satisfies the requirement another way.
+# moqx top-level CMakeLists.txt requires cmake_minimum_required(VERSION 3.22).
+# All current targets (Ubuntu 22.04, 24.04+, Debian 12+, recent Homebrew
+# macOS) ship a new-enough cmake out of the box. Override with
+# MOQX_SKIP_CMAKE_CHECK=1 if your environment uses a non-default path.
 require_cmake_version() {
   [[ "${MOQX_SKIP_CMAKE_CHECK:-}" == "1" ]] && return 0
 
   if ! command -v cmake >/dev/null 2>&1; then
     cat >&2 <<'EOF'
 Error: cmake not found in PATH.
-moqx requires CMake 3.25+. Install:
-  Ubuntu 24.04+ / Debian 12+:  sudo apt-get install cmake
-  Ubuntu 22.04 (Jammy):        cmake 3.22 in apt is too old; install from Kitware:
-                               see BUILD.md "Installing CMake 3.25+"
+moqx requires CMake 3.22+. Install:
+  Ubuntu 22.04+ / Debian 12+:  sudo apt-get install cmake
   macOS:                       brew install cmake
 
 To bypass this check (advanced): export MOQX_SKIP_CMAKE_CHECK=1
@@ -61,28 +58,17 @@ EOF
   ver=$(cmake --version | head -1 | sed 's/[^0-9]*\([0-9]*\.[0-9]*\).*/\1/')
   major=$(echo "$ver" | cut -d. -f1)
   minor=$(echo "$ver" | cut -d. -f2)
-  if (( major < 3 || (major == 3 && minor < 25) )); then
+  if (( major < 3 || (major == 3 && minor < 22) )); then
     cat >&2 <<EOF
-Error: CMake $ver is too old. moqx requires 3.25+ (top-level CMakeLists.txt).
+Error: CMake $ver is too old. moqx requires 3.22+ (top-level CMakeLists.txt).
 
   $(command -v cmake) — $(cmake --version | head -1)
 
-The moqx configure step will fail with this version. To install 3.25+:
+To install a newer cmake:
+  Ubuntu 22.04+ / Debian 12+:  sudo apt-get install cmake
+  macOS:                       brew install cmake
 
-  Ubuntu 22.04 (Jammy):
-    sudo apt-get remove --purge cmake
-    sudo apt-get install -y gpg wget
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \\
-      | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ \$(lsb_release -cs) main" \\
-      | sudo tee /etc/apt/sources.list.d/kitware.list
-    sudo apt-get update && sudo apt-get install -y cmake
-
-  Ubuntu 24.04+:  sudo apt-get install cmake
-  macOS:          brew install cmake
-
-To bypass this check (e.g. you have a 3.25+ cmake on a non-default path
-and have set CMAKE in your environment): export MOQX_SKIP_CMAKE_CHECK=1
+To bypass this check: export MOQX_SKIP_CMAKE_CHECK=1
 EOF
     exit 1
   fi
@@ -164,9 +150,9 @@ check_system_deps() {
     fi
   fi
 
-  # NOTE: CMake version is enforced by require_cmake_version() — kept separate
-  # because the install instructions differ from a plain apt-get (Kitware repo
-  # required on Ubuntu 22.04).
+  # NOTE: CMake version is enforced by require_cmake_version() — kept
+  # separate so we can give a clean, focused error if cmake is missing or
+  # too old before any other dep checks run.
 
   for w in "${warnings[@]+"${warnings[@]}"}"; do
     echo "  Warning: $w"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,12 +68,21 @@ target_compile_definitions(moqx_config_test PRIVATE
   CONFIG_EXAMPLE_PATH="${PROJECT_SOURCE_DIR}/config.example.yaml"
 )
 if(NOT GFLAGS_SHARED)
-  target_link_libraries(moqx_config_test PRIVATE
-    "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
-  )
-  set_property(TARGET moqx_config_test PROPERTY
-    LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
-  )
+  # Force gflags's DEFINE_FLAG-registered .o files into the binary, even
+  # though the test code doesn't reference gflags symbols directly. Cross-
+  # platform raw linker flags — works with cmake 3.22, unlike the
+  # $<LINK_LIBRARY:WHOLE_ARCHIVE,...> genex which needs cmake 3.24+.
+  if(APPLE)
+    target_link_libraries(moqx_config_test PRIVATE
+      "-Wl,-force_load,$<TARGET_FILE:gflags_nothreads_static>"
+    )
+  else()
+    target_link_libraries(moqx_config_test PRIVATE
+      "-Wl,--whole-archive"
+      gflags_nothreads_static
+      "-Wl,--no-whole-archive"
+    )
+  endif()
 endif()
 gtest_discover_tests(moqx_config_test)
 
@@ -86,12 +95,17 @@ target_link_libraries(moqx_config_resolver_test PRIVATE
   GTest::gmock
 )
 if(NOT GFLAGS_SHARED)
-  target_link_libraries(moqx_config_resolver_test PRIVATE
-    "$<LINK_LIBRARY:WHOLE_ARCHIVE,gflags_nothreads_static>"
-  )
-  set_property(TARGET moqx_config_resolver_test PROPERTY
-    LINK_LIBRARY_OVERRIDE "WHOLE_ARCHIVE,gflags_nothreads_static"
-  )
+  if(APPLE)
+    target_link_libraries(moqx_config_resolver_test PRIVATE
+      "-Wl,-force_load,$<TARGET_FILE:gflags_nothreads_static>"
+    )
+  else()
+    target_link_libraries(moqx_config_resolver_test PRIVATE
+      "-Wl,--whole-archive"
+      gflags_nothreads_static
+      "-Wl,--no-whole-archive"
+    )
+  endif()
 endif()
 gtest_discover_tests(moqx_config_resolver_test)
 


### PR DESCRIPTION
Closes #296.

## What

Drop `cmake_minimum_required(VERSION 3.25 → 3.22)` so Ubuntu 22.04 (Jammy) stock cmake works out of the box. No Kitware repo install needed, no `MOQX_SKIP_CMAKE_CHECK` workaround.

## How

The 3.25 requirement was driven by one cmake 3.24+ feature: `$<LINK_LIBRARY:WHOLE_ARCHIVE,...>` in `test/CMakeLists.txt` (forces gflags's `DEFINE_FLAG`-registered `.o` files into the test binary, since the test code doesn't reference gflags symbols directly).

Replaced with cross-platform raw linker flags:

```cmake
if(NOT GFLAGS_SHARED)
  if(APPLE)
    target_link_libraries(<test> PRIVATE
      "-Wl,-force_load,$<TARGET_FILE:gflags_nothreads_static>"
    )
  else()
    target_link_libraries(<test> PRIVATE
      "-Wl,--whole-archive"
      gflags_nothreads_static
      "-Wl,--no-whole-archive"
    )
  endif()
endif()
```

Same runtime effect; works on cmake 3.22.

## Files changed

| File | Change |
|---|---|
| `CMakeLists.txt` | `cmake_minimum_required(VERSION 3.25 → 3.22)` |
| `test/CMakeLists.txt` | replace `LINK_LIBRARY:WHOLE_ARCHIVE` + `LINK_LIBRARY_OVERRIDE` with platform-conditional raw flags (4 sites) |
| `scripts/build.sh` | preflight check 3.22+; drop Kitware repo install nudge from error messages |
| `README.md` | Quick Start prereq trimmed: `CMake 3.22+` works on all targets natively |
| `BUILD.md` | "Installing CMake 3.25+" section removed; reduced to `apt-get install cmake` / `brew install cmake` |

## Scope

Doesn't change moqx's gflags use itself. `DEFINE_FLAG` calls remain in `src/main.cpp`, `src/config/ConfigInit.cpp`, `test/TrackFilterLoadTest.cpp`. The production binary doesn't need WHOLE_ARCHIVE because `main()` references gflags symbols directly; tests need it because they don't.

Full gflags exorcism (replacing moqx's CLI11 use of gflags + folly fork patches for `FOLLY_USE_GFLAGS=OFF`) is a much larger effort — separate proposal, coordinated with the logging retrofit. Tracked separately.

## Test plan

- [ ] PR's own `ci pr` passes — exercises the new linker flags on the linux job
- [ ] After merge, validate locally on a fresh Ubuntu 22.04 VM with stock cmake 3.22.1: `bash scripts/build.sh setup && bash scripts/build.sh && bash scripts/build.sh test` should complete without cmake-version-too-old errors
- [ ] Validate on a macOS dev box: same commands, `-Wl,-force_load` path used

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/297)
<!-- Reviewable:end -->
