### PR TITLE
stats: add keyed loop observer removal to fix use-after-free

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -979,7 +979,7 @@ void MoqxRelay::onEmpty(MoQForwarder* forwarder) {
   }
 }
 
-void MoqxRelay::forwardChanged(MoQForwarder* forwarder) {
+void MoqxRelay::forwardChanged(MoQForwarder* forwarder, bool forward) {
   const auto& ftn = forwarder->fullTrackName();
   auto upstreamView = registry_.getUpstreamView(ftn);
   if (!upstreamView) {
@@ -994,18 +994,10 @@ void MoqxRelay::forwardChanged(MoQForwarder* forwarder) {
     XLOG(DBG4) << "Ignoring forward change for " << ftn << " - publisher terminated";
     return;
   }
-  XLOG(INFO) << "Updating forward for " << ftn
-             << " numForwardingSubs=" << forwarder->numForwardingSubscribers();
+  XLOG(INFO) << "Updating forward for " << ftn << " forward=" << forward;
 
   auto exec = upstreamView->upstream->getExecutor();
-  co_withExecutor(
-      exec,
-      doSubscribeUpdate(
-          upstreamView->handle,
-          /*forward=*/forwarder->numForwardingSubscribers() > 0
-      )
-  )
-      .start();
+  co_withExecutor(exec, doSubscribeUpdate(upstreamView->handle, forward)).start();
 }
 
 void MoqxRelay::newGroupRequested(MoQForwarder* forwarder, uint64_t group) {

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -244,7 +244,7 @@ private:
   NamespaceTree namespaceTree_{*this};
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
-  void forwardChanged(moxygen::MoQForwarder* forwarder) override;
+  void forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) override;
   void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override;
 
   folly::coro::Task<void> publishNamespaceToSession(

--- a/src/UpstreamProvider.cpp
+++ b/src/UpstreamProvider.cpp
@@ -54,10 +54,6 @@ namespace {
 class PendingTrackConsumer : public TrackConsumerFilter {
 public:
   PendingTrackConsumer() : TrackConsumerFilter(nullptr) {}
-
-  void setDownstream(std::shared_ptr<TrackConsumer> downstream) {
-    downstream_ = std::move(downstream);
-  }
 };
 
 } // namespace

--- a/src/stats/EventBaseStatsCollector.cpp
+++ b/src/stats/EventBaseStatsCollector.cpp
@@ -19,9 +19,23 @@ EventBaseStatsCollector::create(std::shared_ptr<StatsRegistry> registry, folly::
 
 EventBaseStatsCollector::EventBaseStatsCollector(folly::EventBase* evb) : evb_(evb) {}
 
-void EventBaseStatsCollector::addLoopObserver(std::function<void(int64_t, int64_t)> cb) {
-  evb_->runImmediatelyOrRunInEventBaseThread([this, cb = std::move(cb)]() mutable {
-    observers_.emplace_back(std::move(cb));
+void EventBaseStatsCollector::addLoopObserver(
+    const void* key,
+    std::function<void(int64_t, int64_t)> cb
+) {
+  evb_->runImmediatelyOrRunInEventBaseThread([this, key, cb = std::move(cb)]() mutable {
+    observers_.emplace_back(key, std::move(cb));
+  });
+}
+
+void EventBaseStatsCollector::removeLoopObserver(const void* key) {
+  evb_->runImmediatelyOrRunInEventBaseThread([this, key] {
+    auto it = std::find_if(observers_.begin(), observers_.end(), [key](const auto& p) {
+      return p.first == key;
+    });
+    if (it != observers_.end()) {
+      observers_.erase(it);
+    }
   });
 }
 
@@ -29,7 +43,7 @@ void EventBaseStatsCollector::loopSample(int64_t busyUs, int64_t idleUs) {
   evbLoopBusy_.addValue(static_cast<uint64_t>(busyUs));
   evbLoopIdle_.addValue(static_cast<uint64_t>(idleUs));
 
-  for (auto& cb : observers_) {
+  for (auto& [_, cb] : observers_) {
     cb(busyUs, idleUs);
   }
 }

--- a/src/stats/EventBaseStatsCollector.h
+++ b/src/stats/EventBaseStatsCollector.h
@@ -46,8 +46,12 @@ public:
 
   // Subscribe to loop samples.  cb is invoked on the EVB thread each iteration.
   // May be called from any thread; the subscription is installed asynchronously.
-  // The caller must ensure the objects captured by cb outlive this collector.
-  void addLoopObserver(std::function<void(int64_t, int64_t)> cb);
+  // key identifies the subscription for removal; typically the owning object's `this`.
+  void addLoopObserver(const void* key, std::function<void(int64_t, int64_t)> cb);
+
+  // Remove the subscription registered under key.  Safe to call from any thread;
+  // the removal is posted to the EVB thread.  No-op if key was never registered.
+  void removeLoopObserver(const void* key);
 
 private:
   explicit EventBaseStatsCollector(folly::EventBase* evb);
@@ -55,7 +59,7 @@ private:
   folly::EventBase* evb_;
 
   // Only accessed on evb_ thread.
-  std::vector<std::function<void(int64_t, int64_t)>> observers_;
+  std::vector<std::pair<const void*, std::function<void(int64_t, int64_t)>>> observers_;
 
 #define DEFINE_HISTOGRAM(name, bounds, unit) BoundedHistogram<bounds.size()> name##_{bounds};
   STATS_EVB_HISTOGRAM_FIELDS(DEFINE_HISTOGRAM)

--- a/src/stats/PicoQuicStatsCollector.cpp
+++ b/src/stats/PicoQuicStatsCollector.cpp
@@ -19,17 +19,20 @@ std::shared_ptr<PicoQuicStatsCollector> PicoQuicStatsCollector::create(
   auto collector = std::shared_ptr<PicoQuicStatsCollector>(new PicoQuicStatsCollector(evb));
   registry->registerCollector(collector);
   if (evbCollector) {
-    evbCollector->addLoopObserver([c = collector.get()](int64_t busyUs, int64_t /*idleUs*/) {
-      uint64_t sent = c->quicPacketsSent_;
-      uint64_t recv = c->quicPacketsReceived_;
-      uint64_t dSent = sent - c->prevLoopPktsSent_;
-      uint64_t dRecv = recv - c->prevLoopPktsRecv_;
-      c->evbPktsSentPerLoop_.addValue(dSent);
-      c->evbPktsRecvPerLoop_.addValue(dRecv);
-      c->prevLoopPktsSent_ = sent;
-      c->prevLoopPktsRecv_ = recv;
-      FOLLY_SDT(moqx, evb_loop_sample, busyUs, dSent, dRecv);
-    });
+    evbCollector->addLoopObserver(
+        collector.get(),
+        [c = collector.get()](int64_t busyUs, int64_t /*idleUs*/) {
+          uint64_t sent = c->quicPacketsSent_;
+          uint64_t recv = c->quicPacketsReceived_;
+          uint64_t dSent = sent - c->prevLoopPktsSent_;
+          uint64_t dRecv = recv - c->prevLoopPktsRecv_;
+          c->evbPktsSentPerLoop_.addValue(dSent);
+          c->evbPktsRecvPerLoop_.addValue(dRecv);
+          c->prevLoopPktsSent_ = sent;
+          c->prevLoopPktsRecv_ = recv;
+          FOLLY_SDT(moqx, evb_loop_sample, busyUs, dSent, dRecv);
+        }
+    );
   }
   return collector;
 }

--- a/src/stats/QuicStatsCollector.cpp
+++ b/src/stats/QuicStatsCollector.cpp
@@ -25,7 +25,11 @@ public:
     }
   }
 
-  ~Callback() override = default;
+  ~Callback() override {
+    if (auto coll = evbColl_.lock()) {
+      coll->removeLoopObserver(data_.get());
+    }
+  }
 
   // --- Tracked callbacks ---
   // Based on QuicServerWorker, the first ones to trigger can be onPacketReceived or
@@ -155,23 +159,28 @@ private:
 
     if (auto reg = registry_.lock()) {
       if (auto evbColl = reg->findEvbCollector(evb).lock()) {
-        evbColl->addLoopObserver([d = data_.get()](int64_t busyUs, int64_t /*idleUs*/) {
-          uint64_t sent = d->quicPacketsSent_;
-          uint64_t recv = d->quicPacketsReceived_;
-          uint64_t dSent = sent - d->prevLoopPktsSent_;
-          uint64_t dRecv = recv - d->prevLoopPktsRecv_;
-          d->evbPktsSentPerLoop_.addValue(dSent);
-          d->evbPktsRecvPerLoop_.addValue(dRecv);
-          d->prevLoopPktsSent_ = sent;
-          d->prevLoopPktsRecv_ = recv;
-          FOLLY_SDT(moqx, evb_loop_sample, busyUs, dSent, dRecv);
-        });
+        evbColl_ = evbColl;
+        evbColl->addLoopObserver(
+            data_.get(),
+            [d = data_.get()](int64_t busyUs, int64_t /*idleUs*/) {
+              uint64_t sent = d->quicPacketsSent_;
+              uint64_t recv = d->quicPacketsReceived_;
+              uint64_t dSent = sent - d->prevLoopPktsSent_;
+              uint64_t dRecv = recv - d->prevLoopPktsRecv_;
+              d->evbPktsSentPerLoop_.addValue(dSent);
+              d->evbPktsRecvPerLoop_.addValue(dRecv);
+              d->prevLoopPktsSent_ = sent;
+              d->prevLoopPktsRecv_ = recv;
+              FOLLY_SDT(moqx, evb_loop_sample, busyUs, dSent, dRecv);
+            }
+        );
       }
     }
   }
 
   std::shared_ptr<QuicStatsCollector> data_;
   std::weak_ptr<StatsRegistry> registry_;
+  std::weak_ptr<EventBaseStatsCollector> evbColl_;
 };
 
 QuicStatsCollector::Factory::Factory(std::shared_ptr<StatsRegistry> registry)


### PR DESCRIPTION

QuicStatsCollector::Callback registered an EVB loop observer capturing
data_.get() as a raw pointer.  If the Callback was destroyed while its
EventBaseStatsCollector was still alive, the observer would continue to
fire and dereference the freed pointer.

Fix by giving addLoopObserver a key (typically the owning object's `this`)
and adding removeLoopObserver(key), which posts an erase to the EVB thread.
Callback's destructor now calls removeLoopObserver so the subscription is
torn down safely.  PicoQuicStatsCollector's observer is similarly keyed
for consistency.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openmoq/moqx/pull/325).
* __->__ #325
* #324
* #323

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/325)
<!-- Reviewable:end -->
