### PR TITLE
relay: IOThreadPoolExecutor owned exclusively by main

### DIFF
--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -68,7 +68,7 @@ std::string resolveKey(const config::ListenerConfig& cfg) {
 MoqxPicoRelayServer::MoqxPicoRelayServer(
     const config::ListenerConfig& listenerCfg,
     std::shared_ptr<MoqxRelayContext> context,
-    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
+    folly::IOThreadPoolExecutor* ioExecutor
 )
     : MoQPicoQuicEventBaseServer(
           resolveCert(listenerCfg),

--- a/src/MoqxPicoRelayServer.h
+++ b/src/MoqxPicoRelayServer.h
@@ -28,7 +28,7 @@ public:
   MoqxPicoRelayServer(
       const config::ListenerConfig& listenerCfg,
       std::shared_ptr<MoqxRelayContext> context,
-      std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
+      folly::IOThreadPoolExecutor* ioExecutor
   );
 
   ~MoqxPicoRelayServer() override;

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -128,14 +128,14 @@ buildTransportSettings(const config::QuicConfig& quic, const config::MvfstConfig
 MoqxRelayServer::MoqxRelayServer(
     const config::ListenerConfig& listenerCfg,
     std::shared_ptr<MoqxRelayContext> context,
-    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
+    folly::IOThreadPoolExecutor* ioExecutor
 )
     : MoQServer(
           buildFizzContext(listenerCfg),
           listenerCfg.endpoint,
           buildTransportSettings(listenerCfg.quic, listenerCfg.mvfst)
       ),
-      listenerCfg_(listenerCfg), context_(std::move(context)), ioExecutor_(std::move(ioExecutor)) {}
+      listenerCfg_(listenerCfg), context_(std::move(context)), ioExecutor_(ioExecutor) {}
 
 MoqxRelayServer::~MoqxRelayServer() {
   // Close incoming connections, drain worker EVBs, then destroy EVBs.
@@ -157,6 +157,7 @@ void MoqxRelayServer::start() {
   for (auto& ka : evbKAs) {
     evbs.push_back(ka.get());
   }
+  ioExecutor_ = nullptr;
   MoQServer::start(listenerCfg_.address, std::move(evbs));
 }
 

--- a/src/MoqxRelayServer.h
+++ b/src/MoqxRelayServer.h
@@ -21,7 +21,7 @@ public:
   MoqxRelayServer(
       const config::ListenerConfig& listenerCfg,
       std::shared_ptr<MoqxRelayContext> context,
-      std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
+      folly::IOThreadPoolExecutor* ioExecutor
   );
 
   ~MoqxRelayServer() override;
@@ -53,7 +53,7 @@ protected:
 private:
   config::ListenerConfig listenerCfg_;
   std::shared_ptr<MoqxRelayContext> context_;
-  std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+  folly::IOThreadPoolExecutor* ioExecutor_;
 };
 
 } // namespace openmoq::moqx

--- a/src/MoqxServerFactory.h
+++ b/src/MoqxServerFactory.h
@@ -22,20 +22,16 @@ namespace openmoq::moqx {
 inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
     const config::ListenerConfig& listenerCfg,
     std::shared_ptr<MoqxRelayContext> context,
-    std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor,
+    folly::IOThreadPoolExecutor* ioExecutor,
     std::shared_ptr<stats::StatsRegistry> statsRegistry
 ) {
   if (listenerCfg.quicStack == config::QuicStack::Picoquic) {
-    auto server = std::make_shared<MoqxPicoRelayServer>(
-        listenerCfg,
-        std::move(context),
-        std::move(ioExecutor)
-    );
+    auto server =
+        std::make_shared<MoqxPicoRelayServer>(listenerCfg, std::move(context), ioExecutor);
     server->setStatsRegistry(std::move(statsRegistry));
     return server;
   }
-  auto server =
-      std::make_shared<MoqxRelayServer>(listenerCfg, std::move(context), std::move(ioExecutor));
+  auto server = std::make_shared<MoqxRelayServer>(listenerCfg, std::move(context), ioExecutor);
   server->setStatsRegistry(std::move(statsRegistry));
   return server;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
   // === 4. Initialize resources ===
   quicReuseportSetEnabled(config.mvfstBpfSteering);
 
-  auto ioExecutor = std::make_shared<folly::IOThreadPoolExecutor>(
+  auto ioExecutor = std::make_unique<folly::IOThreadPoolExecutor>(
       config.threads,
       std::make_shared<folly::NamedThreadFactory>("moqx-io")
   );
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
 
   std::vector<std::shared_ptr<moxygen::MoQServerBase>> servers;
   for (const auto& listenerCfg : config.listeners) {
-    servers.emplace_back(makeRelayServer(listenerCfg, context, ioExecutor, statsRegistry));
+    servers.emplace_back(makeRelayServer(listenerCfg, context, ioExecutor.get(), statsRegistry));
   }
 
   if (!servers.empty()) {


### PR DESCRIPTION
Relay servers now hold a raw pointer to the IOThreadPoolExecutor rather than a shared_ptr. main() owns the executor via unique_ptr and is responsible for destroying it — ensuring thread pool teardown happens after all servers are stopped, not whenever the last shared_ptr drops.

MoqxRelayServer::start() nulls out the pointer once EVBs are extracted, since the executor is no longer needed after that point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/351)
<!-- Reviewable:end -->
