### PR TITLE
test: wrap relay state queries in verifyOnRelayExec

### DIFF
--- a/test/MoqxRelayFetchTests.cpp
+++ b/test/MoqxRelayFetchTests.cpp
@@ -49,7 +49,7 @@ TEST_F(MoQRelayTest, FetchAfterPublisherTermination) {
   Fetch fetch(RequestID(0), kTestTrackName, AbsoluteLocation{0, 0}, AbsoluteLocation{1, 0});
   auto fetchConsumer = std::make_shared<NiceMock<MockFetchConsumer>>();
   withSessionContext(fetchSession, [&]() {
-    auto task = relay_->fetch(std::move(fetch), fetchConsumer);
+    auto task = publisherInterface()->fetch(std::move(fetch), fetchConsumer);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     // Should return an error, not crash
     EXPECT_FALSE(res.hasValue());

--- a/test/MoqxRelayNGRTests.cpp
+++ b/test/MoqxRelayNGRTests.cpp
@@ -22,7 +22,7 @@ TEST_F(MoQRelayTest, RelayPublishPropagatesDynamicGroupsToSubscribers) {
   setPublisherDynamicGroups(pub, true);
 
   withSessionContext(publisherSession, [&]() {
-    auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
     ASSERT_TRUE(res.hasValue());
     getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
   });
@@ -142,7 +142,7 @@ TEST_F(MoQRelayTest, RelaySubscribeLateJoinerNGRForwardedUpstream) {
 
   std::shared_ptr<SubscriptionHandle> handle2{nullptr};
   withSessionContext(subscriber2, [&]() {
-    auto task = relay_->subscribe(std::move(sub2), consumer2);
+    auto task = publisherInterface()->subscribe(std::move(sub2), consumer2);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     ASSERT_TRUE(res.hasValue());
     handle2 = *res;

--- a/test/MoqxRelayPeerTests.cpp
+++ b/test/MoqxRelayPeerTests.cpp
@@ -59,7 +59,7 @@ TEST_F(MoQRelayTest, NamespaceBridgeHandleForwardsDoneMsg) {
 // path for draft-16 is synchronous: namespacePublishHandle->namespaceMsg().
 TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBackOnReconnect) {
   // Relay must have a relayID for peer detection to activate.
-  relay_ = std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1");
+  resetRelay(std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1"));
   relay_->setAllowedNamespacePrefix(kAllowedPrefix);
 
   // Step 1: session1 is the peer's old (unreaped) connection.  Inject NS as
@@ -85,7 +85,7 @@ TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBackOnReconnect) {
 
   withSessionContext(session2, [&]() {
     // makePeerSubNs("jp-osa-1") carries jp-osa-1's relay ID in the auth token.
-    auto task = relay_->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle);
+    auto task = publisherInterface()->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle);
     folly::coro::blockingWait(std::move(task), exec_.get());
   });
 
@@ -98,7 +98,7 @@ TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBackOnReconnect) {
 // Complement: namespaces from LOCAL publishers (not from the peer) must still
 // be delivered when that peer subscribes.
 TEST_F(MoQRelayTest, LocalNamespaceDeliveredToPeerOnReconnect) {
-  relay_ = std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1");
+  resetRelay(std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1"));
   relay_->setAllowedNamespacePrefix(kAllowedPrefix);
 
   // Local publisher session announces kTestNamespace.
@@ -117,7 +117,7 @@ TEST_F(MoQRelayTest, LocalNamespaceDeliveredToPeerOnReconnect) {
   });
 
   withSessionContext(peerSession, [&]() {
-    auto task = relay_->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle);
+    auto task = publisherInterface()->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle);
     folly::coro::blockingWait(std::move(task), exec_.get());
   });
   EXPECT_TRUE(delivered) << "Relay failed to deliver a local namespace to a peer subscriber";
@@ -171,10 +171,10 @@ private:
 //
 // Unlike PeerNamespaceNotEchoedBackOnReconnect (which injects the namespace
 // directly via makeNamespaceBridgeHandle), this test goes through the full
-// relay_->subscribeNamespace() production path so the bug in the call-site is
+// publisherInterface()->subscribeNamespace() production path so the bug in the call-site is
 // exercised.
 TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBack_FullProductionPath) {
-  relay_ = std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1");
+  resetRelay(std::make_shared<MoqxRelay>(config::CacheConfig{.maxCachedTracks = 0}, "sg-sin-2-1"));
   relay_->setAllowedNamespacePrefix(kAllowedPrefix);
 
   // Step 1: jp-osa-1 connects as session1.  It will announce kTestNamespace
@@ -189,7 +189,7 @@ TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBack_FullProductionPath) {
 
   auto nsHandle1 = std::make_shared<NiceMock<MockNamespacePublishHandle>>();
   withSessionContext(session1, [&]() {
-    auto task = relay_->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle1);
+    auto task = publisherInterface()->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle1);
     folly::coro::blockingWait(std::move(task), exec_.get());
   });
 
@@ -209,7 +209,7 @@ TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBack_FullProductionPath) {
   });
 
   withSessionContext(session2, [&]() {
-    auto task = relay_->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle2);
+    auto task = publisherInterface()->subscribeNamespace(makePeerSubNs("jp-osa-1"), nsHandle2);
     folly::coro::blockingWait(std::move(task), exec_.get());
   });
 

--- a/test/MoqxRelayPeerTests.cpp
+++ b/test/MoqxRelayPeerTests.cpp
@@ -20,9 +20,13 @@ TEST_F(MoQRelayTest, NamespaceBridgeHandleForwardsNamespaceMsg) {
   auto handle = makeNamespaceBridgeHandle(relay_, peerSession);
   handle->namespaceMsg(kTestNamespace);
 
-  auto sessions = relay_->findPublishNamespaceSessions(kTestNamespace);
-  ASSERT_EQ(sessions.size(), 1u);
-  EXPECT_EQ(sessions[0], peerSession);
+  verifyOnRelayExec([&] {
+    auto sessions = relay_->findPublishNamespaceSessions(kTestNamespace);
+    EXPECT_EQ(sessions.size(), 1u);
+    if (!sessions.empty()) {
+      EXPECT_EQ(sessions[0], peerSession);
+    }
+  });
 
   removeSession(peerSession);
 }
@@ -33,10 +37,14 @@ TEST_F(MoQRelayTest, NamespaceBridgeHandleForwardsDoneMsg) {
   auto handle = makeNamespaceBridgeHandle(relay_, peerSession);
 
   handle->namespaceMsg(kTestNamespace);
-  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  verifyOnRelayExec([&] {
+    EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  });
 
   handle->namespaceDoneMsg(kTestNamespace);
-  EXPECT_TRUE(relay_->findPublishNamespaceSessions(kTestNamespace).empty());
+  verifyOnRelayExec([&] {
+    EXPECT_TRUE(relay_->findPublishNamespaceSessions(kTestNamespace).empty());
+  });
 
   removeSession(peerSession);
 }
@@ -67,7 +75,9 @@ TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBackOnReconnect) {
   auto session1 = createMockSession();
   auto bridgeHandle = makeNamespaceBridgeHandle(relay_, session1, "jp-osa-1");
   bridgeHandle->namespaceMsg(kTestNamespace);
-  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  verifyOnRelayExec([&] {
+    EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  });
 
   // Step 2: jp-osa-1 reconnects as session2 and sends a peer SUBSCRIBE_NAMESPACE.
   // Peer-to-peer sessions negotiate draft-16 (empty prefix is a 16+ feature).
@@ -194,7 +204,9 @@ TEST_F(MoQRelayTest, PeerNamespaceNotEchoedBack_FullProductionPath) {
   });
 
   // kTestNamespace should now be in the tree with sourcePeerID="jp-osa-1".
