### PR TITLE
test: wire up res->reply coroutine in relay publish tests

### DIFF
--- a/test/MoqxRelayNGRTests.cpp
+++ b/test/MoqxRelayNGRTests.cpp
@@ -25,6 +25,8 @@ TEST_F(MoQRelayTest, RelayPublishPropagatesDynamicGroupsToSubscribers) {
     auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
     ASSERT_TRUE(res.hasValue());
     getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
+    co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(res->reply))
+        .start();
   });
 
   auto consumer = createMockConsumer();

--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -33,6 +33,7 @@ TEST_F(MoQRelayTest, PublishSuccess) {
   doPublish(publisherSession, kTestTrackName);
 
   // Cleanup: remove the session from relay to avoid mock leak warning
+  exec_->drive();
   removeSession(publisherSession);
 }
 
@@ -87,6 +88,8 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToSubscribers) {
     EXPECT_TRUE(res.hasValue());
     if (res.hasValue()) {
       getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
+      co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(res->reply))
+          .start();
     }
   });
   exec_->drive();
@@ -142,6 +145,8 @@ TEST_F(MoQRelayTest, PublishExtensionsForwardedToLateJoiners) {
     EXPECT_TRUE(res.hasValue());
     if (res.hasValue()) {
       getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
+      co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(res->reply))
+          .start();
     }
   });
   exec_->drive();
@@ -241,6 +246,7 @@ TEST_F(MoQRelayTest, PublisherReconnectWithOpenSubgroupNoSegfault) {
   auto consumer2 = doPublish(reconnectedSession, kTestTrackName);
   EXPECT_NE(consumer2, nullptr) << "re-publish after reconnect should succeed";
 
+  exec_->drive();
   removeSession(publisherSession);
   removeSession(subscriberSession);
   removeSession(reconnectedSession);
@@ -376,6 +382,7 @@ TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeScopeGuardCrash) {
               EXPECT_TRUE(res.hasValue()) << "publish in mock unexpectedly failed";
               if (res.hasValue()) {
                 pub2Consumer = res->consumer;
+                co_await std::move(res->reply);
               }
             }
 
@@ -449,6 +456,7 @@ TEST_F(MoQRelayTest, PublishReconnectDuringSubscribeSuccessPathCrash) {
               EXPECT_TRUE(res.hasValue()) << "publish in mock unexpectedly failed";
               if (res.hasValue()) {
                 pub2Consumer = res->consumer;
+                co_await std::move(res->reply);
               }
             }
 
@@ -528,6 +536,7 @@ TEST_F(MoQRelayTest, PublishDonePrunesNamespaceTreeNode) {
     EXPECT_FALSE(state.nodeExists) << "Node persists after publish ended; pruning did not run";
   });
 
+  exec_->drive();
   removeSession(publisher);
 }
 

--- a/test/MoqxRelayTestFixture.cpp
+++ b/test/MoqxRelayTestFixture.cpp
@@ -193,6 +193,8 @@ std::shared_ptr<TrackConsumer> MoQRelayTest::doPublish(
       if (addToState) {
         getOrCreateMockState(session)->publishConsumers.push_back(res->consumer);
       }
+      co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(res->reply))
+          .start();
       return res->consumer;
     }
     return std::shared_ptr<TrackConsumer>(nullptr);
@@ -251,6 +253,8 @@ std::shared_ptr<TrackConsumer> MoQRelayTest::doPublishWithHandle(
     }
     auto consumer = res->consumer;
     getOrCreateMockState(session)->publishConsumers.push_back(consumer);
+    co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(res->reply))
+        .start();
     return consumer;
   });
 }


### PR DESCRIPTION
Tests were ignoring the reply field added to publish results, so the relay's async handling never ran. Drive it via co_withExecutor/start in fire-and-forget contexts, co_await in coroutine bodies, and add exec_->drive() before removeSession calls to flush pending work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/348)
<!-- Reviewable:end -->
