### PR TITLE
build: add TSan (ThreadSanitizer) build mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,20 @@ endif()
 option(MOQX_BUILD_TESTS "Build tests" ON)
 option(MOQX_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(MOQX_ENABLE_SANITIZERS "Enable ASAN/UBSAN (non-Release)" OFF)
+option(MOQX_ENABLE_TSAN "Enable TSan (non-Release)" OFF)
+
+if(MOQX_ENABLE_SANITIZERS AND MOQX_ENABLE_TSAN)
+  message(FATAL_ERROR "MOQX_ENABLE_SANITIZERS and MOQX_ENABLE_TSAN are mutually exclusive")
+endif()
 
 if(MOQX_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
   add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
   add_link_options(-fsanitize=address,undefined)
+endif()
+
+if(MOQX_ENABLE_TSAN AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+  add_compile_options(-fsanitize=thread -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=thread)
 endif()
 
 # Prefer static libraries for all transitive deps (from-release mode).

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,18 @@
         "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
       }
+    },
+    {
+      "name": "tsan",
+      "displayName": "ThreadSanitizer (TSan)",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build-tsan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "MOQX_ENABLE_TSAN": "ON",
+        "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+      }
     }
   ],
   "buildPresets": [
@@ -39,6 +51,10 @@
     {
       "name": "san",
       "configurePreset": "san"
+    },
+    {
+      "name": "tsan",
+      "configurePreset": "tsan"
     }
   ],
   "testPresets": [

--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -69,6 +69,18 @@ if [[ "$PROFILE" == "san" ]]; then
     "-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address"
     "-DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=address"
   )
+elif [[ "$PROFILE" == "tsan" ]]; then
+  CMAKE_BUILD_TYPE="Debug"
+  # TSan must instrument the full dep chain: folly/mvfst atomics and EventBase
+  # internals are invisible to TSan without instrumentation, causing false positives
+  # on every lock operation.
+  SAN_FLAGS="-fsanitize=thread -fno-omit-frame-pointer"
+  EXTRA_CMAKE_ARGS+=(
+    "-DCMAKE_C_FLAGS=${SAN_FLAGS}"
+    "-DCMAKE_CXX_FLAGS=${SAN_FLAGS}"
+    "-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=thread"
+    "-DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=thread"
+  )
 fi
 
 echo "==> Configuring standalone moxygen build (profile: ${PROFILE})..."


### PR DESCRIPTION
Adds a `tsan` CMake preset, build preset, and `MOQX_ENABLE_TSAN` option, parallel to the existing `san` (ASAN/UBSAN) mode.  The two are mutually exclusive — TSan cannot be combined with ASAN/UBSAN.

`setup-deps-standalone.sh` propagates TSan flags through the full dependency chain (folly, mvfst).  Without full-chain instrumentation, TSan reports false positives on every lock operation because it cannot see the sanitized atomics inside EventBase and other dep internals.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/349)
<!-- Reviewable:end -->
