### PR TITLE
config+server: add MvfstConfig and wire into TransportSettings

### DIFF
--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -53,18 +53,20 @@ buildFizzContext(const config::ListenerConfig& cfg) {
   );
 }
 
-quic::TransportSettings buildTransportSettings(const config::QuicConfig& quic) {
+quic::TransportSettings
+buildTransportSettings(const config::QuicConfig& quic, const config::MvfstConfig& mvfst) {
   // Start with MoQServer's optimized defaults, then apply config overrides.
   quic::TransportSettings ts;
   ts.defaultCongestionController = quic::CongestionControlType::Copa;
-  ts.copaDeltaParam = 0.05;
-  ts.pacingEnabled = true;
-  ts.maxCwndInMss = quic::kLargeMaxCwndInMss;
-  ts.batchingMode = quic::QuicBatchingMode::BATCHING_MODE_GSO;
-  ts.maxBatchSize = 48;
+  ts.pacingEnabled = mvfst.pacingEnabled;
+  ts.maxCwndInMss = mvfst.maxCwndInMss;
+  ts.batchingMode = mvfst.enableGSO ? quic::QuicBatchingMode::BATCHING_MODE_GSO
+                                    : quic::QuicBatchingMode::BATCHING_MODE_SENDMMSG;
+  ts.maxBatchSize = mvfst.maxConnPacketsSentPerLoop;
+  ts.writeConnectionDataPacketsLimit = mvfst.maxConnPacketsSentPerLoop;
   ts.dataPathType = quic::DataPathType::ContinuousMemory;
-  ts.maxServerRecvPacketsPerLoop = 10;
-  ts.writeConnectionDataPacketsLimit = 48;
+  ts.maxServerRecvPacketsPerLoop = mvfst.maxServerRecvPacketsPerLoop;
+  ts.numGROBuffers_ = mvfst.numGROBuffers;
   ts.advertisedInitialConnectionFlowControlWindow = quic.maxData;
   ts.advertisedInitialBidiLocalStreamFlowControlWindow = quic.maxStreamData;
   ts.advertisedInitialBidiRemoteStreamFlowControlWindow = quic.maxStreamData;
@@ -81,6 +83,38 @@ quic::TransportSettings buildTransportSettings(const config::QuicConfig& quic) {
   if (ccType) {
     ts.defaultCongestionController = *ccType;
   }
+  // Wire CongestionControlConfig fields.
+  auto& cca = ts.ccaConfig;
+  // Copa
+  ts.copaDeltaParam = mvfst.copa.deltaParam;
+
+  // BBR
+  cca.conservativeRecovery = mvfst.bbr.conservativeRecovery;
+  cca.largeProbeRttCwnd = mvfst.bbr.largeProbeRttCwnd;
+  cca.enableAckAggregationInStartup = mvfst.bbr.enableAckAggregationInStartup;
+  cca.probeRttDisabledIfAppLimited = mvfst.bbr.probeRttDisabledIfAppLimited;
+  cca.drainToTarget = mvfst.bbr.drainToTarget;
+
+  // Cubic
+  cca.additiveIncreaseAfterHystart = mvfst.cubic.additiveIncreaseAfterHystart;
+  cca.onlyGrowCwndWhenLimited = mvfst.cubic.onlyGrowCwndWhenLimited;
+  cca.leaveHeadroomForCwndLimited = mvfst.cubic.leaveHeadroomForCwndLimited;
+
+  // BBR2
+  cca.ignoreInflightLongTerm = mvfst.bbr2.ignoreInflightLongTerm;
+  cca.ignoreShortTerm = mvfst.bbr2.ignoreShortTerm;
+  cca.exitStartupOnLoss = mvfst.bbr2.exitStartupOnLoss;
+  cca.enableRecoveryInStartup = mvfst.bbr2.enableRecoveryInStartup;
+  cca.enableRecoveryInProbeStates = mvfst.bbr2.enableRecoveryInProbeStates;
+  cca.enableRenoCoexistence = mvfst.bbr2.enableRenoCoexistence;
+  cca.paceInitCwnd = mvfst.bbr2.paceInitCwnd;
+  cca.overrideCruisePacingGain = mvfst.bbr2.overrideCruisePacingGain;
+  cca.overrideCruiseCwndGain = mvfst.bbr2.overrideCruiseCwndGain;
+  cca.overrideStartupPacingGain = mvfst.bbr2.overrideStartupPacingGain;
+  cca.overrideBwShortBeta = mvfst.bbr2.overrideBwShortBeta;
+
+  // L4S
+  cca.l4sCETarget = mvfst.l4s.ceTarget;
   // TODO: wire defaultStreamPriority / defaultDatagramPriority for mvfst once
   // moxygen exposes a function to construct a PriorityQueue::Priority from an integer.
   return ts;
@@ -96,7 +130,7 @@ MoqxRelayServer::MoqxRelayServer(
     : MoQServer(
           buildFizzContext(listenerCfg),
           listenerCfg.endpoint,
-          buildTransportSettings(listenerCfg.quic)
+          buildTransportSettings(listenerCfg.quic, listenerCfg.mvfst)
       ),
       listenerCfg_(listenerCfg), context_(std::move(context)), ioExecutor_(std::move(ioExecutor)) {}
 

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -57,6 +57,82 @@ struct QuicConfig {
   std::string ccAlgo{"bbr"};          // congestion control algorithm name
 };
 
+// mvfst-specific transport tunables organised by congestion-control algorithm.
+// Defaults match mvfst's own defaults except where moqx intentionally overrides
+// them (noted inline).  CC-specific fields are in sub-structs that map to
+// mvfst: <algo>: blocks in YAML.  General fields sit directly at the mvfst: level.
+struct MvfstConfig {
+  // Max congestion window in MSS (quic::kLargeMaxCwndInMss = 860000).
+  uint64_t maxCwndInMss{860000};
+
+  // Pacing: enabled by default. BBR and BBR2 require pacing; Copa and Cubic
+  // support optional pacing; NewReno and None are always unpaced.
+  bool pacingEnabled{true};
+
+  // Send-path batching: sendmmsg + gso select the QuicBatchingMode (2×2).
+  bool enableGSO{true}; // GSO segmentation; falls back to sendmmsg if unavailable at runtime
+  // Per-connection write loop limit. Written to both maxBatchSize and
+  // writeConnectionDataPacketsLimit so the cap is honored in all batching modes.
+  uint32_t maxConnPacketsSentPerLoop{48};
+
+  // Receive-path tuning.
+  // Max incoming packets processed per event-loop read callback. 0 = unlimited.
+  // mvfst default is 1; moqx was hardcoded to 10.
+  uint16_t maxServerRecvPacketsPerLoop{10};
+  // Number of UDP GRO buffers. 1 = disabled. > 1 enables kernel GRO coalescing.
+  uint32_t numGROBuffers{1};
+
+  // BBR (BBR1) congestion control tunables.
+  // conservativeRecovery is shared with BBR2.
+  struct BBR {
+    bool conservativeRecovery{false}; // also applies to BBR2
+    bool largeProbeRttCwnd{false};
+    bool enableAckAggregationInStartup{false};
+    bool probeRttDisabledIfAppLimited{false};
+    bool drainToTarget{false};
+  };
+
+  // BBR2 congestion control tunables (BBR2-specific fields only;
+  // shared fields like conservativeRecovery live in bbr:).
+  struct BBR2 {
+    bool ignoreInflightLongTerm{false};
+    bool ignoreShortTerm{false};
+    bool exitStartupOnLoss{true};
+    bool enableRecoveryInStartup{true};
+    bool enableRecoveryInProbeStates{true};
+    bool enableRenoCoexistence{false};
+    bool paceInitCwnd{false};
+    float overrideCruisePacingGain{-1.0f};  // -1 = use BBR2 default
+    float overrideCruiseCwndGain{-1.0f};    // -1 = use BBR2 default
+    float overrideStartupPacingGain{-1.0f}; // -1 = use BBR2 default
+    float overrideBwShortBeta{0.0f};
+  };
+
+  // Cubic congestion control tunables.
+  struct Cubic {
+    bool additiveIncreaseAfterHystart{false};
+    bool onlyGrowCwndWhenLimited{false};
+    bool leaveHeadroomForCwndLimited{false};
+  };
+
+  // Copa congestion control tunables.
+  struct Copa {
+    // Target utilisation sensitivity (moqx default: 0.05).
+    double deltaParam{0.05};
+  };
+
+  // L4S tunables (usable alongside any ECN-aware CC algorithm).
+  struct L4S {
+    float ceTarget{0.0f}; // 0 = disabled
+  };
+
+  BBR bbr;
+  BBR2 bbr2;
+  Cubic cubic;
+  Copa copa;
+  L4S l4s;
+};
+
 struct ListenerConfig {
   std::string name;
   folly::SocketAddress address;
@@ -64,7 +140,8 @@ struct ListenerConfig {
   std::string endpoint;
   std::string moqtVersions; // comma-separated string
   QuicStack quicStack{QuicStack::Mvfst};
-  QuicConfig quic; // merged from listener_defaults.quic + per-listener quic override
+  QuicConfig quic;   // merged from listener_defaults.quic + per-listener quic override
+  MvfstConfig mvfst; // merged from listener_defaults.mvfst + per-listener mvfst override
 };
 
 struct UpstreamTlsConfig {

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -441,6 +441,85 @@ QuicConfig mergeQuicConfig(
   return result;
 }
 
+void applyMvfstOverride(MvfstConfig& base, const ParsedMvfstConfig& overlay) {
+  if (auto v = overlay.max_cwnd_in_mss.value())
+    base.maxCwndInMss = *v;
+  if (auto v = overlay.pacing_enabled.value())
+    base.pacingEnabled = *v;
+  if (auto v = overlay.enable_gso.value())
+    base.enableGSO = *v;
+  if (auto v = overlay.max_conn_packets_sent_per_loop.value())
+    base.maxConnPacketsSentPerLoop = *v;
+  if (auto v = overlay.max_server_recv_packets_per_loop.value())
+    base.maxServerRecvPacketsPerLoop = *v;
+  if (auto v = overlay.num_gro_buffers.value())
+    base.numGROBuffers = *v;
+  if (const auto& b = overlay.bbr.value()) {
+    if (auto v = b->conservative_recovery.value())
+      base.bbr.conservativeRecovery = *v;
+    if (auto v = b->large_probe_rtt_cwnd.value())
+      base.bbr.largeProbeRttCwnd = *v;
+    if (auto v = b->enable_ack_aggregation_in_startup.value())
+      base.bbr.enableAckAggregationInStartup = *v;
+    if (auto v = b->probe_rtt_disabled_if_app_limited.value())
+      base.bbr.probeRttDisabledIfAppLimited = *v;
+    if (auto v = b->drain_to_target.value())
+      base.bbr.drainToTarget = *v;
+  }
+  if (const auto& b2 = overlay.bbr2.value()) {
+    if (auto v = b2->ignore_inflight_long_term.value())
+      base.bbr2.ignoreInflightLongTerm = *v;
+    if (auto v = b2->ignore_short_term.value())
+      base.bbr2.ignoreShortTerm = *v;
+    if (auto v = b2->exit_startup_on_loss.value())
+      base.bbr2.exitStartupOnLoss = *v;
+    if (auto v = b2->enable_recovery_in_startup.value())
+      base.bbr2.enableRecoveryInStartup = *v;
+    if (auto v = b2->enable_recovery_in_probe_states.value())
+      base.bbr2.enableRecoveryInProbeStates = *v;
+    if (auto v = b2->enable_reno_coexistence.value())
+      base.bbr2.enableRenoCoexistence = *v;
+    if (auto v = b2->pace_init_cwnd.value())
+      base.bbr2.paceInitCwnd = *v;
+    if (auto v = b2->override_cruise_pacing_gain.value())
+      base.bbr2.overrideCruisePacingGain = *v;
+    if (auto v = b2->override_cruise_cwnd_gain.value())
+      base.bbr2.overrideCruiseCwndGain = *v;
+    if (auto v = b2->override_startup_pacing_gain.value())
+      base.bbr2.overrideStartupPacingGain = *v;
+    if (auto v = b2->override_bw_short_beta.value())
+      base.bbr2.overrideBwShortBeta = *v;
+  }
+  if (const auto& c = overlay.cubic.value()) {
+    if (auto v = c->additive_increase_after_hystart.value())
+      base.cubic.additiveIncreaseAfterHystart = *v;
+    if (auto v = c->only_grow_cwnd_when_limited.value())
+      base.cubic.onlyGrowCwndWhenLimited = *v;
+    if (auto v = c->leave_headroom_for_cwnd_limited.value())
+      base.cubic.leaveHeadroomForCwndLimited = *v;
+  }
+  if (const auto& cp = overlay.copa.value()) {
+    if (auto v = cp->delta_param.value())
+      base.copa.deltaParam = *v;
+  }
+  if (const auto& ls = overlay.l4s.value()) {
+    if (auto v = ls->ce_target.value())
+      base.l4s.ceTarget = *v;
+  }
+}
+
+MvfstConfig mergeMvfstConfig(
+    const std::optional<ParsedMvfstConfig>& defaults,
+    const std::optional<ParsedMvfstConfig>& perListener
+) {
+  MvfstConfig result; // starts with C++ struct defaults
+  if (defaults)
+    applyMvfstOverride(result, *defaults);
+  if (perListener)
+    applyMvfstOverride(result, *perListener);
+  return result;
+}
+
 void validateQuicConfig(
     const QuicConfig& quic,
     QuicStack stack,
@@ -478,21 +557,56 @@ void validateQuicConfig(
         ") must be >= min_ack_delay_us (" + std::to_string(quic.minAckDelayUs) + ")"
     );
   }
-  // (excluded: mvfst "custom"/"staticcwnd" require programmatic setup; "none" disables CC)
+  // (excluded: mvfst "custom"/"staticcwnd" require programmatic setup)
   static const std::unordered_set<std::string> kPicoCcAlgos =
       {"bbr", "bbr1", "c4", "cubic", "dcubic", "fast", "newreno", "prague", "reno"};
   static const std::unordered_set<std::string> kMvfstCcAlgos =
-      {"bbr", "bbr2", "bbr2modular", "copa", "cubic", "newreno"};
+      {"bbr", "bbr2", "bbr2modular", "copa", "cubic", "newreno", "none"};
   const auto& validAlgos = (stack == QuicStack::Picoquic) ? kPicoCcAlgos : kMvfstCcAlgos;
   const auto& validList = (stack == QuicStack::Picoquic)
                               ? "bbr, bbr1, c4, cubic, dcubic, fast, newreno, prague, reno"
-                              : "bbr, bbr2, bbr2modular, copa, cubic, newreno";
+                              : "bbr, bbr2, bbr2modular, copa, cubic, newreno, none";
   if (!validAlgos.count(quic.ccAlgo)) {
     errors.push_back(
         context + " quic: cc_algo '" + quic.ccAlgo +
         "' is not valid for this stack"
         " (valid: " +
         validList + ")"
+    );
+  }
+}
+
+void validateMvfstConfig(
+    const MvfstConfig& mvfst,
+    const std::string& context,
+    std::vector<std::string>& errors,
+    std::vector<std::string>& warnings
+) {
+  if (mvfst.maxCwndInMss == 0) {
+    errors.push_back(context + " mvfst: max_cwnd_in_mss must be >= 1");
+  }
+  if (mvfst.maxConnPacketsSentPerLoop == 0) {
+    errors.push_back(context + " mvfst: max_conn_packets_sent_per_loop must be >= 1");
+  }
+  if (mvfst.numGROBuffers == 0) {
+    errors.push_back(context + " mvfst: num_gro_buffers must be >= 1");
+  }
+  if (mvfst.numGROBuffers > 64) {
+    warnings.push_back(
+        context + " mvfst: num_gro_buffers (" + std::to_string(mvfst.numGROBuffers) +
+        ") exceeds 64; most kernels cap GRO at 64 buffers"
+    );
+  }
+  if (mvfst.copa.deltaParam <= 0.0 || mvfst.copa.deltaParam >= 1.0) {
+    errors.push_back(
+        context + " mvfst: copa.delta_param (" + std::to_string(mvfst.copa.deltaParam) +
+        ") must be in (0, 1)"
+    );
+  }
+  if (mvfst.l4s.ceTarget < 0.0f || mvfst.l4s.ceTarget >= 1.0f) {
+    errors.push_back(
+        context + " mvfst: l4s.ce_target (" + std::to_string(mvfst.l4s.ceTarget) +
+        ") must be 0 (disabled) or in (0, 1)"
     );
   }
 }
@@ -538,7 +652,11 @@ void validatePicoServicePaths(
   }
 }
 
-ListenerConfig resolveListener(const ParsedListenerConfig& listener, const QuicConfig& quic) {
+ListenerConfig resolveListener(
+    const ParsedListenerConfig& listener,
+    const QuicConfig& quic,
+    const MvfstConfig& mvfst
+) {
   const auto& sock = listener.udp.value().socket.value();
   const auto& tls = listener.tls.value();
 
@@ -560,6 +678,7 @@ ListenerConfig resolveListener(const ParsedListenerConfig& listener, const QuicC
       .moqtVersions = moqtVersionsToString(listener),
       .quicStack = quicStack,
       .quic = quic,
+      .mvfst = mvfst,
   };
 }
 
@@ -621,13 +740,16 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
     return folly::makeUnexpected(std::string("At least one listener is required"));
   }
 
-  // Extract listener_defaults.quic for use in per-listener merge
+  // Extract listener_defaults for use in per-listener merge
   std::optional<ParsedQuicConfig> quicDefaults;
+  std::optional<ParsedMvfstConfig> mvfstDefaults;
   if (auto ld = config.listener_defaults.value()) {
     quicDefaults = ld->quic.value();
+    mvfstDefaults = ld->mvfst.value();
   }
 
   std::vector<QuicConfig> mergedQuicConfigs;
+  std::vector<MvfstConfig> mergedMvfstConfigs;
   {
     std::unordered_set<std::string> listenerAddrs;
     for (const auto& listener : config.listeners.value()) {
@@ -642,6 +764,23 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
       const auto stack = (stackStr == kStackPicoquic) ? QuicStack::Picoquic : QuicStack::Mvfst;
       validateQuicConfig(quic, stack, "Listener '" + listener.name.value() + "'", errors, warnings);
       mergedQuicConfigs.push_back(quic);
+      mergedMvfstConfigs.push_back(mergeMvfstConfig(mvfstDefaults, listener.mvfst.value()));
+      validateMvfstConfig(
+          mergedMvfstConfigs.back(),
+          "Listener '" + listener.name.value() + "'",
+          errors,
+          warnings
+      );
+      if (!mergedMvfstConfigs.back().pacingEnabled) {
+        const auto& cc = quic.ccAlgo;
+        if (cc == "bbr" || cc == "bbr2" || cc == "bbr2modular") {
+          errors.push_back(
+              "Listener '" + listener.name.value() +
+              "': mvfst: pacing_enabled: false is incompatible with cc_algo '" + cc +
+              "' (bbr, bbr2, and bbr2modular require pacing)"
+          );
+        }
+      }
     }
   }
 
@@ -724,7 +863,9 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
                     v.reserve(config.listeners.value().size());
                     const auto& listeners = config.listeners.value();
                     for (size_t i = 0; i < listeners.size(); ++i) {
-                      v.push_back(resolveListener(listeners[i], mergedQuicConfigs[i]));
+                      v.push_back(
+                          resolveListener(listeners[i], mergedQuicConfigs[i], mergedMvfstConfigs[i])
+                      );
                     }
                     return v;
                   }(),

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -76,9 +76,149 @@ struct ParsedQuicConfig {
   rfl::Description<
       "Congestion control algorithm (default: bbr). "
       "picoquic: bbr, bbr1, c4, cubic, dcubic, fast, newreno, prague, reno. "
-      "mvfst: bbr, bbr2, bbr2modular, copa, cubic, newreno.",
+      "mvfst: bbr, bbr2, bbr2modular, copa, cubic, newreno, none.",
       std::optional<std::string>>
       cc_algo;
+};
+
+// mvfst-specific transport tunables organised by CC algorithm.
+// General fields (max_cwnd_in_mss, GSO/GRO) sit directly at the mvfst: level.
+// CC-specific tunables are nested under mvfst: <algo>: blocks.
+// All fields are optional; absent = use MvfstConfig defaults.
+struct ParsedMvfstConfig {
+  rfl::Description<
+      "Maximum congestion window in MSS (default: 860000 = quic::kLargeMaxCwndInMss). "
+      "Applies to all CC algorithms.",
+      std::optional<uint64_t>>
+      max_cwnd_in_mss;
+  rfl::Description<
+      "Enable pacing (default: true). "
+      "Required for bbr and bbr2; optional for copa and cubic; "
+      "ignored (always off) for newreno and none.",
+      std::optional<bool>>
+      pacing_enabled;
+  rfl::Description<
+      "Enable GSO (Generic Segmentation Offload) for packet segmentation (default: true). "
+      "Requires kernel GSO support. Falls back to sendmmsg automatically if GSO is "
+      "unavailable at runtime. Disable only on kernels or VMs where GSO is advertised "
+      "but broken.",
+      std::optional<bool>>
+      enable_gso;
+  rfl::Description<
+      "Max packets written per connection per event-loop iteration (default: 48). "
+      "Written to both maxBatchSize and writeConnectionDataPacketsLimit so the cap "
+      "applies in all batching modes.",
+      std::optional<uint32_t>>
+      max_conn_packets_sent_per_loop;
+  rfl::Description<
+      "Max incoming packets processed per event-loop read callback. "
+      "0 = unlimited. Default 10.",
+      std::optional<uint16_t>>
+      max_server_recv_packets_per_loop;
+  rfl::Description<
+      "Number of UDP GRO (Generic Receive Offload) buffers. "
+      "1 = disabled (default). Values > 1 enable kernel-side packet coalescing: "
+      "up to max value packets are merged per recvmsg call, reducing syscall "
+      "overhead at high packet rates. Max 64. Requires kernel GRO support.",
+      std::optional<uint32_t>>
+      num_gro_buffers;
+
+  // BBR (BBR1) congestion control tunables.
+  // conservative_recovery is shared with BBR2 — set it here when using either.
+  struct ParsedBBR {
+    rfl::Description<
+        "Enter conservative recovery on loss (also applies to BBR2).",
+        std::optional<bool>>
+        conservative_recovery;
+    rfl::Description<"Use a large cwnd during PROBE_RTT.", std::optional<bool>>
+        large_probe_rtt_cwnd;
+    rfl::Description<
+        "Estimate ACK aggregation in STARTUP for more aggressive cwnd growth.",
+        std::optional<bool>>
+        enable_ack_aggregation_in_startup;
+    rfl::Description<"Skip PROBE_RTT rounds when the sender is app-limited.", std::optional<bool>>
+        probe_rtt_disabled_if_app_limited;
+    rfl::Description<"Drain cwnd to the estimated BDP after STARTUP.", std::optional<bool>>
+        drain_to_target;
+  };
+
+  // BBR2-specific congestion control tunables.
+  // Also set bbr.conservative_recovery if you want conservative recovery with BBR2.
+  struct ParsedBBR2 {
+    rfl::Description<
+        "Ignore long-term inflight samples when estimating bandwidth.",
+        std::optional<bool>>
+        ignore_inflight_long_term;
+    rfl::Description<"Ignore short-term bandwidth samples.", std::optional<bool>> ignore_short_term;
+    rfl::Description<"Exit STARTUP on packet loss (default: true).", std::optional<bool>>
+        exit_startup_on_loss;
+    rfl::Description<"Allow cwnd recovery inside STARTUP (default: true).", std::optional<bool>>
+        enable_recovery_in_startup;
+    rfl::Description<
+        "Allow cwnd recovery during PROBE_BW and PROBE_RTT states (default: true).",
+        std::optional<bool>>
+        enable_recovery_in_probe_states;
+    rfl::Description<"Coexist with Reno/Cubic flows (halve cwnd on loss).", std::optional<bool>>
+        enable_reno_coexistence;
+    rfl::Description<"Pace the initial cwnd instead of sending it as a burst.", std::optional<bool>>
+        pace_init_cwnd;
+    rfl::Description<
+        "Override the PROBE_BW cruise pacing gain; -1 = use BBR2 default (~1.0).",
+        std::optional<float>>
+        override_cruise_pacing_gain;
+    rfl::Description<
+        "Override the PROBE_BW cruise cwnd gain; -1 = use BBR2 default (~2.0).",
+        std::optional<float>>
+        override_cruise_cwnd_gain;
+    rfl::Description<
+        "Override the STARTUP pacing gain; -1 = use BBR2 default (~2.77).",
+        std::optional<float>>
+        override_startup_pacing_gain;
+    rfl::Description<
+        "Beta used to reduce the short-term bandwidth estimate; 0 = use BBR2 default.",
+        std::optional<float>>
+        override_bw_short_beta;
+  };
+
+  // Cubic congestion control tunables.
+  struct ParsedCubic {
+    rfl::Description<
+        "Use additive cwnd increase instead of multiplicative after HyStart exit.",
+        std::optional<bool>>
+        additive_increase_after_hystart;
+    rfl::Description<"Only grow cwnd when the connection is cwnd-limited.", std::optional<bool>>
+        only_grow_cwnd_when_limited;
+    rfl::Description<
+        "Leave headroom below cwnd for the OS send buffer when cwnd-limited.",
+        std::optional<bool>>
+        leave_headroom_for_cwnd_limited;
+  };
+
+  // Copa congestion control tunables.
+  struct ParsedCopa {
+    rfl::Description<
+        "Delta parameter controlling the target utilisation (moqx default: 0.05).",
+        std::optional<double>>
+        delta_param;
+  };
+
+  // L4S tunables (usable alongside any ECN-aware CC algorithm).
+  struct ParsedL4S {
+    rfl::Description<"ECN CE marking threshold target (0 = disabled).", std::optional<float>>
+        ce_target;
+  };
+
+  rfl::Description<
+      "BBR congestion control tunables. conservative_recovery also applies to BBR2.",
+      std::optional<ParsedBBR>>
+      bbr;
+  rfl::Description<"BBR2-specific congestion control tunables.", std::optional<ParsedBBR2>> bbr2;
+  rfl::Description<"Cubic congestion control tunables.", std::optional<ParsedCubic>> cubic;
+  rfl::Description<"Copa congestion control tunables.", std::optional<ParsedCopa>> copa;
+  rfl::Description<
+      "L4S tunables (ECN CE target). Usable alongside any ECN-aware CC algorithm.",
+      std::optional<ParsedL4S>>
+      l4s;
 };
 
 struct ParsedListenerConfig {
@@ -98,6 +238,10 @@ struct ParsedListenerConfig {
       "QUIC transport settings (overrides listener_defaults.quic)",
       std::optional<ParsedQuicConfig>>
       quic;
+  rfl::Description<
+      "mvfst-specific CC tunables (overrides listener_defaults.mvfst; mvfst stack only)",
+      std::optional<ParsedMvfstConfig>>
+      mvfst;
 };
 
 struct ParsedCacheConfig {
@@ -209,6 +353,8 @@ struct ParsedListenerDefaultsConfig {
       "Default QUIC transport settings for all listeners",
       std::optional<ParsedQuicConfig>>
       quic;
+  rfl::Description<"Default mvfst CC tunables for all listeners", std::optional<ParsedMvfstConfig>>
+      mvfst;
 };
 
 struct ParsedServiceDefaultsConfig {

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -1451,5 +1451,198 @@ TEST(ResolveConfig, CacheByteLimitsMergeWithDefaults) {
   EXPECT_EQ(resolved.services.at("overrider").cache.minEvictionKb, 512u);
 }
 
+// --- MvfstConfig resolution and validation tests ---
+
+static void setListenerMvfst(ParsedConfig& cfg, ParsedMvfstConfig mvfst) {
+  cfg.listeners.value()[0].mvfst = std::optional<ParsedMvfstConfig>{std::move(mvfst)};
+}
+
+// All struct defaults are correct after resolving a config with no mvfst: block.
+TEST(ResolveConfig, MvfstDefaultsRoundTrip) {
+  auto cfg = makeMinimalInsecureConfig();
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& mvfst = result.value().config.listeners[0].mvfst;
+  EXPECT_EQ(mvfst.maxCwndInMss, 860000u);
+  EXPECT_TRUE(mvfst.enableGSO);
+  EXPECT_EQ(mvfst.maxConnPacketsSentPerLoop, 48u);
+  EXPECT_EQ(mvfst.maxServerRecvPacketsPerLoop, 10u);
+  EXPECT_EQ(mvfst.numGROBuffers, 1u);
+  EXPECT_DOUBLE_EQ(mvfst.copa.deltaParam, 0.05);
+  EXPECT_FALSE(mvfst.bbr.conservativeRecovery);
+  EXPECT_TRUE(mvfst.bbr2.exitStartupOnLoss);
+  EXPECT_TRUE(mvfst.bbr2.enableRecoveryInStartup);
+  EXPECT_TRUE(mvfst.bbr2.enableRecoveryInProbeStates);
+  EXPECT_FLOAT_EQ(mvfst.l4s.ceTarget, 0.0f);
+}
+
+// listener_defaults.mvfst propagates to listeners; per-listener overrides win;
+// validation runs on the merged result (not just the per-listener fragment).
+TEST(ResolveConfig, MvfstInheritanceAndOverride) {
+  // listener_defaults sets max_cwnd=100000, num_gro=4; per-listener bumps max_cwnd to 200000.
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedMvfstConfig defaults;
+  defaults.max_cwnd_in_mss = std::optional<uint64_t>{100000};
+  defaults.num_gro_buffers = std::optional<uint32_t>{4};
+  ParsedListenerDefaultsConfig ld;
+  ld.mvfst = std::optional<ParsedMvfstConfig>{std::move(defaults)};
+  cfg.listener_defaults = std::optional<ParsedListenerDefaultsConfig>{std::move(ld)};
+
+  ParsedMvfstConfig perListener;
+  perListener.max_cwnd_in_mss = std::optional<uint64_t>{200000};
+  setListenerMvfst(cfg, std::move(perListener));
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& mvfst = result.value().config.listeners[0].mvfst;
+  EXPECT_EQ(mvfst.maxCwndInMss, 200000u); // per-listener wins
+  EXPECT_EQ(mvfst.numGROBuffers, 4u);     // from defaults
+
+  // Validation uses merged values: max_conn_packets_sent_per_loop=0 in defaults
+  // triggers error even when the per-listener fragment doesn't set it.
+  auto cfg2 = makeMinimalInsecureConfig();
+  ParsedMvfstConfig badDefaults;
+  badDefaults.max_conn_packets_sent_per_loop = std::optional<uint32_t>{0};
+  ParsedListenerDefaultsConfig ld2;
+  ld2.mvfst = std::optional<ParsedMvfstConfig>{std::move(badDefaults)};
+  cfg2.listener_defaults = std::optional<ParsedListenerDefaultsConfig>{std::move(ld2)};
+  EXPECT_TRUE(resolveConfig(cfg2).hasError());
+}
+
+// Zero values for fields that must be >= 1 all produce distinct error messages.
+TEST(ResolveConfig, MvfstZeroValuesAreErrors) {
+  struct ZeroCase {
+    std::string field;
+    std::function<void(ParsedMvfstConfig&)> set;
+  };
+  std::vector<ZeroCase> cases = {
+      {"max_cwnd_in_mss",
+       [](ParsedMvfstConfig& m) { m.max_cwnd_in_mss = std::optional<uint64_t>{0}; }},
+      {"max_conn_packets_sent_per_loop",
+       [](ParsedMvfstConfig& m) { m.max_conn_packets_sent_per_loop = std::optional<uint32_t>{0}; }},
+      {"num_gro_buffers",
+       [](ParsedMvfstConfig& m) { m.num_gro_buffers = std::optional<uint32_t>{0}; }},
+  };
+  for (const auto& tc : cases) {
+    auto cfg = makeMinimalInsecureConfig();
+    ParsedMvfstConfig mvfst;
+    tc.set(mvfst);
+    setListenerMvfst(cfg, std::move(mvfst));
+    auto result = resolveConfig(cfg);
+    ASSERT_TRUE(result.hasError()) << "expected error for " << tc.field;
+    EXPECT_THAT(result.error(), HasSubstr(tc.field));
+  }
+}
+
+// copa.delta_param must be in (0, 1); l4s.ce_target must be 0 or in (0, 1).
+TEST(ResolveConfig, MvfstBoundsCheckedParamsErrors) {
+  auto makeCopa = [](double v) {
+    ParsedMvfstConfig m;
+    ParsedMvfstConfig::ParsedCopa copa;
+    copa.delta_param = std::optional<double>{v};
+    m.copa = std::optional<ParsedMvfstConfig::ParsedCopa>{std::move(copa)};
+    return m;
+  };
+  auto makeL4s = [](float v) {
+    ParsedMvfstConfig m;
+    ParsedMvfstConfig::ParsedL4S l4s;
+    l4s.ce_target = std::optional<float>{v};
+    m.l4s = std::optional<ParsedMvfstConfig::ParsedL4S>{std::move(l4s)};
+    return m;
+  };
+
+  for (double bad : {0.0, 1.0}) {
+    auto cfg = makeMinimalInsecureConfig();
+    setListenerMvfst(cfg, makeCopa(bad));
+    auto result = resolveConfig(cfg);
+    ASSERT_TRUE(result.hasError()) << "copa.delta_param=" << bad;
+    EXPECT_THAT(result.error(), HasSubstr("copa.delta_param"));
+  }
+  for (float bad : {-0.1f, 1.0f}) {
+    auto cfg = makeMinimalInsecureConfig();
+    setListenerMvfst(cfg, makeL4s(bad));
+    auto result = resolveConfig(cfg);
+    ASSERT_TRUE(result.hasError()) << "l4s.ce_target=" << bad;
+    EXPECT_THAT(result.error(), HasSubstr("l4s.ce_target"));
+  }
+}
+
+// num_gro_buffers > 64 is allowed but produces a warning.
+TEST(ResolveConfig, MvfstNumGroBuffersAbove64Warning) {
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedMvfstConfig mvfst;
+  mvfst.num_gro_buffers = std::optional<uint32_t>{65};
+  setListenerMvfst(cfg, std::move(mvfst));
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_THAT(result.value().warnings, ::testing::Contains(HasSubstr("num_gro_buffers")));
+}
+
+// enable_gso toggles between GSO (default) and sendmmsg-only mode.
+TEST(ResolveConfig, MvfstBatchingModeRoundTrip) {
+  for (bool gso : {true, false}) {
+    auto cfg = makeMinimalInsecureConfig();
+    ParsedMvfstConfig mvfst;
+    mvfst.enable_gso = std::optional<bool>{gso};
+    setListenerMvfst(cfg, std::move(mvfst));
+    auto result = resolveConfig(cfg);
+    ASSERT_TRUE(result.hasValue()) << "enable_gso=" << gso;
+    EXPECT_EQ(result.value().config.listeners[0].mvfst.enableGSO, gso);
+  }
+}
+
+// Each algo sub-struct round-trips through resolveConfig correctly.
+TEST(ResolveConfig, MvfstAlgoFieldsRoundTrip) {
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedMvfstConfig mvfst;
+
+  ParsedMvfstConfig::ParsedBBR bbr;
+  bbr.conservative_recovery = std::optional<bool>{true};
+  bbr.large_probe_rtt_cwnd = std::optional<bool>{true};
+  bbr.drain_to_target = std::optional<bool>{true};
+  mvfst.bbr = std::optional<ParsedMvfstConfig::ParsedBBR>{std::move(bbr)};
+
+  ParsedMvfstConfig::ParsedBBR2 bbr2;
+  bbr2.exit_startup_on_loss = std::optional<bool>{false};
+  bbr2.enable_reno_coexistence = std::optional<bool>{true};
+  bbr2.override_cruise_pacing_gain = std::optional<float>{1.25f};
+  mvfst.bbr2 = std::optional<ParsedMvfstConfig::ParsedBBR2>{std::move(bbr2)};
+
+  ParsedMvfstConfig::ParsedCubic cubic;
+  cubic.additive_increase_after_hystart = std::optional<bool>{true};
+  cubic.only_grow_cwnd_when_limited = std::optional<bool>{true};
+  mvfst.cubic = std::optional<ParsedMvfstConfig::ParsedCubic>{std::move(cubic)};
+
+  ParsedMvfstConfig::ParsedCopa copa;
+  copa.delta_param = std::optional<double>{0.1};
+  mvfst.copa = std::optional<ParsedMvfstConfig::ParsedCopa>{std::move(copa)};
+
+  ParsedMvfstConfig::ParsedL4S l4s;
+  l4s.ce_target = std::optional<float>{0.05f};
+  mvfst.l4s = std::optional<ParsedMvfstConfig::ParsedL4S>{std::move(l4s)};
+
+  setListenerMvfst(cfg, std::move(mvfst));
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  const auto& out = result.value().config.listeners[0].mvfst;
+
+  EXPECT_TRUE(out.bbr.conservativeRecovery);
+  EXPECT_TRUE(out.bbr.largeProbeRttCwnd);
+  EXPECT_TRUE(out.bbr.drainToTarget);
+  EXPECT_FALSE(out.bbr.probeRttDisabledIfAppLimited); // unchanged default
+
+  EXPECT_FALSE(out.bbr2.exitStartupOnLoss);
+  EXPECT_TRUE(out.bbr2.enableRenoCoexistence);
+  EXPECT_FLOAT_EQ(out.bbr2.overrideCruisePacingGain, 1.25f);
+  EXPECT_TRUE(out.bbr2.enableRecoveryInStartup); // unchanged default
+
+  EXPECT_TRUE(out.cubic.additiveIncreaseAfterHystart);
+  EXPECT_TRUE(out.cubic.onlyGrowCwndWhenLimited);
+  EXPECT_FALSE(out.cubic.leaveHeadroomForCwndLimited); // unchanged default
+
+  EXPECT_DOUBLE_EQ(out.copa.deltaParam, 0.1);
+  EXPECT_FLOAT_EQ(out.l4s.ceTarget, 0.05f);
+}
+
 } // namespace
 } // namespace openmoq::moqx::config


### PR DESCRIPTION
Add MvfstConfig struct (and ParsedMvfstConfig for YAML loading) with tunables for congestion control, pacing, flow control, and loss detection. Wire it through ConfigResolver into MoqxRelayServer::buildTransportSettings so operators can tune mvfst without recompiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/301)
<!-- Reviewable:end -->
