### PR TITLE
docker: make WebTransport endpoint configurable via MOQX_ENDPOINT

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,7 @@
 #   MOQX_MAX_TRACKS — max cached tracks (default: 1000)
 #   MOQX_MAX_GROUPS — max groups per track in cache (default: 100)
 #   MOQX_BIND_ADDR  — listen address: "0.0.0.0" (IPv4, default) or "::" (IPv6/dual-stack)
+#   MOQX_ENDPOINT   — WebTransport endpoint path (default: /moq-relay)
 #
 # Env vars (always apply):
 #   MOQX_LOG_LEVEL  — min log level: 0=INFO 1=WARNING 2=ERROR 3=FATAL (default: 0)
@@ -49,7 +50,7 @@ listeners:
       cert_file: "${MOQX_CERT:-}"
       key_file: "${MOQX_KEY:-}"
       insecure: ${MOQX_INSECURE:-false}
-    endpoint: "/moq-relay"
+    endpoint: "${MOQX_ENDPOINT:-/moq-relay}"
 
 services:
   default:


### PR DESCRIPTION
## Summary
- Add `MOQX_ENDPOINT` env var to `docker/entrypoint.sh` (default `/moq-relay`, preserves existing behavior)
- Replaces the hardcoded `endpoint: "/moq-relay"` in the generated config with `endpoint: "${MOQX_ENDPOINT:-/moq-relay}"`

Step 1 of resolving #316.

## Why
[moq-interop-runner](https://github.com/englishm/moq-interop-runner) registers relays at `https://relay:4443` (no path). moqx is currently registered with only `remote` endpoints (no docker), so each client only runs 2 transport modes × 6 tests = 12 tests against the moqx relay — that's the gap Will flagged in #316. The fix is a docker-mode adapter for the runner, and the adapter needs to override the endpoint path to `/` (the runner's `RELAY_URL` convention).

Mounting a custom config works but is heavier than a one-line env-var. This unblocks a follow-up PR to moq-interop-runner that adds `adapters/moqx/Dockerfile.relay`, registers moqx in the docker column, and brings the relay matrix cell from 12/12 to 18/18 for well-behaved clients.

## Test plan
- [x] Default behavior preserved: `docker run -e MOQX_INSECURE=true ...` still generates `endpoint: "/moq-relay"` in `/tmp/relay.yaml`
- [x] Override works: `docker run -e MOQX_ENDPOINT=/ -e MOQX_INSECURE=true ...` generates `endpoint: "/"`
- [x] Validated end-to-end locally: built a test image overlaying the new entrypoint, wrapped it in the interop adapter, ran the interop test client suite — all 6/6 tests pass against moqx-as-relay over docker on UDP 4443, endpoint `/`. Confirmed pairings: moqx↔moqx, moxygen→moqx, aiomoqt→moqx, moqlivemock→moqx, moq-rs→moqx, moq-rs-draft-16→moqx (all 6/6).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/319)
<!-- Reviewable:end -->
