### PR TITLE
scripts: add perf-test.sh and perf-metrics.sh

### DIFF
--- a/scripts/perf-metrics.sh
+++ b/scripts/perf-metrics.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# perf-metrics.sh — generic moqx /metrics poller
+#
+# Discovers all metric names on startup, prints a tab-separated header row,
+# then one row per second of per-second deltas (counters), interval averages
+# (histograms), and instantaneous values (gauges), plus system stats.
+#
+# Bucket lines are skipped; histogram _sum/_count pairs are collapsed into a
+# single avg_ column.
+#
+# Usage: scripts/perf-metrics.sh [admin_port] [log_file]
+#   admin_port  default 19701
+#   log_file    default /tmp/moqx_metrics_<timestamp>.log
+#
+# Terminal tip: column -t -s $'\t'   or   awk -F'\t' '{print $N}' to slice
+
+set -uo pipefail
+
+ADMIN_PORT="${1:-19701}"
+LOG_FILE="${2:-/tmp/moqx_metrics_$(date +%Y%m%d_%H%M%S).log}"
+
+SEP=$'\t'
+CLK_TCK=$(getconf CLK_TCK 2>/dev/null || echo 100)
+
+# ---------------------------------------------------------------------------
+# parse_prom: prometheus text → "KEY VALUE" lines, one per metric.
+#   - strips moqx_ prefix
+#   - condenses labels to values only: {role="io",le="1000"} → [io,1000]
+#   - drops _bucket lines and comment/empty lines
+# ---------------------------------------------------------------------------
+parse_prom() {
+  awk '
+    /^#/ || /^$/ { next }
+    {
+      if (match($0, /\{[^}]*\}/)) {
+        name = substr($0, 1, RSTART-1)
+        labels = substr($0, RSTART+1, RLENGTH-2)
+        rest = substr($0, RSTART+RLENGTH)
+        sub(/^ +/, "", rest); sub(/ .*/, "", rest); val = rest
+        gsub(/[a-zA-Z_]+=/, "", labels)
+        gsub(/"/, "", labels)
+        key = name "[" labels "]"
+      } else {
+        key = $1; val = $2
+      }
+      if (key ~ /_bucket/) next
+      sub(/^moqx_/, "", key)
+      print key " " val
+    }
+  '
+}
+
+# ---------------------------------------------------------------------------
+# col_name: human-readable column header for a raw key
+#   quicBytesWritten_total        → quicBytesWritten/s
+#   quicRttSample_milliseconds_sum → avg_quicRttSample_ms
+#   evbLoopBusy_microseconds_sum[io] → avg_evbLoopBusy_us[io]
+#   quicActiveConnections         → quicActiveConnections  (gauge, unchanged)
+# ---------------------------------------------------------------------------
+col_name() {
+  local key="$1"
+  if [[ "$key" == *_total || "$key" == *_total\[* ]]; then
+    echo "${key/_total//s}"
+  elif [[ "$key" == *_sum || "$key" == *_sum\[* ]]; then
+    local base="${key/_sum/}"
+    base="${base/_milliseconds/_ms}"
+    base="${base/_microseconds/_us}"
+    base="${base/_bytes/_B}"
+    base="${base/_bits_per_second/_bps}"
+    base="${base/_packets/_pkts}"
+    echo "avg_${base}"
+  else
+    echo "$key"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+declare -A prev=()
+declare -A sys_prev=()
+declare -A cur=()
+declare -a col_order=()
+header_printed=false
+start_ms=$(date +%s%3N)
+prev_tick_ms=$start_ms
+prev_relay_cpu=0
+
+# Sleep only the remainder of the current 1s tick window.
+tick_sleep() {
+  local rem=$(( tick_start_ms + 1000 - $(date +%s%3N) ))
+  [[ $rem -gt 0 ]] && sleep "$(awk -v ms="$rem" 'BEGIN { printf "%.3f", ms/1000 }')"
+}
+
+while true; do
+  tick_start_ms=$(date +%s%3N)
+  raw=$(curl -sf "http://localhost:${ADMIN_PORT}/metrics" 2>/dev/null) || { tick_sleep; continue; }
+
+  cur=()
+  while read -r key val; do
+    cur["$key"]="$val"
+  done < <(printf '%s\n' "$raw" | parse_prom)
+
+  now_ms=$(date +%s%3N)
+  elapsed=$(( (now_ms - start_ms) / 1000 ))
+  interval_s=$(awk -v d="$(( now_ms - prev_tick_ms ))" 'BEGIN { printf "%.3f", d/1000 }')
+
+  # System stats
+  relay_pid=$(pgrep -x moqx 2>/dev/null | head -1 || true)
+  cpu_pct="?" rss_mb="?" cur_relay_cpu=0
+  if [[ -n "$relay_pid" ]] && [[ -r "/proc/$relay_pid/stat" ]]; then
+    stat_info=$(awk '{print $14+$15, $24}' "/proc/$relay_pid/stat" 2>/dev/null || true)
+    if [[ -n "$stat_info" ]]; then
+      cur_relay_cpu=${stat_info%% *}
+      rss_pages=${stat_info##* }
+      rss_mb=$(awk -v p="$rss_pages" 'BEGIN { printf "%.0f", p * 4 / 1024 }')
+      cpu_pct=$(awk -v d="$(( cur_relay_cpu - prev_relay_cpu ))" \
+                    -v hz="$CLK_TCK" \
+                    -v ms="$(( now_ms - prev_tick_ms ))" \
+                'BEGIN { if (ms > 0) printf "%.1f", d/hz*1000/ms*100; else printf "0.0" }')
+    fi
+  fi
+
+  lo_now=$(awk '/^ *lo:/  { print $10+0 }' /proc/net/dev)
+  tx_now=$(awk 'NR>2 && !/^ *lo:/ { sum += $10 } END { print sum+0 }' /proc/net/dev)
+  udp_snmp=$(awk '/^Udp:/ { if (!h) { h=$0 } else { d=$0; exit } } END { print h"\n"d }' \
+             /proc/net/snmp)
+  udp_err=$(paste <(printf '%s\n' "$udp_snmp" | head -1 | tr ' ' '\n') \
+                  <(printf '%s\n' "$udp_snmp" | tail -1 | tr ' ' '\n') \
+            | awk '$1=="InErrors" { print $2 }')
+  udp_buf=$(paste <(printf '%s\n' "$udp_snmp" | head -1 | tr ' ' '\n') \
+                  <(printf '%s\n' "$udp_snmp" | tail -1 | tr ' ' '\n') \
+            | awk '$1=="RcvbufErrors" { print $2 }')
+
+  # First tick: discover column order and print header
+  if [[ "$header_printed" == false ]]; then
+    for key in "${!cur[@]}"; do
+      [[ "$key" == *_count || "$key" == *_count\[* ]] && continue
+      col_order+=("$key")
+    done
+    mapfile -t col_order < <(printf '%s\n' "${col_order[@]}" | sort)
+
+    header="elapsed"
+    for key in "${col_order[@]}"; do
+      header+="${SEP}$(col_name "$key")"
+    done
+    header+="${SEP}CPU%${SEP}RSS_MB${SEP}lo_Mbps${SEP}ext_Mbps${SEP}UDPErr/s${SEP}UDPBufDrop/s"
+    printf '%s\n' "$header" | tee "$LOG_FILE"
+
+    for key in "${!cur[@]}"; do prev["$key"]="${cur[$key]}"; done
+    sys_prev[lo]="${lo_now:-0}"
+    sys_prev[tx]="${tx_now:-0}"
+    sys_prev[udp_err]="${udp_err:-0}"
+    sys_prev[udp_buf]="${udp_buf:-0}"
+    prev_relay_cpu=$cur_relay_cpu
+    prev_tick_ms=$now_ms
+    header_printed=true
+    tick_sleep
+    continue
+  fi
+
+  # Emit data row
+  row="$elapsed"
+  for key in "${col_order[@]}"; do
+    cur_val="${cur[$key]:-0}"
+    prev_val="${prev[$key]:-0}"
+    if [[ "$key" == *_total || "$key" == *_total\[* ]]; then
+      val=$(awk -v c="$cur_val" -v p="$prev_val" -v s="$interval_s" \
+            'BEGIN { if (s>0) printf "%.1f", (c-p)/s; else printf "0.0" }')
+    elif [[ "$key" == *_sum || "$key" == *_sum\[* ]]; then
+      count_key="${key/_sum/_count}"
+      cur_cnt="${cur[$count_key]:-0}"
+      prev_cnt="${prev[$count_key]:-0}"
+      val=$(awk -v cs="$cur_val" -v ps="$prev_val" \
+                -v cc="$cur_cnt"  -v pc="$prev_cnt" \
+            'BEGIN { s=cs-ps; c=cc-pc; if (c>0) printf "%.2f", s/c; else printf "0.00" }')
+    else
+      val="$cur_val"
+    fi
+    row+="${SEP}${val}"
+  done
+
+  dlo=$(( ${lo_now:-0}        - ${sys_prev[lo]:-0} ))
+  dtx=$(( ${tx_now:-0}        - ${sys_prev[tx]:-0} ))
+  dudp_err=$(( ${udp_err:-0}  - ${sys_prev[udp_err]:-0} ))
+  dudp_buf=$(( ${udp_buf:-0}  - ${sys_prev[udp_buf]:-0} ))
+  lo_mbps=$(awk  -v d="$dlo" -v s="$interval_s" 'BEGIN { if (s>0) printf "%.2f", d*8/1e6/s; else printf "0.00" }')
+  ext_mbps=$(awk -v d="$dtx" -v s="$interval_s" 'BEGIN { if (s>0) printf "%.2f", d*8/1e6/s; else printf "0.00" }')
+  derr_s=$(awk   -v d="$dudp_err" -v s="$interval_s" 'BEGIN { if (s>0) printf "%.1f", d/s; else printf "0.0" }')
+  dbuf_s=$(awk   -v d="$dudp_buf" -v s="$interval_s" 'BEGIN { if (s>0) printf "%.1f", d/s; else printf "0.0" }')
+
+  row+="${SEP}${cpu_pct}${SEP}${rss_mb}${SEP}${lo_mbps}${SEP}${ext_mbps}${SEP}${derr_s}${SEP}${dbuf_s}"
+  printf '%s\n' "$row" | tee -a "$LOG_FILE"
+
+  for key in "${!cur[@]}"; do prev["$key"]="${cur[$key]}"; done
+  sys_prev[lo]="${lo_now:-0}"
+  sys_prev[tx]="${tx_now:-0}"
+  sys_prev[udp_err]="${udp_err:-0}"
+  sys_prev[udp_buf]="${udp_buf:-0}"
+  prev_relay_cpu=$cur_relay_cpu
+  prev_tick_ms=$now_ms
+  tick_sleep
+done

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# perf-test.sh — relay throughput/subscriber perf test
+#
+# Starts a moqx relay, moqtest_server (publisher), and moqperf_test_client
+# (subscriber ramp), then prints the client's output.  Logs for all three
+# processes are always saved to /tmp/moqx-perf-<timestamp>/.
+#
+# Usage: scripts/perf-test.sh [options]
+#   --relay PATH           Path to moqx binary (default: build/moqx)
+#   --moqbin PATH          Path to moxygen bin dir
+#                          (default: .scratch/moxygen-install/bin)
+#   --subscriber-max N     Max total subscribers (default: 500)
+#   --ramp N               Subscribers added per second (default: 100)
+#   --duration N           Test duration in seconds (default: 30)
+#   --delivery-timeout N   Delivery timeout in ms (default: 500)
+#   --transport TYPE       quic or webtransport (default: quic)
+#   --no-relay-thread      Disable relay exec thread (use_relay_thread: false)
+#   --io-threads N         Number of relay IO threads (default: 1)
+#   --threads N            Number of perf client threads (default: 2)
+#   --relay-log SPEC       folly XLOG config passed as --logging=SPEC to relay
+#   --bpf-steering         Enable BPF reuseport steering (requires MOQX_BPF_STEERING build)
+#   --no-bpf-steering      Disable BPF reuseport steering (default)
+#   --jemalloc             LD_PRELOAD jemalloc (auto-detected from /lib64/libjemalloc.so.2)
+#   --metrics              Run perf-metrics.sh alongside the relay; logs to LOG_DIR/metrics.log
+#   --perf-duration N      Run perf record -F 99 -g on relay for N seconds; starts after
+#                          subscribers finish ramping (delay = 3*max/ramp s); saves to LOG_DIR/
+#   --remote-client HOST   Run moqperf_test_client on HOST via ssh instead of
+#                          locally.  The binary is expected at
+#                          /tmp/moqperf_test_client on the remote host.
+#                          HOST may include a user prefix (user@host).
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ── Defaults ───────────────────────────────────────────────────────────────────
+BINARY="${RELAY:-$REPO/build/moqx}"
+MOQBIN="${MOQBIN:-$REPO/.scratch/moxygen-install/bin}"
+SUBSCRIBER_MAX=500
+RAMP=100
+DURATION=30
+DELIVERY_TIMEOUT=500
+TRANSPORT="quic"
+USE_RELAY_THREAD="true"
+IO_THREADS=1
+CLIENT_THREADS=2
+RELAY_LOG_SPEC=""
+BPF_STEERING="false"
+JEMALLOC=""
+RUN_METRICS=false
+PERF_DURATION=0
+REMOTE_CLIENT_HOST=""
+
+RELAY_PORT=4433
+RELAY_ADMIN_PORT=19701
+ENDPOINT="/moq-relay"
+
+# ── Arg parsing ────────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --relay)            BINARY="$2";            shift 2 ;;
+    --moqbin)           MOQBIN="$2";            shift 2 ;;
+    --subscriber-max)   SUBSCRIBER_MAX="$2";    shift 2 ;;
+    --ramp)             RAMP="$2";              shift 2 ;;
+    --duration)         DURATION="$2";          shift 2 ;;
+    --delivery-timeout) DELIVERY_TIMEOUT="$2";  shift 2 ;;
+    --transport)        TRANSPORT="$2";         shift 2 ;;
+    --no-relay-thread)  USE_RELAY_THREAD="false"; shift ;;
+    --io-threads)       IO_THREADS="$2";          shift 2 ;;
+    --threads)          CLIENT_THREADS="$2";      shift 2 ;;
+    --relay-log)        RELAY_LOG_SPEC="$2";      shift 2 ;;
+    --bpf-steering)     BPF_STEERING="true";      shift ;;
+    --no-bpf-steering)  BPF_STEERING="false";     shift ;;
+    --jemalloc)         JEMALLOC="auto";           shift ;;
+    --metrics)          RUN_METRICS=true;          shift ;;
+    --perf-duration)    PERF_DURATION="$2";        shift 2 ;;
+    --remote-client)    REMOTE_CLIENT_HOST="$2";  shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+MOQTEST_SERVER="$MOQBIN/moqtest_server"
+MOQPERF_CLIENT="$MOQBIN/moqperf_test_client"
+METRICS_SCRIPT="$REPO/scripts/perf-metrics.sh"
+
+# ── jemalloc resolution ───────────────────────────────────────────────────────
+if [[ "$JEMALLOC" == "auto" ]]; then
+  if [[ -f /lib64/libjemalloc.so.2 ]]; then
+    JEMALLOC=/lib64/libjemalloc.so.2
+  else
+    echo "WARNING: --jemalloc requested but /lib64/libjemalloc.so.2 not found; ignoring" >&2
+    JEMALLOC=""
+  fi
+fi
+
+# ── Log directory (always on) ─────────────────────────────────────────────────
+LOG_DIR="/tmp/moqx-perf-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$LOG_DIR"
+RELAY_LOG="$LOG_DIR/relay.log"
+SERVER_LOG="$LOG_DIR/server.log"
+CLIENT_LOG="$LOG_DIR/client.log"
+echo "Logs: $LOG_DIR"
+
+# ── Prereq checks ──────────────────────────────────────────────────────────────
+CHECK_BINS=("$BINARY" "$MOQTEST_SERVER")
+[[ -z "$REMOTE_CLIENT_HOST" ]] && CHECK_BINS+=("$MOQPERF_CLIENT")
+[[ "$RUN_METRICS" == true ]] && CHECK_BINS+=("$METRICS_SCRIPT")
+if [[ "$PERF_DURATION" -gt 0 ]] && ! command -v perf >/dev/null 2>&1; then
+  echo "ERROR: --perf-duration requires 'perf' in PATH" >&2; exit 1
+fi
+for f in "${CHECK_BINS[@]}"; do
+  if [[ ! -x "$f" ]]; then
+    echo "ERROR: not found or not executable: $f" >&2; exit 1
+  fi
+done
+
+if [[ "$TRANSPORT" != "quic" && "$TRANSPORT" != "webtransport" ]]; then
+  echo "ERROR: --transport must be 'quic' or 'webtransport'" >&2; exit 1
+fi
+if [[ "$RAMP" -le 0 ]]; then
+  echo "ERROR: --ramp must be > 0" >&2; exit 1
+fi
+
+for port in "$RELAY_PORT" "$RELAY_ADMIN_PORT"; do
+  if ss -tunlp 2>/dev/null | grep -q ":$port "; then
+    echo "ERROR: port $port already in use" >&2; exit 1
+  fi
+done
+
+# ── URL scheme ────────────────────────────────────────────────────────────────
+if [[ -n "$REMOTE_CLIENT_HOST" ]]; then
+  LOCAL_IP="$(hostname -I | awk '{print $1}')"
+  RELAY_URL="https://${LOCAL_IP}:${RELAY_PORT}${ENDPOINT}"
+else
+  RELAY_URL="https://127.0.0.1:${RELAY_PORT}${ENDPOINT}"
+fi
+if [[ "$TRANSPORT" == "quic" ]]; then
+  QUIC_FLAG="--quic_transport=true"
+else
+  QUIC_FLAG="--quic_transport=false"
+fi
+
+# ── Temp dir for relay config ─────────────────────────────────────────────────
+TMPDIR_SCRIPT="$(mktemp -d)"
+RELAY_CFG="$TMPDIR_SCRIPT/relay.yaml"
+
+# ── Cleanup ───────────────────────────────────────────────────────────────────
+PIDS=()
+RELAY_PID=""
+cleanup() {
+  [[ -n "$RELAY_PID" ]] && kill "$RELAY_PID" 2>/dev/null || true
+  for pid in "${PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
+  local deadline=$(( $(date +%s) + 5 ))
+  for pid in "${PIDS[@]}"; do
+    while kill -0 "$pid" 2>/dev/null; do
+      (( $(date +%s) >= deadline )) && { kill -KILL "$pid" 2>/dev/null || true; break; }
+      sleep 0.1
+    done
+  done
+  [[ ${#PIDS[@]} -gt 0 ]] && wait "${PIDS[@]}" 2>/dev/null || true
+  [[ -n "$RELAY_PID" ]] && wait "$RELAY_PID" 2>/dev/null || true
+  rm -rf "$TMPDIR_SCRIPT"
+  echo "Logs saved to $LOG_DIR"
+}
+trap cleanup EXIT
+
+# ── Relay config ──────────────────────────────────────────────────────────────
+cat >"$RELAY_CFG" <<EOF
+relay_id: "perf-test-relay"
+threads: $IO_THREADS
+use_relay_thread: $USE_RELAY_THREAD
+listeners:
+  - name: perf
+    udp:
+      socket:
+        address: "::"
+        port: $RELAY_PORT
+    tls:
+      insecure: true
+    endpoint: "$ENDPOINT"
+    mvfst:
+      enable_gso: true
+      max_conn_packets_sent_per_loop: 16
+      max_server_recv_packets_per_loop: 32
+      bbr2:
+        exit_startup_on_loss: true
+        enable_recovery_in_startup: true
+        enable_recovery_in_probe_states: true
+    quic:
+      cc_algo: bbr2
+services:
+  default:
+    match:
+      - authority: {any: true}
+        path: {prefix: "/"}
+    cache:
+      enabled: false
+      max_tracks: 0
+      max_groups_per_track: 0
+admin:
+  port: $RELAY_ADMIN_PORT
+  address: "::"
+  plaintext: true
+EOF
+
+cp "$RELAY_CFG" "$LOG_DIR/relay.yaml"
+
+# ── Run params ────────────────────────────────────────────────────────────────
+{
+  echo "date:             $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "moqx_git:         $(git -C "$REPO" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  echo "moxygen_git:      $(git -C "$REPO/deps/moxygen" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  echo "relay_binary:     $BINARY"
+  echo "moqbin:           $MOQBIN"
+  echo "relay_url:        $RELAY_URL"
+  echo "transport:        $TRANSPORT"
+  echo "io_threads:       $IO_THREADS"
+  echo "use_relay_thread: $USE_RELAY_THREAD"
+  echo "subscriber_max:   $SUBSCRIBER_MAX"
+  echo "ramp:             $RAMP"
+  echo "duration:         $DURATION"
+  echo "delivery_timeout: $DELIVERY_TIMEOUT"
+  echo "client_threads:   $CLIENT_THREADS"
+  echo "jemalloc:         ${JEMALLOC:-none}"
+  echo "bpf_steering:     $BPF_STEERING"
+  [[ "$PERF_DURATION" -gt 0 ]] && echo "perf_duration:    ${PERF_DURATION}s (delay=$(( 3 * SUBSCRIBER_MAX / RAMP ))s)" || true
+  [[ -n "$REMOTE_CLIENT_HOST" ]] && echo "remote_client:    $REMOTE_CLIENT_HOST" || true
+} | tee "$LOG_DIR/run_params.txt"
+echo ""
+
+# ── Start relay ───────────────────────────────────────────────────────────────
+ulimit -n 65536 2>/dev/null || true
+echo "Starting relay (use_relay_thread=$USE_RELAY_THREAD, io_threads=$IO_THREADS, transport=$TRANSPORT, bpf_steering=$BPF_STEERING)..."
+RELAY_LOGGING_ARG=()
+[[ -n "$RELAY_LOG_SPEC" ]] && RELAY_LOGGING_ARG=("--logging=$RELAY_LOG_SPEC")
+if [[ -n "$JEMALLOC" ]]; then
+  echo "Using jemalloc: $JEMALLOC"
+  LD_PRELOAD="$JEMALLOC" "$BINARY" --config="$RELAY_CFG" "${RELAY_LOGGING_ARG[@]}" >"$RELAY_LOG" 2>&1 &
+else
+  "$BINARY" --config="$RELAY_CFG" "${RELAY_LOGGING_ARG[@]}" >"$RELAY_LOG" 2>&1 &
+fi
+RELAY_PID=$!
+
+deadline=$(( $(date +%s) + 10 ))
+until curl -sf "http://localhost:$RELAY_ADMIN_PORT/info" >/dev/null 2>&1; do
+  (( $(date +%s) >= deadline )) && { echo "ERROR: relay not ready after 10s" >&2; exit 1; }
+  sleep 0.1
+done
+echo "Relay ready on port $RELAY_PORT"
+
+# ── Start metrics poller (optional) ──────────────────────────────────────────
+if [[ "$RUN_METRICS" == true ]]; then
+  METRICS_LOG="$LOG_DIR/metrics.log"
+  echo "Starting metrics poller → $METRICS_LOG"
+  bash "$METRICS_SCRIPT" "$RELAY_ADMIN_PORT" "$METRICS_LOG" >"$LOG_DIR/metrics_stderr.log" 2>&1 &
+  PIDS+=($!)
+fi
+
+# ── Start moqtest_server (publisher) ─────────────────────────────────────────
+echo "Starting moqtest_server -> $RELAY_URL ..."
+"$MOQTEST_SERVER" \
+  --relay_url="$RELAY_URL" \
+  $QUIC_FLAG \
+  >"$SERVER_LOG" 2>&1 &
+PIDS+=($!)
+
+deadline=$(( $(date +%s) + 10 ))
+until [[ "$(curl -sf "http://localhost:$RELAY_ADMIN_PORT/metrics" 2>/dev/null \
+           | grep "^moqx_moqActiveSessions " | awk '{print $2}')" -ge 1 ]] 2>/dev/null; do
+  (( $(date +%s) >= deadline )) && { echo "ERROR: moqtest_server did not connect after 10s" >&2; exit 1; }
+  sleep 0.1
+done
+echo "Publisher connected"
+
+# ── Start perf record (optional) ─────────────────────────────────────────────
+if [[ "$PERF_DURATION" -gt 0 ]]; then
+  perf_delay=$(( 3 * SUBSCRIBER_MAX / RAMP ))
+  perf_data="$LOG_DIR/perf.data"
+  echo "perf record: starts in ${perf_delay}s, runs ${PERF_DURATION}s → $perf_data"
+  ( sleep "$perf_delay" && \
+    perf record -F 99 -g -p "$RELAY_PID" -o "$perf_data" -- sleep "$PERF_DURATION" \
+    && echo "perf record complete → $perf_data" ) &
+  PIDS+=($!)
+fi
+
+# ── Run moqperf_test_client ───────────────────────────────────────────────────
+CLIENT_ARGS=(
+  --relay_url="$RELAY_URL"
+  $QUIC_FLAG
+  --subscriber_max="$SUBSCRIBER_MAX"
+  --subscriber_ramp="$RAMP"
+  --duration="$DURATION"
+  --delivery_timeout="$DELIVERY_TIMEOUT"
+  --num_threads="$CLIENT_THREADS"
+)
+
+if [[ -n "$REMOTE_CLIENT_HOST" ]]; then
+  echo "Syncing moqperf_test_client to $REMOTE_CLIENT_HOST..."
+  rsync -az -e ssh "$MOQPERF_CLIENT" "${REMOTE_CLIENT_HOST}:/tmp/moqperf_test_client"
+  echo "Running perf client on $REMOTE_CLIENT_HOST: subscriber_max=$SUBSCRIBER_MAX ramp=$RAMP duration=${DURATION}s delivery_timeout=${DELIVERY_TIMEOUT}ms threads=$CLIENT_THREADS"
+  echo "---"
+  ssh "$REMOTE_CLIENT_HOST" \
+    "ulimit -n 65536 2>/dev/null || true; /tmp/moqperf_test_client ${CLIENT_ARGS[*]@Q}" \
+    2>&1 | tee "$CLIENT_LOG"
+else
+  ulimit -n 65536 2>/dev/null || true
+  echo "Running perf client: subscriber_max=$SUBSCRIBER_MAX ramp=$RAMP duration=${DURATION}s delivery_timeout=${DELIVERY_TIMEOUT}ms threads=$CLIENT_THREADS"
+  echo "---"
+  "$MOQPERF_CLIENT" "${CLIENT_ARGS[@]}" 2>&1 | tee "$CLIENT_LOG"
+fi


### PR DESCRIPTION
perf-test.sh orchestrates a full relay throughput test: starts moqx, moqtest_server, and moqperf_test_client (optionally remote via ssh), with optional perf record and metrics polling.

perf-metrics.sh polls /metrics each second and emits a TSV of per-second counter deltas, histogram averages, and system stats (CPU%, RSS, lo_Mbps, ext_Mbps, UDP errors).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/314)
<!-- Reviewable:end -->
