### PR TITLE
mvfst: enable recvmmsg by default, bump recv batch size to 64

### DIFF
--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -66,7 +66,9 @@ buildTransportSettings(const config::QuicConfig& quic, const config::MvfstConfig
   ts.maxBatchSize = mvfst.maxConnPacketsSentPerLoop;
   ts.writeConnectionDataPacketsLimit = mvfst.maxConnPacketsSentPerLoop;
   ts.dataPathType = quic::DataPathType::ContinuousMemory;
+  ts.shouldUseWrapperRecvmmsgForBatchRecv = mvfst.useRecvmmsg;
   ts.maxServerRecvPacketsPerLoop = mvfst.maxServerRecvPacketsPerLoop;
+  ts.maxRecvBatchSize = mvfst.maxServerRecvPacketsPerLoop;
   ts.numGROBuffers_ = mvfst.numGROBuffers;
   ts.advertisedInitialConnectionFlowControlWindow = quic.maxData;
   ts.advertisedInitialBidiLocalStreamFlowControlWindow = quic.maxStreamData;

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -76,9 +76,11 @@ struct MvfstConfig {
   uint32_t maxConnPacketsSentPerLoop{48};
 
   // Receive-path tuning.
+  // Use recvmmsg for batch receives in QuicServerWorker.
+  bool useRecvmmsg{true};
   // Max incoming packets processed per event-loop read callback. 0 = unlimited.
   // mvfst default is 1; moqx was hardcoded to 10.
-  uint16_t maxServerRecvPacketsPerLoop{10};
+  uint16_t maxServerRecvPacketsPerLoop{64};
   // Number of UDP GRO buffers. 1 = disabled. > 1 enables kernel GRO coalescing.
   uint32_t numGROBuffers{1};
 

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -450,6 +450,8 @@ void applyMvfstOverride(MvfstConfig& base, const ParsedMvfstConfig& overlay) {
     base.enableGSO = *v;
   if (auto v = overlay.max_conn_packets_sent_per_loop.value())
     base.maxConnPacketsSentPerLoop = *v;
+  if (auto v = overlay.use_recvmmsg.value())
+    base.useRecvmmsg = *v;
   if (auto v = overlay.max_server_recv_packets_per_loop.value())
     base.maxServerRecvPacketsPerLoop = *v;
   if (auto v = overlay.num_gro_buffers.value())

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -111,8 +111,14 @@ struct ParsedMvfstConfig {
       std::optional<uint32_t>>
       max_conn_packets_sent_per_loop;
   rfl::Description<
+      "Use recvmmsg for batch receives in QuicServerWorker (default: true). "
+      "Enables the recvmmsg kernel call to read multiple UDP packets per syscall, "
+      "reducing overhead at high packet rates.",
+      std::optional<bool>>
+      use_recvmmsg;
+  rfl::Description<
       "Max incoming packets processed per event-loop read callback. "
-      "0 = unlimited. Default 10.",
+      "0 = unlimited. Default 64.",
       std::optional<uint16_t>>
       max_server_recv_packets_per_loop;
   rfl::Description<

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -1466,7 +1466,8 @@ TEST(ResolveConfig, MvfstDefaultsRoundTrip) {
   EXPECT_EQ(mvfst.maxCwndInMss, 860000u);
   EXPECT_TRUE(mvfst.enableGSO);
   EXPECT_EQ(mvfst.maxConnPacketsSentPerLoop, 48u);
-  EXPECT_EQ(mvfst.maxServerRecvPacketsPerLoop, 10u);
+  EXPECT_TRUE(mvfst.useRecvmmsg);
+  EXPECT_EQ(mvfst.maxServerRecvPacketsPerLoop, 64u);
   EXPECT_EQ(mvfst.numGROBuffers, 1u);
   EXPECT_DOUBLE_EQ(mvfst.copa.deltaParam, 0.05);
   EXPECT_FALSE(mvfst.bbr.conservativeRecovery);


### PR DESCRIPTION
Enable shouldUseWrapperRecvmmsgForBatchRecv by default via a new useRecvmmsg config field, and raise maxServerRecvPacketsPerLoop / maxRecvBatchSize from 10 to 64 so the recvmmsg batch size matches the loop limit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/337)
<!-- Reviewable:end -->
