### PR TITLE
scripts: perf-test and perf-metrics improvements

### DIFF
--- a/scripts/perf-metrics.sh
+++ b/scripts/perf-metrics.sh
@@ -85,6 +85,9 @@ header_printed=false
 start_ms=$(date +%s%3N)
 prev_tick_ms=$start_ms
 prev_relay_cpu=0
+declare -A io_prev_cpu=()   # keyed by thread name (e.g. moqx-io0)
+declare -A io_tid=()        # thread name → tid
+declare -a io_names=()      # ordered list of discovered io thread names
 
 # Sleep only the remainder of the current 1s tick window.
 tick_sleep() {
@@ -108,6 +111,7 @@ while true; do
   # System stats
   relay_pid=$(pgrep -x moqx 2>/dev/null | head -1 || true)
   cpu_pct="?" rss_mb="?" cur_relay_cpu=0
+  declare -A io_cpu=()
   if [[ -n "$relay_pid" ]] && [[ -r "/proc/$relay_pid/stat" ]]; then
     stat_info=$(awk '{print $14+$15, $24}' "/proc/$relay_pid/stat" 2>/dev/null || true)
     if [[ -n "$stat_info" ]]; then
@@ -119,6 +123,31 @@ while true; do
                     -v ms="$(( now_ms - prev_tick_ms ))" \
                 'BEGIN { if (ms > 0) printf "%.1f", d/hz*1000/ms*100; else printf "0.0" }')
     fi