-  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  verifyOnRelayExec([&] {
+    EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  });
 
   // Step 2: jp-osa-1 reconnects as session2 and re-subscribes.
   // kTestNamespace must NOT be echoed back.
@@ -232,15 +244,19 @@ TEST_F(MoQRelayTest, BridgeHandleDestructorCleansUpNamespaces) {
   // it, as happens when the relay subscribes to an upstream/peer.
   auto bridgeHandle = makeNamespaceBridgeHandle(relay_, upstreamSession, /*peerID=*/{});
   bridgeHandle->namespaceMsg(kTestNamespace);
-  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  verifyOnRelayExec([&] {
+    EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  });
 
   // Drop the bridge handle without graceful namespaceDoneMsg — simulates
   // ungraceful session close destroying SubNsStreamCallback.
   bridgeHandle.reset();
 
   // Tree entry must be gone.
-  EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 0u)
-      << "Stale namespace tree entry persists after bridge handle destruction";
+  verifyOnRelayExec([&] {
+    EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 0u)
+        << "Stale namespace tree entry persists after bridge handle destruction";
+  });
 
   removeSession(upstreamSession);
 }
@@ -255,19 +271,25 @@ TEST_F(MoQRelayTest, BridgeHandleDestructorDoesNotEvictNewPublisher) {
   // session1 announces NS via bridge handle.
   auto bridgeHandle1 = makeNamespaceBridgeHandle(relay_, session1, /*peerID=*/{});
   bridgeHandle1->namespaceMsg(kTestNamespace);
-  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  verifyOnRelayExec([&] {
+    EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  });
 
   // session2 takes over NS (conflict path evicts session1, sets sourceSession=session2).
   auto bridgeHandle2 = makeNamespaceBridgeHandle(relay_, session2, /*peerID=*/{});
   bridgeHandle2->namespaceMsg(kTestNamespace);
-  ASSERT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  verifyOnRelayExec([&] {
+    EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u);
+  });
 
   // Now session1's handle is destroyed (ungraceful close detected late).
   // It must NOT evict session2's entry.
   bridgeHandle1.reset();
 
