### PR TITLE
relay: fix shutdown hang when sessions hold lingering server refs

### DIFF
--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -89,8 +89,16 @@ MoqxPicoRelayServer::MoqxPicoRelayServer(
       evb_(ioExecutor->getAllEventBases()[0].get()) {}
 
 MoqxPicoRelayServer::~MoqxPicoRelayServer() {
+  stop();
+}
+
+void MoqxPicoRelayServer::stop() {
+  if (!context_) {
+    return;
+  }
   context_->stop();
   evb_->runImmediatelyOrRunInEventBaseThreadAndWait([this] { MoQPicoQuicEventBaseServer::stop(); });
+  context_.reset();
 }
 
 void MoqxPicoRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {

--- a/src/MoqxPicoRelayServer.h
+++ b/src/MoqxPicoRelayServer.h
@@ -33,6 +33,9 @@ public:
 
   ~MoqxPicoRelayServer() override;
 
+  // Idempotent; safe to call from main and again from ~MoqxPicoRelayServer.
+  void stop() override;
+
   void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
 
   // Preferred entry point: binds the address from the stored ListenerConfig.

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -139,7 +139,16 @@ MoqxRelayServer::MoqxRelayServer(
 
 MoqxRelayServer::~MoqxRelayServer() {
   // Close incoming connections, drain worker EVBs, then destroy EVBs.
+  stop();
+}
+
+void MoqxRelayServer::stop() {
+  if (!context_) {
+    return;
+  }
+  // QuicServer::shutdown drives terminateClientSession, which uses context_.
   MoQServer::stop();
+  context_.reset();
 }
 
 void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {

--- a/src/MoqxRelayServer.h
+++ b/src/MoqxRelayServer.h
@@ -26,6 +26,9 @@ public:
 
   ~MoqxRelayServer() override;
 
+  // Idempotent; safe to call from main and again from ~MoqxRelayServer.
+  void stop() override;
+
   void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
 
   // Preferred entry point: binds the address from the stored ListenerConfig.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,6 +181,14 @@ int main(int argc, char* argv[]) {
   // Stop admin last — allows a final metrics scrape during drain.
   adminServer.stop();
 
+  // Stop servers before joining the IO pool — stop() needs worker EVBs alive,
+  // and lingering shared_ptr refs could delay ~MoqxRelayServer past that point.
+  for (auto& server : servers) {
+    server->stop();
+  }
+  servers.clear();
+  ioExecutor.reset();
+
   // === 14. Exit with appropriate code ===
   return 0;
 }


### PR DESCRIPTION
main() now owns the IOThreadPoolExecutor via unique_ptr (servers hold a
raw pointer) and explicitly stops + clears servers before joining the IO
pool. Previously, lingering shared_ptr<MoQServerBase> refs from in-flight
sessions or coroutines could delay ~MoqxRelayServer past the executor's
destruction, leaving QuicServer::shutdown to post to dead worker EVBs
and hang shutdown until the 10s watchdog fired.

MoqxRelayServer::stop() and MoqxPicoRelayServer::stop() are made
idempotent using context_ as the sentinel, so ~MoqxRelayServer is a
no-op once main has already stopped the server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/359)
<!-- Reviewable:end -->
