### PR TITLE
chore(test): macOS dev hygiene — portable head + drop unused exec captures

### DIFF
--- a/test/MoqxCacheTest.cpp
+++ b/test/MoqxCacheTest.cpp
@@ -1869,7 +1869,7 @@ CO_TEST_F(MoqxCacheTest, TestFetchPartialMissTwoUpstreamFetchesTailDesc) {
 
         expectUpstreamFetch({1, 3}, {3, 0}, 0, AbsoluteLocation{3, 0}, GroupOrder::NewestFirst)
             .via(exec)
-            .thenTry([this, exec](const auto&) {
+            .thenTry([this](const auto&) {
               expectFetchObjectsDescending({1, 3}, {4, 0}, true, 10, 1, 1, true);
               serveCacheRangeFromUpstreamDescending({1, 3}, {4, 0}, 10, 1, 1, true);
             });
@@ -1895,7 +1895,7 @@ CO_TEST_F(MoqxCacheTest, TestFetchPartialMissTwoUpstreamFetchesTail) {
         expectFetchObjects({0, 5}, {0, 7}, false, 10, 1, 1, false);
         expectUpstreamFetch({0, 7}, {0, 9}, 0, AbsoluteLocation{0, 9})
             .via(exec)
-            .thenTry([this, exec](const auto&) {
+            .thenTry([this](const auto&) {
               expectFetchObjects({0, 7}, {0, 9}, true, 10, 1, 1, true);
               serveCacheRangeFromUpstream({0, 7}, {0, 9}, 10, 1, 1, true);
             });

--- a/test/test_relay_chain.sh
+++ b/test/test_relay_chain.sh
@@ -126,7 +126,8 @@ check_state() {
     echo "FAIL [$label /state]: curl failed (exit $?)" >&2; return 1;
   }
   http_code=$(printf '%s' "$raw" | tail -1)
-  response=$(printf '%s' "$raw" | head -n -1)
+  # sed '$d' drops the last line, portably (BSD head on macOS rejects -n -N).
+  response=$(printf '%s' "$raw" | sed '$d')
   if [[ "$http_code" != "200" ]]; then
     echo "FAIL [$label /state]: HTTP $http_code" >&2; return 1;
   fi


### PR DESCRIPTION
## Summary

Two small fixes that surface on a fresh Apple Silicon dev mac (e.g. the one being prepped as a moqx dev/test env) but not in CI, because GitHub's ``macos-15`` runner image happens to mask both.

## Fix 1: portable ``head`` in ``test/test_relay_chain.sh``

Line 129 was using ``head -n -1`` (GNU "all but last line"). BSD ``head`` on macOS rejects negative line counts:

```
head: illegal line count -- -1
```

Swapped to ``sed '$d'`` which means the same thing portably (drops the last line of input) on BSD ``sed`` and GNU ``sed`` alike.

This is the proximate cause of the ``relay_chain`` ctest going red on dev macs; the test is also known-flaky for other reasons, but at least the script no longer reliably fails before doing useful work.

## Fix 2: drop unused ``exec`` from two inner lambda captures in ``MoqxCacheTest.cpp``

clang emits two ``-Wunused-lambda-capture`` warnings for the inner ``.thenTry`` lambdas in ``TestFetchPartialMissTwoUpstreamFetchesTailDesc`` (line 1872) and ``TestFetchPartialMissTwoUpstreamFetchesTail`` (line 1898). The outer lambdas in those same expression chains genuinely use ``exec`` (via ``.via(exec)``) — those captures stay. Only the two inner captures are unused; this PR drops just those two.

All other ``[this, exec]`` captures in the file use ``exec`` somewhere in their body (``.via(exec)`` or ``exec->add(...)``) — verified by grep — so they are unchanged.

## Why CI didn't flag either before

- The ``head -n -1`` line only fires from a relay-chain test that's already known-flaky; CI's pass on it is partly luck.
- The lambda warnings are non-fatal; CI compiled with them and the build succeeded. They are just noise that confused dev-mac diagnostics when looking at the failed build's tail.

## Test plan

- [x] ``bash test/test_relay_chain.sh`` no longer fails with the BSD ``head`` error on macOS.
- [x] ``bash scripts/build.sh`` on macOS produces fewer warnings (the two -Wunused-lambda-capture diagnostics from this file are gone).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/333)
<!-- Reviewable:end -->