-  EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u)
-      << "Stale bridge handle destructor evicted the new publisher's entry";
+  verifyOnRelayExec([&] {
+    EXPECT_EQ(relay_->findPublishNamespaceSessions(kTestNamespace).size(), 1u)
+        << "Stale bridge handle destructor evicted the new publisher's entry";
+  });
 
   bridgeHandle2.reset();
   removeSession(session1);

--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -83,7 +83,7 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToSubscribers) {
   pub.extensions.insertMutableExtension(Extension{0xBEEF'0000, 42});
 
   withSessionContext(publisherSession, [&]() {
-    auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
     EXPECT_TRUE(res.hasValue());
     if (res.hasValue()) {
       getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
@@ -138,7 +138,7 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToLateJoiners) {
   pub.extensions.insertMutableExtension(Extension{0xCAFE'0000, 99});
 
   withSessionContext(publisherSession, [&]() {
-    auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
     EXPECT_TRUE(res.hasValue());
     if (res.hasValue()) {
       getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
@@ -371,7 +371,8 @@ TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeScopeGuardCrash) {
               );
               PublishRequest pub;
               pub.fullTrackName = kTestTrackName;
-              auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+              auto res =
+                  subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
               EXPECT_TRUE(res.hasValue()) << "publish in mock unexpectedly failed";
               if (res.hasValue()) {
                 pub2Consumer = res->consumer;
@@ -393,7 +394,7 @@ TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeScopeGuardCrash) {
     sub.requestID = RequestID(1);
     sub.locType = LocationType::LargestObject;
     auto result = folly::coro::blockingWait(
-        relay_->subscribe(std::move(sub), createMockConsumer()),
+        publisherInterface()->subscribe(std::move(sub), createMockConsumer()),
         exec_.get()
     );
     // With the fix: subscribe returns an error without crashing.
@@ -443,7 +444,8 @@ TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeSuccessPathCrash) {
               );
               PublishRequest pub;
               pub.fullTrackName = kTestTrackName;
-              auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+              auto res =
+                  subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
               EXPECT_TRUE(res.hasValue()) << "publish in mock unexpectedly failed";
               if (res.hasValue()) {
                 pub2Consumer = res->consumer;
@@ -468,7 +470,7 @@ TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeSuccessPathCrash) {
     sub.requestID = RequestID(1);
     sub.locType = LocationType::LargestObject;
     auto result = folly::coro::blockingWait(
-        relay_->subscribe(std::move(sub), createMockConsumer()),
+        publisherInterface()->subscribe(std::move(sub), createMockConsumer()),
         exec_.get()
     );
     EXPECT_FALSE(result.hasValue()) << "subscribe should fail (publisher reconnected)";
@@ -531,7 +533,7 @@ TEST_F(MoQRelayTest, EmptyNamespacePublishNamespaceDone) {
   PublishNamespace ann;
   ann.trackNamespace = emptyNs;
   withSessionContext(publisher, [&]() {
-    auto task = relay_->publishNamespace(std::move(ann), nullptr);
+    auto task = subscriberInterface()->publishNamespace(std::move(ann), nullptr);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     if (res.hasValue()) {
       getOrCreateMockState(publisher)->publishNamespaceHandles.push_back(res.value());

--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -497,9 +497,11 @@ TEST_F(MoQRelayTest, PublishDonePrunesNamespaceTreeNode) {
   auto consumer = doPublish(publisher, kTestTrackName);
 
   // Verify the publish is visible in the tree
-  auto state = relay_->findPublishState(kTestTrackName);
-  EXPECT_TRUE(state.nodeExists);
-  EXPECT_EQ(state.session, publisher);
+  verifyOnRelayExec([&] {
+    auto state = relay_->findPublishState(kTestTrackName);
+    EXPECT_TRUE(state.nodeExists);
+    EXPECT_EQ(state.session, publisher);
+  });
 
   // publishNamespaceDone — node stays alive because the track publish is still active
   withSessionContext(publisher, [&]() {
@@ -507,9 +509,11 @@ TEST_F(MoQRelayTest, PublishDonePrunesNamespaceTreeNode) {
     getOrCreateMockState(publisher)->publishNamespaceHandles.clear();
   });
 
-  state = relay_->findPublishState(kTestTrackName);
-  EXPECT_TRUE(state.nodeExists);
-  EXPECT_EQ(state.session, publisher);
+  verifyOnRelayExec([&] {
+    auto state = relay_->findPublishState(kTestTrackName);
+    EXPECT_TRUE(state.nodeExists);
+    EXPECT_EQ(state.session, publisher);
+  });
 
   // End the track publish — node should now be pruned
   withSessionContext(publisher, [&]() {
@@ -518,9 +522,11 @@ TEST_F(MoQRelayTest, PublishDonePrunesNamespaceTreeNode) {
     );
   });
 
-  state = relay_->findPublishState(kTestTrackName);
-  EXPECT_EQ(state.session, nullptr);
-  EXPECT_FALSE(state.nodeExists) << "Node persists after publish ended; pruning did not run";
+  verifyOnRelayExec([&] {
+    auto state = relay_->findPublishState(kTestTrackName);
+    EXPECT_EQ(state.session, nullptr);
+    EXPECT_FALSE(state.nodeExists) << "Node persists after publish ended; pruning did not run";
+  });
 
   removeSession(publisher);
 }

--- a/test/MoqxRelaySubNsTests.cpp
+++ b/test/MoqxRelaySubNsTests.cpp
@@ -98,7 +98,7 @@ TEST_F(MoQRelayTest, SubscribeNamespaceEmptyPrefixRejectedPreV16) {
   subNs.trackNamespacePrefix = emptyNs;
 
   withSessionContext(session, [&]() {
-    auto task = relay_->subscribeNamespace(std::move(subNs), nullptr);
+    auto task = publisherInterface()->subscribeNamespace(std::move(subNs), nullptr);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     ASSERT_FALSE(res.hasValue()
     ) << "Empty namespace prefix should be rejected for pre-v16 sessions";

--- a/test/MoqxRelaySubscribeTests.cpp
+++ b/test/MoqxRelaySubscribeTests.cpp
@@ -85,7 +85,7 @@ TEST_F(MoQRelayTest, Subscribe_SecondForwardingSubscriber_SingleRequestUpdate) {
     sub.forward = false;
     withSessionContext(s1, [&]() {
       auto res = folly::coro::blockingWait(
-          relay_->subscribe(std::move(sub), createMockConsumer()),
+          publisherInterface()->subscribe(std::move(sub), createMockConsumer()),
           exec_.get()
       );
       EXPECT_TRUE(res.hasValue());
@@ -115,7 +115,7 @@ TEST_F(MoQRelayTest, Subscribe_SecondForwardingSubscriber_SingleRequestUpdate) {
     sub.forward = true;
     withSessionContext(s2, [&]() {
       auto res = folly::coro::blockingWait(
-          relay_->subscribe(std::move(sub), createMockConsumer()),
+          publisherInterface()->subscribe(std::move(sub), createMockConsumer()),
           exec_.get()
       );
       EXPECT_TRUE(res.hasValue());

--- a/test/MoqxRelayTestFixture.cpp
+++ b/test/MoqxRelayTestFixture.cpp
@@ -32,6 +32,10 @@ void MoQRelayTest::SetUp() {
   relay_->setAllowedNamespacePrefix(kAllowedPrefix);
 }
 
+void MoQRelayTest::resetRelay(std::shared_ptr<MoqxRelay> relay) {
+  relay_ = std::move(relay);
+}
+
 void MoQRelayTest::TearDown() {
   relay_.reset();
 }
@@ -81,7 +85,7 @@ std::shared_ptr<SubscriptionHandle> MoQRelayTest::subscribeToTrack(
   sub.locType = LocationType::LargestObject;
   std::shared_ptr<SubscriptionHandle> handle{nullptr};
   withSessionContext(session, [&]() {
-    auto task = relay_->subscribe(std::move(sub), consumer);
+    auto task = publisherInterface()->subscribe(std::move(sub), consumer);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     if (expectedError.has_value()) {
       EXPECT_FALSE(res.hasValue());
@@ -162,7 +166,7 @@ std::shared_ptr<Subscriber::PublishNamespaceHandle> MoQRelayTest::doPublishNames
   PublishNamespace ann;
   ann.trackNamespace = ns;
   return withSessionContext(session, [&]() {
-    auto task = relay_->publishNamespace(std::move(ann), nullptr);
+    auto task = subscriberInterface()->publishNamespace(std::move(ann), nullptr);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     EXPECT_TRUE(res.hasValue());
     if (res.hasValue()) {
@@ -183,7 +187,7 @@ std::shared_ptr<TrackConsumer> MoQRelayTest::doPublish(
   PublishRequest pub;
   pub.fullTrackName = trackName;
   return withSessionContext(session, [&]() {
-    auto res = relay_->publish(std::move(pub), createMockSubscriptionHandle());
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
     EXPECT_TRUE(res.hasValue());
     if (res.hasValue()) {
       if (addToState) {
@@ -203,7 +207,7 @@ std::shared_ptr<Publisher::SubscribeNamespaceHandle> MoQRelayTest::doSubscribeNa
   SubscribeNamespace subNs;
   subNs.trackNamespacePrefix = nsPrefix;
   return withSessionContext(session, [&]() {
-    auto task = relay_->subscribeNamespace(std::move(subNs), nullptr);
+    auto task = publisherInterface()->subscribeNamespace(std::move(subNs), nullptr);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     EXPECT_TRUE(res.hasValue());
     if (res.hasValue()) {
@@ -240,7 +244,7 @@ std::shared_ptr<TrackConsumer> MoQRelayTest::doPublishWithHandle(
   return withSessionContext(session, [&]() -> std::shared_ptr<TrackConsumer> {
     PublishRequest pub;
     pub.fullTrackName = trackName;
-    auto res = relay_->publish(std::move(pub), std::move(handle));
+    auto res = subscriberInterface()->publish(std::move(pub), std::move(handle));
     EXPECT_TRUE(res.hasValue());
     if (!res.hasValue()) {
       return nullptr;
@@ -260,7 +264,7 @@ std::shared_ptr<Publisher::SubscribeNamespaceHandle> MoQRelayTest::doSubscribeNa
   subNs.trackNamespacePrefix = nsPrefix;
   subNs.forward = forward;
   return withSessionContext(session, [&]() {
-    auto task = relay_->subscribeNamespace(std::move(subNs), nullptr);
+    auto task = publisherInterface()->subscribeNamespace(std::move(subNs), nullptr);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     EXPECT_TRUE(res.hasValue());
     if (!res.hasValue()) {

--- a/test/MoqxRelayTestFixture.h
+++ b/test/MoqxRelayTestFixture.h
@@ -69,6 +69,8 @@ protected:
       folly::Optional<SubscribeErrorCode> expectedError = folly::none
   );
 
+  template <typename Func> void verifyOnRelayExec(Func&& func) { func(); }
+
   template <typename Func>
   auto withSessionContext(std::shared_ptr<MoQSession> session, Func&& func) -> decltype(func()) {
     folly::RequestContextScopeGuard guard;

--- a/test/MoqxRelayTestFixture.h
+++ b/test/MoqxRelayTestFixture.h
@@ -132,6 +132,22 @@ protected:
 
   std::shared_ptr<NiceMock<MockSubscriptionHandle>> makePublishHandle();
 
+  // Replace relay_ and rebuild cross-exec filters if in MT mode.
+  // Use this instead of assigning relay_ directly in tests that need a custom relay.
+  void resetRelay(std::shared_ptr<MoqxRelay> relay);
+
+  // In MT mode: cross-exec filter wrappers that route test calls through relayExec_.
+  // In ST mode: null — accessors fall back to relay_ directly.
+  std::shared_ptr<moxygen::Publisher> publisherInterface_;
+  std::shared_ptr<moxygen::Subscriber> subscriberInterface_;
+
+  moxygen::Publisher* publisherInterface() {
+    return publisherInterface_ ? publisherInterface_.get() : relay_.get();
+  }
+  moxygen::Subscriber* subscriberInterface() {
+    return subscriberInterface_ ? subscriberInterface_.get() : relay_.get();
+  }
+
   std::shared_ptr<TestMoQExecutor> exec_;
   std::shared_ptr<MoqxRelay> relay_;
 };

--- a/test/MoqxRelayTrackStatusTests.cpp
+++ b/test/MoqxRelayTrackStatusTests.cpp
@@ -20,7 +20,7 @@ TEST_F(MoQRelayTest, TrackStatusNonExistentTrack) {
   trackStatus.requestID = RequestID(1);
 
   withSessionContext(clientSession, [&]() {
-    auto task = relay_->trackStatus(trackStatus);
+    auto task = publisherInterface()->trackStatus(trackStatus);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
 
     // Should return error indicating track not found
@@ -48,7 +48,7 @@ TEST_F(MoQRelayTest, TrackStatusSuccessfulForward) {
   trackStatus.requestID = RequestID(2);
 
   withSessionContext(clientSession, [&]() {
-    auto task = relay_->trackStatus(trackStatus);
+    auto task = publisherInterface()->trackStatus(trackStatus);
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
 
     // Should return status from local forwarder
@@ -93,7 +93,7 @@ TEST_F(MoQRelayTest, TrackStatusViaPrefixMatching) {
   trackStatus.fullTrackName = kTestTrackName;
 
   withSessionContext(requester, [&]() {
-    auto task = relay_->trackStatus(trackStatus);
+    auto task = publisherInterface()->trackStatus(trackStatus);
     auto result = folly::coro::blockingWait(std::move(task), exec_.get());
 
     // Should successfully forward via prefix matching and return the result


### PR DESCRIPTION

Add verifyOnRelayExec stub to fixture (runs func() inline for now,
will dispatch to relay executor in MT mode). Wrap all bare relay_->
state queries — findPublishNamespaceSessions and findPublishState —
so they are race-free when MT mode sets the relay executor.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
* #345
* __->__ #344
* #343

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/344)
<!-- Reviewable:end -->
