### PR TITLE
Add mlog structured logging integration to relay server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ add_library(moqx_core STATIC
   src/relay/WeakRelayForwarderCallback.cpp
   src/relay/PublisherCrossExecFilter.cpp
   src/relay/SubscriberCrossExecFilter.cpp
+  src/logging/MLogSetup.cpp
 )
 
 target_include_directories(moqx_core
@@ -177,6 +178,9 @@ target_link_libraries(moqx_core PUBLIC
   moxygen::moxygen_moqclient
   OpenSSL::Crypto
   catapult
+  moxygen::moxygen_mlog_file_mlogger
+  moxygen::moxygen_mlog_mlogger_factory
+  moxygen::moxygen_mlog_sampling_mlogger_factory
 )
 
 target_compile_options(moqx_core PRIVATE -Wall -Wextra -Wpedantic)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -83,6 +83,12 @@ admin:
   #   cert_file: /path/to/cert.pem
   #   key_file: /path/to/key.pem
 
+logging:                    # Logging configuration (optional)
+  mlog:                     # MoQ-level structured logging
+    dir: "/tmp/moqx-mlog"          # Output directory for per-session mlog files
+    sample_rate: 1              # Fraction of sessions to log (0.0–1.0, default: 1.0)
+
+
 # relay_id: "my-relay-1"     # Relay identity (optional; random hex string generated if absent)
 
 # listener_defaults:          # Default settings inherited by all listeners

--- a/docs/config.md
+++ b/docs/config.md
@@ -246,6 +246,34 @@ upstream routing.
 
 ---
 
+## Logging
+
+### `logging.mlog`
+
+Enables MoQ-level (mlog) structured logging of control messages and protocol
+events, one file per session.
+
+```yaml
+logging:
+  mlog:
+    dir: "/var/log/moqx/mlog"   # required to enable; empty string disables
+    sample_rate: 0.01            # log 1% of sessions (default: 1.0 = all)
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `dir` | `string` | — (disabled) | Output directory. Each session writes to `<dir>/<dcid>.mlog`. If empty, mlog is disabled. |
+| `sample_rate` | `float` | `1.0` | Fraction of sessions to log, in `[0.0, 1.0]`. `1.0` logs all sessions; `0.01` logs ~1%. |
+
+
+#### Lifecycle
+
+| Field | Lifecycle |
+|---|---|
+| `dir`, `sample_rate` | Static — requires restart |
+
+---
+
 ## Admin Server
 
 The admin server exposes an HTTP management API. It is optional; omit the

--- a/scripts/mlog-cleanup.sh
+++ b/scripts/mlog-cleanup.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# mlog-cleanup.sh — Manual retention cleanup for moqx .mlog files.
+#
+# Usage:
+#   mlog-cleanup.sh --dir <path> [--max-age-days <N>] [--max-dir-mb <N>] [--dry-run]
+#
+# Options:
+#   --dir <path>          Directory containing .mlog files (required).
+#   --max-age-days <N>    Delete .mlog files last modified more than N days ago.
+#                         N must be >= 1.
+#   --max-dir-mb <N>      After age-based deletion, trim the directory to N MB
+#                         by deleting the oldest files first.
+#                         N must be >= 1.
+#   --dry-run             Print what would be deleted without actually deleting.
+#   -h, --help            Show this help message.
+#
+# At least one of --max-age-days or --max-dir-mb must be provided.
+#
+# Example — delete files older than 7 days and cap the directory at 1 GB:
+#   mlog-cleanup.sh --dir /var/log/moqx/mlog --max-age-days 7 --max-dir-mb 1024
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+DIR=""
+MAX_AGE_DAYS=""
+MAX_DIR_MB=""
+DRY_RUN=0
+
+usage() {
+  grep '^#' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)
+      DIR="${2:?'--dir requires a path argument'}"
+      shift 2
+      ;;
+    --max-age-days)
+      MAX_AGE_DAYS="${2:?'--max-age-days requires a numeric argument'}"
+      shift 2
+      ;;
+    --max-dir-mb)
+      MAX_DIR_MB="${2:?'--max-dir-mb requires a numeric argument'}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+if [[ -z "$DIR" ]]; then
+  echo "Error: --dir is required." >&2
+  usage 1
+fi
+
+if [[ -z "$MAX_AGE_DAYS" && -z "$MAX_DIR_MB" ]]; then
+  echo "Error: at least one of --max-age-days or --max-dir-mb must be provided." >&2
+  usage 1
+fi
+
+if [[ -n "$MAX_AGE_DAYS" ]]; then
+  if ! [[ "$MAX_AGE_DAYS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: --max-age-days must be an integer >= 1, got '$MAX_AGE_DAYS'." >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "$MAX_DIR_MB" ]]; then
+  if ! [[ "$MAX_DIR_MB" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: --max-dir-mb must be an integer >= 1, got '$MAX_DIR_MB'." >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -d "$DIR" ]]; then
+  echo "Error: directory not found or not accessible: $DIR" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() { echo "[mlog-cleanup] $*"; }
+warn() { echo "[mlog-cleanup] WARNING: $*" >&2; }
+
+remove_file() {
+  local path="$1"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "dry-run: would delete $path"
+  else
+    rm -f -- "$path"
+    log "deleted $path"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: Age-based deletion
+# ---------------------------------------------------------------------------
+
+if [[ -n "$MAX_AGE_DAYS" ]]; then
+  log "Phase 1: removing .mlog files older than ${MAX_AGE_DAYS} day(s) in '$DIR'..."
+  while IFS= read -r -d '' file; do
+    remove_file "$file"
+  done < <(find "$DIR" -maxdepth 1 -name '*.mlog' -type f \
+    -mtime +"$((MAX_AGE_DAYS - 1))" -print0)
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2: Size-based deletion (oldest-first)
+# ---------------------------------------------------------------------------
+
+if [[ -n "$MAX_DIR_MB" ]]; then
+  MAX_DIR_BYTES=$(( MAX_DIR_MB * 1024 * 1024 ))
+
+  # Build a list of (mtime_epoch path size_bytes) sorted oldest-first.
+  # stat flags differ between macOS/BSD and Linux.
+  if stat --version &>/dev/null 2>&1; then
+    # GNU stat (Linux)
+    stat_fmt=( stat --printf='%Y %n %s\n' )
+  else
+    # BSD/macOS stat
+    stat_fmt=( stat -f '%m %N %z' )
+  fi
+
+  # Collect current .mlog files with mtime and size.
+  mapfile -d '' files < <(find "$DIR" -maxdepth 1 -name '*.mlog' -type f -print0)
+
+  if [[ ${#files[@]} -eq 0 ]]; then
+    log "Phase 2: no .mlog files found, skipping size check."
+  else
+    # Build sortable lines: "<epoch> <size> <path>"
+    tmp_list=()
+    total_bytes=0
+    for f in "${files[@]}"; do
+      read -r mtime_epoch fpath fsize < <("${stat_fmt[@]}" -- "$f" 2>/dev/null \
+        | awk '{print $1, $2, $3}') || { warn "could not stat $f, skipping"; continue; }
+      tmp_list+=( "$mtime_epoch $fsize $fpath" )
+      total_bytes=$(( total_bytes + fsize ))
+    done
+
+    log "Phase 2: current directory size is $(( total_bytes / 1024 / 1024 )) MB," \
+        "limit is ${MAX_DIR_MB} MB."
+
+    if (( total_bytes > MAX_DIR_BYTES )); then
+      # Sort oldest-first (ascending mtime).
+      while IFS= read -r line; do
+        if (( total_bytes <= MAX_DIR_BYTES )); then
+          break
+        fi
+        fpath="${line#* * }"        # strip "<epoch> <size> "
+        fsize="${line%% *}"         # first field is epoch; second is size
+        # Re-parse properly:
+        read -r _epoch _size _path <<< "$line"
+        remove_file "$_path"
+        if [[ "$DRY_RUN" -eq 0 ]]; then
+          total_bytes=$(( total_bytes - _size ))
+        fi
+      done < <(printf '%s\n' "${tmp_list[@]}" | sort -n)
+    else
+      log "Phase 2: directory is within the size limit, nothing to delete."
+    fi
+  fi
+fi
+
+log "Done."

--- a/src/MoqxPicoRelayServer.h
+++ b/src/MoqxPicoRelayServer.h
@@ -13,6 +13,7 @@
 #include "stats/StatsRegistry.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <moxygen/events/MoQExecutor.h>
+#include <moxygen/mlog/MLoggerFactory.h>
 #include <moxygen/openmoq/transport/pico/MoQPicoQuicEventBaseServer.h>
 #include <proxygen/lib/http/webtransport/WebTransport.h>
 
@@ -37,6 +38,10 @@ public:
   void stop() override;
 
   void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
+
+  void setMLoggerFactory(std::shared_ptr<moxygen::MLoggerFactory> factory) {
+    moxygen::MoQServerBase::setMLoggerFactory(std::move(factory));
+  }
 
   // Preferred entry point: binds the address from the stored ListenerConfig.
   void start();

--- a/src/MoqxRelayServer.h
+++ b/src/MoqxRelayServer.h
@@ -13,6 +13,7 @@
 #include "stats/StatsRegistry.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <moxygen/MoQServer.h>
+#include <moxygen/mlog/MLoggerFactory.h>
 
 namespace openmoq::moqx {
 
@@ -30,6 +31,10 @@ public:
   void stop() override;
 
   void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
+
+  void setMLoggerFactory(std::shared_ptr<moxygen::MLoggerFactory> factory) {
+    moxygen::MoQServerBase::setMLoggerFactory(std::move(factory));
+  }
 
   // Preferred entry point: binds the address from the stored ListenerConfig.
   void start();

--- a/src/MoqxServerFactory.h
+++ b/src/MoqxServerFactory.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "MoqxPicoRelayServer.h"
 #include "MoqxQmuxRelayServer.h"
@@ -16,20 +17,27 @@
 #include "stats/StatsRegistry.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <moxygen/MoQServerBase.h>
+#include <moxygen/mlog/MLoggerFactory.h>
+
 namespace openmoq::moqx {
 
 // Creates the appropriate relay server for the given listener config and wires
 // stats. Both stack paths accept the same ioExecutor for a uniform call site.
+// Optionally wires an mlog factory for per-session logging.
 inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
     const config::ListenerConfig& listenerCfg,
     std::shared_ptr<MoqxRelayContext> context,
     folly::IOThreadPoolExecutor* ioExecutor,
-    std::shared_ptr<stats::StatsRegistry> statsRegistry
+    std::shared_ptr<stats::StatsRegistry> statsRegistry,
+    std::shared_ptr<moxygen::MLoggerFactory> mlogFactory = nullptr
 ) {
   if (listenerCfg.quicStack == config::QuicStack::Picoquic) {
     auto server =
         std::make_shared<MoqxPicoRelayServer>(listenerCfg, std::move(context), ioExecutor);
     server->setStatsRegistry(std::move(statsRegistry));
+    if (mlogFactory) {
+      server->setMLoggerFactory(std::move(mlogFactory));
+    }
     return server;
   }
   if (listenerCfg.quicStack == config::QuicStack::ProxygenQmux) {
@@ -40,6 +48,9 @@ inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
   }
   auto server = std::make_shared<MoqxRelayServer>(listenerCfg, std::move(context), ioExecutor);
   server->setStatsRegistry(std::move(statsRegistry));
+  if (mlogFactory) {
+    server->setMLoggerFactory(std::move(mlogFactory));
+  }
   return server;
 }
 

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -213,6 +213,15 @@ struct AdminConfig {
   std::optional<TlsConfig> tls;
 };
 
+struct MLogConfig {
+  std::string dir;        // output directory; empty = disabled
+  float sampleRate{1.0f}; // 1.0 = log all sessions, 0.0 = none
+};
+
+struct LoggingConfig {
+  std::optional<MLogConfig> mlog;
+};
+
 struct Config {
   std::vector<ListenerConfig> listeners;
   folly::F14FastMap<std::string, ServiceConfig> services;
@@ -222,6 +231,7 @@ struct Config {
   bool useRelayThread{true};
   bool useLocalForwarders{false};
   bool mvfstBpfSteering{true};
+  std::optional<LoggingConfig> logging;
 };
 
 } // namespace openmoq::moqx::config

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -6,6 +6,7 @@
 
 #include "config/loader/ConfigResolver.h"
 
+#include <filesystem>
 #include <iomanip>
 #include <random>
 #include <sstream>
@@ -937,6 +938,22 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
 
   const bool mvfstBpfSteering = config.mvfst_bpf_steering.value().value_or(true);
 
+  // === Validate logging ===
+  if (config.logging.value().has_value()) {
+    const auto& logging = *config.logging.value();
+    if (logging.mlog.value().has_value()) {
+      const auto& mlog = *logging.mlog.value();
+      if (mlog.sample_rate.value().has_value()) {
+        float rate = *mlog.sample_rate.value();
+        if (rate < 0.0f || rate > 1.0f) {
+          errors.push_back(
+              "logging.mlog.sample_rate must be in [0.0, 1.0], got " + std::to_string(rate)
+          );
+        }
+      }
+    }
+  }
+
   if (!errors.empty()) {
     return folly::makeUnexpected("Config validation failed:\n  - " + folly::join("\n  - ", errors));
   }
@@ -967,6 +984,35 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
   // Resolve relayID: use configured value or generate a random hex string
   std::string relayID = config.relay_id.value().value_or(generateRelayID());
 
+  // Resolve logging config
+  std::optional<LoggingConfig> loggingConfig;
+  if (config.logging.value().has_value()) {
+    const auto& parsedLogging = *config.logging.value();
+    LoggingConfig resolved;
+    if (parsedLogging.mlog.value().has_value()) {
+      const auto& parsedMlog = *parsedLogging.mlog.value();
+      MLogConfig mlogConfig;
+      mlogConfig.dir = parsedMlog.dir.value();
+      mlogConfig.sampleRate = parsedMlog.sample_rate.value().value_or(1.0f);
+      if (!mlogConfig.dir.empty()) {
+        std::error_code ec;
+        const auto st = std::filesystem::status(mlogConfig.dir, ec);
+        if (ec) {
+          return folly::makeUnexpected(
+              "Failed to access mlog directory '" + mlogConfig.dir + "': " + ec.message()
+          );
+        }
+        if (std::filesystem::exists(st) && !std::filesystem::is_directory(st)) {
+          return folly::makeUnexpected(
+              "logging.mlog.dir must be a directory path: '" + mlogConfig.dir + "'"
+          );
+        }
+      }
+      resolved.mlog = std::move(mlogConfig);
+    }
+    loggingConfig = std::move(resolved);
+  }
+
   return ResolvedConfig{
       .config =
           Config{
@@ -989,6 +1035,7 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
               .useRelayThread = useRelayThread,
               .useLocalForwarders = useLocalForwarders,
               .mvfstBpfSteering = mvfstBpfSteering,
+              .logging = std::move(loggingConfig),
           },
       .warnings = std::move(warnings),
   };

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -406,6 +406,16 @@ struct ParsedServiceDefaultsConfig {
   rfl::Description<"Default cache settings for services", std::optional<ParsedCacheConfig>> cache;
 };
 
+struct ParsedMLogConfig {
+  rfl::Description<"Directory for per-session MoQ log files (empty = disabled)", std::string> dir;
+  rfl::Description<"Fraction of sessions to log (0.0-1.0, default 1.0)", std::optional<float>>
+      sample_rate;
+};
+
+struct ParsedLoggingConfig {
+  rfl::Description<"MoQ-level (mlog) per-session logging", std::optional<ParsedMLogConfig>> mlog;
+};
+
 struct ParsedConfig {
   rfl::Description<
       "Listener definitions (currently exactly one supported)",
@@ -443,6 +453,7 @@ struct ParsedConfig {
       "Disable to fall back to kernel RSS distribution.",
       std::optional<bool>>
       mvfst_bpf_steering;
+  rfl::Description<"Logging configuration", std::optional<ParsedLoggingConfig>> logging;
 };
 
 } // namespace openmoq::moqx::config

--- a/src/logging/MLogSetup.cpp
+++ b/src/logging/MLogSetup.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "logging/MLogSetup.h"
+
+#include <filesystem>
+
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
+#include <folly/logging/xlog.h>
+#include <moxygen/mlog/FileMLoggerFactory.h>
+#include <moxygen/mlog/SamplingMLoggerFactory.h>
+
+namespace openmoq::moqx::logging {
+
+folly::Expected<MLogSetup, int> setupMLog(const config::Config& config) {
+  MLogSetup result;
+  if (!config.logging || !config.logging->mlog) {
+    return result;
+  }
+  const auto& mcfg = *config.logging->mlog;
+  if (mcfg.dir.empty()) {
+    return result;
+  }
+
+  std::error_code ec;
+  std::filesystem::create_directories(mcfg.dir, ec);
+  if (ec) {
+    XLOG(ERR) << "Failed to create mlog directory '" << mcfg.dir << "': " << ec.message();
+    return folly::makeUnexpected(1);
+  }
+
+  auto baseFactory =
+      std::make_shared<moxygen::DirMLoggerFactory>(mcfg.dir, moxygen::VantagePoint::SERVER);
+  result.executor = std::make_shared<folly::IOThreadPoolExecutor>(
+      1,
+      std::make_shared<folly::NamedThreadFactory>("moqx-mlog")
+  );
+  baseFactory->setWriteExecutor(result.executor);
+  if (mcfg.sampleRate < 1.0f) {
+    result.factory =
+        std::make_shared<moxygen::SamplingMLoggerFactory>(baseFactory, mcfg.sampleRate);
+  } else {
+    result.factory = std::move(baseFactory);
+  }
+
+  return result;
+}
+
+} // namespace openmoq::moqx::logging

--- a/src/logging/MLogSetup.h
+++ b/src/logging/MLogSetup.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "config/Config.h"
+
+#include <memory>
+
+#include <folly/Expected.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <moxygen/mlog/MLoggerFactory.h>
+
+namespace openmoq::moqx::logging {
+
+/**
+ * Owns all runtime mlog resources: the logger factory and the background
+ * write executor.
+ */
+struct MLogSetup {
+  std::shared_ptr<moxygen::MLoggerFactory> factory;
+  std::shared_ptr<folly::IOThreadPoolExecutor> executor;
+};
+
+/**
+ * Constructs an MLogSetup from the resolved config.
+ * Creates the mlog directory if it does not already exist.
+ * Returns makeUnexpected(1) (exit code) on failure.
+ */
+folly::Expected<MLogSetup, int> setupMLog(const config::Config& config);
+
+} // namespace openmoq::moqx::logging

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "admin/StateHandler.h"
 #include "bpf/QuicReuseportSteering.h"
 #include "config/loader/ConfigInit.h"
+#include "logging/MLogSetup.h"
 #include "stats/StatsRegistry.h"
 
 #include <csignal>
@@ -103,6 +104,11 @@ int main(int argc, char* argv[]) {
   // folly logging is initialized by folly::Init above using the
   // FOLLY_INIT_LOGGING_CONFIG default at file scope. Override with
   // --logging=<config> or the FOLLY_LOGGING env var.
+  auto mlogResult = logging::setupMLog(config);
+  if (!mlogResult) {
+    return mlogResult.error();
+  }
+  auto mlog = std::move(*mlogResult);
 
   // === 3. Set up signal handling ===
   folly::EventBase evb;
@@ -135,7 +141,9 @@ int main(int argc, char* argv[]) {
   std::vector<std::shared_ptr<moxygen::MoQServerBase>> servers;
   try {
     for (const auto& listenerCfg : config.listeners) {
-      servers.emplace_back(makeRelayServer(listenerCfg, context, ioExecutor.get(), statsRegistry));
+      servers.emplace_back(
+          makeRelayServer(listenerCfg, context, ioExecutor.get(), statsRegistry, mlog.factory)
+      );
     }
   } catch (const std::exception& e) {
     // Listener setup (e.g. TLS cert loading) can throw. Report cleanly and exit
@@ -215,6 +223,13 @@ int main(int argc, char* argv[]) {
   }
   servers.clear();
   ioExecutor.reset();
+
+  // Join mlog write executor last: sessions are destroyed by the teardown above
+  // (their outputLogs() calls schedule writes here), so we must not join until
+  // after the IO pool drains.
+  if (mlog.executor) {
+    mlog.executor->join();
+  }
 
   // === 14. Exit with appropriate code ===
   return 0;


### PR DESCRIPTION
Enables per-session mlog logging with configurable directory and sample rate. Generates unique log IDs combining timestamp and session pointer address.

This is dependent on : https://github.com/openmoq/moxygen/pull/209



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/306)
<!-- Reviewable:end -->
