### PR TITLE
ci: enable macOS-15 build

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -54,13 +54,10 @@ jobs:
           # arm64 is validated by the publish-side docker build (publish arm64
           # entry below); skipped here to avoid the ubuntu-runner ↔ bookworm-tarball
           # glog ABI mismatch. arm64 issues surface at the publish step.
-          # macOS disabled: moxygen tarball bakes brew Cellar versioned paths
-          # that break when the runner has different brew package versions.
-          # Re-enable once moxygen upstream fixes cmake to use opt symlinks.
-          # - name: macos
-          #   preset: default
-          #   build_dir: build
-          #   runner: macos-latest
+          - name: macos
+            preset: default
+            build_dir: build
+            runner: macos-15
           - name: asan debug
             preset: san
             build_dir: build-san

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -40,13 +40,10 @@ jobs:
           # arm64 is validated by the publish-side docker build (ci-main publish
           # arm64 entry); skipped here to avoid the ubuntu-runner ↔ bookworm-tarball
           # glog ABI mismatch. arm64 regressions surface at main-push time.
-          # macOS disabled: moxygen tarball bakes brew Cellar versioned paths
-          # that break when the runner has different brew package versions.
-          # Re-enable once moxygen upstream fixes cmake to use opt symlinks.
-          # - name: macos
-          #   preset: default
-          #   build_dir: build
-          #   runner: macos-latest
+          - name: macos
+            preset: default
+            build_dir: build
+            runner: macos-15
           - name: asan debug
             preset: san
             build_dir: build-san


### PR DESCRIPTION
**WIP — do not merge yet.** Depends on facebookexperimental/moxygen#162 syncing into openmoq/moxygen main.

## What this does

Enables the macOS-15 (Apple Silicon) build job in both \`ci-pr.yml\` and \`ci-main.yml\`. The matrix entry was previously commented out with the comment "moxygen tarball bakes brew Cellar versioned paths that break when the runner has different brew package versions" — that's the issue addressed by facebookexperimental/moxygen#162.

Bumps \`deps/moxygen\` submodule to \`2540d9e9\` on branch \`fix/macos-openssl-stable-path-omoq\` (a temporary openmoq-side carry of the same patch). CI's three-mode setup detects the off-main SHA and auto-falls back to source build, so the macOS job builds moxygen from the patched branch rather than the (broken) snapshot tarball.

## Testing so far

Verified end-to-end on argo (macOS Apple Silicon, M-series):

- \`bash scripts/build.sh setup\` — auto-detects off-main submodule SHA, prints actionable error, falls back to source build:
  \`\`\`
  ==> Moxygen submodule SHA: 2540d9e
  ==> Snapshot release SHA:  9f6bee4
  Error: snapshot-latest does not match the moxygen submodule pin.
  Release artifacts not available — falling back to source build...
  \`\`\`
- moxygen builds from source against the patched submodule
- Install tree contains stable opt-symlink paths only — no openssl@3 Cellar references:
  \`\`\`
  $ grep -rE 'Cellar/openssl@3' .scratch/moxygen-install/lib/cmake/
  (empty)
  $ grep -rE 'opt/openssl@3' .scratch/moxygen-install/lib/cmake/ | head
  fizz/fizz-targets.cmake:    .../opt/openssl@3/lib/libssl.dylib...
  folly/folly-targets.cmake:  .../opt/openssl@3/include...
  \`\`\`
- moqx builds successfully against this install tree

## Scope

- \`build\` job only (matrix entry on macOS-15)
- Conformance for macOS: deferred to follow-up (matrix is currently linux-only; refactor needed)
- Publish for macOS: deferred to follow-up (Docker doesn't make sense; need to decide standalone-tarball strategy)

## Path to merge

1. facebookexperimental/moxygen#162 reviewed and merged
2. openmoq/moxygen daily upstream-sync workflow brings the patch into main
3. Drop the submodule bump in this PR (revert to a current-main SHA)
4. Drop \`WIP:\` prefix
5. Merge

\`\`\`
Closes openmoq/moxygen carry branch 'fix/macos-openssl-stable-path-omoq'.
\`\`\`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/304)
<!-- Reviewable:end -->