+
+    # Discover io threads on first sighting (names like moqx-io*)
+    if [[ ${#io_names[@]} -eq 0 ]]; then
+      for tid_dir in /proc/$relay_pid/task/*/; do
+        local_tid="${tid_dir%/}"; local_tid="${local_tid##*/}"
+        tname=$(cat "/proc/$relay_pid/task/$local_tid/comm" 2>/dev/null || true)
+        if [[ "$tname" == moqx-io* ]]; then
+          io_tid["$tname"]="$local_tid"
+          io_names+=("$tname")
+        fi
+      done
+      mapfile -t io_names < <(printf '%s\n' "${io_names[@]}" | sort)
+    fi
+
+    # Per-io-thread CPU%
+    for tname in "${io_names[@]}"; do
+      local_tid="${io_tid[$tname]}"
+      cur_ticks=$(awk '{print $14+$15}' "/proc/$relay_pid/task/$local_tid/stat" 2>/dev/null || echo 0)
+      prev_ticks="${io_prev_cpu[$tname]:-0}"
+      io_cpu[$tname]=$(awk -v d="$(( cur_ticks - prev_ticks ))" \
+                           -v hz="$CLK_TCK" \
+                           -v ms="$(( now_ms - prev_tick_ms ))" \
+                       'BEGIN { if (ms>0) printf "%.1f", d/hz*1000/ms*100; else printf "0.0" }')
+      io_prev_cpu["$tname"]="$cur_ticks"
+    done
   fi
 
   lo_now=$(awk '/^ *lo:/  { print $10+0 }' /proc/net/dev)
@@ -144,7 +173,9 @@ while true; do
     for key in "${col_order[@]}"; do
       header+="${SEP}$(col_name "$key")"
     done
-    header+="${SEP}CPU%${SEP}RSS_MB${SEP}lo_Mbps${SEP}ext_Mbps${SEP}UDPErr/s${SEP}UDPBufDrop/s"
+    header+="${SEP}CPU%"
+    for tname in "${io_names[@]}"; do header+="${SEP}${tname}_CPU%"; done
+    header+="${SEP}RSS_MB${SEP}lo_Mbps${SEP}ext_Mbps${SEP}UDPErr/s${SEP}UDPBufDrop/s"
     printf '%s\n' "$header" | tee "$LOG_FILE"
 
     for key in "${!cur[@]}"; do prev["$key"]="${cur[$key]}"; done
@@ -180,6 +211,8 @@ while true; do
     row+="${SEP}${val}"
   done
 
+  row+="${SEP}${cpu_pct}"
+  for tname in "${io_names[@]}"; do row+="${SEP}${io_cpu[$tname]:-?}"; done
   dlo=$(( ${lo_now:-0}        - ${sys_prev[lo]:-0} ))
   dtx=$(( ${tx_now:-0}        - ${sys_prev[tx]:-0} ))
   dudp_err=$(( ${udp_err:-0}  - ${sys_prev[udp_err]:-0} ))
@@ -189,7 +222,7 @@ while true; do
   derr_s=$(awk   -v d="$dudp_err" -v s="$interval_s" 'BEGIN { if (s>0) printf "%.1f", d/s; else printf "0.0" }')
   dbuf_s=$(awk   -v d="$dudp_buf" -v s="$interval_s" 'BEGIN { if (s>0) printf "%.1f", d/s; else printf "0.0" }')
 
-  row+="${SEP}${cpu_pct}${SEP}${rss_mb}${SEP}${lo_mbps}${SEP}${ext_mbps}${SEP}${derr_s}${SEP}${dbuf_s}"
+  row+="${SEP}${rss_mb}${SEP}${lo_mbps}${SEP}${ext_mbps}${SEP}${derr_s}${SEP}${dbuf_s}"
   printf '%s\n' "$row" | tee -a "$LOG_FILE"
 
   for key in "${!cur[@]}"; do prev["$key"]="${cur[$key]}"; done

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -22,12 +22,22 @@
 #   --no-bpf-steering      Disable BPF reuseport steering (default)
 #   --jemalloc             LD_PRELOAD jemalloc (auto-detected from /lib64/libjemalloc.so.2)
 #   --metrics              Run perf-metrics.sh alongside the relay; logs to LOG_DIR/metrics.log
-#   --perf-duration N      Run perf record -F 99 -g on relay for N seconds; starts after
+#   --perf-duration N      Run perf record -F 499 -g -e cycles on relay for N seconds; starts after
 #                          subscribers finish ramping (delay = 3*max/ramp s); saves to LOG_DIR/
+#   --perf-events EVENTS   Run a second perf record -F 99 -g with these events alongside --perf-duration
+#                          e.g. --perf-events cache-misses,dTLB-load-misses; saves to LOG_DIR/perf-events.data
+#   --perf-stat            Run perf stat for the full test duration; saves to LOG_DIR/perf-stat.txt
+#   --trace-script PATH    Run PATH <relay_pid> for the duration; output → LOG_DIR/trace.log
+#   --client-args ARGS     Extra flags appended to moqperf_test_client invocation
+#                          e.g. --client-args "--first_object_size=5000 --object_size=1400"
 #   --remote-client HOST   Run moqperf_test_client on HOST via ssh instead of
 #                          locally.  The binary is expected at
 #                          /tmp/moqperf_test_client on the remote host.
 #                          HOST may include a user prefix (user@host).
+#
+# Linux-only options (not supported on macOS):
+#   --metrics, --perf-duration, --perf-events, --perf-stat, --jemalloc,
+#   --remote-client
 
 set -euo pipefail
 
@@ -49,7 +59,11 @@ BPF_STEERING="false"
 JEMALLOC=""
 RUN_METRICS=false
 PERF_DURATION=0
+PERF_EVENTS=""
+RUN_PERF_STAT=false
 REMOTE_CLIENT_HOST=""
+TRACE_SCRIPT=""
+CLIENT_EXTRA_ARGS=()
 
 RELAY_PORT=4433
 RELAY_ADMIN_PORT=19701
@@ -74,6 +88,10 @@ while [[ $# -gt 0 ]]; do
     --jemalloc)         JEMALLOC="auto";           shift ;;
     --metrics)          RUN_METRICS=true;          shift ;;
     --perf-duration)    PERF_DURATION="$2";        shift 2 ;;
+    --perf-events)      PERF_EVENTS="$2";          shift 2 ;;
+    --perf-stat)        RUN_PERF_STAT=true;        shift ;;
+    --trace-script)     TRACE_SCRIPT="$2";         shift 2 ;;
+    --client-args)      read -ra CLIENT_EXTRA_ARGS <<< "$2"; shift 2 ;;
     --remote-client)    REMOTE_CLIENT_HOST="$2";  shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -121,8 +139,15 @@ if [[ "$RAMP" -le 0 ]]; then
   echo "ERROR: --ramp must be > 0" >&2; exit 1
 fi
 
+is_port_in_use() {
+  if command -v ss >/dev/null 2>&1; then
+    ss -tunlp 2>/dev/null | grep -q ":$1 "
+  else
+    lsof -iTCP:"$1" -sTCP:LISTEN -P -n 2>/dev/null | grep -q .
+  fi
+}
 for port in "$RELAY_PORT" "$RELAY_ADMIN_PORT"; do
