### PR TITLE
bpf: attach classic reuseport steering filter to QUIC worker sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,15 @@ option(MOQX_BUILD_TESTS "Build tests" ON)
 option(MOQX_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(MOQX_ENABLE_SANITIZERS "Enable ASAN/UBSAN (non-Release)" OFF)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(_moqx_bpf_default ON)
+else()
+  set(_moqx_bpf_default OFF)
+endif()
+option(MOQX_ENABLE_BPF_STEERING
+  "Attach a classic BPF reuseport filter to steer QUIC packets to the correct worker (Linux only)"
+  ${_moqx_bpf_default})
+
 if(MOQX_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
   add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
   add_link_options(-fsanitize=address,undefined)
@@ -190,6 +199,14 @@ target_compile_options(moqx_config_loader PRIVATE -Wall -Wextra -Wpedantic)
 add_executable(moqx
   src/main.cpp
 )
+
+if(MOQX_ENABLE_BPF_STEERING)
+  # QuicReuseportSteering.cpp defines mvfst_hook_on_socket_create, overriding
+  # the weak symbol in mvfst. It must live in the executable (not a static lib)
+  # so the linker always includes it without a --whole-archive trick.
+  target_sources(moqx PRIVATE src/bpf/QuicReuseportSteering.cpp)
+  target_compile_definitions(moqx PRIVATE MOQX_ENABLE_BPF_STEERING)
+endif()
 
 target_link_libraries(moqx PRIVATE moqx_core moqx_config_loader)
 

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -18,8 +18,8 @@
 #   --io-threads N         Number of relay IO threads (default: 1)
 #   --threads N            Number of perf client threads (default: 2)
 #   --relay-log SPEC       folly XLOG config passed as --logging=SPEC to relay
-#   --bpf-steering         Enable BPF reuseport steering (requires MOQX_BPF_STEERING build)
-#   --no-bpf-steering      Disable BPF reuseport steering (default)
+#   --bpf-steering         Enable mvfst BPF reuseport steering (requires MOQX_ENABLE_BPF_STEERING build)
+#   --no-bpf-steering      Disable mvfst BPF reuseport steering (default)
 #   --jemalloc             LD_PRELOAD jemalloc (auto-detected from /lib64/libjemalloc.so.2)
 #   --metrics              Run perf-metrics.sh alongside the relay; logs to LOG_DIR/metrics.log
 #   --perf-duration N      Run perf record -F 499 -g -e cycles on relay for N seconds; starts after
@@ -206,6 +206,7 @@ cat >"$RELAY_CFG" <<EOF
 relay_id: "perf-test-relay"
 threads: $IO_THREADS
 use_relay_thread: $USE_RELAY_THREAD
+mvfst_bpf_steering: $BPF_STEERING
 listeners:
   - name: perf
     udp:
@@ -259,7 +260,7 @@ cp "$RELAY_CFG" "$LOG_DIR/relay.yaml"
   echo "delivery_timeout: $DELIVERY_TIMEOUT"
   echo "client_threads:   $CLIENT_THREADS"
   echo "jemalloc:         ${JEMALLOC:-none}"
-  echo "bpf_steering:     $BPF_STEERING"
+  echo "mvfst_bpf_steering: $BPF_STEERING"
   [[ "$PERF_DURATION" -gt 0 ]] && echo "perf_duration:    ${PERF_DURATION}s (delay=$(( 3 * SUBSCRIBER_MAX / RAMP ))s)" || true
   [[ -n "$PERF_EVENTS" ]] && echo "perf_events:      $PERF_EVENTS" || true
   [[ -n "$REMOTE_CLIENT_HOST" ]] && echo "remote_client:    $REMOTE_CLIENT_HOST" || true
@@ -268,7 +269,7 @@ echo ""
 
 # ── Start relay ───────────────────────────────────────────────────────────────
 ulimit -n 65536 2>/dev/null || true
-echo "Starting relay (use_relay_thread=$USE_RELAY_THREAD, io_threads=$IO_THREADS, transport=$TRANSPORT, bpf_steering=$BPF_STEERING)..."
+echo "Starting relay (use_relay_thread=$USE_RELAY_THREAD, io_threads=$IO_THREADS, transport=$TRANSPORT, mvfst_bpf_steering=$BPF_STEERING)..."
 RELAY_LOGGING_ARG=()
 [[ -n "$RELAY_LOG_SPEC" ]] && RELAY_LOGGING_ARG=("--logging=$RELAY_LOG_SPEC")
 if [[ -n "$JEMALLOC" ]]; then

--- a/src/bpf/QuicReuseportSteering.cpp
+++ b/src/bpf/QuicReuseportSteering.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Overrides the weak mvfst_hook_on_socket_create symbol to attach a classic
+// BPF reuseport steering filter to each QUIC worker socket.
+//
+// For short-header (1-RTT) packets the filter extracts workerId from the
+// mvfst default V1 connection ID encoding:
+//   CID byte 2 (UDP offset 11): bits 7:2 → upper 6 bits of workerId
+//   CID byte 3 (UDP offset 12): bits 7:6 → lower 2 bits of workerId
+//   workerId = (CID[2] << 2) | (CID[3] >> 6)
+// The kernel selects socket[workerId % num_sockets], matching mvfst's own
+// routing for non-initial packets.
+//
+// For long-header packets (initial/handshake, client-chosen CIDs) the filter
+// returns the UDP source port, distributing new connections across workers.
+
+#include "bpf/QuicReuseportSteering.h"
+
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+
+#include <linux/filter.h>
+#include <sys/socket.h>
+
+#include <folly/logging/xlog.h>
+
+namespace openmoq::moqx {
+
+static std::atomic<bool> gEnabled{true};
+
+void quicReuseportSetEnabled(bool enabled) {
+  gEnabled.store(enabled, std::memory_order_relaxed);
+}
+
+} // namespace openmoq::moqx
+
+// UDP header is 8 bytes. QUIC packet begins immediately after.
+// Short-header layout (offsets relative to start of UDP header):
+//   [8]  QUIC first byte — bit 7 = 0 for short header
+//   [9]  CID byte 0
+//   [10] CID byte 1
+//   [11] CID byte 2  (upper 6 bits of workerId)
+//   [12] CID byte 3  (lower 2 bits of workerId in bits 7:6)
+
+// clang-format off
+static const struct sock_filter kFilter[] = {
+    // Load QUIC first byte.
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS,        8),
+    // Isolate the long-header bit (MSB).
+    BPF_STMT(BPF_ALU | BPF_AND | BPF_K,    0x80),
+    // A == 0 → short header: skip 2 to CID extraction.
+    // A != 0 → long header: fall through to source-port hash.
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,    0x00, 2, 0),
+    // Long-header path: spread by UDP source port.
+    BPF_STMT(BPF_LD | BPF_H | BPF_ABS,        0),
+    BPF_STMT(BPF_RET | BPF_A,                 0),
+    // Short-header path: reconstruct workerId.
+    BPF_STMT(BPF_LD  | BPF_B | BPF_ABS,      11),  // A = CID[2]
+    BPF_STMT(BPF_ALU | BPF_LSH | BPF_K,       2),  // A <<= 2
+    BPF_STMT(BPF_MISC | BPF_TAX,              0),   // X = A
+    BPF_STMT(BPF_LD  | BPF_B | BPF_ABS,      12),  // A = CID[3]
+    BPF_STMT(BPF_ALU | BPF_RSH | BPF_K,       6),  // A >>= 6
+    BPF_STMT(BPF_ALU | BPF_OR  | BPF_X,       0),  // A |= X  → workerId
+    BPF_STMT(BPF_RET | BPF_A,                 0),
+};
+// clang-format on
+
+static const struct sock_fprog kProg = {
+    .len = static_cast<unsigned short>(sizeof(kFilter) / sizeof(kFilter[0])),
+    .filter = const_cast<struct sock_filter*>(kFilter),
+};
+
+extern "C" void mvfst_hook_on_socket_create(int fd) {
+  if (!openmoq::moqx::gEnabled.load(std::memory_order_relaxed)) {
+    return;
+  }
+  if (setsockopt(fd, SOL_SOCKET, SO_ATTACH_REUSEPORT_CBPF, &kProg, sizeof(kProg)) != 0) {
+    XLOG(WARN) << "quic reuseport BPF steering: setsockopt failed: " << std::strerror(errno);
+  }
+}

