### PR TITLE
MoqxCache: cap publisher cache duration, skip caching when mcd=0

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -8,6 +8,7 @@
 
 #include "MoqxCache.h"
 #include <folly/logging/xlog.h>
+#include <moxygen/MoQTrackProperties.h>
 
 // Maxmimum cache size / per track? Number of groups
 // Fancy: handle streaming incomplete objects (forwarder?)
@@ -592,7 +593,7 @@ public:
 
   folly::Expected<folly::Unit, MoQPublishError>
   object(uint64_t objID, Payload payload, Extensions ext, bool finSub) override {
-    if (cacheTrack_.evicted) {
+    if (cacheTrack_.shouldSkipCaching()) {
       return consumer_->object(objID, std::move(payload), std::move(ext), finSub);
     }
     auto res = cacheTrack_.updateLargest({group_, objID});
@@ -626,7 +627,7 @@ public:
   folly::Expected<folly::Unit, MoQPublishError>
   beginObject(uint64_t objectID, uint64_t length, Payload initialPayload, Extensions extensions)
       override {
-    if (cacheTrack_.evicted) {
+    if (cacheTrack_.shouldSkipCaching()) {
       return consumer_
           ->beginObject(objectID, length, std::move(initialPayload), std::move(extensions));
     }
@@ -665,7 +666,7 @@ public:
 
   folly::Expected<ObjectPublishStatus, MoQPublishError>
   objectPayload(Payload payload, bool finSubgroup) override {
-    if (cacheTrack_.evicted) {
+    if (cacheTrack_.shouldSkipCaching()) {
       return consumer_->objectPayload(std::move(payload), finSubgroup);
     }
     auto& object = cacheGroup_.objects[currentObject_];
@@ -689,7 +690,7 @@ public:
   }
 
   folly::Expected<folly::Unit, MoQPublishError> endOfGroup(uint64_t endOfGroupObjectID) override {
-    if (cacheTrack_.evicted) {
+    if (cacheTrack_.shouldSkipCaching()) {
       return consumer_->endOfGroup(endOfGroupObjectID);
     }
     auto res = cacheTrack_.updateLargest({group_, endOfGroupObjectID});
@@ -722,7 +723,7 @@ public:
 
   folly::Expected<folly::Unit, MoQPublishError> endOfTrackAndGroup(uint64_t endOfTrackObjectID
   ) override {
-    if (cacheTrack_.evicted) {
+    if (cacheTrack_.shouldSkipCaching()) {
       return consumer_->endOfTrackAndGroup(endOfTrackObjectID);
     }
     auto res = cacheTrack_.updateLargest({group_, endOfTrackObjectID}, true);
@@ -820,7 +821,7 @@ public:
       );
     }
     auto res = consumer_->beginSubgroup(groupID, subgroupID, priority);
-    if (res.hasValue() && !track_.evicted) {
+    if (res.hasValue() && !track_.shouldSkipCaching()) {
       track_.getOrCreateGroupWithEviction(groupID, cache_, ftn_);
       return std::make_shared<SubgroupWriteback>(
           groupID,
@@ -842,7 +843,7 @@ public:
 
   folly::Expected<folly::Unit, MoQPublishError>
   objectStream(const ObjectHeader& header, Payload payload, bool /*lastInGroup*/ = false) override {
-    if (track_.evicted) {
+    if (track_.shouldSkipCaching()) {
       return consumer_->objectStream(header, std::move(payload));
     }
     // TODO: Handle lastInGroup parameter when caching
@@ -871,7 +872,7 @@ public:
 
   folly::Expected<folly::Unit, MoQPublishError>
   datagram(const ObjectHeader& header, Payload payload, bool /*lastInGroup*/ = false) override {
-    if (track_.evicted) {
+    if (track_.shouldSkipCaching()) {
       return consumer_->datagram(header, std::move(payload));
     }
     // TODO: Handle lastInGroup parameter when caching
@@ -995,7 +996,7 @@ public:
       bool fin,
       bool forwardingPreferenceIsDatagram = false
   ) override {
-    if (fetchRangeIt_.track->evicted) {
+    if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->object(
           gID,
           sgID,
@@ -1043,7 +1044,7 @@ public:
       Payload initPayload,
       Extensions ext
   ) override {
-    if (fetchRangeIt_.track->evicted) {
+    if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->beginObject(gID, sgID, objID, len, std::move(initPayload), std::move(ext));
     }
     constexpr auto kNormal = ObjectStatus::NORMAL;
@@ -1063,7 +1064,7 @@ public:
 
   folly::Expected<ObjectPublishStatus, MoQPublishError>
   objectPayload(Payload payload, bool finFetch) override {
-    if (fetchRangeIt_.track->evicted) {
+    if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->objectPayload(std::move(payload), finFetch && proxyFin_);
     }
     auto& group =
@@ -1098,7 +1099,7 @@ public:
 
   folly::Expected<folly::Unit, MoQPublishError>
   endOfGroup(uint64_t gID, uint64_t sgID, uint64_t objID, bool fin) override {
-    if (fetchRangeIt_.track->evicted) {
+    if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->endOfGroup(gID, sgID, objID, fin && proxyFin_);
     }
     // cacheImpl -> cacheObject inserts gap for remaining objects in this group
@@ -1112,7 +1113,7 @@ public:
 
   folly::Expected<folly::Unit, MoQPublishError>
   endOfTrackAndGroup(uint64_t gID, uint64_t sgID, uint64_t objID) override {
-    if (fetchRangeIt_.track->evicted) {
+    if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->endOfTrackAndGroup(gID, sgID, objID);
     }
     // cacheImpl -> cacheObject inserts gaps for remaining objects and groups
@@ -1759,7 +1760,24 @@ void MoqxCache::clearMaxCacheDuration(const FullTrackName& ftn) {
   }
 }
 
+std::optional<std::chrono::milliseconds>
+MoqxCache::getEffectiveCacheDuration(const Extensions& extensions) const {
+  if (auto ms = moxygen::detail::getIntExtension(extensions, kMaxCacheDurationExtensionType)) {
+    auto dur = std::chrono::milliseconds(*ms);
+    if (maxAllowedCacheDuration_) {
+      dur = std::min(dur, *maxAllowedCacheDuration_);
+    }
+    return dur;
+  }
+  return defaultMaxCacheDuration_;
+}
+
 void MoqxCache::setTrackExtensions(const FullTrackName& ftn, Extensions extensions) {
+  if (auto dur = getEffectiveCacheDuration(extensions)) {
+    setMaxCacheDuration(ftn, *dur);
+  } else {
+    clearMaxCacheDuration(ftn);
+  }
   auto it = cache_.find(ftn);
   if (it == cache_.end()) {
     it = cache_.emplace(ftn, std::make_shared<CacheTrack>()).first;

--- a/src/MoqxCache.h
+++ b/src/MoqxCache.h
@@ -119,9 +119,6 @@ public:
     }
   }
 
-  void setMaxCacheDuration(const moxygen::FullTrackName& ftn, std::chrono::milliseconds duration);
-  void clearMaxCacheDuration(const moxygen::FullTrackName& ftn);
-
   // Sets the default max cache duration applied to all tracks that do not have
   // a per-track duration set via setMaxCacheDuration(). Pass std::nullopt to
   // remove the default (objects never expire by default).
@@ -130,6 +127,16 @@ public:
   }
   std::optional<std::chrono::milliseconds> getDefaultMaxCacheDuration() const {
     return defaultMaxCacheDuration_;
+  }
+
+  // Sets a hard upper bound on per-track cache durations. Any duration
+  // extracted from publisher extensions that exceeds this cap is clamped to it.
+  // Pass std::nullopt to remove the cap.
+  void setMaxAllowedCacheDuration(std::optional<std::chrono::milliseconds> duration) {
+    maxAllowedCacheDuration_ = duration;
+  }
+  std::optional<std::chrono::milliseconds> getMaxAllowedCacheDuration() const {
+    return maxAllowedCacheDuration_;
   }
 
   void setTrackExtensions(const moxygen::FullTrackName& ftn, moxygen::Extensions extensions);
@@ -283,6 +290,12 @@ private:
     // Returns true if track can be evicted (not live, no active fetches)
     bool canEvict() const { return liveWritebackCount == 0 && fetchesInProgress.empty(); }
 
+    // Returns true if objects should be forwarded without caching.
+    // Optimistic: nullopt maxCacheDuration means "unknown, cache it".
+    bool shouldSkipCaching() const {
+      return evicted || (maxCacheDuration && maxCacheDuration->count() == 0);
+    }
+
     // Insert a known-non-existent range into both gaps and cachedContent.
     // The two sets must stay aligned: cachedContent doubles as the union
     // (real objects + known gaps) used by skipUncached().
@@ -359,6 +372,10 @@ private:
   // std::nullopt means objects do not expire by default.
   std::optional<std::chrono::milliseconds> defaultMaxCacheDuration_;
 
+  // Hard cap on per-track durations extracted from publisher extensions.
+  // std::nullopt means no cap is enforced.
+  std::optional<std::chrono::milliseconds> maxAllowedCacheDuration_;
+
   // Injectable clock for testing
   std::function<TimePoint()> clock_;
 
@@ -388,6 +405,14 @@ private:
 
   folly::coro::Task<folly::Expected<folly::Unit, moxygen::FetchError>>
   handleBlocked(std::shared_ptr<moxygen::FetchConsumer> consumer, const moxygen::Fetch& fetch);
+
+  void setMaxCacheDuration(const moxygen::FullTrackName& ftn, std::chrono::milliseconds duration);
+  void clearMaxCacheDuration(const moxygen::FullTrackName& ftn);
+
+  // Returns publisher duration (clamped to maxAllowedCacheDuration_), or
+  // defaultMaxCacheDuration_, or nullopt if neither is set.
+  std::optional<std::chrono::milliseconds>
+  getEffectiveCacheDuration(const moxygen::Extensions& extensions) const;
 
   // Track LRU management helpers
   void addTrackToLRU(const moxygen::FullTrackName& ftn, CacheTrack& track);

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -111,8 +111,7 @@ public:
       cache_->setMaxCachedBytes(static_cast<size_t>(cache.maxCachedMb) * 1024 * 1024);
       cache_->setMinEvictionBytes(static_cast<size_t>(cache.minEvictionKb) * 1024);
       cache_->setDefaultMaxCacheDuration(cache.defaultMaxCacheDuration);
-      // TODO: wire cache.maxCacheDuration once MoqxCache supports clamping
-      // publisher-set track durations.
+      cache_->setMaxAllowedCacheDuration(cache.maxCacheDuration);
     }
   }
 

--- a/test/MoqxCacheTest.cpp
+++ b/test/MoqxCacheTest.cpp
@@ -15,6 +15,7 @@
 #include <folly/logging/xlog.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
+#include <moxygen/MoQTrackProperties.h>
 #include <moxygen/test/Mocks.h>
 
 using namespace testing;
@@ -22,6 +23,12 @@ namespace openmoq::moqx::test {
 using namespace moxygen; // NOLINT: bring moxygen protocol types into scope
 
 const FullTrackName kTestTrackName{TrackNamespace{{"foo"}}, "bar"};
+
+Extensions makeCacheDurationExt(uint64_t ms) {
+  Extensions ext;
+  ext.insertMutableExtension(Extension{kMaxCacheDurationExtensionType, ms});
+  return ext;
+}
 
 // Matcher for chain data length
 MATCHER_P(HasChainDataLengthOf, n, "") {
@@ -2318,7 +2325,7 @@ CO_TEST_F(MoqxCacheTest, TestSkipUncachedAfterTTLExpiration) {
   // takes the "live track" fast path and fires fetchImpl asynchronously.
   auto currentTime = std::make_shared<MoqxCache::TimePoint>(MoqxCache::SteadyClock::now());
   cache_.setClockForTesting([currentTime]() { return *currentTime; });
-  cache_.setMaxCacheDuration(kTestTrackName, std::chrono::milliseconds(1000));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(1000));
 
   auto wb = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
   wb->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
@@ -3397,7 +3404,7 @@ TEST_F(MoqxCacheTest, TestMaxCacheDurationExpiration) {
   populateCacheRange({0, 0}, {0, 5});
   EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
 
-  cache_.setMaxCacheDuration(kTestTrackName, std::chrono::milliseconds(1000));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(1000));
 
   // Advance clock past TTL
   currentTime += std::chrono::milliseconds(1001);
@@ -3412,7 +3419,7 @@ TEST_F(MoqxCacheTest, TestMaxCacheDurationNotExpired) {
   cache_.setClockForTesting([&currentTime]() { return currentTime; });
 
   populateCacheRange({0, 0}, {0, 5});
-  cache_.setMaxCacheDuration(kTestTrackName, std::chrono::milliseconds(1000));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(1000));
 
   // Advance clock within TTL
   currentTime += std::chrono::milliseconds(999);
@@ -3442,7 +3449,7 @@ TEST_F(MoqxCacheTest, TestMaxCacheDurationRefreshOnRecache) {
   auto currentTime = MoqxCache::SteadyClock::now();
   cache_.setClockForTesting([&currentTime]() { return currentTime; });
 
-  cache_.setMaxCacheDuration(kTestTrackName, std::chrono::milliseconds(1000));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(1000));
 
   // Cache object at T=0
   populateCacheRange({0, 0}, {0, 1});
@@ -3467,7 +3474,7 @@ CO_TEST_F(MoqxCacheTest, TestMaxCacheDurationFetchMissOnExpired) {
   cache_.setClockForTesting([&currentTime]() { return currentTime; });
 
   populateCacheRange({0, 0}, {0, 10});
-  cache_.setMaxCacheDuration(kTestTrackName, std::chrono::milliseconds(1000));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(1000));
 
   // Advance past TTL
   currentTime += std::chrono::milliseconds(1001);
@@ -3495,7 +3502,7 @@ TEST_F(MoqxCacheTest, TestMaxCacheDurationMixedExpiration) {
   auto currentTime = MoqxCache::SteadyClock::now();
   cache_.setClockForTesting([&currentTime]() { return currentTime; });
 
-  cache_.setMaxCacheDuration(kTestTrackName, std::chrono::milliseconds(1000));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(1000));
 
   // Cache objects 0-4 at T=0
   populateCacheRange({0, 0}, {0, 5});
@@ -3520,10 +3527,10 @@ TEST_F(MoqxCacheTest, TestClearMaxCacheDuration) {
   cache_.setClockForTesting([&currentTime]() { return currentTime; });
 
   populateCacheRange({0, 0}, {0, 5});
-  cache_.setMaxCacheDuration(kTestTrackName, std::chrono::milliseconds(1000));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(1000));
 
-  // Clear the TTL
-  cache_.clearMaxCacheDuration(kTestTrackName);
+  // Clear the TTL by updating extensions without a cache duration
+  cache_.setTrackExtensions(kTestTrackName, Extensions{});
 
   // Advance clock past what was the TTL
   currentTime += std::chrono::milliseconds(2000);
@@ -3556,7 +3563,7 @@ TEST_F(MoqxCacheTest, TestPerTrackDurationOverridesDefault) {
   cache_.setClockForTesting([&currentTime]() { return currentTime; });
 
   cache_.setDefaultMaxCacheDuration(std::chrono::milliseconds(500));
-  cache_.setMaxCacheDuration(kTestTrackName, std::chrono::milliseconds(2000));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(2000));
   populateCacheRange({0, 0}, {0, 5});
 
   // Past the default TTL but within the per-track TTL
@@ -3565,6 +3572,68 @@ TEST_F(MoqxCacheTest, TestPerTrackDurationOverridesDefault) {
 
   // Past the per-track TTL
   currentTime += std::chrono::milliseconds(1500);
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+}
+
+TEST_F(MoqxCacheTest, TestZeroDefaultDurationSkipsCaching) {
+  // defaultMaxCacheDuration=0ms + no publisher duration → objects not cached.
+  cache_.setDefaultMaxCacheDuration(std::chrono::milliseconds(0));
+  cache_.setTrackExtensions(kTestTrackName, Extensions{});
+  populateCacheRange({0, 0}, {0, 5});
+
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 4}));
+}
+
+TEST_F(MoqxCacheTest, TestZeroDefaultDurationPublisherOverrides) {
+  // defaultMaxCacheDuration=0ms but publisher sets 1000ms → objects are cached.
+  auto currentTime = MoqxCache::SteadyClock::now();
+  cache_.setClockForTesting([&currentTime]() { return currentTime; });
+
+  cache_.setDefaultMaxCacheDuration(std::chrono::milliseconds(0));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(1000));
+  populateCacheRange({0, 0}, {0, 5});
+
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+
+  // Past publisher TTL
+  currentTime += std::chrono::milliseconds(1001);
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+}
+
+TEST_F(MoqxCacheTest, TestMaxAllowedCacheDurationClampsPublisher) {
+  // Publisher requests 2000ms but cap is 500ms — objects expire at 500ms.
+  auto currentTime = MoqxCache::SteadyClock::now();
+  cache_.setClockForTesting([&currentTime]() { return currentTime; });
+
+  cache_.setMaxAllowedCacheDuration(std::chrono::milliseconds(500));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(2000));
+  populateCacheRange({0, 0}, {0, 5});
+
+  // Within the cap
+  currentTime += std::chrono::milliseconds(499);
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+
+  // Past the cap (would still be live if 2000ms were honoured)
+  currentTime += std::chrono::milliseconds(2);
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+}
+
+TEST_F(MoqxCacheTest, TestMaxAllowedCacheDurationNoClampWhenUnder) {
+  // Publisher requests 300ms, cap is 500ms — publisher value is used as-is.
+  auto currentTime = MoqxCache::SteadyClock::now();
+  cache_.setClockForTesting([&currentTime]() { return currentTime; });
+
+  cache_.setMaxAllowedCacheDuration(std::chrono::milliseconds(500));
+  cache_.setTrackExtensions(kTestTrackName, makeCacheDurationExt(300));
+  populateCacheRange({0, 0}, {0, 5});
+
+  // Within publisher TTL
+  currentTime += std::chrono::milliseconds(299);
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+
+  // Past publisher TTL (before cap would expire)
+  currentTime += std::chrono::milliseconds(2);
   EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
 }
 
@@ -4142,7 +4211,7 @@ TEST_F(MoqxCacheTest, ExpiredObjectByteAccounting) {
   // Set per-track cache duration on track A only, and advance clock past expiry
   auto testClock = MoqxCache::SteadyClock::now();
   cache_.setClockForTesting([&testClock]() { return testClock; });
-  cache_.setMaxCacheDuration(trackA, std::chrono::milliseconds(1));
+  cache_.setTrackExtensions(trackA, makeCacheDurationExt(1));
   testClock += std::chrono::milliseconds(100);
 
   // Trigger expiry erasure on track A's object — leaks 100 bytes in


### PR DESCRIPTION
Adds setMaxAllowedCacheDuration() so operators can cap publisher-set cache durations. setTrackExtensions() now extracts the publisher's max cache duration extension, clamps it to the cap, and falls back to defaultMaxCacheDuration_ when the publisher doesn't set one. setMaxCacheDuration/clearMaxCacheDuration are now private; callers should go through setTrackExtensions.

Adds CacheTrack::shouldSkipCaching() which returns true when evicted or when maxCacheDuration is explicitly 0ms. defaultMaxCacheDuration=0ms acts as "opt-in only" mode: publisher must set a non-zero duration or objects are forwarded without being written to cache.

Wires cache.maxCacheDuration from CacheConfig into the new setMaxAllowedCacheDuration() call in MoqxRelay, removing the TODO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/302)
<!-- Reviewable:end -->