-  if ss -tunlp 2>/dev/null | grep -q ":$port "; then
+  if is_port_in_use "$port"; then
     echo "ERROR: port $port already in use" >&2; exit 1
   fi
 done
@@ -147,17 +172,29 @@ RELAY_CFG="$TMPDIR_SCRIPT/relay.yaml"
 # ── Cleanup ───────────────────────────────────────────────────────────────────
 PIDS=()
 RELAY_PID=""
+PERF_STAT_PID=""
 cleanup() {
+  # Send SIGINT to perf stat first so it prints its summary before we kill the relay
+  [[ -n "$PERF_STAT_PID" ]] && kill -INT "$PERF_STAT_PID" 2>/dev/null || true
   [[ -n "$RELAY_PID" ]] && kill "$RELAY_PID" 2>/dev/null || true
-  for pid in "${PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
+  # Wait for perf stat to finish writing (up to 3s)
+  if [[ -n "$PERF_STAT_PID" ]]; then
+    local ps_deadline=$(( $(date +%s) + 3 ))
+    while kill -0 "$PERF_STAT_PID" 2>/dev/null; do
+      (( $(date +%s) >= ps_deadline )) && { kill -KILL "$PERF_STAT_PID" 2>/dev/null || true; break; }
+      sleep 0.1
+    done
+    wait "$PERF_STAT_PID" 2>/dev/null || true
+  fi
+  for pid in ${PIDS[@]+"${PIDS[@]}"}; do kill "$pid" 2>/dev/null || true; done
   local deadline=$(( $(date +%s) + 5 ))
-  for pid in "${PIDS[@]}"; do
+  for pid in ${PIDS[@]+"${PIDS[@]}"}; do
     while kill -0 "$pid" 2>/dev/null; do
       (( $(date +%s) >= deadline )) && { kill -KILL "$pid" 2>/dev/null || true; break; }
       sleep 0.1
     done
   done
-  [[ ${#PIDS[@]} -gt 0 ]] && wait "${PIDS[@]}" 2>/dev/null || true
+  [[ ${#PIDS[@]} -gt 0 ]] && wait ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null || true
   [[ -n "$RELAY_PID" ]] && wait "$RELAY_PID" 2>/dev/null || true
   rm -rf "$TMPDIR_SCRIPT"
   echo "Logs saved to $LOG_DIR"
@@ -224,6 +261,7 @@ cp "$RELAY_CFG" "$LOG_DIR/relay.yaml"
   echo "jemalloc:         ${JEMALLOC:-none}"
   echo "bpf_steering:     $BPF_STEERING"
   [[ "$PERF_DURATION" -gt 0 ]] && echo "perf_duration:    ${PERF_DURATION}s (delay=$(( 3 * SUBSCRIBER_MAX / RAMP ))s)" || true
+  [[ -n "$PERF_EVENTS" ]] && echo "perf_events:      $PERF_EVENTS" || true
   [[ -n "$REMOTE_CLIENT_HOST" ]] && echo "remote_client:    $REMOTE_CLIENT_HOST" || true
 } | tee "$LOG_DIR/run_params.txt"
 echo ""
@@ -235,9 +273,9 @@ RELAY_LOGGING_ARG=()
 [[ -n "$RELAY_LOG_SPEC" ]] && RELAY_LOGGING_ARG=("--logging=$RELAY_LOG_SPEC")
 if [[ -n "$JEMALLOC" ]]; then
   echo "Using jemalloc: $JEMALLOC"
-  LD_PRELOAD="$JEMALLOC" "$BINARY" --config="$RELAY_CFG" "${RELAY_LOGGING_ARG[@]}" >"$RELAY_LOG" 2>&1 &
+  LD_PRELOAD="$JEMALLOC" "$BINARY" --config="$RELAY_CFG" ${RELAY_LOGGING_ARG[@]+"${RELAY_LOGGING_ARG[@]}"} >"$RELAY_LOG" 2>&1 &
 else
-  "$BINARY" --config="$RELAY_CFG" "${RELAY_LOGGING_ARG[@]}" >"$RELAY_LOG" 2>&1 &
+  "$BINARY" --config="$RELAY_CFG" ${RELAY_LOGGING_ARG[@]+"${RELAY_LOGGING_ARG[@]}"} >"$RELAY_LOG" 2>&1 &
 fi
 RELAY_PID=$!
 
@@ -247,6 +285,22 @@ until curl -sf "http://localhost:$RELAY_ADMIN_PORT/info" >/dev/null 2>&1; do
   sleep 0.1
 done
 echo "Relay ready on port $RELAY_PORT"
+
+# ── Trace script (optional) ───────────────────────────────────────────────────
+if [[ -n "$TRACE_SCRIPT" ]]; then
+  echo "Starting trace script $TRACE_SCRIPT (pid=$RELAY_PID) → $LOG_DIR/trace.log"
+  bash "$TRACE_SCRIPT" "$RELAY_PID" >"$LOG_DIR/trace.log" 2>&1 &
+  PIDS+=($!)
+fi
+
+# ── perf stat (optional) ──────────────────────────────────────────────────────
+if [[ "$RUN_PERF_STAT" == true ]]; then
+  perf_stat_out="$LOG_DIR/perf-stat.txt"
+  echo "Starting perf stat → $perf_stat_out"
+  perf stat -e cycles,instructions,cache-misses,cache-references,context-switches,cpu-migrations,dTLB-load-misses,L1-dcache-load-misses \
+    -p "$RELAY_PID" >"$perf_stat_out" 2>&1 &
+  PERF_STAT_PID=$!
+fi
 
 # ── Start metrics poller (optional) ──────────────────────────────────────────
 if [[ "$RUN_METRICS" == true ]]; then
@@ -261,6 +315,7 @@ echo "Starting moqtest_server -> $RELAY_URL ..."
 "$MOQTEST_SERVER" \
   --relay_url="$RELAY_URL" \
   $QUIC_FLAG \
+  --include_timestamp_extension=true \
   >"$SERVER_LOG" 2>&1 &
 PIDS+=($!)
 
@@ -278,9 +333,21 @@ if [[ "$PERF_DURATION" -gt 0 ]]; then
   perf_data="$LOG_DIR/perf.data"
   echo "perf record: starts in ${perf_delay}s, runs ${PERF_DURATION}s → $perf_data"
   ( sleep "$perf_delay" && \
-    perf record -F 99 -g -p "$RELAY_PID" -o "$perf_data" -- sleep "$PERF_DURATION" \
+    perf record -F 499 -g -e cycles -p "$RELAY_PID" -o "$perf_data" -- sleep "$PERF_DURATION" \
     && echo "perf record complete → $perf_data" ) &
   PIDS+=($!)
+fi
+
+if [[ -n "$PERF_EVENTS" && "$PERF_DURATION" -gt 0 ]]; then
+  perf_delay=$(( 3 * SUBSCRIBER_MAX / RAMP ))
+  perf_events_data="$LOG_DIR/perf-events.data"
+  echo "perf record ($PERF_EVENTS): starts in ${perf_delay}s, runs ${PERF_DURATION}s → $perf_events_data"
+  ( sleep "$perf_delay" && \
+    perf record -F 99 -g -e "$PERF_EVENTS" -p "$RELAY_PID" -o "$perf_events_data" -- sleep "$PERF_DURATION" \
+    && echo "perf record ($PERF_EVENTS) complete → $perf_events_data" ) &
+  PIDS+=($!)
+elif [[ -n "$PERF_EVENTS" ]]; then
+  echo "WARNING: --perf-events requires --perf-duration; ignoring" >&2
 fi
 
 # ── Run moqperf_test_client ───────────────────────────────────────────────────
@@ -292,6 +359,7 @@ CLIENT_ARGS=(
   --duration="$DURATION"
   --delivery_timeout="$DELIVERY_TIMEOUT"
   --num_threads="$CLIENT_THREADS"
+  "${CLIENT_EXTRA_ARGS[@]+"${CLIENT_EXTRA_ARGS[@]}"}"
 )
 
 if [[ -n "$REMOTE_CLIENT_HOST" ]]; then


### PR DESCRIPTION
perf-test.sh:
- Add --perf-events, --perf-stat, --trace-script, --client-args options
- Update perf record to -F 499 -g -e cycles
- Add --include_timestamp_extension=true to moqtest_server
- Fix port-in-use check: ss with lsof fallback for macOS
- Empty-array guards for PIDS/RELAY_LOGGING_ARG (bash 3 compat)
- PERF_STAT_PID cleanup: SIGINT first so perf stat prints its summary
- Document Linux-only options in header

perf-metrics.sh:
- Track per-io-thread CPU% via /proc (auto-discovered moqx-io* threads)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/341)
<!-- Reviewable:end -->
