### PR TITLE
relay: wrap consumer in CrossExecFilter inside PublisherCrossExecFilter

### DIFF
--- a/src/relay/PublisherCrossExecFilter.cpp
+++ b/src/relay/PublisherCrossExecFilter.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "relay/PublisherCrossExecFilter.h"
+#include "relay/CrossExecFilter.h"
 
 namespace openmoq::moqx {
 
@@ -131,9 +132,12 @@ folly::coro::Task<moxygen::Publisher::SubscribeResult> PublisherCrossExecFilter:
     moxygen::SubscribeRequest sub,
     std::shared_ptr<moxygen::TrackConsumer> callback
 ) {
+  auto callerExec = co_await folly::coro::co_current_executor;
+  auto wrappedConsumer =
+      std::make_shared<CrossExecFilter>(callerExec, std::move(callback), /*deepCopyPayload=*/false);
   auto result = co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(targetExec_),
-      inner_->subscribe(std::move(sub), std::move(callback))
+      inner_->subscribe(std::move(sub), std::move(wrappedConsumer))
   );
   if (result.hasValue()) {
     co_return std::make_shared<CrossExecSubscriptionHandle>(std::move(result.value()), targetExec_);
@@ -145,13 +149,20 @@ folly::coro::Task<moxygen::Publisher::FetchResult> PublisherCrossExecFilter::fet
     moxygen::Fetch fetchReq,
     std::shared_ptr<moxygen::FetchConsumer> fetchCallback
 ) {
+  auto callerExec = co_await folly::coro::co_current_executor;
+  auto wrappedConsumer =
+      FetchCrossExecFilter::create(callerExec, std::move(fetchCallback), /*deepCopyPayload=*/false);
+  auto consumerRef = wrappedConsumer;
   auto result = co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(targetExec_),
-      inner_->fetch(std::move(fetchReq), std::move(fetchCallback))
+      inner_->fetch(std::move(fetchReq), std::move(wrappedConsumer))
   );
   if (result.hasValue()) {
     co_return std::make_shared<CrossExecFetchHandle>(std::move(result.value()), targetExec_);
   }
+  // inner never stored or used the consumer, so no lambdas are in-flight;
+  // deactivate() releases selfGuard_ inline without dispatching.
+  consumerRef->deactivate();
   co_return result;
 }
 

--- a/test/PublisherCrossExecFilterTest.cpp
+++ b/test/PublisherCrossExecFilterTest.cpp
@@ -7,8 +7,10 @@
 #include "relay/PublisherCrossExecFilter.h"
 
 #include <folly/coro/BlockingWait.h>
+#include <folly/coro/ViaIfAsync.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/ManualExecutor.h>
+#include <folly/io/async/EventBase.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
 #include <moxygen/test/Mocks.h>
@@ -121,25 +123,64 @@ TEST_F(PublisherCrossExecFilterTest, FetchForwardsToInner) {
   EXPECT_EQ(result.error().errorCode, FetchErrorCode::NOT_SUPPORTED);
 }
 
+TEST_F(PublisherCrossExecFilterTest, FetchErrorDoesNotCallEndOfFetch) {
+  EXPECT_CALL(*inner_, fetch(_, _))
+      .WillOnce(
+          [](Fetch, std::shared_ptr<FetchConsumer>) -> folly::coro::Task<Publisher::FetchResult> {
+            co_return folly::makeUnexpected(
+                FetchError{RequestID(4), FetchErrorCode::NOT_SUPPORTED, "nope"}
+            );
+          }
+      );
+
+  auto fetchCallback = std::make_shared<StrictMock<MockFetchConsumer>>();
+  // deactivate() releases selfGuard_ inline; endOfFetch must not be called.
+  Fetch fetchReq;
+  fetchReq.requestID = RequestID(4);
+  auto result =
+      folly::coro::blockingWait(filter_->fetch(std::move(fetchReq), std::move(fetchCallback)));
+  EXPECT_FALSE(result.hasValue());
+  EXPECT_EQ(result.error().errorCode, FetchErrorCode::NOT_SUPPORTED);
+}
+
 TEST_F(PublisherCrossExecFilterTest, FetchReturnsSuccess) {
   FetchOk ok;
   ok.requestID = RequestID(4);
   auto handle = std::make_shared<NiceMock<MockFetchHandle>>(ok);
+  std::shared_ptr<FetchConsumer> capturedConsumer;
   EXPECT_CALL(*inner_, fetch(_, _))
       .WillOnce(
-          [handle](Fetch, std::shared_ptr<FetchConsumer>)
+          [handle, &capturedConsumer](Fetch, std::shared_ptr<FetchConsumer> consumer)
               -> folly::coro::Task<Publisher::FetchResult> {
-            co_return folly::makeExpected<FetchError>(std::shared_ptr<Publisher::FetchHandle>(handle
-            ));
+            capturedConsumer = std::move(consumer);
+            co_return std::shared_ptr<Publisher::FetchHandle>(handle);
           }
       );
 
+  // Schedule on the EventBase so callerExec captured inside fetch() is the
+  // EventBase (not blockingWait's internal ManualExecutor, which dies on return).
+  // This keeps targetExec_ alive for the post-blockingWait endOfFetch drain.
+  folly::EventBase evb;
+  auto fetchCallback = std::make_shared<NiceMock<MockFetchConsumer>>();
+  EXPECT_CALL(*fetchCallback, endOfFetch()).WillOnce([]() {
+    return folly::Expected<folly::Unit, MoQPublishError>(folly::unit);
+  });
   Fetch fetchReq;
   fetchReq.requestID = RequestID(4);
-  auto result = folly::coro::blockingWait(filter_->fetch(std::move(fetchReq), nullptr));
+  auto result = folly::coro::blockingWait(
+      folly::coro::co_withExecutor(
+          folly::getKeepAliveToken(&evb),
+          filter_->fetch(std::move(fetchReq), std::move(fetchCallback))
+      ),
+      &evb
+  );
   ASSERT_TRUE(result.hasValue());
   ASSERT_NE(result.value(), nullptr);
   EXPECT_EQ(result.value()->fetchOk().requestID, RequestID(4));
+
+  ASSERT_NE(capturedConsumer, nullptr);
+  capturedConsumer->endOfFetch();
+  evb.loopOnce();
 }
 
 // ---- subscribeNamespace ----


### PR DESCRIPTION
subscribe() and fetch() now capture the caller's executor and wrap the consumer before dispatching to targetExec_, so upstream data is delivered back on the caller's executor without call-site boilerplate. On fetch error, inner_ never stored the consumer so no lambdas are in-flight; deactivate() breaks the selfGuard_ cycle to prevent a leak.

Test: FetchErrorDoesNotCallEndOfFetch asserts endOfFetch is not called on error; FetchReturnsSuccess is updated to run on an EventBase so the captured callerExec stays alive for the endOfFetch drain.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/352)
<!-- Reviewable:end -->
