### PR TITLE
fix(build): write cmake_prefix_path.txt in dev-artifact setup mode

### DIFF
--- a/scripts/setup-deps-dev-artifact.sh
+++ b/scripts/setup-deps-dev-artifact.sh
@@ -114,4 +114,9 @@ if [[ ! -f "$INSTALL_DIR/lib/cmake/moxygen/moxygen-config.cmake" ]] && \
     exit 1
 fi
 
+# Write the sentinel cmake_prefix_path.txt that build.sh checks before
+# building. Mirrors setup-deps-tarball.sh / setup-deps-standalone.sh so the
+# dev-artifact mode produces the same post-setup state as the other modes.
+echo "$INSTALL_DIR" > "${SCRATCH}/cmake_prefix_path.txt"
+
 echo "==> Done: dev-build artifact extracted to ${INSTALL_DIR}"


### PR DESCRIPTION
## Symptom

After ``bash scripts/build.sh setup`` completes successfully via the dev-artifact path (added in #315), running ``bash scripts/build.sh`` immediately errors:

```
Error: Dependencies not set up. Run: ./scripts/build.sh setup
```

## Root cause

``build.sh`` line 381 gates on the existence of ``${SCRATCH}/cmake_prefix_path.txt``. Both ``setup-deps-tarball.sh`` (line 174) and ``setup-deps-standalone.sh`` (line 98) write that sentinel at the end of their successful path. The new ``setup-deps-dev-artifact.sh`` doesn't — so the dev-artifact path leaves setup half-complete from ``build.sh``'s perspective.

## Fix

Append the same sentinel write at the end of ``setup-deps-dev-artifact.sh``.

## Test plan

- [x] Empirically reproduced on argo: after #315 merge, ``setup`` reports ``from-dev-artifact`` mode + extracts the artifact, but ``build.sh`` exits with the dependencies error. With this fix the sentinel is present and ``build.sh`` proceeds to configure normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/321)
<!-- Reviewable:end -->
