### PR TITLE
relay: add cross-exec handle wrappers for Publisher/Subscriber results

### DIFF
--- a/src/relay/PublisherCrossExecFilter.cpp
+++ b/src/relay/PublisherCrossExecFilter.cpp
@@ -8,6 +8,117 @@
 
 namespace openmoq::moqx {
 
+namespace {
+
+// Dispatches unsubscribe() and requestUpdate() to the subscriber session's
+// executor (targetExec), which owns the session state.  Held by the relay
+// on relay exec and called back from there.
+class CrossExecSubscriptionHandle : public moxygen::SubscriptionHandle {
+public:
+  CrossExecSubscriptionHandle(
+      std::shared_ptr<moxygen::SubscriptionHandle> inner,
+      folly::Executor* exec
+  )
+      : inner_(std::move(inner)), exec_(exec) {}
+
+  const moxygen::SubscribeOk& subscribeOk() const override { return inner_->subscribeOk(); }
+
+  void unsubscribe() override {
+    exec_->add([inner = inner_]() mutable { inner->unsubscribe(); });
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate update) override {
+    co_return co_await folly::coro::co_withExecutor(
+        folly::getKeepAliveToken(exec_),
+        inner_->requestUpdate(std::move(update))
+    );
+  }
+
+private:
+  std::shared_ptr<moxygen::SubscriptionHandle> inner_;
+  folly::Executor* exec_;
+};
+
+class CrossExecFetchHandle : public moxygen::Publisher::FetchHandle {
+public:
+  CrossExecFetchHandle(
+      std::shared_ptr<moxygen::Publisher::FetchHandle> inner,
+      folly::Executor* exec
+  )
+      : inner_(std::move(inner)), exec_(exec) {}
+
+  const moxygen::FetchOk& fetchOk() const override { return inner_->fetchOk(); }
+
+  void fetchCancel() override {
+    exec_->add([inner = inner_]() mutable { inner->fetchCancel(); });
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate update) override {
+    co_return co_await folly::coro::co_withExecutor(
+        folly::getKeepAliveToken(exec_),
+        inner_->requestUpdate(std::move(update))
+    );
+  }
+
+private:
+  std::shared_ptr<moxygen::Publisher::FetchHandle> inner_;
+  folly::Executor* exec_;
+};
+
+// Wraps a NamespacePublishHandle so that namespaceMsg() and namespaceDoneMsg()
+// are dispatched back to the caller's executor.  Held by the inner session on
+// targetExec_ and called from there.
+class CrossExecNamespacePublishHandle : public moxygen::Publisher::NamespacePublishHandle {
+public:
+  CrossExecNamespacePublishHandle(
+      std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> inner,
+      folly::Executor::KeepAlive<> exec
+  )
+      : inner_(std::move(inner)), exec_(std::move(exec)) {}
+
+  void namespaceMsg(const moxygen::TrackNamespace& ns) override {
+    exec_->add([inner = inner_, ns]() mutable { inner->namespaceMsg(ns); });
+  }
+
+  void namespaceDoneMsg(const moxygen::TrackNamespace& ns) override {
+    exec_->add([inner = inner_, ns]() mutable { inner->namespaceDoneMsg(ns); });
+  }
+
+private:
+  std::shared_ptr<moxygen::Publisher::NamespacePublishHandle> inner_;
+  folly::Executor::KeepAlive<> exec_;
+};
+
+class CrossExecSubscribeNamespaceHandle : public moxygen::Publisher::SubscribeNamespaceHandle {
+public:
+  CrossExecSubscribeNamespaceHandle(
+      std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle> inner,
+      folly::Executor* exec
+  )
+      : inner_(std::move(inner)), exec_(exec) {}
+
+  const moxygen::SubscribeNamespaceOk& subscribeNamespaceOk() const override {
+    return inner_->subscribeNamespaceOk();
+  }
+
+  void unsubscribeNamespace() override {
+    exec_->add([inner = inner_]() mutable { inner->unsubscribeNamespace(); });
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate update) override {
+    co_return co_await folly::coro::co_withExecutor(
+        folly::getKeepAliveToken(exec_),
+        inner_->requestUpdate(std::move(update))
+    );
+  }
+
+private:
+  std::shared_ptr<moxygen::Publisher::SubscribeNamespaceHandle> inner_;
+  folly::Executor* exec_;
+};
+
+} // namespace
+
 folly::coro::Task<moxygen::Publisher::TrackStatusResult>
 PublisherCrossExecFilter::trackStatus(moxygen::TrackStatus trackStatus) {
   co_return co_await folly::coro::co_withExecutor(
@@ -20,31 +131,52 @@ folly::coro::Task<moxygen::Publisher::SubscribeResult> PublisherCrossExecFilter:
     moxygen::SubscribeRequest sub,
     std::shared_ptr<moxygen::TrackConsumer> callback
 ) {
-  co_return co_await folly::coro::co_withExecutor(
+  auto result = co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(targetExec_),
       inner_->subscribe(std::move(sub), std::move(callback))
   );
+  if (result.hasValue()) {
+    co_return std::make_shared<CrossExecSubscriptionHandle>(std::move(result.value()), targetExec_);
+  }
+  co_return result;
 }
 
 folly::coro::Task<moxygen::Publisher::FetchResult> PublisherCrossExecFilter::fetch(
     moxygen::Fetch fetchReq,
     std::shared_ptr<moxygen::FetchConsumer> fetchCallback
 ) {
-  co_return co_await folly::coro::co_withExecutor(
+  auto result = co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(targetExec_),
       inner_->fetch(std::move(fetchReq), std::move(fetchCallback))
   );
+  if (result.hasValue()) {
+    co_return std::make_shared<CrossExecFetchHandle>(std::move(result.value()), targetExec_);
+  }
+  co_return result;
 }
 
 folly::coro::Task<moxygen::Publisher::SubscribeNamespaceResult>
 PublisherCrossExecFilter::subscribeNamespace(
-    moxygen::SubscribeNamespace subAnn,
+    moxygen::SubscribeNamespace subNs,
     std::shared_ptr<NamespacePublishHandle> namespacePublishHandle
 ) {
-  co_return co_await folly::coro::co_withExecutor(
+  auto callerExec = co_await folly::coro::co_current_executor;
+  auto wrappedHandle = namespacePublishHandle ? std::make_shared<CrossExecNamespacePublishHandle>(
+                                                    std::move(namespacePublishHandle),
+                                                    std::move(callerExec)
+                                                )
+                                              : nullptr;
+  auto result = co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(targetExec_),
-      inner_->subscribeNamespace(std::move(subAnn), std::move(namespacePublishHandle))
+      inner_->subscribeNamespace(std::move(subNs), std::move(wrappedHandle))
   );
+  if (result.hasValue()) {
+    co_return std::make_shared<CrossExecSubscribeNamespaceHandle>(
+        std::move(result.value()),
+        targetExec_
+    );
+  }
+  co_return result;
 }
 
 void PublisherCrossExecFilter::goaway(moxygen::Goaway goaway) {

--- a/src/relay/SubscriberCrossExecFilter.cpp
+++ b/src/relay/SubscriberCrossExecFilter.cpp
@@ -10,15 +10,88 @@
 
 namespace openmoq::moqx {
 
+namespace {
+
+// Wraps a PublishNamespaceCallback so that publishNamespaceCancel() is
+// dispatched back to the caller's executor.  Held by the inner session on
+// targetExec_ and called from there.
+class CrossExecPublishNamespaceCallback : public moxygen::Subscriber::PublishNamespaceCallback {
+public:
+  CrossExecPublishNamespaceCallback(
+      std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback> inner,
+      folly::Executor::KeepAlive<> exec
+  )
+      : inner_(std::move(inner)), exec_(std::move(exec)) {}
+
+  void publishNamespaceCancel(
+      moxygen::PublishNamespaceErrorCode errorCode,
+      std::string reasonPhrase
+  ) override {
+    exec_->add([inner = inner_, errorCode, reason = std::move(reasonPhrase)]() mutable {
+      inner->publishNamespaceCancel(errorCode, std::move(reason));
+    });
+  }
+
+private:
+  std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback> inner_;
+  folly::Executor::KeepAlive<> exec_;
+};
+
+// Wraps a PublishNamespaceHandle so that publishNamespaceDone() and
+// requestUpdate() are dispatched to targetExec_ (the inner session's exec).
+// Held by the caller and invoked from the caller's executor.
+class CrossExecPublishNamespaceHandle : public moxygen::Subscriber::PublishNamespaceHandle {
+public:
+  CrossExecPublishNamespaceHandle(
+      std::shared_ptr<moxygen::Subscriber::PublishNamespaceHandle> inner,
+      folly::Executor* exec
+  )
+      : inner_(std::move(inner)), exec_(exec) {}
+
+  const moxygen::PublishNamespaceOk& publishNamespaceOk() const override {
+    return inner_->publishNamespaceOk();
+  }
+
+  void publishNamespaceDone() override {
+    exec_->add([inner = inner_]() mutable { inner->publishNamespaceDone(); });
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate update) override {
+    co_return co_await folly::coro::co_withExecutor(
+        folly::getKeepAliveToken(exec_),
+        inner_->requestUpdate(std::move(update))
+    );
+  }
+
+private:
+  std::shared_ptr<moxygen::Subscriber::PublishNamespaceHandle> inner_;
+  folly::Executor* exec_;
+};
+
+} // namespace
+
 folly::coro::Task<moxygen::Subscriber::PublishNamespaceResult>
 SubscriberCrossExecFilter::publishNamespace(
-    moxygen::PublishNamespace ann,
+    moxygen::PublishNamespace pubNs,
     std::shared_ptr<PublishNamespaceCallback> callback
 ) {
-  co_return co_await folly::coro::co_withExecutor(
+  auto callerExec = co_await folly::coro::co_current_executor;
+  auto wrappedCallback = callback ? std::make_shared<CrossExecPublishNamespaceCallback>(
+                                        std::move(callback),
+                                        std::move(callerExec)
+                                    )
+                                  : nullptr;
+  auto result = co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(targetExec_),
-      inner_->publishNamespace(std::move(ann), std::move(callback))
+      inner_->publishNamespace(std::move(pubNs), std::move(wrappedCallback))
   );
+  if (result.hasValue()) {
+    co_return std::make_shared<CrossExecPublishNamespaceHandle>(
+        std::move(result.value()),
+        targetExec_
+    );
+  }
+  co_return result;
 }
 
 moxygen::Subscriber::PublishResult SubscriberCrossExecFilter::publish(


### PR DESCRIPTION
The original filters only handled the initial verbs (publish, subscribe, etc).  The returned handles that are used for e.g. unsubscribe, requestUpdate, and the passed relay->session (pubNsCancel, subNs response) were missed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/342)
<!-- Reviewable:end -->
