### PR TITLE
relay: drop redundant setDownstream() from PendingTrackConsumer

### DIFF
--- a/src/UpstreamProvider.cpp
+++ b/src/UpstreamProvider.cpp
@@ -54,10 +54,6 @@ namespace {
 class PendingTrackConsumer : public TrackConsumerFilter {
 public:
   PendingTrackConsumer() : TrackConsumerFilter(nullptr) {}
-
-  void setDownstream(std::shared_ptr<TrackConsumer> downstream) {
-    downstream_ = std::move(downstream);
-  }
 };
 
 } // namespace


### PR DESCRIPTION

TrackConsumerFilter now provides setDownstream() directly.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openmoq/moqx/pull/323).
* #325
* #324
* __->__ #323

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/323)
<!-- Reviewable:end -->