--- a/src/bpf/QuicReuseportSteering.h
+++ b/src/bpf/QuicReuseportSteering.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace openmoq::moqx {
+
+// Enable or disable BPF reuseport steering at runtime.
+// Must be called before the QUIC server starts binding sockets.
+#ifdef MOQX_ENABLE_BPF_STEERING
+void quicReuseportSetEnabled(bool enabled);
+#else
+inline void quicReuseportSetEnabled(bool) {}
+#endif
+
+} // namespace openmoq::moqx

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -194,6 +194,7 @@ struct Config {
   std::optional<AdminConfig> admin;
   std::string relayID; // always set: from config or randomly generated
   uint32_t threads{1};
+  bool mvfstBpfSteering{true};
 };
 
 } // namespace openmoq::moqx::config

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -824,6 +824,8 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
     errors.push_back("threads > 1 is not yet supported");
   }
 
+  const bool mvfstBpfSteering = config.mvfst_bpf_steering.value().value_or(true);
+
   if (!errors.empty()) {
     return folly::makeUnexpected("Config validation failed:\n  - " + folly::join("\n  - ", errors));
   }
@@ -873,6 +875,7 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
               .admin = std::move(adminConfig),
               .relayID = std::move(relayID),
               .threads = threads,
+              .mvfstBpfSteering = mvfstBpfSteering,
           },
       .warnings = std::move(warnings),
   };

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -381,6 +381,12 @@ struct ParsedConfig {
       std::optional<ParsedListenerDefaultsConfig>>
       listener_defaults;
   rfl::Description<"Number of IO worker threads (default: 1)", std::optional<uint32_t>> threads;
+  rfl::Description<
+      "Attach a classic BPF reuseport filter to steer QUIC packets to the correct mvfst worker "
+      "based on the connection ID's workerId field (Linux only, mvfst stack only, default: true). "
+      "Disable to fall back to kernel RSS distribution.",
+      std::optional<bool>>
+      mvfst_bpf_steering;
 };
 
 } // namespace openmoq::moqx::config

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "admin/CachePurgeHandler.h"
 #include "admin/MetricsHandler.h"
 #include "admin/StateHandler.h"
+#include "bpf/QuicReuseportSteering.h"
 #include "config/loader/ConfigInit.h"
 #include "stats/StatsRegistry.h"
 
@@ -96,6 +97,8 @@ int main(int argc, char* argv[]) {
   ShutdownSignalHandler signalHandler(&evb);
 
   // === 4. Initialize resources ===
+  quicReuseportSetEnabled(config.mvfstBpfSteering);
+
   auto ioExecutor = std::make_shared<folly::IOThreadPoolExecutor>(
       config.threads,
       std::make_shared<folly::NamedThreadFactory>("moqx-io")

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -1178,6 +1178,7 @@ TEST(ResolveConfig, QuicCcAlgoPicoOnlyRejectedByMvfst) {
   cfg.listeners.value()[0].tls.value().insecure = false;
   cfg.listeners.value()[0].tls.value().cert_file = std::optional<std::string>{"cert.pem"};
   cfg.listeners.value()[0].tls.value().key_file = std::optional<std::string>{"key.pem"};
+  cfg.mvfst_bpf_steering = std::optional<bool>{false};
   auto result2 = resolveConfig(cfg);
   ASSERT_TRUE(result2.hasValue());
   EXPECT_EQ(result2.value().config.listeners[0].quic.ccAlgo, "dcubic");
@@ -1226,6 +1227,7 @@ ParsedConfig makeMinimalPicoConfig() {
   lc.tls.value().insecure = false;
   lc.tls.value().cert_file = std::optional<std::string>{"cert.pem"};
   lc.tls.value().key_file = std::optional<std::string>{"key.pem"};
+  cfg.mvfst_bpf_steering = std::optional<bool>{false};
   return cfg;
 }
 


### PR DESCRIPTION
Adds MOQX_ENABLE_BPF_STEERING (default ON on Linux) which overrides mvfst's weak mvfst_hook_on_socket_create hook to attach a cBPF filter that routes non-initial QUIC packets directly to the owning worker by decoding the workerId from mvfst's default V1 connection ID encoding. Long-header (initial/handshake) packets are spread by UDP source port.

Note: threads is still forced to 1 so this doesn't do anything _yet_ but it will real soon now (TM)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/350)
<!-- Reviewable:end -->
