### PR TITLE
relay: per-thread local forwarder data path (use_local_forwarders)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(moqx_core STATIC
   src/relay/PropertyRanking.cpp
   src/relay/CrossExecFilter.cpp
   src/relay/CrossExecForwarderCallback.cpp
+  src/relay/WeakRelayForwarderCallback.cpp
   src/relay/PublisherCrossExecFilter.cpp
   src/relay/SubscriberCrossExecFilter.cpp
 )

--- a/docs/dev/local-forwarder-flow.md
+++ b/docs/dev/local-forwarder-flow.md
@@ -1,0 +1,313 @@
+# Local-Forwarder Data Plane
+
+In **LocalForwarder (LF) mode** the relay runs across multiple I/O threads. The core idea is
+to keep the expensive per-subscriber **delivery** fan-out on the publisher's and subscribers'
+own executors, so it never runs on the central relay executor. `relayExec_` is not bypassed
+entirely, though: it still carries a *single* passive copy of every object for relay-global
+concerns (the cache and Top-N ranking), plus all lifecycle/control events.
+
+Three kinds of traffic move between the executors:
+
+- **Subscriber delivery** flows *outward* from the publisher's forwarder, on the publisher and
+  subscriber threads — off `relayExec_`. This is the N-way fan-out we want to keep off the
+  hot central thread.
+- **One passive object copy** flows to `relayExec_`, feeding the cache and Top-N ranking — one
+  copy per object regardless of subscriber count.
+- **Lifecycle/control events** (`onEmpty`, `forwardChanged`, `newGroupRequested`) flow through
+  the callback chains, either to relay state on `relayExec_` or back to the publisher on
+  `[Pub]` depending on which forwarder fired.
+
+See [Data flow](#data-flow) for how objects move, and [Control](#control-the-callback-flow) for
+the callback chains.
+
+## Modes
+
+`createPublisherFilter()` / `createSubscriberFilter()` pick the per-session handler based on
+mode:
+
+| Mode | Publish entry | Subscribe entry | Delivery data plane |
+| --- | --- | --- | --- |
+| `SingleThread` | `publish()` | `subscribe()` | calling thread |
+| `RelayExec` | `publish()` (on `relayExec_`) | `subscribe()` (on `relayExec_`) | `relayExec_` |
+| `LocalForwarder` | `LocalPublishFilter::publish` → `publishFromPublisherExec` | `LocalSubscribeFilter::subscribe` → `subscribeFromSubscriberExec` | publisher/subscriber execs |
+
+> Naming convention: `…FromPublisherExec` / `…FromSubscriberExec` is an entry point that
+> *starts* on that executor; `…OnRelayExec` is a continuation that *runs* on `relayExec_`.
+
+Executor legend used below:
+
+```
+[Pub]   the publisher forwarder's exec (local publisher's exec, or the upstream session's
+        exec when the track is relay-sourced)
+[Relay] relayExec_
+[Sub]   the subscriber session's exec
+──▶  direct call        ⇢⇢▶  executor hop (co_withExecutor / fire-and-forget)
+```
+
+---
+
+## Publish
+
+A publisher's local forwarder **is** the publisher forwarder — the same object serves as the
+on-thread data-plane forwarder and as the registry's publisher entry (no second forwarder is
+constructed on `relayExec_`, unlike the `RelayExec`-mode branch in `publishWithSession`).
+
+### Setup
+
+```
+[Pub]   LocalPublishFilter::publish()
+[Pub]    └─▶ publishFromPublisherExec()
+[Pub]         ├─▶ createPublisherForwarder(pub)               # build forwarder + control chain
+[Pub]         │     └─ setCallback( LocalForwarderCallback )
+[Pub]         ├─▶ tlForwarders_->set(ftn, fwd)                # cache for same-thread reuse
+[Pub]         ├─▶ localPubFwd->addChannelSubscriber(passive)  # passive copy → [Relay]
+[Pub]         └─▶ co_invoke(reply) ⇢⇢▶ [Relay]
+[Relay]            └─▶ registerPublishOnRelayExec()
+[Relay]                 ├─▶ publishWithSession()              # registry + namespace tree
+[Relay]                 │     └─▶ addSubscriberAndPublish()   # attach existing SUBSCRIBE_NAMESPACE subs (see Publish fan-out)
+[Relay]                 └─▶ relayChainFilter->setDownstream(topNFilter)
+[Pub]         return {consumer, replyTask}                    # immediate
+```
+
+The publisher starts writing into `localPubFwd` on `[Pub]` as soon as `publishFromPublisherExec`
+returns; `[Relay]` registration completes in parallel. FIFO ordering on `[Relay]` guarantees
+`relayChainFilter` is wired to `topNFilter` before any tapped object arrives.
+
+`createPublisherForwarder` also installs the forwarder's control chain (publisher forwarder →
+relay state); see [Control](#control-the-callback-flow).
+
+---
+
+## Publish fan-out
+
+A session that sent `SUBSCRIBE_NAMESPACE` receives a `PUBLISH` for each matching track. When a
+track appears (or a namespace-subscriber arrives), the relay adds that session as a subscriber
+to the forwarder and starts publishing to it. This is publish-side flow, not the
+track-`subscribe()` path — but the LF variant mirrors `subscribeFromSubscriberExec`:
+`acquireLocalForwarder` → `startPublish` → buffer-and-replay → a single `[Pub]` sortie to wire
+the channel sub. The difference is the entry point (dispatched from `[Relay]` to the
+namespace-subscriber's `[Sub]`) and that there is no upstream/relay-chain setup here — that is
+already owned by the publisher's forwarder.
+
+```
+[Relay] addSubscriberAndPublish()                          # dispatcher (LF variant vs startPublish)
+[Relay]  └─ LF mode ─▶ ⇢⇢▶ [Sub] addSubscriberAndPublishViaLocalForwarder()
+[Sub]         ├─ fast path: tlForwarders_->get(ftn) hit
+[Sub]         │     └─▶ startPublish() ─▶ awaitPublishReply()   # zero hops
+[Sub]         ├─▶ acquireLocalForwarder(ftn)  getOrCreate       # shared with subscribe
+[Sub]         ├─▶ startPublish()                                # issue PUBLISH to the sub
+[Sub]         ├─ NOT new ─▶ awaitPublishReply() ─▶ return
+[Sub]         └─ isNew ── this thread owns setup:
+[Sub]              ├─▶ setCallback( PendingForwarderCallback )   # buffer events during setup
+[Sub]              ├─▶ CrossExecFilter(subscriberExec, localFwd) # deep-copy per thread
+[Sub]              ├─▶ addLocalForwarderToPublisher()
+[Sub]              │     └─▶ ⇢⇢▶ [Pub] installChannelSubscriber(localFwd ↔ publisherFwd)
+[Sub]              ├─ sawOnEmpty? ─▶ teardownLocalForwarderOnFailure()
+[Sub]              ├─▶ replayPendingFowarderEvents()             # drain buffered events
+[Sub]              └─▶ awaitPublishReply()
+```
+
+Callers of `addSubscriberAndPublish` (all on `[Relay]`): `publishWithSession` (publisher
+arrives → attach existing namespace-subscribers), `subscribeNamespaceImpl` (namespace-subscriber
+arrives → attach existing publishes), `onTrackSelected` (ranking promotes a track).
+
+---
+
+## Subscribe (track `subscribe()`)
+
+Subscribe is a three-executor dance: it starts on `[Sub]`, hops to `[Relay]` for registry +
+upstream work, and nests a single sortie to `[Pub]` to wire the channel sub.
+
+### Setup
+
+```
+[Sub]   LocalSubscribeFilter::subscribe()
+[Sub]    └─▶ subscribeFromSubscriberExec()
+[Sub]         ├─▶ acquireLocalForwarder(ftn)  getOrCreate       # serializes same-thread races
+[Sub]         │
+[Sub]         ├─ NOT new ─▶ attachSubscriber() ─▶ return        # fast path, zero hops
+[Sub]         │
+[Sub]         └─ isNew ── this thread owns setup:
+[Sub]              ├─▶ setCallback( PendingForwarderCallback )   # buffer events during setup
+[Sub]              ├─▶ CrossExecFilter(subscriberExec, localFwd) # deep-copy per thread
+[Sub]              ├─▶ localFwd->addSubscriber()                 # so `forward` is right pre-hop
+[Sub]              └─▶ ⇢⇢▶ [Relay] attachNewLocalForwarderOnRelayExec()
+[Relay]                 ├─▶ joinOrPrepareUpstreamSubscription()  # registry: first vs subsequent
+[Relay]                 ├─▶ buildLocalToPublisherCallbacks()
+[Relay]                 └─▶ ⇢⇢▶ [Pub]  single sortie:
+[Pub]                        ├─▶ installChannelSubscriber(localFwd ↔ publisherFwd)
+[Pub]                        └─ if FIRST subscriber:
+[Pub]                             ├─▶ addChannelSubscriber(relayChain, passive)
+[Pub]                             └─▶ subscribeUpstreamAndApplyOk()
+[Relay]                 ◀── back on relayExec_
+[Relay]                 ├─ if FIRST: relayChainFilter->setDownstream(topNFilter)
+[Relay]                 └─ if FIRST: completeUpstreamSubscription() pending.complete()
+[Sub]              ◀── back on subscriberExec (tail)
+[Sub]              ├─ sawOnEmpty? ─▶ teardownLocalForwarderOnFailure()
+[Sub]              ├─ error?      ─▶ publishDone + remove
+[Sub]              ├─▶ apply upstreamOk extensions / largest
+[Sub]              ├─▶ replayPendingFowarderEvents()             # drain buffered events
+[Sub]              └─▶ return sub
+```
+
+The first subscriber does the heavy lifting (upstream subscribe + installing the relay chain,
+the same passive cache/Top-N chain described in [Data flow](#data-flow)). Subsequent
+subscribers on the same thread hit the `attachSubscriber` fast path; on other threads they take
+only the `installChannelSubscriber` half of the sortie.
+
+### Why each guard exists
+
+- **`acquireLocalForwarder` before the hop** — `getOrCreate` serializes same-thread subscribers
+  so only one runs setup; the rest see `isNew=false` and attach.
+- **`PendingForwarderCallback` installed first** — events firing mid-setup are buffered, then
+  replayed by `replayPendingFowarderEvents` so none are lost across the hops.
+- **`addSubscriber` before the hop** — `numForwardingSubscribers()` must be correct when
+  `addChannelSubscriber` runs on `[Pub]`, so the `forward` flag is right from the start.
+- **Single `[Pub]` sortie** — merges channel-sub install + relay chain + upstream subscribe
+  into one round-trip instead of bouncing `[Relay]↔[Pub]` twice.
+- **`sawOnEmpty` check in the tail** — all subscribers may cancel during the hops; if so,
+  unwind the channel subs cleanly.
+
+---
+
+## Data flow
+
+Once setup is done, every object the publisher writes goes to three kinds of destination. The
+first two are delivery (off `relayExec_`); the third is the single passive copy for
+relay-global state.
+
+```
+[Pub]  publisher writes object ──▶ publisher forwarder (localPubFwd)
+[Pub]    ├──▶ same-thread subscribers                          # direct, fast path
+[Pub]    ├──▶ CrossExecFilter ⇢⇢▶ [Sub]  localFwd ──▶ consumer # one hop per other thread, deep-copy
+[Pub]    └──▶ relayChainFilter (passive) ⇢⇢▶ [Relay]           # cache + Top-N (below)
+```
+
+The cross-exec delivery copies payloads (`deepCopyPayload=true`) so each subscriber thread owns
+its own IOBuf chain. Sharing one chain would mean every thread's `IOBuf` add/release writes the
+same atomic refcount, bouncing that cache line between CPUs; a per-thread copy keeps those
+refcount writes CPU-local and off the shared line.
+
+### Objects on relayExec_: caching and Top-N
+
+Subscriber *delivery* stays off `relayExec_`, but the relay still needs a single coherent view
+of every object for two relay-global concerns — the **cache** and **Top-N ranking** — both of
+which live on `relayExec_`. The publisher's forwarder carries one passive channel subscriber
+that copies every object inward:
+
+```
+[Pub]  localPubFwd / publisherFwd dispatches object
+        └──▶ relayChainFilter (CrossExecFilter, passive) ⇢⇢▶ [Relay]
+[Relay]      └──▶ topNFilter ──▶ TerminationFilter ──▶ cache passive consumer
+```
+
+This chain is built in the LF branch of `buildFilterChain`:
+
+- `relayChainFilter` is a `CrossExecFilter` targeting `relayExec_`; its downstream is set to
+  `topNFilter` once the registry entry exists (in `registerPublishOnRelayExec` for the publish
+  path, or `attachNewLocalForwarderOnRelayExec` for a relay-sourced track's first subscriber).
+- The chain ends at `cache_->makePassiveConsumer(ftn)` (or a `NullTrackConsumer` when the
+  cache is disabled).
+
+It is added with `forward=true, passive=true`: the chain observes **every** object, but does
+not count as a forwarding subscriber and is excluded from the `onEmpty` quorum — so the
+publisher's `onEmpty` still fires when the last *real* subscriber leaves.
+
+What each stage does:
+
+- **`TopNFilter`** — reads the ranking property from each object's extensions and updates
+  `PropertyRanking`. Ranking is relay-global, so it must observe the full object stream on one
+  thread; this is what decides which tracks are "selected" for track-filter subscribers. See
+  [track-filter-ranking.md](track-filter-ranking.md).
+- **`TerminationFilter`** — intercepts `publishDone` to clean up relay state.
+- **cache passive consumer** — populates the cache so later subscribers / fetches can be
+  served from it.
+
+The cost is one copy per object, independent of subscriber count; the per-subscriber fan-out
+is what the delivery data plane keeps off `relayExec_`.
+
+---
+
+## Control: the callback flow
+
+A `MoQForwarder` fires three control callbacks: `onEmpty` (last real subscriber left),
+`forwardChanged` (forwarding-subscriber count crossed zero), and `newGroupRequested` (a
+subscriber issued `NEW_GROUP_REQUEST`). In LF mode each forwarder wraps these in a short chain
+of adapter callbacks so the event reaches the right thread and the right owner. There are
+**two** distinct chains, depending on which forwarder fired. (Single-thread mode skips all of
+this: `forwarder.callback = MoqxRelay` directly.) See the `MoQForwarder::Callback chain
+overview` comment block in `MoqxRelay.cpp` for the canonical wiring.
+
+The reusable adapter layers:
+
+| Callback | Runs on | Role |
+| --- | --- | --- |
+| `PendingForwarderCallback` | forwarder's exec | buffers events during the setup window, replayed onto the real callback afterward |
+| `LocalForwarderCallback` | forwarder's exec | owns removal from `tlForwarders_` (identity-checked); passes the rest through |
+| `CrossExecForwarderCallback` | hops | dispatches each event to a target exec, fire-and-forget |
+| `WeakRelayForwarderCallback` | `[Relay]` | terminal for the publisher chain: recovers the relay, calls the `…Impl` methods |
+| `ChannelForwarderCallback` | `[Pub]` | terminal for the local-forwarder chain: detaches the channel sub / issues `requestUpdate` |
+
+### Publisher forwarder → relay state
+
+Built by `createPublisherForwarder`. Lifecycle events on the publisher's own forwarder must
+reach relay-global state on `relayExec_`:
+
+```
+[Pub]  publisherFwd fires onEmpty / forwardChanged / newGroupRequested
+        └─ LocalForwarderCallback              # owns tlForwarders_ removal (removeOnEmpty=false)
+             └─ CrossExecForwarderCallback ⇢⇢▶ [Relay]
+[Relay]           └─ WeakRelayForwarderCallback ──▶ MoqxRelay::onEmptyImpl / forwardChangedImpl / newGroupRequestedImpl
+```
+
+### Local forwarder → publisher
+
+Built by `buildLocalToPublisherCallbacks` (subscribe and fan-out paths). A subscriber thread's
+`localFwd` is a channel subscriber of `publisherFwd`; when it empties or its forwarding state
+changes, the publisher on `[Pub]` must react:
+
+```
+[Sub]  localFwd fires onEmpty / forwardChanged / newGroupRequested
+        └─ LocalForwarderCallback              # owns localReg removal (removeOnEmpty=true)
+             └─ CrossExecForwarderCallback ⇢⇢▶ [Pub]
+[Pub]           └─ ChannelForwarderCallback:
+                     onEmpty           → publisherFwd->removeChannelSubscriberByExec(subscriberExec)
+                                         # may cascade into the publisher chain above
+                     forwardChanged    → requestUpdate(handle, forward)   # background coro
+                     newGroupRequested → requestUpdate(handle, group)     # background coro
+```
+
+`ChannelForwarderCallback` holds the channel `handle_` (so it can `requestUpdate` the publisher)
+and the `CrossExecFilter` ref; on `onEmpty` it posts the filter's destruction back to `[Sub]`
+so FIFO ordering lets any in-flight object lambdas there run before the filter is torn down.
+
+### Setup window: `PendingForwarderCallback`
+
+Between `getOrCreate` and the real callback being installed, the forwarder can already fire
+events. `PendingForwarderCallback` is installed first to capture them: it records the last
+`forwardChanged`, the max `newGroupRequested` group, and whether `onEmpty` fired. After setup,
+`replayPendingFowarderEvents` installs the real callback and replays the captured state; if
+`onEmpty` was seen, the caller unwinds instead (`teardownLocalForwarderOnFailure`).
+
+### Weak-ptr discipline
+
+Two ownership cycles are deliberately broken with `weak_ptr`:
+
+- `WeakRelayForwarderCallback` holds `weak_ptr<relay>` to break
+  `registry → forwarder → callback → relay → registry`.
+- `CrossExecForwarderCallback` holds `weak_ptr<forwarder>` to avoid a permanent ownership
+  cycle; it locks eagerly on the calling thread (where the forwarder is known alive) and moves
+  the resulting `shared_ptr` into the dispatched lambda to keep it alive across the hop.
+
+### Teardown
+
+```
+source ends ──▶ TerminationFilter::publishDone()
+  └─▶ onPublishDone(ftn)                                    # relay state cleanup
+forwarder onPublishDone ──▶ LocalForwarderCallback ──▶ tlForwarders_->remove()   # identity-checked
+```
+
+Identity-checked removal makes teardown order-independent: a terminated forwarder can never
+evict a newer one that has claimed the same track name. Subscriber-path local forwarders use
+`removeOnEmpty=true`, so they also vacate when their last subscriber leaves; the publisher's
+forwarder uses `removeOnEmpty=false` (see [Publish](#publish)).

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -15,6 +15,8 @@
 #   --delivery-timeout N   Delivery timeout in ms (default: 500)
 #   --transport TYPE       quic or webtransport (default: quic)
 #   --no-relay-thread      Disable relay exec thread (use_relay_thread: false)
+#   --local-forwarders     Enable per-subscriber-thread local forwarders
+#                          (use_local_forwarders: true; requires relay thread)
 #   --io-threads N         Number of relay IO threads (default: 1)
 #   --threads N            Number of perf client threads (default: 2)
 #   --relay-log SPEC       folly XLOG config passed as --logging=SPEC to relay
@@ -55,6 +57,7 @@ DURATION=30
 DELIVERY_TIMEOUT=500
 TRANSPORT="quic"
 USE_RELAY_THREAD="true"
+USE_LOCAL_FORWARDERS="false"
 IO_THREADS=1
 CLIENT_THREADS=2
 RELAY_LOG_SPEC=""
@@ -84,6 +87,7 @@ while [[ $# -gt 0 ]]; do
     --delivery-timeout) DELIVERY_TIMEOUT="$2";  shift 2 ;;
     --transport)        TRANSPORT="$2";         shift 2 ;;
     --no-relay-thread)  USE_RELAY_THREAD="false"; shift ;;
+    --local-forwarders) USE_LOCAL_FORWARDERS="true"; shift ;;
     --io-threads)       IO_THREADS="$2";          shift 2 ;;
     --threads)          CLIENT_THREADS="$2";      shift 2 ;;
     --relay-log)        RELAY_LOG_SPEC="$2";      shift 2 ;;
@@ -211,6 +215,7 @@ cat >"$RELAY_CFG" <<EOF
 relay_id: "perf-test-relay"
 threads: $IO_THREADS
 use_relay_thread: $USE_RELAY_THREAD
+use_local_forwarders: $USE_LOCAL_FORWARDERS
 mvfst_bpf_steering: $BPF_STEERING
 listeners:
   - name: perf
@@ -260,6 +265,7 @@ cp "$RELAY_CFG" "$LOG_DIR/relay.yaml"
   echo "transport:        $TRANSPORT"
   echo "io_threads:       $IO_THREADS"
   echo "use_relay_thread: $USE_RELAY_THREAD"
+  echo "local_forwarders: $USE_LOCAL_FORWARDERS"
   echo "subscriber_max:   $SUBSCRIBER_MAX"
   echo "ramp:             $RAMP"
   echo "duration:         $DURATION"
@@ -276,7 +282,7 @@ echo ""
 
 # ── Start relay ───────────────────────────────────────────────────────────────
 ulimit -n 65536 2>/dev/null || true
-echo "Starting relay (use_relay_thread=$USE_RELAY_THREAD, io_threads=$IO_THREADS, transport=$TRANSPORT, mvfst_bpf_steering=$BPF_STEERING)..."
+echo "Starting relay (use_relay_thread=$USE_RELAY_THREAD, local_forwarders=$USE_LOCAL_FORWARDERS, io_threads=$IO_THREADS, transport=$TRANSPORT, mvfst_bpf_steering=$BPF_STEERING)..."
 RELAY_LOGGING_ARG=()
 [[ -n "$RELAY_LOG_SPEC" ]] && RELAY_LOGGING_ARG=("--logging=$RELAY_LOG_SPEC")
 if [[ -n "$JEMALLOC" ]]; then

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -7,9 +7,13 @@
  */
 
 #include "MoqxRelay.h"
+#include "relay/CrossExecFilter.h"
 #include "relay/CrossExecForwarderCallback.h"
-#include "relay/RelayExecUtil.h"
+#include "relay/LocalForwarderCallback.h"
+#include "relay/NullConsumers.h"
+#include "relay/PublisherCrossExecFilter.h"
 #include "relay/SubscriberCrossExecFilter.h"
+#include "relay/WeakRelayForwarderCallback.h"
 #include <folly/container/F14Set.h>
 #include <moxygen/MoQFilters.h>
 #include <moxygen/MoQTrackProperties.h>
@@ -17,11 +21,167 @@
 namespace {
 constexpr uint8_t kDefaultUpstreamPriority = 128;
 constexpr std::chrono::seconds kUpstreamConnectWaitTimeout(5);
+
+// Fire-and-forget an upstream-update coroutine on exec — the
+// co_withExecutor(getKeepAliveToken(exec), ...).start() idiom shared by the
+// forwarder-callback update paths.
+void launchUpdate(folly::Executor* exec, folly::coro::Task<void> task) {
+  folly::coro::co_withExecutor(folly::getKeepAliveToken(exec), std::move(task)).start();
+}
+
+// Free coroutines, not inline lambdas — captures would dangle past suspension.
+folly::coro::Task<void>
+doSubscribeUpdate(std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle, bool forward) {
+  auto res = co_await handle->requestUpdate(moxygen::RequestUpdate{
+      moxygen::RequestID(0),
+      handle->subscribeOk().requestID,
+      moxygen::kLocationMin,
+      moxygen::kLocationMax.group,
+      moxygen::kDefaultPriority,
+      forward
+  });
+  if (res.hasError()) {
+    XLOG(ERR) << "requestUpdate failed: " << res.error().reasonPhrase;
+  }
+}
+
+folly::coro::Task<void> doNewGroupRequestUpdate(
+    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+    uint64_t group
+) {
+  XLOG(DBG4) << "Sending NEW_GROUP_REQUEST update: " << group;
+  moxygen::RequestUpdate update;
+  update.requestID = moxygen::RequestID(0);
+  update.existingRequestID = handle->subscribeOk().requestID;
+  update.params.insertParam(moxygen::Parameter(
+      folly::to_underlying(moxygen::TrackRequestParamKey::NEW_GROUP_REQUEST),
+      group
+  ));
+  auto res = co_await handle->requestUpdate(std::move(update));
+  if (res.hasError()) {
+    XLOG(ERR) << "NEW_GROUP_REQUEST update failed: " << res.error().reasonPhrase;
+  }
+}
+
+// Strips the first prefixLen labels off a namespace, yielding the suffix that a
+// downstream subscriber (which subscribed with that prefix) should see.
+moxygen::TrackNamespace makeNamespaceSuffix(const moxygen::TrackNamespace& src, size_t prefixLen) {
+  return moxygen::TrackNamespace(
+      std::vector<std::string>(src.trackNamespace.begin() + prefixLen, src.trackNamespace.end())
+  );
+}
+
+// Rejects an AbsoluteRange subscription whose endGroup is already behind the
+// forwarder's largest group (the client should FETCH instead). Returns
+// std::nullopt when the range is acceptable.
+std::optional<moxygen::SubscribeError>
+checkRangeNotInPast(moxygen::MoQForwarder& fwd, const moxygen::SubscribeRequest& subReq) {
+  if (fwd.largest() && subReq.locType == moxygen::LocationType::AbsoluteRange &&
+      subReq.endGroup < fwd.largest()->group) {
+    return moxygen::SubscribeError{
+        subReq.requestID,
+        moxygen::SubscribeErrorCode::INVALID_RANGE,
+        "Range in the past, use FETCH"
+    };
+  }
+  return std::nullopt;
+}
+
+// Derives the upstream SubscribeRequest from a downstream one: fetch from latest at
+// upstream priority/default group order, session-assigned requestID, caller's forward.
+moxygen::SubscribeRequest makeUpstreamSubReq(moxygen::SubscribeRequest base, bool forward) {
+  base.priority = kDefaultUpstreamPriority;
+  base.groupOrder = moxygen::GroupOrder::Default;
+  base.locType = moxygen::LocationType::LargestObject;
+  base.forward = forward;
+  base.requestID = moxygen::RequestID(0);
+  return base;
+}
 } // namespace
 
 using namespace moxygen;
 
 namespace openmoq::moqx {
+
+// === LocalSubscribeFilter and LocalPublishFilter ===
+
+// LF-mode publish handler: overrides subscribe() to run subscribeFromSubscriberExec
+// on the subscriber's executor (no relayExec_ hop). Other Publisher methods fall
+// through to PublisherCrossExecFilter.
+class MoqxRelay::LocalSubscribeFilter final : public PublisherCrossExecFilter {
+public:
+  LocalSubscribeFilter(folly::Executor* relayExec, std::shared_ptr<MoqxRelay> relay)
+      : PublisherCrossExecFilter(relayExec, relay), relay_(std::move(relay)) {}
+
+  folly::coro::Task<SubscribeResult> subscribe(
+      moxygen::SubscribeRequest subReq,
+      std::shared_ptr<moxygen::TrackConsumer> consumer
+  ) override {
+    if (subReq.fullTrackName.trackNamespace.empty()) {
+      co_return folly::makeUnexpected(moxygen::SubscribeError{
+          subReq.requestID,
+          moxygen::SubscribeErrorCode::DOES_NOT_EXIST,
+          "namespace required"
+      });
+    }
+    auto session = moxygen::MoQSession::getRequestSession();
+    auto* subscriberExec = session->getExecutor();
+    // No executor hop: subscribeFromSubscriberExec starts on subscriberExec.
+    co_return co_await relay_->subscribeFromSubscriberExec(
+        std::move(subReq),
+        std::move(consumer),
+        std::move(session),
+        subscriberExec
+    );
+  }
+
+private:
+  std::shared_ptr<MoqxRelay> relay_;
+};
+
+std::shared_ptr<moxygen::Publisher> MoqxRelay::createPublisherFilter() {
+  switch (mode()) {
+  case Mode::LocalForwarder:
+    return std::make_shared<LocalSubscribeFilter>(relayExec_, shared_from_this());
+  case Mode::RelayExec:
+    return std::make_shared<PublisherCrossExecFilter>(relayExec_, shared_from_this());
+  case Mode::SingleThread:
+    break;
+  }
+  return shared_from_this();
+}
+
+// LF-mode subscribe handler: overrides publish() to create the publisher's local
+// forwarder on its own executor (no cross-exec hop for data). Other Subscriber methods
+// fall through to SubscriberCrossExecFilter.
+class MoqxRelay::LocalPublishFilter final : public SubscriberCrossExecFilter {
+public:
+  LocalPublishFilter(folly::Executor* relayExec, std::shared_ptr<MoqxRelay> relay)
+      : SubscriberCrossExecFilter(relayExec, relay), relay_(std::move(relay)) {}
+
+  PublishResult publish(
+      moxygen::PublishRequest pub,
+      std::shared_ptr<moxygen::SubscriptionHandle> handle
+  ) override {
+    auto session = moxygen::MoQSession::getRequestSession();
+    return relay_->publishFromPublisherExec(std::move(pub), std::move(handle), std::move(session));
+  }
+
+private:
+  std::shared_ptr<MoqxRelay> relay_;
+};
+
+std::shared_ptr<moxygen::Subscriber> MoqxRelay::createSubscriberFilter() {
+  switch (mode()) {
+  case Mode::LocalForwarder:
+    return std::make_shared<LocalPublishFilter>(relayExec_, shared_from_this());
+  case Mode::RelayExec:
+    return std::make_shared<SubscriberCrossExecFilter>(relayExec_, shared_from_this());
+  case Mode::SingleThread:
+    break;
+  }
+  return shared_from_this();
+}
 
 // Bridges NAMESPACE/NAMESPACE_DONE messages from a peer relay directly into
 // MoqxRelay::doPublishNamespace/doPublishNamespaceDone — no coroutine overhead,
@@ -116,59 +276,6 @@ void MoqxRelay::onUpstreamDisconnect() {
   upstreamSubNsHandle_.reset();
 }
 
-std::shared_ptr<Publisher> MoqxRelay::createPublisherFilter() {
-  if (relayExec_) {
-    return std::make_shared<PublisherCrossExecFilter>(relayExec_, shared_from_this());
-  }
-  return shared_from_this();
-}
-
-std::shared_ptr<Subscriber> MoqxRelay::createSubscriberFilter() {
-  if (relayExec_) {
-    return std::make_shared<SubscriberCrossExecFilter>(relayExec_, shared_from_this());
-  }
-  return shared_from_this();
-}
-
-// Sends SUBSCRIBE_UPDATE to update forwarding state. Called from:
-// - subscribeNamespace: forwarder was empty, new subscriber added
-// (forward=true)
-// - subscribe: first forwarding subscriber added (forward=true)
-// - onEmpty: last subscriber left a publish subscription (forward=false)
-// - forwardChanged: forwarding subscriber count changed
-folly::coro::Task<void>
-MoqxRelay::doSubscribeUpdate(std::shared_ptr<Publisher::SubscriptionHandle> handle, bool forward) {
-  auto updateRes = co_await handle->requestUpdate(
-      {RequestID(0),
-       handle->subscribeOk().requestID,
-       kLocationMin,
-       kLocationMax.group,
-       kDefaultPriority,
-       /*forward=*/forward}
-  );
-  if (updateRes.hasError()) {
-    XLOG(ERR) << "requestUpdate failed: " << updateRes.error().reasonPhrase;
-  }
-}
-
-// Sends a REQUEST_UPDATE that carries only the NEW_GROUP_REQUEST parameter.
-folly::coro::Task<void> MoqxRelay::doNewGroupRequestUpdate(
-    std::shared_ptr<Publisher::SubscriptionHandle> handle,
-    uint64_t newGroupRequestValue
-) {
-  XLOG(DBG4) << "Sending NEW_GROUP_REQUEST update: " << newGroupRequestValue;
-  RequestUpdate update;
-  update.requestID = RequestID(0);
-  update.existingRequestID = handle->subscribeOk().requestID;
-  update.params.insertParam(
-      Parameter(folly::to_underlying(TrackRequestParamKey::NEW_GROUP_REQUEST), newGroupRequestValue)
-  );
-  auto updateRes = co_await handle->requestUpdate(std::move(update));
-  if (updateRes.hasError()) {
-    XLOG(ERR) << "NEW_GROUP_REQUEST update failed: " << updateRes.error().reasonPhrase;
-  }
-}
-
 std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespace(
     PublishNamespace pubNs,
     std::shared_ptr<MoQSession> session,
@@ -206,10 +313,7 @@ std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespac
       auto maybeVersion = outSession->getNegotiatedVersion();
       if (maybeVersion.has_value() && getDraftMajorVersion(*maybeVersion) >= 16 &&
           info.namespacePublishHandle) {
-        TrackNamespace suffix(std::vector<std::string>(
-            pubNs.trackNamespace.trackNamespace.begin() + info.trackNamespacePrefix.size(),
-            pubNs.trackNamespace.trackNamespace.end()
-        ));
+        auto suffix = makeNamespaceSuffix(pubNs.trackNamespace, info.trackNamespacePrefix.size());
         info.namespacePublishHandle->namespaceMsg(suffix);
       } else {
         // Draft <= 15: send PUBLISH_NAMESPACE on a new stream
@@ -284,10 +388,7 @@ void MoqxRelay::doPublishNamespaceDone(
       auto maybeVersion = outSession->getNegotiatedVersion();
       if (maybeVersion.has_value() && getDraftMajorVersion(*maybeVersion) >= 16) {
         if (info.namespacePublishHandle) {
-          TrackNamespace suffix(std::vector<std::string>(
-              trackNamespace.trackNamespace.begin() + info.trackNamespacePrefix.size(),
-              trackNamespace.trackNamespace.end()
-          ));
+          auto suffix = makeNamespaceSuffix(trackNamespace, info.trackNamespacePrefix.size());
           info.namespacePublishHandle->namespaceDoneMsg(suffix);
         }
       }
@@ -314,45 +415,164 @@ void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
   }
 }
 
+// Validates a publish namespace against allowedNamespacePrefix_ (UNINTERESTED)
+// and non-emptiness (INTERNAL_ERROR). Returns std::nullopt on success. Safe to
+// call on any thread (reads only immutable config).
+std::optional<PublishError>
+MoqxRelay::validatePublishNamespace(const FullTrackName& ftn, RequestID requestID) const {
+  if (!ftn.trackNamespace.startsWith(allowedNamespacePrefix_)) {
+    return PublishError{requestID, PublishErrorCode::UNINTERESTED, "bad namespace"};
+  }
+  if (ftn.trackNamespace.empty()) {
+    return PublishError{requestID, PublishErrorCode::INTERNAL_ERROR, "namespace required"};
+  }
+  return std::nullopt;
+}
+
+// Constructs the publisher's local forwarder and installs its callback chain (Weak ->
+// CrossExec -> LocalForwarder) on publisherExec, before the reply hops to relayExec_.
+// tlForwarders_ must already be initialized.
+std::shared_ptr<MoQForwarder> MoqxRelay::createPublisherForwarder(const PublishRequest& pub) {
+  const auto& ftn = pub.fullTrackName;
+  auto localPubFwd = std::make_shared<MoQForwarder>(ftn, pub.largest);
+  localPubFwd->setExtensions(pub.extensions);
+
+  // removeOnEmpty=false: the publisher's forwarder must survive subscriber churn, so
+  // LocalForwarderCallback removes it from tlForwarders_ only when the source ends.
+  auto relayAdapter = std::make_shared<WeakRelayForwarderCallback>(weak_from_this());
+  auto crossExec = std::make_shared<CrossExecForwarderCallback>(
+      relayExec_,
+      localPubFwd,
+      std::move(relayAdapter)
+  );
+  localPubFwd->setCallback(std::make_shared<LocalForwarderCallback>(
+      tlForwarders_.get(),
+      ftn,
+      std::move(crossExec),
+      /*removeOnEmpty=*/false
+  ));
+
+  return localPubFwd;
+}
+
+// Called from LocalPublishFilter::publish() on publisherExec. Creates the publisher's
+// local forwarder and sets up the publisher forwarder on relayExec_.
+Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
+    PublishRequest pub,
+    std::shared_ptr<Publisher::SubscriptionHandle> handle,
+    std::shared_ptr<MoQSession> session
+) {
+  if (auto err = validatePublishNamespace(pub.fullTrackName, pub.requestID)) {
+    return folly::makeUnexpected(std::move(*err));
+  }
+
+  if (!tlForwarders_.get()) {
+    tlForwarders_.reset(new LocalForwarderRegistry());
+  }
+
+  auto localPubFwd = createPublisherForwarder(pub);
+
+  // The publisher's forwarder is authoritative — claim the slot, displacing any
+  // stale subscribe-path local forwarder so same-thread subscribers reuse THIS
+  // forwarder via the fast path.
+  tlForwarders_->set(pub.fullTrackName, localPubFwd);
+
+  // crossExecFilter is a channel subscriber for the relay exec
+  // regulsterPublishOnRelay exec completes wiring the chain (topNFilter → terminationFilter →
+  // cache).
+  auto crossExecFilter = std::make_shared<CrossExecFilter>(relayExec_, nullptr);
+  // forward=true + passive=true: internal relay chain observes all objects but
+  // does not count as a real forwarding subscriber.
+  localPubFwd
+      ->addChannelSubscriber(relayExec_, /*forward=*/true, crossExecFilter, /*passive=*/true);
+
+  auto reply = folly::coro::co_invoke(
+      [exec = relayExec_,
+       relay = shared_from_this(),
+       pub = std::move(pub),
+       handle = std::move(handle),
+       session = std::move(session),
+       localPubFwd,
+       crossExecFilter]() mutable -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
+        co_return co_await folly::coro::co_withExecutor(
+            folly::getKeepAliveToken(exec),
+            relay->registerPublishOnRelayExec(
+                std::move(pub),
+                std::move(handle),
+                std::move(session),
+                std::move(localPubFwd),
+                std::move(crossExecFilter)
+            )
+        );
+      }
+  );
+
+  auto consumer = std::static_pointer_cast<TrackConsumer>(std::move(localPubFwd));
+  return PublishConsumerAndReplyTask{std::move(consumer), std::move(reply)};
+}
+
+// Runs on relayExec_. Registers publisherFwd in the registry and wires
+// relayChainFilter to the topN filter.
+folly::coro::Task<folly::Expected<PublishOk, PublishError>> MoqxRelay::registerPublishOnRelayExec(
+    PublishRequest pub,
+    std::shared_ptr<Publisher::SubscriptionHandle> handle,
+    std::shared_ptr<MoQSession> session,
+    std::shared_ptr<MoQForwarder> publisherFwd,
+    std::shared_ptr<CrossExecFilter> relayChainFilter
+) {
+  auto ftn = pub.fullTrackName;
+  auto setup =
+      publishWithSession(std::move(pub), std::move(handle), std::move(session), publisherFwd);
+  if (setup.hasError()) {
+    co_return folly::makeUnexpected(setup.error());
+  }
+
+  auto topNView = registry_.getTopNView(ftn);
+  XCHECK(topNView && topNView->topNFilter)
+      << "registerPublishOnRelayExec: topNFilter always present in MT mode";
+  relayChainFilter->setDownstream(topNView->topNFilter);
+
+  co_return setup.value().publishOk;
+}
+
+// Publisher::publish entry point for SingleThread/RelayExec modes (LF mode uses
+// publishFromPublisherExec instead).
 Subscriber::PublishResult
 MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHandle> handle) {
   XLOG(DBG1) << __func__ << " ftn=" << pub.fullTrackName;
   XCHECK(handle) << "Publish handle cannot be null";
   // getRequestSession() stays valid on relayExec_: RequestContext propagates
-  // across the filter's executor hop. Authorize/validate before touching state.
+  // across the filter's executor hop. Validate before touching state.
   auto session = MoQSession::getRequestSession();
-  if (!pub.fullTrackName.trackNamespace.startsWith(allowedNamespacePrefix_)) {
-    return folly::makeUnexpected(
-        PublishError{pub.requestID, PublishErrorCode::UNINTERESTED, "bad namespace"}
-    );
+  if (auto err = validatePublishNamespace(pub.fullTrackName, pub.requestID)) {
+    return folly::makeUnexpected(std::move(*err));
   }
-  if (pub.fullTrackName.trackNamespace.empty()) {
-    return folly::makeUnexpected(
-        PublishError({pub.requestID, PublishErrorCode::INTERNAL_ERROR, "namespace required"})
-    );
-  }
+  XCHECK(mode() != Mode::LocalForwarder) << "publish() bypassed by LocalPublishFilter in LF mode";
+
   maybeSetSessionExec(*session);
-  return publishWithSession(std::move(pub), std::move(handle), std::move(session));
+  auto setup = publishWithSession(std::move(pub), std::move(handle), std::move(session));
+  if (setup.hasError()) {
+    return folly::makeUnexpected(setup.error());
+  }
+  return PublishConsumerAndReplyTask{
+      std::move(setup.value().consumer),
+      folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(
+          folly::Expected<PublishOk, PublishError>(std::move(setup.value().publishOk))
+      )
+  };
 }
 
-Subscriber::PublishResult MoqxRelay::publishWithSession(
+MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
     PublishRequest pub,
     std::shared_ptr<Publisher::SubscriptionHandle> handle,
-    std::shared_ptr<MoQSession> session
+    std::shared_ptr<MoQSession> session,
+    std::shared_ptr<MoQForwarder> forwarder
 ) {
   // Handle duplicate publisher at relay level before registering in the tree.
-  // Move the forwarder out and erase the entry BEFORE calling publishDone.
-  // publishDone iterates subscribers via forEachSubscriber; if a subscriber
-  // has no open subgroups, drainSubscriber → onEmpty fires. If the entry
-  // still existed, onEmpty would erase it (destroying the forwarder) while
-  // forEachSubscriber is still iterating → use-after-free.
-  // handle is null when the previous publisher already terminated (e.g.
-  // reconnect after a dropped connection with subscribers still draining open
-  // subgroups).  onPublishDone() already reset handle and drained the
-  // forwarder, so skip both calls to avoid a null deref and a double
-  // publishDone.
-  auto forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
-  forwarder->setExtensions(pub.extensions);
+  if (!forwarder) {
+    forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
+    forwarder->setExtensions(pub.extensions);
+  }
 
   auto publisherWrapped = maybeWrapPublisher(relayExec_, session);
   auto publishEntry = registry_.createFromPublish(
@@ -366,8 +586,12 @@ Subscriber::PublishResult MoqxRelay::publishWithSession(
   );
 
   if (publishEntry.evicted) {
+    // A new publisher replaced a live one. createFromPublish already erased the old registry entry
+    // and handed us its last ref, so the onEmpty that publishDone may re-enter (via
+    // drainSubscriber) can't destroy the forwarder mid-forEachSubscriber.
     XLOG(DBG1) << "New publisher for existing subscription";
     auto& evicted = *publishEntry.evicted;
+    // Null handle => previous publisher already terminated and onPublishDone() tore it down; skip.
     if (evicted.handle) {
       evicted.handle->unsubscribe();
       evicted.forwarder->publishDone(
@@ -402,15 +626,16 @@ Subscriber::PublishResult MoqxRelay::publishWithSession(
       }
   );
 
-  // The publisher data path already runs on relayExec_, but the subscriber
-  // control path (unsubscribe/requestUpdate) reaches the forwarder from a
-  // session I/O thread, so its callbacks must hop back before touching state.
-  if (relayExec_) {
-    forwarder->setCallback(
-        std::make_shared<CrossExecForwarderCallback>(relayExec_, forwarder, shared_from_this())
-    );
-  } else {
-    forwarder->setCallback(shared_from_this());
+  switch (mode()) {
+  case Mode::SingleThread:
+  case Mode::RelayExec:
+    // Weak ref breaks the registry → forwarder → callback → relay cycle.
+    forwarder->setCallback(std::make_shared<WeakRelayForwarderCallback>(weak_from_this()));
+    break;
+  case Mode::LocalForwarder:
+    // Local forwarder already had its CrossExecForwarderCallback installed by
+    // publishFromPublisherExec (dispatches onEmpty to relayExec_); don't overwrite.
+    break;
   }
 
   uint64_t nSubscribers = 0;
@@ -425,7 +650,14 @@ Subscriber::PublishResult MoqxRelay::publishWithSession(
     if (outSession != session && (info.options == SubscribeNamespaceOptions::PUBLISH ||
                                   info.options == SubscribeNamespaceOptions::BOTH)) {
       nSubscribers++;
-      if (!addSubscriberAndPublish(outSession, forwarder, info.forward, /*pinned=*/true)) {
+      auto* publisherExec = relayExec_ ? session->getExecutor() : nullptr;
+      if (!addSubscriberAndPublish(
+              outSession,
+              forwarder,
+              info.forward,
+              /*pinned=*/true,
+              publisherExec
+          )) {
         XLOG(ERR) << "addSubscriberAndPublish failed for " << forwarder->fullTrackName();
         continue;
       }
@@ -437,9 +669,9 @@ Subscriber::PublishResult MoqxRelay::publishWithSession(
   // When subscribers join later via subscribeNamespace, forwardChanged() sends REQUEST_UPDATE.
   bool shouldForward = (nSubscribers > 0) || hasTrackFilterSub;
 
-  return PublishConsumerAndReplyTask{
+  return PublishSetup{
       publishEntry.consumer,
-      folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(PublishOk{
+      PublishOk{
           pub.requestID,
           /*forward=*/shouldForward,
           kDefaultPriority,
@@ -447,16 +679,14 @@ Subscriber::PublishResult MoqxRelay::publishWithSession(
           LocationType::AbsoluteRange,
           kLocationMin,
           kLocationMax.group
-      })
+      }
   };
 }
 
 namespace {
 
-// Free-function coroutine: awaits the publish reply and calls onPublishOk.
-// Holds forwarder alive because subscriber keeps a raw ref into it.
 folly::coro::Task<void> awaitPublishReply(
-    std::shared_ptr<MoQForwarder> forwarder,
+    std::shared_ptr<MoQForwarder> forwarder, // keeps subscriber's raw ref alive
     std::shared_ptr<MoQForwarder::Subscriber> subscriber,
     folly::coro::Task<folly::Expected<PublishOk, PublishError>> reply
 ) {
@@ -480,6 +710,9 @@ folly::coro::Task<void> awaitPublishReply(
 
 } // namespace
 
+// Sync setup: addSubscriber → set pinned → session->publish (optionally via
+// SubscriberCrossExecFilter when subscriberExec is non-null) → set trackConsumer.
+// Returns nullopt and cleans up on any synchronous failure.
 std::optional<MoqxRelay::PreparedPublish> MoqxRelay::startPublish(
     std::shared_ptr<MoQSession> session,
     std::shared_ptr<MoQForwarder> forwarder,
@@ -493,7 +726,6 @@ std::optional<MoqxRelay::PreparedPublish> MoqxRelay::startPublish(
     return std::nullopt;
   }
   subscriber->pinned = pinned;
-  XLOG(DBG4) << "added subscriber for ftn=" << forwarder->fullTrackName();
   Subscriber::PublishResult pub;
   if (subscriberExec) {
     SubscriberCrossExecFilter wrapped(subscriberExec, session);
@@ -510,14 +742,34 @@ std::optional<MoqxRelay::PreparedPublish> MoqxRelay::startPublish(
   return PreparedPublish{std::move(subscriber), std::move(pub->reply)};
 }
 
+// In relay+local-forwarder mode: dispatches addSubscriberAndPublishViaLocalForwarder
+// to subscriberExec. Otherwise: calls startPublish sync and fires reply async.
+// Returns false on synchronous failure.
 bool MoqxRelay::addSubscriberAndPublish(
-    std::shared_ptr<MoQSession> session,
+    std::shared_ptr<MoQSession> subscriberSession,
     std::shared_ptr<MoQForwarder> forwarder,
     bool forward,
-    bool pinned
+    bool pinned,
+    folly::Executor* publisherExec
 ) {
-  folly::Executor* subscriberExec = relayExec_ ? session->getExecutor() : nullptr;
-  auto p = startPublish(session, forwarder, forward, pinned, subscriberExec);
+  if (mode() == Mode::LocalForwarder) {
+    XCHECK(publisherExec
+    ) << "addSubscriberAndPublish: publisherExec required in local-forwarder mode";
+    co_withExecutor(
+        folly::getKeepAliveToken(subscriberSession->getExecutor()),
+        addSubscriberAndPublishViaLocalForwarder(
+            subscriberSession,
+            forwarder,
+            publisherExec,
+            forward,
+            pinned
+        )
+    )
+        .start();
+    return true;
+  }
+  folly::Executor* subscriberExec = relayExec_ ? subscriberSession->getExecutor() : nullptr;
+  auto p = startPublish(subscriberSession, forwarder, forward, pinned, subscriberExec);
   if (!p) {
     return false;
   }
@@ -529,6 +781,360 @@ bool MoqxRelay::addSubscriberAndPublish(
   )
       .start();
   return true;
+}
+
+namespace {
+
+// Tears down an aborted local-forwarder setup: drops the channel sub(s) on the publisher (hopping
+// to publisherExec; the relayExec entry only when relayExec is non-null and drains localFwd via
+// publishDone if given.
+void teardownLocalForwarderOnFailure(
+    folly::Executor* publisherExec,
+    std::shared_ptr<MoQForwarder> publisherFwd,
+    folly::Executor* subscriberExec,
+    folly::Executor* relayExec,
+    const std::shared_ptr<MoQForwarder>& localFwd = nullptr,
+    std::string publishDoneReason = {}
+) {
+  if (publisherFwd && publisherExec) {
+    folly::via(
+        publisherExec,
+        [pf = std::move(publisherFwd), ex = subscriberExec, re = relayExec]() noexcept {
+          pf->removeChannelSubscriberByExec(ex);
+          if (re) {
+            pf->removeChannelSubscriberByExec(re);
+          }
+        }
+    );
+  }
+  if (localFwd) {
+    localFwd->publishDone(PublishDone{
+        RequestID(0),
+        PublishDoneStatusCode::INTERNAL_ERROR,
+        0,
+        std::move(publishDoneReason)
+    });
+  }
+}
+
+// === MoQForwarder::Callback chain overview ===
+//
+// MoQForwarder fires three callbacks: onEmpty (last subscriber left),
+// forwardChanged (forwarding subscriber count crossed zero), and
+// newGroupRequested (subscriber issued a NEW_GROUP_REQUEST).
+//
+// Single-threaded mode:
+//   forwarder.callback = MoqxRelay (direct, no hop)
+//
+// Multi-threaded — publisher forwarder (lives on publisherExec):
+//   publisherFwd.callback =
+//     CrossExecForwarderCallback(relayExec_, publisherFwd,
+//       WeakRelayForwarderCallback(relay))
+//
+//   [publisherExec] CrossExecForwarderCallback: captures ftn by value,
+//                 dispatches to relayExec_ fire-and-forget
+//       ↓
+//   [relayExec_]  WeakRelayForwarderCallback: recovers relay via weak_ptr,
+//                 calls onEmptyImpl / forwardChangedImpl / newGroupRequestedImpl
+//
+// Multi-threaded — local forwarder (lives on subscriberExec, subscribe path):
+//   During setup window:
+//     localFwd.callback = PendingForwarderCallback
+//       captures events; replayed onto finalCallback after setup
+//
+//   After setup:
+//     localFwd.callback =
+//       LocalForwarderCallback(localReg, ftn,
+//         CrossExecForwarderCallback(publisherExec, localFwd,
+//           ChannelForwarderCallback(publisherFwd, subscriberExec, publisherExec)))
+//
+//   [subscriberExec] LocalForwarderCallback: removes from localReg on onEmpty,
+//                    passes through forwardChanged / newGroupRequested
+//       ↓ (CrossExecForwarderCallback dispatches to publisherExec)
+//   [publisherExec]    ChannelForwarderCallback:
+//                      onEmpty → publisherFwd->removeChannelSubscriberByExec(subscriberExec)
+//                                (may cascade into publisherFwd's own callback chain above)
+//                      forwardChanged / newGroupRequested → launch background coro
+//                                                           → requestUpdate(handle_)
+//
+// Weak-ptr discipline:
+//   WeakRelayForwarderCallback holds weak_ptr<relay> to break the cycle
+//   registry → forwarder → callback → relay → registry.
+//   CrossExecForwarderCallback holds weak_ptr<forwarder> to avoid a permanent
+//   ownership cycle; it locks eagerly on the calling thread (where the forwarder
+//   is alive) and moves the shared_ptr into the lambda to keep it alive across
+//   the executor hop.
+
+// Captures forwardChanged/newGroupRequested/onEmpty during setup (getOrCreate→setCallback window)
+// so they can be replayed once the real callback is installed.
+class PendingForwarderCallback : public moxygen::MoQForwarder::Callback {
+public:
+  PendingForwarderCallback(
+      openmoq::moqx::LocalForwarderRegistry* localReg,
+      moxygen::FullTrackName ftn
+  )
+      : localReg_(localReg), ftn_(std::move(ftn)) {}
+
+  void forwardChanged(moxygen::MoQForwarder*, bool f) override { lastForward_ = f; }
+  void newGroupRequested(moxygen::MoQForwarder*, uint64_t g) override {
+    maxGroup_ = std::max(maxGroup_.value_or(0), g);
+  }
+  void onEmpty(moxygen::MoQForwarder* forwarder) override {
+    localReg_->remove(ftn_, forwarder);
+    sawOnEmpty_ = true;
+  }
+
+  openmoq::moqx::LocalForwarderRegistry* localReg_;
+  moxygen::FullTrackName ftn_;
+  std::optional<bool> lastForward_;
+  std::optional<uint64_t> maxGroup_;
+  bool sawOnEmpty_{false};
+};
+
+// Runs on the publisher forwarder's executor (publisher's iothread). Propagates
+// channel-subscriber lifecycle events to the publisher and upstream handle.
+class ChannelForwarderCallback : public moxygen::MoQForwarder::Callback {
+public:
+  ChannelForwarderCallback(
+      std::weak_ptr<moxygen::MoQForwarder> weakPublisher,
+      folly::Executor* subscriberExec,
+      folly::Executor* publisherExec
+  )
+      : weakPublisher_(std::move(weakPublisher)), subscriberExec_(subscriberExec),
+        publisherExec_(publisherExec) {}
+
+  // Called on publisherExec immediately after addChannelSubscriber returns.
+  void setHandle(std::shared_ptr<moxygen::Publisher::SubscriptionHandle> h) {
+    handle_ = std::move(h);
+  }
+
+  // Holds the last filter ref so onEmpty can defer its destruction to subscriberExec_,
+  // letting in-flight this-capturing lambdas there run first (FIFO).
+  void setFilter(std::shared_ptr<CrossExecFilter> filter) { crossExecFilter_ = std::move(filter); }
+
+  void onEmpty(moxygen::MoQForwarder* /*localFwd*/) override {
+    auto publisher = weakPublisher_.lock();
+    if (publisher) {
+      publisher->removeChannelSubscriberByExec(subscriberExec_);
+    }
+    // handle_ pins the chain (localFwd → callbacks → handle_ → CrossExecFilter → localFwd).
+    // removeChannelSubscriberByExec drops the publisher's ref but not this; in the replace
+    // scenario it never ran, so reset handle_ unconditionally.
+    handle_.reset();
+    // Post filter destruction to subscriberExec_ so FIFO ordering guarantees
+    // all previously-enqueued this-capturing lambdas run before the destructor.
+    if (crossExecFilter_) {
+      subscriberExec_->add([f = std::move(crossExecFilter_)]() {});
+    }
+  }
+
+  void forwardChanged(moxygen::MoQForwarder*, bool forward) override {
+    if (!handle_) {
+      return;
+    }
+    launchUpdate(publisherExec_, doSubscribeUpdate(handle_, forward));
+  }
+
+  void newGroupRequested(moxygen::MoQForwarder*, uint64_t group) override {
+    if (!handle_) {
+      return;
+    }
+    launchUpdate(publisherExec_, doNewGroupRequestUpdate(handle_, group));
+  }
+
+private:
+  std::weak_ptr<moxygen::MoQForwarder> weakPublisher_;
+  folly::Executor* subscriberExec_;
+  folly::Executor* publisherExec_;
+  std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle_;
+  std::shared_ptr<CrossExecFilter> crossExecFilter_;
+};
+
+// Builds the local->publisher callback chain (Channel -> CrossExec -> LocalForwarder).
+// channelCb is wired with the channel handle/filter later, on publisherExec.
+struct LocalToPublisherCallbacks {
+  std::shared_ptr<ChannelForwarderCallback> channelCb;
+  std::shared_ptr<moxygen::MoQForwarder::Callback> finalCallback;
+};
+LocalToPublisherCallbacks buildLocalToPublisherCallbacks(
+    openmoq::moqx::LocalForwarderRegistry* localReg,
+    moxygen::FullTrackName ftn,
+    const std::shared_ptr<moxygen::MoQForwarder>& localFwd,
+    const std::shared_ptr<moxygen::MoQForwarder>& publisherFwd,
+    folly::Executor* publisherExec,
+    folly::Executor* subscriberExec
+) {
+  auto channelCb =
+      std::make_shared<ChannelForwarderCallback>(publisherFwd, subscriberExec, publisherExec);
+  auto crossExecCb =
+      std::make_shared<CrossExecForwarderCallback>(publisherExec, localFwd, channelCb);
+  auto finalCallback =
+      std::make_shared<LocalForwarderCallback>(localReg, std::move(ftn), std::move(crossExecCb));
+  return {std::move(channelCb), std::move(finalCallback)};
+}
+
+// Adds the local channel subscriber on publisherFwd and records its handle/filter on
+// channelCb. Must run on publisherExec.
+void installChannelSubscriber(
+    ChannelForwarderCallback& channelCb,
+    moxygen::MoQForwarder& publisherFwd,
+    folly::Executor* subscriberExec,
+    bool forward,
+    const std::shared_ptr<CrossExecFilter>& crossExecFilter
+) {
+  auto chanHandle = publisherFwd.addChannelSubscriber(subscriberExec, forward, crossExecFilter);
+  if (chanHandle) {
+    channelCb.setHandle(chanHandle);
+  }
+  channelCb.setFilter(crossExecFilter);
+}
+
+// Wires localFwd to publisherFwd as a channel subscriber, hopping to publisherExec.
+// Returns the finalCallback to install on localFwd. Used by the publish LF path.
+folly::coro::Task<std::shared_ptr<moxygen::MoQForwarder::Callback>> addLocalForwarderToPublisher(
+    openmoq::moqx::LocalForwarderRegistry* localReg,
+    moxygen::FullTrackName ftn,
+    std::shared_ptr<moxygen::MoQForwarder> localFwd,
+    std::shared_ptr<moxygen::MoQForwarder> publisherFwd,
+    folly::Executor* publisherExec,
+    folly::Executor* subscriberExec,
+    std::shared_ptr<CrossExecFilter> crossExecFilter,
+    bool forward
+) {
+  auto cbs = buildLocalToPublisherCallbacks(
+      localReg,
+      std::move(ftn),
+      localFwd,
+      publisherFwd,
+      publisherExec,
+      subscriberExec
+  );
+  co_await folly::coro::co_withExecutor(
+      folly::getKeepAliveToken(publisherExec),
+      [&]() -> folly::coro::Task<void> {
+        installChannelSubscriber(
+            *cbs.channelCb,
+            *publisherFwd,
+            subscriberExec,
+            forward,
+            crossExecFilter
+        );
+        co_return;
+      }()
+  );
+  co_return cbs.finalCallback;
+}
+
+// Installs finalCallback on localFwd and replays any forwardChanged/newGroupRequested
+// events captured during setup. Must run on subscriberExec.
+void replayPendingFowarderEvents(
+    moxygen::MoQForwarder* localFwd,
+    const std::shared_ptr<moxygen::MoQForwarder::Callback>& finalCallback,
+    const PendingForwarderCallback& pendingCb,
+    bool forward
+) {
+  localFwd->setCallback(finalCallback);
+  if (pendingCb.lastForward_ && *pendingCb.lastForward_ != forward) {
+    finalCallback->forwardChanged(localFwd, *pendingCb.lastForward_);
+  }
+  if (pendingCb.maxGroup_) {
+    finalCallback->newGroupRequested(localFwd, *pendingCb.maxGroup_);
+  }
+}
+} // namespace
+
+// Runs on subscriberExec. Gets or creates the thread-local forwarder for ftn, wires
+// it to publisherFwd as a channel subscriber (isNew path), and awaits the publish reply.
+folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
+    std::shared_ptr<MoQSession> subscriberSession,
+    std::shared_ptr<MoQForwarder> publisherFwd,
+    folly::Executor* publisherExec,
+    bool forward,
+    bool pinned
+) {
+  auto* subscriberExec = subscriberSession->getExecutor();
+  const auto& ftn = publisherFwd->fullTrackName();
+
+  // Fast path: local forwarder already exists on this thread.
+  if (auto* localReg = tlForwarders_.get()) {
+    if (auto localFwd = localReg->get(ftn)) {
+      auto p = startPublish(subscriberSession, localFwd, forward, pinned, nullptr);
+      if (p) {
+        co_await awaitPublishReply(localFwd, std::move(p->subscriber), std::move(p->reply));
+      }
+      co_return;
+    }
+  }
+
+  auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, [&] {
+    auto fwd = std::make_shared<MoQForwarder>(ftn, publisherFwd->largest());
+    fwd->setExtensions(publisherFwd->extensions());
+    return fwd;
+  });
+
+  auto p = startPublish(subscriberSession, localFwd, forward, pinned, nullptr);
+  if (!p) {
+    if (isNew) {
+      localReg->remove(ftn, localFwd.get());
+    }
+    co_return;
+  }
+
+  if (!isNew) {
+    co_await awaitPublishReply(localFwd, std::move(p->subscriber), std::move(p->reply));
+    co_return;
+  }
+
+  // isNew=true: wire localFwd into publisherFwd as a channel subscriber.
+  auto pendingCb = std::make_shared<PendingForwarderCallback>(localReg, ftn);
+  localFwd->setCallback(pendingCb);
+  // deepCopyPayload=true (default): each subscriber thread owns its IOBuf chain,
+  // avoiding cross-thread contention on the shared atomic refcount.
+  auto crossExecFilter = std::make_shared<CrossExecFilter>(subscriberExec, localFwd);
+  bool hasForwardingSub = (localFwd->numForwardingSubscribers() > 0);
+
+  auto finalCallback = co_await addLocalForwarderToPublisher(
+      localReg,
+      ftn,
+      localFwd,
+      publisherFwd,
+      publisherExec,
+      subscriberExec,
+      crossExecFilter,
+      hasForwardingSub
+  );
+
+  // Natural unwind: back on subscriberExec.
+
+  if (pendingCb->sawOnEmpty_) {
+    teardownLocalForwarderOnFailure(
+        publisherExec,
+        publisherFwd,
+        subscriberExec,
+        /*relayExec=*/nullptr,
+        localFwd,
+        "all subscribers cancelled during setup"
+    );
+    co_return;
+  }
+
+  replayPendingFowarderEvents(localFwd.get(), finalCallback, *pendingCb, hasForwardingSub);
+  co_await awaitPublishReply(localFwd, std::move(p->subscriber), std::move(p->reply));
+}
+
+// Slow-path local-forwarder bootstrap shared by the publish and subscribe LF paths:
+// ensures the thread-local registry, then getOrCreates the forwarder for ftn. Callers
+// handle the fast path and install the PendingForwarderCallback (timing differs).
+MoqxRelay::LocalForwarderBootstrap MoqxRelay::acquireLocalForwarder(
+    const FullTrackName& ftn,
+    folly::FunctionRef<std::shared_ptr<MoQForwarder>()> factory
+) {
+  if (!tlForwarders_.get()) {
+    tlForwarders_.reset(new LocalForwarderRegistry());
+  }
+  auto* localReg = tlForwarders_.get();
+  auto [localFwd, isNew] = localReg->getOrCreate(ftn, factory);
+  return {std::move(localFwd), isNew, localReg};
 }
 
 class MoqxRelay::NamespaceSubscription : public Publisher::SubscribeNamespaceHandle {
@@ -606,10 +1212,27 @@ std::shared_ptr<TrackConsumer> MoqxRelay::getSubscribeWriteback(
 
 SubscriptionRegistry::FilterChainResult
 MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForwarder> forwarder) {
-  // Build chain: TopNFilter → TerminationFilter → Forwarder
-  // Cache (if present) attaches as a passive subscriber of the forwarder so
-  // that it receives objects without affecting the forwarding-subscriber count
-  // or the upstream subscription lifecycle.
+  if (mode() == Mode::LocalForwarder) {
+    // Multi-iothread with local forwarders: publisher writes directly to forwarder on
+    // publisherExec. relayChainFilter (added by publish()) fans off to
+    // topNFilter/termination/cache.
+    std::shared_ptr<TrackConsumer> chainEnd =
+        cache_ ? cache_->makePassiveConsumer(ftn) : std::make_shared<moxygen::NullTrackConsumer>();
+    auto terminationFilter =
+        std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(chainEnd));
+    auto topNFilter = std::make_shared<TopNFilter>(
+        ftn,
+        std::static_pointer_cast<TrackConsumer>(terminationFilter)
+    );
+    topNFilter->setActivityThreshold(activityThreshold_);
+    return SubscriptionRegistry::FilterChainResult{
+        .consumer = std::static_pointer_cast<TrackConsumer>(forwarder),
+        .topNFilter = topNFilter
+    };
+  }
+
+  // Single-threaded: chain wraps forwarder directly (no cross-exec needed).
+  // Cache attaches as a passive subscriber of the forwarder.
   if (cache_) {
     forwarder->addSubscriber(
         /*session=*/nullptr,
@@ -626,7 +1249,6 @@ MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForward
   auto topNFilter =
       std::make_shared<TopNFilter>(ftn, std::static_pointer_cast<TrackConsumer>(terminationFilter));
   topNFilter->setActivityThreshold(activityThreshold_);
-
   return SubscriptionRegistry::FilterChainResult{
       .consumer = std::static_pointer_cast<TrackConsumer>(topNFilter),
       .topNFilter = topNFilter
@@ -678,7 +1300,6 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
   auto maybeNegotiatedVersion = session->getNegotiatedVersion();
   CHECK(maybeNegotiatedVersion.has_value());
 
-  // check auth
   // Allow empty namespace prefix only for draft-16 and above.
   if (subNs.trackNamespacePrefix.empty() && getDraftMajorVersion(*maybeNegotiatedVersion) < 16) {
     co_return folly::makeUnexpected(SubscribeNamespaceError{
@@ -732,10 +1353,7 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
             if (subNs.options == SubscribeNamespaceOptions::NAMESPACE ||
                 subNs.options == SubscribeNamespaceOptions::BOTH) {
               // Compute the suffix: prefix minus subNs.trackNamespacePrefix
-              TrackNamespace suffix(std::vector<std::string>(
-                  prefix.trackNamespace.begin() + subNs.trackNamespacePrefix.size(),
-                  prefix.trackNamespace.end()
-              ));
+              auto suffix = makeNamespaceSuffix(prefix, subNs.trackNamespacePrefix.size());
               namespacePublishHandle->namespaceMsg(suffix);
             }
           } else {
@@ -768,7 +1386,14 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
               (subNs.options == SubscribeNamespaceOptions::BOTH ||
                subNs.options == SubscribeNamespaceOptions::PUBLISH)) {
             if (publishSession != session) {
-              if (!addSubscriberAndPublish(session, forwarder, subNs.forward, /*pinned=*/true)) {
+              auto* publisherExec = relayExec_ ? publishSession->getExecutor() : nullptr;
+              if (!addSubscriberAndPublish(
+                      session,
+                      forwarder,
+                      subNs.forward,
+                      /*pinned=*/true,
+                      publisherExec
+                  )) {
                 XLOG(ERR) << "addSubscriberAndPublish failed for " << ftn;
                 return;
               }
@@ -807,7 +1432,6 @@ MoqxRelay::PublishState MoqxRelay::findPublishState(const FullTrackName& ftn) {
   );
 
   if (!nodePtr) {
-    // Node doesn't exist - tree was properly pruned
     return state;
   }
 
@@ -817,6 +1441,389 @@ MoqxRelay::PublishState MoqxRelay::findPublishState(const FullTrackName& ftn) {
 
   return state;
 }
+
+// === Multi-iothread subscribe helpers ===
+
+namespace {
+
+// The error returned when addSubscriber yields null (forwarder draining). Shared
+// by every subscribe path that attaches to a live forwarder; callers wrap it with
+// folly::makeUnexpected for their SubscribeResult.
+SubscribeError makeAddSubscriberError(RequestID requestID) {
+  return SubscribeError{requestID, SubscribeErrorCode::INTERNAL_ERROR, "failed to add subscriber"};
+}
+
+// Adds a subscriber to fwd, fires any pending NEW_GROUP_REQUEST, and maps a null
+// result (forwarder draining) to INTERNAL_ERROR. Shared by the subscribe paths
+// that attach to an already-live forwarder.
+Publisher::SubscribeResult attachSubscriber(
+    MoQForwarder& fwd,
+    std::shared_ptr<MoQSession> session,
+    const SubscribeRequest& subReq,
+    std::shared_ptr<TrackConsumer> consumer
+) {
+  auto subscriber = fwd.addSubscriber(std::move(session), subReq, std::move(consumer));
+  if (!subscriber) {
+    XLOG(ERR) << "addSubscriber returned null (draining?) for " << fwd.fullTrackName()
+              << " reqID=" << subReq.requestID;
+    return folly::makeUnexpected(makeAddSubscriberError(subReq.requestID));
+  }
+  XLOG(DBG4) << "added subscriber for ftn=" << fwd.fullTrackName();
+  fwd.tryProcessNewGroupRequest(subReq.params);
+  return subscriber;
+}
+
+} // namespace
+
+// Issues the upstream SUBSCRIBE on `upstream` and, on success, applies the OK to
+// publisherFwd (latest/extensions/NGR), returning the resolved OK. forward must
+// already be set on upstreamSubReq.
+folly::coro::Task<folly::Expected<MoqxRelay::UpstreamOk, SubscribeError>>
+MoqxRelay::subscribeUpstreamAndApplyOk(
+    std::shared_ptr<Publisher> upstream,
+    SubscribeRequest upstreamSubReq,
+    std::shared_ptr<TrackConsumer> upstreamConsumer,
+    std::shared_ptr<MoQForwarder> publisherFwd,
+    RequestID clientRequestID
+) {
+  auto params = upstreamSubReq.params; // copy before upstreamSubReq is moved
+  auto subRes =
+      co_await upstream->subscribe(std::move(upstreamSubReq), std::move(upstreamConsumer));
+  if (subRes.hasError()) {
+    co_return folly::makeUnexpected(SubscribeError{
+        clientRequestID,
+        subRes.error().errorCode,
+        folly::to<std::string>("upstream subscribe failed: ", subRes.error().reasonPhrase)
+    });
+  }
+  // Apply the OK to the forwarder; the NGR rides the outgoing SUBSCRIBE (record, don't fire).
+  const auto& ok = subRes.value()->subscribeOk();
+  if (ok.largest) {
+    publisherFwd->updateLargest(ok.largest->group, ok.largest->object);
+  }
+  publisherFwd->setExtensions(ok.extensions);
+  publisherFwd->tryProcessNewGroupRequest(params, /*fire=*/false);
+  // Moving the handle shared_ptr keeps the pointee (and `ok`) alive, so reading ok.*
+  // in the same initializer is well-defined.
+  co_return UpstreamOk{std::move(subRes.value()), ok.requestID, ok.extensions, ok.largest};
+}
+
+// Runs on relayExec_: caches the OK's extensions and fulfills `pending`, returning a
+// SubscribeError on reconnect (pending replaced) or nullopt. Shared by subscribeImpl
+// and the LF path; the caller applies upstreamOk.largest (target differs per path).
+std::optional<SubscribeError> MoqxRelay::completeUpstreamSubscription(
+    const FullTrackName& ftn,
+    UpstreamOk& upstreamOk,
+    SubscriptionRegistry::UpstreamSubscribePending& pending,
+    std::shared_ptr<MoQSession> upstreamSession,
+    std::shared_ptr<Publisher> upstreamPublisher,
+    RequestID clientRequestID
+) {
+  if (cache_) {
+    cache_->setTrackExtensions(ftn, upstreamOk.extensions);
+  }
+  if (!pending.complete(
+          std::move(upstreamOk.handle),
+          upstreamOk.requestID,
+          std::move(upstreamSession),
+          std::move(upstreamPublisher)
+      )) {
+    XLOG(ERR) << "Subscription replaced by reconnecting publisher: " << ftn;
+    return SubscribeError{
+        clientRequestID,
+        SubscribeErrorCode::INTERNAL_ERROR,
+        "publisher reconnected during subscribe"
+    };
+  }
+  return std::nullopt;
+}
+
+// Runs on relayExec_. Registers the subscribe and wires the local forwarder to the
+// publisher; if it's a new subscription,also installs the passive relay chain, issues the
+// upstream subscribe, and completes the setup. The subscriberExec tail reads the
+// returned PublisherAttachment (handles upstreamOk).
+folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwarderOnRelayExec(
+    const SubscribeRequest& subReq,
+    LocalForwarderRegistry* localReg,
+    std::shared_ptr<MoQForwarder> localFwd,
+    folly::Executor* subscriberExec,
+    std::shared_ptr<CrossExecFilter> crossExecFilter,
+    bool forward
+) {
+  // Runs on relayExec_.
+  const auto& ftn = subReq.fullTrackName;
+  PublisherAttachment attach;
+
+  auto sr = co_await joinOrPrepareUpstreamSubscription(subReq);
+  if (sr.error) {
+    attach.error = std::move(*sr.error);
+    co_return attach; // pending dtor fires when sr is destroyed, cleaning the registry
+  }
+  attach.publisherFwd = sr.publisherForwarder;
+  attach.publisherExec = sr.publisherExec;
+  if (!attach.publisherFwd || !attach.publisherExec) {
+    co_return attach;
+  }
+  attach.ownsRelayChain = sr.firstSetup.has_value();
+
+  // Single publisherExec sortie for all publisherFwd mutation: the local channel sub and,
+  // for the first subscriber, the passive relay chain + upstream subscribe. Merging the
+  // two installs drops a relayExec_ round-trip.
+  auto cbs = buildLocalToPublisherCallbacks(
+      localReg,
+      ftn,
+      localFwd,
+      attach.publisherFwd,
+      attach.publisherExec,
+      subscriberExec
+  );
+  attach.finalCallback = cbs.finalCallback;
+
+  std::shared_ptr<CrossExecFilter> relayChainFilter;
+  std::optional<folly::Expected<UpstreamOk, SubscribeError>> upstreamResult;
+
+  co_await folly::coro::co_withExecutor(
+      folly::getKeepAliveToken(attach.publisherExec),
+      [&]() -> folly::coro::Task<void> {
+        installChannelSubscriber(
+            *cbs.channelCb,
+            *attach.publisherFwd,
+            subscriberExec,
+            forward,
+            crossExecFilter
+        );
+
+        if (sr.firstSetup) {
+          auto& setup = *sr.firstSetup;
+          // Passive relay chain (top-N/termination/cache): forward=true so it observes every
+          // object, passive=true so it doesn't count as a forwarding subscriber or in the
+          // onEmpty quorum (the publisher's onEmpty still fires when the last real sub leaves).
+          relayChainFilter = std::make_shared<CrossExecFilter>(relayExec_, nullptr);
+          attach.publisherFwd->addChannelSubscriber(
+              relayExec_,
+              /*forward=*/true,
+              relayChainFilter,
+              /*passive=*/true
+          );
+          setup.upstreamSubReq.forward = forward;
+          upstreamResult = co_await subscribeUpstreamAndApplyOk(
+              setup.upstreamSession,
+              std::move(setup.upstreamSubReq),
+              std::move(setup.upstreamConsumer),
+              attach.publisherFwd,
+              setup.clientRequestID
+          );
+        }
+      }()
+  );
+  // Back on relayExec_.
+
+  if (!sr.firstSetup) {
+    co_return attach; // subsequent subscriber: wired to the live publisher, done
+  }
+
+  if (upstreamResult->hasError()) {
+    // Upstream subscribe failed: drop the channel sub(s) we installed (the relay-exec
+    // sub too, since firstSetup owns the relay chain). localFwd is drained by the tail.
+    teardownLocalForwarderOnFailure(
+        attach.publisherExec,
+        attach.publisherFwd,
+        subscriberExec,
+        relayChainFilter ? relayExec_ : nullptr
+    );
+    attach.error = folly::makeUnexpected(std::move(upstreamResult->error()));
+    co_return attach;
+  }
+  auto upstreamOk = std::move(upstreamResult->value());
+
+  // Wire the relay chain to topNFilter before pending.complete() so buffered objects
+  // see the filter.
+  if (relayChainFilter) {
+    auto topNView = registry_.getTopNView(ftn);
+    if (topNView && topNView->topNFilter) {
+      relayChainFilter->setDownstream(topNView->topNFilter);
+    }
+  }
+
+  auto& setup = *sr.firstSetup;
+  if (auto err = completeUpstreamSubscription(
+          ftn,
+          upstreamOk,
+          setup.pending,
+          setup.upstreamSession,
+          maybeWrapPublisher(relayExec_, setup.upstreamSession),
+          setup.clientRequestID
+      )) {
+    // Reconnect race: matches prior behavior — no channel-sub teardown here; the tail
+    // drains localFwd, and the replaced registry entry already owns the publisher.
+    attach.error = folly::makeUnexpected(std::move(*err));
+    co_return attach;
+  }
+  attach.upstreamOk = std::move(upstreamOk);
+  co_return attach;
+}
+
+// Runs on relayExec_: registry lookup + FirstSubscriber setup. Defers the upstream
+// subscribe to attachNewLocalForwarderOnRelayExec (issued from its publisherExec sortie,
+// after the channel subs are installed); returns firstSetup for it to complete.
+folly::coro::Task<MoqxRelay::StatefulSubscribeResult>
+MoqxRelay::joinOrPrepareUpstreamSubscription(SubscribeRequest subReq) {
+  const auto& ftn = subReq.fullTrackName;
+
+  if (!registry_.exists(ftn) && upstream_ &&
+      !namespaceTree_.findPublisherSession(ftn.trackNamespace)) {
+    co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
+  }
+
+  auto firstOrSubsequent = registry_.getOrCreateFromSubscribe(
+      ftn,
+      shared_from_this(),
+      [this, &ftn](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(ftn, std::move(f)); }
+  );
+
+  if (auto* first = std::get_if<SubscriptionRegistry::FirstSubscriber>(&firstOrSubsequent)) {
+    auto upstreamSession = namespaceTree_.findPublisherSession(ftn.trackNamespace);
+    if (!upstreamSession) {
+      co_return StatefulSubscribeResult{
+          nullptr,
+          nullptr,
+          folly::makeUnexpected(SubscribeError{
+              subReq.requestID,
+              SubscribeErrorCode::DOES_NOT_EXIST,
+              "no such namespace or track"
+          }),
+          std::nullopt
+      };
+    }
+
+    const auto clientRequestID = subReq.requestID;
+    // forward updated to its real value in attachNewLocalForwarderOnRelayExec.
+    SubscribeRequest upstreamSubReq = makeUpstreamSubReq(subReq, /*forward=*/false);
+
+    // first->consumer is the publisher forwarder (lives on publisherExec == upstreamSession's
+    // executor). No cross-exec wrapping — upstream delivers on that executor directly.
+    auto upstreamConsumer = first->consumer;
+    StatefulSubscribeResult
+        result{first->forwarder, upstreamSession->getExecutor(), std::nullopt, std::nullopt};
+    result.firstSetup.emplace(StatefulSubscribeResult::FirstSubscriberSetup{
+        upstreamSession,
+        std::move(upstreamSubReq),
+        std::move(upstreamConsumer),
+        std::move(first->pending),
+        clientRequestID
+    });
+    co_return result;
+
+  } else {
+    auto sub = co_await std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
+        std::move(firstOrSubsequent)
+    );
+    auto upstreamView = registry_.getUpstreamView(ftn);
+    auto* publisherExec = upstreamView ? upstreamView->publisherExec : nullptr;
+    co_return StatefulSubscribeResult{sub.forwarder, publisherExec, std::nullopt, std::nullopt};
+  }
+}
+
+// Multi-iothread subscribe: subscriber-thread orchestrator.
+// Dispatches attachNewLocalForwarderOnRelayExec to relayExec_, then on the subscriber thread
+// creates a local forwarder, wires a channel subscriber, and returns.
+folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriberExec(
+    SubscribeRequest subReq,
+    std::shared_ptr<TrackConsumer> consumer,
+    std::shared_ptr<MoQSession> session,
+    folly::Executor* subscriberExec
+) {
+  const auto& ftn = subReq.fullTrackName;
+
+  // getOrCreate before the relay hop: serializes same-iothread races. isNew=false means
+  // the forwarder already exists (or a setup is in progress) on this thread — just attach.
+  auto [localFwd, isNew, localReg] =
+      acquireLocalForwarder(ftn, [&] { return std::make_shared<MoQForwarder>(ftn); });
+
+  if (!isNew) {
+    if (auto err = checkRangeNotInPast(*localFwd, subReq)) {
+      co_return folly::makeUnexpected(std::move(*err));
+    }
+    co_return attachSubscriber(*localFwd, std::move(session), subReq, std::move(consumer));
+  }
+
+  // isNew=true: this thread owns setup. Install PendingForwarderCallback first so
+  // forwardChanged/newGroupRequested/onEmpty events during setup are captured for replay.
+  auto pendingCb = std::make_shared<PendingForwarderCallback>(localReg, ftn);
+  localFwd->setCallback(pendingCb);
+
+  // deepCopyPayload=true (default): each subscriber thread owns its IOBuf chain,
+  // avoiding cross-thread contention on the shared atomic refcount.
+  auto crossExecFilter = std::make_shared<CrossExecFilter>(subscriberExec, localFwd);
+
+  // addSubscriber before the relay hop: numForwardingSubscribers() must be correct
+  // when addChannelSubscriber runs on publisherExec, so forward flag is right from the start.
+  auto sub = localFwd->addSubscriber(session, subReq, std::move(consumer));
+  if (!sub) {
+    localReg->remove(ftn, localFwd.get());
+    co_return folly::makeUnexpected(makeAddSubscriberError(subReq.requestID));
+  }
+  bool forward = (localFwd->numForwardingSubscribers() > 0);
+
+  // Relay phase: register + wire (+ maybe first-subscriber upstream subscribe) on relayExec_,
+  // returning what the tail needs instead of mutating across the suspend.
+  auto attach = co_await folly::coro::co_withExecutor(
+      folly::getKeepAliveToken(relayExec_),
+      attachNewLocalForwarderOnRelayExec(
+          subReq,
+          localReg,
+          localFwd,
+          subscriberExec,
+          crossExecFilter,
+          forward
+      )
+  );
+
+  // Back on subscriberExec.
+
+  if (pendingCb->sawOnEmpty_) {
+    // All subscribers left during setup (localReg entry already removed by
+    // PendingForwarderCallback::onEmpty). Drop the channel sub(s); the registry entry +
+    // upstream sub remain, so a later subscribe takes the SubsequentSubscriber path.
+    teardownLocalForwarderOnFailure(
+        attach.publisherExec,
+        attach.publisherFwd,
+        subscriberExec,
+        attach.ownsRelayChain ? relayExec_ : nullptr
+    );
+    co_return folly::makeUnexpected(SubscribeError{
+        subReq.requestID,
+        SubscribeErrorCode::INTERNAL_ERROR,
+        "all subscribers cancelled during setup"
+    });
+  }
+
+  if (attach.error) {
+    localFwd->publishDone(PublishDone{
+        RequestID(0),
+        PublishDoneStatusCode::INTERNAL_ERROR,
+        0,
+        attach.error->error().reasonPhrase
+    });
+    localReg->remove(ftn, localFwd.get());
+    co_return std::move(*attach.error);
+  }
+
+  if (attach.upstreamOk) {
+    localFwd->setExtensions(attach.upstreamOk->extensions);
+    if (attach.upstreamOk->largest) {
+      localFwd->updateLargest(
+          attach.upstreamOk->largest->group,
+          attach.upstreamOk->largest->object
+      );
+    }
+  }
+  replayPendingFowarderEvents(localFwd.get(), attach.finalCallback, *pendingCb, forward);
+  localFwd->tryProcessNewGroupRequest(subReq.params);
+  co_return sub;
+}
+
+// === End multi-iothread subscribe helpers ===
 
 folly::coro::Task<Publisher::SubscribeResult>
 MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consumer) {
@@ -864,55 +1871,41 @@ MoqxRelay::subscribeImpl(SubscribeRequest subReq, std::shared_ptr<TrackConsumer>
     if (!subscriber) {
       XLOG(ERR) << "addSubscriber returned null (draining?) for " << ftn
                 << " reqID=" << subReq.requestID;
-      co_return folly::makeUnexpected(SubscribeError{
-          subReq.requestID,
-          SubscribeErrorCode::INTERNAL_ERROR,
-          "failed to add subscriber"
-      });
+      co_return folly::makeUnexpected(makeAddSubscriberError(subReq.requestID));
     }
     XLOG(DBG4) << "added subscriber for ftn=" << ftn;
 
-    // Override fields for the upstream subscribe: always request from latest,
-    // upstream priority, and default group order.
+    // Subscribe upstream with forward set only while we have forwarding
+    // subscribers, so an idle relay doesn't pull data it won't deliver.
     const auto clientRequestID = subReq.requestID;
-    subReq.priority = kDefaultUpstreamPriority;
-    subReq.groupOrder = GroupOrder::Default;
-    subReq.locType = LocationType::LargestObject;
-    // Per the spec, we're supposed to always forward=1 upstream
-    subReq.forward = first->forwarder->numForwardingSubscribers() > 0;
+    subReq =
+        makeUpstreamSubReq(std::move(subReq), first->forwarder->numForwardingSubscribers() > 0);
 
-    auto subRes = co_await upstreamPublisher->subscribe(subReq, first->consumer);
-    if (subRes.hasError()) {
-      co_return folly::makeUnexpected(SubscribeError(
-          {clientRequestID,
-           subRes.error().errorCode,
-           folly::to<std::string>("upstream subscribe failed: ", subRes.error().reasonPhrase)}
-      ));
-    } // pending destructor fires on error
-
-    auto largest = subRes.value()->subscribeOk().largest;
-    if (largest) {
-      first->forwarder->updateLargest(largest->group, largest->object);
-      subscriber->updateLargest(*largest);
+    // Upstream subscribe + apply OK to the forwarder (NGR recorded without firing).
+    // pending destructor fires on the error path.
+    auto okOrErr = co_await subscribeUpstreamAndApplyOk(
+        upstreamPublisher,
+        std::move(subReq),
+        first->consumer,
+        first->forwarder,
+        clientRequestID
+    );
+    if (okOrErr.hasError()) {
+      co_return folly::makeUnexpected(std::move(okOrErr.error()));
     }
-    auto& upstreamExtensions = subRes.value()->subscribeOk().extensions;
-    first->forwarder->setExtensions(upstreamExtensions);
-    if (cache_) {
-      cache_->setTrackExtensions(ftn, upstreamExtensions);
+    auto& ok = okOrErr.value();
+    if (ok.largest) {
+      subscriber->updateLargest(*ok.largest);
     }
-
-    // Record NGR as outstanding (no fire — it rides the outgoing SUBSCRIBE).
-    first->forwarder->tryProcessNewGroupRequest(subReq.params, /*fire=*/false);
-
-    auto requestID = subRes.value()->subscribeOk().requestID;
-    if (!first->pending
-             .complete(std::move(subRes.value()), requestID, upstreamSession, upstreamPublisher)) {
-      XLOG(ERR) << "Subscription replaced by reconnecting publisher: " << ftn;
-      co_return folly::makeUnexpected(SubscribeError{
-          clientRequestID,
-          SubscribeErrorCode::INTERNAL_ERROR,
-          "publisher reconnected during subscribe"
-      });
+    if (auto err = completeUpstreamSubscription(
+            ftn,
+            ok,
+            first->pending,
+            upstreamSession,
+            upstreamPublisher,
+            clientRequestID
+        )) {
+      co_return folly::makeUnexpected(std::move(*err));
     }
     co_return subscriber;
 
@@ -921,27 +1914,10 @@ MoqxRelay::subscribeImpl(SubscribeRequest subReq, std::shared_ptr<TrackConsumer>
         std::move(firstOrSubsequent)
     );
     // sub.forwarder is valid: promise was fulfilled by first subscriber
-    if (sub.forwarder->largest() && subReq.locType == LocationType::AbsoluteRange &&
-        subReq.endGroup < sub.forwarder->largest()->group) {
-      co_return folly::makeUnexpected(SubscribeError{
-          subReq.requestID,
-          SubscribeErrorCode::INVALID_RANGE,
-          "Range in the past, use FETCH"
-      });
+    if (auto err = checkRangeNotInPast(*sub.forwarder, subReq)) {
+      co_return folly::makeUnexpected(std::move(*err));
     }
-    auto subscriber = sub.forwarder->addSubscriber(std::move(session), subReq, std::move(consumer));
-    if (!subscriber) {
-      XLOG(ERR) << "addSubscriber returned null (draining?) for " << ftn
-                << " reqID=" << subReq.requestID;
-      co_return folly::makeUnexpected(SubscribeError{
-          subReq.requestID,
-          SubscribeErrorCode::INTERNAL_ERROR,
-          "failed to add subscriber"
-      });
-    }
-    XLOG(DBG4) << "added subscriber for ftn=" << ftn;
-    sub.forwarder->tryProcessNewGroupRequest(subReq.params);
-    co_return subscriber;
+    co_return attachSubscriber(*sub.forwarder, std::move(session), subReq, std::move(consumer));
   }
 }
 
@@ -1111,12 +2087,7 @@ void MoqxRelay::onEmptyImpl(const FullTrackName& ftn) {
   if (upstreamView->isPublish) {
     // if it's publish, don't unsubscribe, just subscribeUpdate forward=false
     XLOG(DBG1) << "Updating upstream subscription forward=false";
-    auto exec = relayExec();
-    co_withExecutor(
-        folly::getKeepAliveToken(exec),
-        doSubscribeUpdate(upstreamView->handle, /*forward=*/false)
-    )
-        .start();
+    launchUpdate(relayExec(), doSubscribeUpdate(upstreamView->handle, /*forward=*/false));
   } else {
     upstreamView->handle->unsubscribe();
     XLOG(DBG4) << "Erasing subscription to " << ftn;
@@ -1144,9 +2115,7 @@ void MoqxRelay::forwardChangedImpl(const FullTrackName& ftn, bool forward) {
   }
   XLOG(INFO) << "Updating forward for " << ftn << " forward=" << forward;
 
-  auto exec = relayExec();
-  co_withExecutor(folly::getKeepAliveToken(exec), doSubscribeUpdate(upstreamView->handle, forward))
-      .start();
+  launchUpdate(relayExec(), doSubscribeUpdate(upstreamView->handle, forward));
 }
 
 void MoqxRelay::newGroupRequested(MoQForwarder* forwarder, uint64_t group) {
@@ -1162,10 +2131,7 @@ void MoqxRelay::newGroupRequestedImpl(const FullTrackName& ftn, uint64_t group) 
   }
   XLOG(INFO) << "New group request detected for " << ftn;
 
-  auto exec = relayExec();
-  auto handle = upstreamView->handle;
-  co_withExecutor(folly::getKeepAliveToken(exec), doNewGroupRequestUpdate(std::move(handle), group))
-      .start();
+  launchUpdate(relayExec(), doNewGroupRequestUpdate(upstreamView->handle, group));
 }
 
 // TRACK_FILTER support
@@ -1291,14 +2257,12 @@ void MoqxRelay::onTrackSelected(
     return;
   }
 
-  auto exec = session->getExecutor();
-  XCHECK(exec) << "onTrackSelected: null executor for session " << session.get();
-
-  // TODO: Consider batching multiple addSubscriberAndPublish calls on the same
-  // executor when multiple tracks are selected for the same session in a single
-  // ranking update.
+  auto upstreamView = registry_.getUpstreamView(ftn);
+  XCHECK(!relayExec_ || (upstreamView && upstreamView->publisherExec))
+      << "onTrackSelected: relayExec set but no publisherExec for " << ftn;
+  auto* publisherExec = relayExec_ ? upstreamView->publisherExec : nullptr;
   // TRACK_FILTER subscribers are unpinned so onTrackEvicted can remove them.
-  addSubscriberAndPublish(session, trackForwarder, forward, /*pinned=*/false);
+  addSubscriberAndPublish(session, trackForwarder, forward, /*pinned=*/false, publisherExec);
 }
 
 void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -13,12 +13,14 @@
 #include "SubscriptionRegistry.h"
 #include "UpstreamProvider.h"
 #include "config/Config.h"
+#include "relay/LocalForwarderRegistry.h"
 #include "relay/PropertyRanking.h"
 #include "relay/RelayExecUtil.h"
 #include <moxygen/MoQSession.h>
 #include <moxygen/relay/MoQForwarder.h>
 
 #include <folly/Executor.h>
+#include <folly/ThreadLocal.h>
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #include <optional>
@@ -27,10 +29,8 @@
 #include <vector>
 
 namespace openmoq::moqx {
-class CrossExecForwarderCallback;
-} // namespace openmoq::moqx
 
-namespace openmoq::moqx {
+class CrossExecFilter;
 
 // Visitor interface for relay state inspection.
 // MoqxRelay::dumpState() calls these methods while walking internal state.
@@ -104,17 +104,20 @@ public:
   static constexpr uint64_t kDefaultMaxDeselected = 0;
 
   // relayExec, when set, is owned by the relay and isolates all state on it;
-  // null runs everything on the calling thread.
+  // null runs everything on the calling thread. useLocalForwarders (requires
+  // relayExec) enables the per-thread local-forwarder data plane.
   explicit MoqxRelay(
       config::CacheConfig cache = {},
       std::string relayID = {},
       std::shared_ptr<folly::Executor> relayExec = nullptr,
+      bool useLocalForwarders = false,
       uint64_t maxDeselected = kDefaultMaxDeselected,
       std::chrono::milliseconds idleTimeout = kDefaultIdleTimeout,
       std::chrono::milliseconds activityThreshold = kDefaultActivityThreshold
   )
       : relayID_(std::move(relayID)), ownedRelayExec_(std::move(relayExec)),
-        relayExec_(ownedRelayExec_.get()), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
+        relayExec_(ownedRelayExec_.get()), useLocalForwarders_(useLocalForwarders),
+        maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
         activityThreshold_(activityThreshold) {
     if (cache.maxCachedTracks > 0) {
       cache_ = std::make_unique<MoqxCache>(cache.maxCachedTracks, cache.maxCachedGroupsPerTrack);
@@ -131,8 +134,8 @@ public:
     allowedNamespacePrefix_ = std::move(allowed);
   }
 
-  // Per-session publish/subscribe handlers. Returns the relay itself today; the
-  // hook exists so cross-exec/data-plane wrapping can slot in here later.
+  // Returns the per-session publish/subscribe handler: a local-forwarder or
+  // cross-exec filter when relayExec_ is set, otherwise the relay itself.
   std::shared_ptr<moxygen::Publisher> createPublisherFilter();
   std::shared_ptr<moxygen::Subscriber> createSubscriberFilter();
 
@@ -248,6 +251,8 @@ public:
 private:
   class NamespaceSubscription;
   class TerminationFilter;
+  class LocalSubscribeFilter;
+  class LocalPublishFilter;
 
   void unsubscribeNamespace(
       const moxygen::TrackNamespace& prefix,
@@ -264,9 +269,8 @@ private:
   void forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) override;
   void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override;
 
-  // FTN-keyed impl variants — called by CrossExecForwarderCallback (relay exec)
-  // or directly from the non-cross-exec callbacks above.
-  friend class CrossExecForwarderCallback;
+  // FTN-keyed impl variants — called by the MoQForwarder::Callback overrides
+  // above (single-thread) or by WeakRelayForwarderCallback on relay exec.
   void onEmptyImpl(const moxygen::FullTrackName& ftn);
   void forwardChangedImpl(const moxygen::FullTrackName& ftn, bool forward);
   void newGroupRequestedImpl(const moxygen::FullTrackName& ftn, uint64_t group);
@@ -277,9 +281,6 @@ private:
       std::shared_ptr<NamespaceTree::NamespaceNode> nodePtr
   );
 
-  // Sync setup: addSubscriber → set pinned → session->publish (via
-  // SubscriberCrossExecFilter when subscriberExec is non-null) → set
-  // trackConsumer. Returns nullopt and cleans up on any synchronous failure.
   struct PreparedPublish {
     std::shared_ptr<moxygen::MoQForwarder::Subscriber> subscriber;
     folly::coro::Task<folly::Expected<moxygen::PublishOk, moxygen::PublishError>> reply;
@@ -292,21 +293,53 @@ private:
       folly::Executor* subscriberExec
   );
 
-  // Calls startPublish and fires the reply as a free-running coroutine.
-  // Returns false and cleans up on any synchronous failure.
+  struct LocalForwarderBootstrap {
+    std::shared_ptr<moxygen::MoQForwarder> localFwd;
+    bool isNew{false};
+    LocalForwarderRegistry* localReg{nullptr};
+  };
+  LocalForwarderBootstrap acquireLocalForwarder(
+      const moxygen::FullTrackName& ftn,
+      folly::FunctionRef<std::shared_ptr<moxygen::MoQForwarder>()> factory
+  );
+
   bool addSubscriberAndPublish(
-      std::shared_ptr<moxygen::MoQSession> session,
+      std::shared_ptr<moxygen::MoQSession> subscriberSession,
       std::shared_ptr<moxygen::MoQForwarder> forwarder,
+      bool forward,
+      bool pinned,
+      folly::Executor* publisherExec = nullptr
+  );
+
+  folly::coro::Task<void> addSubscriberAndPublishViaLocalForwarder(
+      std::shared_ptr<moxygen::MoQSession> subscriberSession,
+      std::shared_ptr<moxygen::MoQForwarder> publisherFwd,
+      folly::Executor* publisherExec,
       bool forward,
       bool pinned
   );
 
-  folly::coro::Task<void>
-  doSubscribeUpdate(std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle, bool forward);
-
-  folly::coro::Task<void> doNewGroupRequestUpdate(
+  moxygen::Subscriber::PublishResult publishFromPublisherExec(
+      moxygen::PublishRequest pub,
       std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
-      uint64_t newGroupRequestValue
+      std::shared_ptr<moxygen::MoQSession> session
+  );
+
+  // Constructs the publisher's local forwarder and installs its callback chain on
+  // publisherExec. tlForwarders_ must already be initialized.
+  std::shared_ptr<moxygen::MoQForwarder> createPublisherForwarder(const moxygen::PublishRequest& pub
+  );
+
+  std::optional<moxygen::PublishError>
+  validatePublishNamespace(const moxygen::FullTrackName& ftn, moxygen::RequestID requestID) const;
+
+  folly::coro::Task<folly::Expected<moxygen::PublishOk, moxygen::PublishError>>
+  registerPublishOnRelayExec(
+      moxygen::PublishRequest pub,
+      std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
+      std::shared_ptr<moxygen::MoQSession> session,
+      std::shared_ptr<moxygen::MoQForwarder> publisherFwd,
+      std::shared_ptr<CrossExecFilter> relayChainFilter
   );
 
   // TRACK_FILTER support
@@ -361,6 +394,81 @@ private:
       std::shared_ptr<moxygen::TrackConsumer> consumer
   );
 
+  // Result of joinOrPrepareUpstreamSubscription (runs on relayExec_).
+  struct StatefulSubscribeResult {
+    std::shared_ptr<moxygen::MoQForwarder> publisherForwarder;
+    folly::Executor* publisherExec{nullptr}; // owning executor of publisherForwarder
+    std::optional<SubscribeResult> error;    // set on failure
+
+    // Set only for the FirstSubscriber path. Consumed by
+    // attachNewLocalForwarderOnRelayExec's publisherExec sortie (passive relay chain +
+    // upstream subscribe). Pending destructor fires on abandoned move.
+    struct FirstSubscriberSetup {
+      std::shared_ptr<moxygen::MoQSession> upstreamSession;
+      moxygen::SubscribeRequest upstreamSubReq;
+      std::shared_ptr<moxygen::TrackConsumer> upstreamConsumer;
+      SubscriptionRegistry::UpstreamSubscribePending pending;
+      moxygen::RequestID clientRequestID;
+    };
+    std::optional<FirstSubscriberSetup> firstSetup;
+  };
+
+  folly::coro::Task<StatefulSubscribeResult>
+  joinOrPrepareUpstreamSubscription(moxygen::SubscribeRequest subReq);
+
+  struct UpstreamOk {
+    std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle;
+    moxygen::RequestID requestID;
+    moxygen::Extensions extensions;
+    std::optional<moxygen::AbsoluteLocation> largest;
+  };
+
+  folly::coro::Task<folly::Expected<UpstreamOk, moxygen::SubscribeError>>
+  subscribeUpstreamAndApplyOk(
+      std::shared_ptr<moxygen::Publisher> upstream,
+      moxygen::SubscribeRequest upstreamSubReq,
+      std::shared_ptr<moxygen::TrackConsumer> upstreamConsumer,
+      std::shared_ptr<moxygen::MoQForwarder> publisherFwd,
+      moxygen::RequestID clientRequestID
+  );
+
+  std::optional<moxygen::SubscribeError> completeUpstreamSubscription(
+      const moxygen::FullTrackName& ftn,
+      UpstreamOk& upstreamOk,
+      SubscriptionRegistry::UpstreamSubscribePending& pending,
+      std::shared_ptr<moxygen::MoQSession> upstreamSession,
+      std::shared_ptr<moxygen::Publisher> upstreamPublisher,
+      moxygen::RequestID clientRequestID
+  );
+
+  // Output of attachNewLocalForwarderOnRelayExec, read on the subscriberExec tail. The relay
+  // chain filter is not exposed (setDownstream/teardown happen inside attach); the tail
+  // needs only ownsRelayChain to gate the sawOnEmpty teardown.
+  struct PublisherAttachment {
+    std::shared_ptr<moxygen::MoQForwarder> publisherFwd;
+    folly::Executor* publisherExec{nullptr};
+    bool ownsRelayChain{false}; // firstSetup path installed the passive relay chain
+    std::shared_ptr<moxygen::MoQForwarder::Callback> finalCallback;
+    std::optional<UpstreamOk> upstreamOk;
+    std::optional<SubscribeResult> error; // set => bail
+  };
+
+  folly::coro::Task<PublisherAttachment> attachNewLocalForwarderOnRelayExec(
+      const moxygen::SubscribeRequest& subReq,
+      LocalForwarderRegistry* localReg,
+      std::shared_ptr<moxygen::MoQForwarder> localFwd,
+      folly::Executor* subscriberExec,
+      std::shared_ptr<CrossExecFilter> crossExecFilter,
+      bool forward
+  );
+
+  folly::coro::Task<SubscribeResult> subscribeFromSubscriberExec(
+      moxygen::SubscribeRequest subReq,
+      std::shared_ptr<moxygen::TrackConsumer> consumer,
+      std::shared_ptr<moxygen::MoQSession> session,
+      folly::Executor* subscriberExec
+  );
+
   // Impl methods — run on relayExec_ when set, or inline when relayExec_==nullptr.
   folly::coro::Task<SubscribeResult>
   subscribeImpl(moxygen::SubscribeRequest subReq, std::shared_ptr<moxygen::TrackConsumer> consumer);
@@ -378,13 +486,26 @@ private:
   );
   folly::coro::Task<void> onUpstreamConnectImpl(std::shared_ptr<moxygen::MoQSession> session);
 
+  // Synchronous result of publishWithSession: the consumer the publisher writes
+  // to and the PublishOk to return to the publisher.  Returned synchronously so
+  // the reply coro (coPublish) can co_return the PublishOk immediately after
+  // setup without waiting for any downstream peer handshake.
+  struct PublishSetup {
+    std::shared_ptr<moxygen::TrackConsumer> consumer;
+    moxygen::PublishOk publishOk;
+  };
+  using PublishSetupResult = folly::Expected<PublishSetup, moxygen::PublishError>;
+
   // Contains all the inline publish() logic, taking session explicitly so it
   // can be called from either the I/O thread (relayExec_==nullptr) or from
   // coPublish on relay exec (where getRequestSession() would return null).
-  PublishResult publishWithSession(
+  // If forwarder is non-null it is used as-is (pre-created by publish()); otherwise
+  // a new forwarder is created from pub (single-threaded or subscribeNamespace path).
+  PublishSetupResult publishWithSession(
       moxygen::PublishRequest pub,
       std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
-      std::shared_ptr<moxygen::MoQSession> session
+      std::shared_ptr<moxygen::MoQSession> session,
+      std::shared_ptr<moxygen::MoQForwarder> forwarder = nullptr
   );
 
   std::shared_ptr<folly::Executor> ownedRelayExec_;
@@ -401,6 +522,20 @@ private:
 
   folly::Executor* relayExec() const { return relayExec_ ? relayExec_ : sessionExec_; }
 
+  // The relay's execution mode, derived from relayExec_/useLocalForwarders_:
+  //   SingleThread   - relayExec_ == nullptr: everything inline on the I/O thread.
+  //   RelayExec      - relayExec_ set, useLocalForwarders_ == false: relay state
+  //                    isolated on relayExec_; sessions hop via cross-exec filters.
+  //   LocalForwarder - relayExec_ set, useLocalForwarders_ == true: per-thread
+  //                    local forwarders shortcut the data plane.
+  enum class Mode { SingleThread, RelayExec, LocalForwarder };
+  Mode mode() const {
+    if (!relayExec_) {
+      return Mode::SingleThread;
+    }
+    return useLocalForwarders_ ? Mode::LocalForwarder : Mode::RelayExec;
+  }
+
   std::shared_ptr<moxygen::Publisher> findUpstreamPublisher(const moxygen::TrackNamespace& ns) {
     auto session = namespaceTree_.findPublisherSession(ns);
     if (!session) {
@@ -408,6 +543,9 @@ private:
     }
     return maybeWrapPublisher(relayExec_, std::move(session));
   }
+
+  bool useLocalForwarders_{false};
+  folly::ThreadLocalPtr<LocalForwarderRegistry> tlForwarders_;
   std::unique_ptr<MoqxCache> cache_;
   uint64_t maxDeselected_{kDefaultMaxDeselected};
 

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -24,7 +24,8 @@ namespace openmoq::moqx {
 MoqxRelayContext::MoqxRelayContext(
     const folly::F14FastMap<std::string, config::ServiceConfig>& services,
     const std::string& relayID,
-    bool useRelayThread
+    bool useRelayThread,
+    bool useLocalForwarders
 )
     : serviceMatcher_(services), relayID_(relayID) {
   if (useRelayThread && !services.empty()) {
@@ -39,7 +40,8 @@ MoqxRelayContext::MoqxRelayContext(
       auto relay = std::make_shared<MoqxRelay>(
           svc.cache,
           relayID,
-          std::make_shared<moxygen::MoQFollyExecutorImpl>(evbs[i++].get())
+          std::make_shared<moxygen::MoQFollyExecutorImpl>(evbs[i++].get()),
+          useLocalForwarders
       );
       services_.emplace(
           name,
@@ -113,12 +115,10 @@ void MoqxRelayContext::initUpstreams(folly::EventBase* workerEvb) {
     auto onDisconnect = [relay, relayExec]() {
       runOnExec(relayExec, [relay]() { relay->onUpstreamDisconnect(); });
     };
-    std::shared_ptr<moxygen::Publisher> pubHandler = relay;
-    std::shared_ptr<moxygen::Subscriber> subHandler = relay;
-    if (relayExec) {
-      pubHandler = std::make_shared<PublisherCrossExecFilter>(relayExec, relay);
-      subHandler = std::make_shared<SubscriberCrossExecFilter>(relayExec, relay);
-    }
+    // Mode-aware filters (as inbound sessions): LF mode needs LocalPublishFilter for upstream
+    // PUBLISH.
+    std::shared_ptr<moxygen::Publisher> pubHandler = relay->createPublisherFilter();
+    std::shared_ptr<moxygen::Subscriber> subHandler = relay->createSubscriberFilter();
     auto provider = std::make_shared<UpstreamProvider>(
         workerExec,
         proxygen::URL(cfg.url),

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -58,7 +58,8 @@ public:
   MoqxRelayContext(
       const folly::F14FastMap<std::string, config::ServiceConfig>& services,
       const std::string& relayID,
-      bool useRelayThread = true
+      bool useRelayThread = true,
+      bool useLocalForwarders = false
   );
 
   void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);

--- a/src/SubscriptionRegistry.cpp
+++ b/src/SubscriptionRegistry.cpp
@@ -183,6 +183,7 @@ SubscriptionRegistry::getUpstreamView(const moxygen::FullTrackName& ftn) const {
       rsub.publisher,
       rsub.handle,
       rsub.requestID,
+      rsub.upstream ? rsub.upstream->getExecutor() : nullptr,
       rsub.isPublish,
       rsub.promise.isFulfilled()
   };

--- a/src/SubscriptionRegistry.h
+++ b/src/SubscriptionRegistry.h
@@ -134,6 +134,7 @@ public:
     std::shared_ptr<moxygen::Publisher> publisher;
     std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle;
     moxygen::RequestID requestID;
+    folly::Executor* publisherExec{nullptr}; // executor the publisher forwarder lives on
     bool isPublish;
     bool isReady; // promise fulfilled
   };

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -216,6 +216,7 @@ struct Config {
   std::string relayID; // always set: from config or randomly generated
   uint32_t threads{1};
   bool useRelayThread{true};
+  bool useLocalForwarders{false};
   bool mvfstBpfSteering{true};
 };
 

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -907,6 +907,11 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
     errors.push_back("use_relay_thread must be true when threads > 1");
   }
 
+  const bool useLocalForwarders = config.use_local_forwarders.value().value_or(false);
+  if (useLocalForwarders && !useRelayThread) {
+    errors.push_back("use_local_forwarders requires use_relay_thread to be true");
+  }
+
   const bool mvfstBpfSteering = config.mvfst_bpf_steering.value().value_or(true);
 
   if (!errors.empty()) {
@@ -959,6 +964,7 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
               .relayID = std::move(relayID),
               .threads = threads,
               .useRelayThread = useRelayThread,
+              .useLocalForwarders = useLocalForwarders,
               .mvfstBpfSteering = mvfstBpfSteering,
           },
       .warnings = std::move(warnings),

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -426,6 +426,12 @@ struct ParsedConfig {
       std::optional<bool>>
       use_relay_thread;
   rfl::Description<
+      "Use per-subscriber-thread local forwarders to minimize cross-thread hops on the "
+      "data path (requires use_relay_thread; default: false). Disable to run all subscribes "
+      "on the relay thread via subscribeImpl.",
+      std::optional<bool>>
+      use_local_forwarders;
+  rfl::Description<
       "Attach a classic BPF reuseport filter to steer QUIC packets to the correct mvfst worker "
       "based on the connection ID's workerId field (Linux only, mvfst stack only, default: true). "
       "Disable to fall back to kernel RSS distribution.",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,8 +117,12 @@ int main(int argc, char* argv[]) {
   // === 6. Initialize services ===
   // Construct and configure the application's own services
   // (MoqxRelayContext, MoqxRelayServer, etc.)
-  auto context =
-      std::make_shared<MoqxRelayContext>(config.services, config.relayID, config.useRelayThread);
+  auto context = std::make_shared<MoqxRelayContext>(
+      config.services,
+      config.relayID,
+      config.useRelayThread,
+      config.useLocalForwarders
+  );
 
   // === 6a. Stats registry ===
   auto statsRegistry = std::make_shared<stats::StatsRegistry>();

--- a/src/relay/CrossExecForwarderCallback.cpp
+++ b/src/relay/CrossExecForwarderCallback.cpp
@@ -18,6 +18,16 @@ void CrossExecForwarderCallback::onEmpty(moxygen::MoQForwarder* /*forwarder*/) {
   });
 }
 
+void CrossExecForwarderCallback::onPublishDone(moxygen::MoQForwarder* /*forwarder*/) {
+  auto f = forwarder_.lock();
+  if (!f) {
+    return;
+  }
+  targetExec_->add([f = std::move(f), downstream = downstream_]() mutable {
+    downstream->onPublishDone(f.get());
+  });
+}
+
 void CrossExecForwarderCallback::forwardChanged(
     moxygen::MoQForwarder* /*forwarder*/,
     bool forward

--- a/src/relay/CrossExecForwarderCallback.h
+++ b/src/relay/CrossExecForwarderCallback.h
@@ -27,6 +27,7 @@ public:
         downstream_(std::move(downstream)) {}
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
+  void onPublishDone(moxygen::MoQForwarder* forwarder) override;
   void forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) override;
   void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override;
 

--- a/src/relay/LocalForwarderCallback.h
+++ b/src/relay/LocalForwarderCallback.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "relay/LocalForwarderRegistry.h"
+
+#include <memory>
+#include <moxygen/relay/MoQForwarder.h>
+
+namespace openmoq::moqx {
+
+// Runs on the local forwarder's executor. Delegates lifecycle events to
+// downstream (a CrossExecForwarderCallback targeting the publisher's executor)
+// and owns the forwarder's removal from tlForwarders_.
+//
+// Removal is identity-checked (only vacates the slot if it still holds THIS
+// forwarder), making teardown order-independent: a terminated forwarder can
+// never clobber a newer one that has claimed the same track name.
+//
+// removeOnEmpty distinguishes the two roles:
+//   - subscribe-path local forwarder (removeOnEmpty=true): when its last
+//     subscriber leaves, its channel sub is pulled from the publisher and it is
+//     dead — remove on onEmpty as well as onPublishDone.
+//   - publisher's publisher forwarder (removeOnEmpty=false): it must survive
+//     subscriber churn (new subscribers may arrive while the publisher is
+//     live), so it is removed ONLY when the source terminates (onPublishDone).
+class LocalForwarderCallback : public moxygen::MoQForwarder::Callback {
+public:
+  LocalForwarderCallback(
+      LocalForwarderRegistry* localReg,
+      moxygen::FullTrackName ftn,
+      std::shared_ptr<moxygen::MoQForwarder::Callback> downstream,
+      bool removeOnEmpty = true
+  )
+      : localReg_(localReg), ftn_(std::move(ftn)), downstream_(std::move(downstream)),
+        removeOnEmpty_(removeOnEmpty) {}
+
+  void onEmpty(moxygen::MoQForwarder* forwarder) override {
+    downstream_->onEmpty(forwarder);
+    if (removeOnEmpty_) {
+      localReg_->remove(ftn_, forwarder);
+    }
+  }
+
+  void onPublishDone(moxygen::MoQForwarder* forwarder) override {
+    downstream_->onPublishDone(forwarder);
+    // Source-driven teardown (publisher/upstream terminated). Identity-checked.
+    localReg_->remove(ftn_, forwarder);
+  }
+
+  void forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) override {
+    downstream_->forwardChanged(forwarder, forward);
+  }
+
+  void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override {
+    downstream_->newGroupRequested(forwarder, group);
+  }
+
+private:
+  LocalForwarderRegistry* localReg_;
+  moxygen::FullTrackName ftn_;
+  std::shared_ptr<moxygen::MoQForwarder::Callback> downstream_;
+  bool removeOnEmpty_;
+};
+
+} // namespace openmoq::moqx

--- a/src/relay/LocalForwarderRegistry.h
+++ b/src/relay/LocalForwarderRegistry.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <moxygen/MoQLocation.h>
+#include <moxygen/relay/MoQForwarder.h>
+
+#include <folly/container/F14Map.h>
+
+namespace openmoq::moqx {
+
+// Thread-local registry mapping FullTrackName → local MoQForwarder on one
+// iothread. All methods must be called on the owning thread. One instance per
+// iothread, stored in MoqxRelay::tlForwarders_.
+class LocalForwarderRegistry {
+public:
+  struct GetOrCreateResult {
+    std::shared_ptr<moxygen::MoQForwarder> localForwarder;
+    // true only on first creation; caller must cross-exec to publisher thread
+    // and add a CrossExecFilter subscriber to the publisher forwarder.
+    bool isNew;
+  };
+
+  // Returns the existing local forwarder for ftn, or calls factory() to create
+  // one. factory() is called at most once per ftn per thread lifetime.
+  GetOrCreateResult getOrCreate(
+      const moxygen::FullTrackName& ftn,
+      folly::FunctionRef<std::shared_ptr<moxygen::MoQForwarder>()> factory
+  ) {
+    auto it = forwarders_.find(ftn);
+    if (it != forwarders_.end()) {
+      return {it->second, /*isNew=*/false};
+    }
+    auto forwarder = factory();
+    forwarders_.emplace(ftn, forwarder);
+    return {std::move(forwarder), /*isNew=*/true};
+  }
+
+  // Claim the slot for ftn unconditionally, returning the previous occupant (if
+  // any). The publisher's forwarder is authoritative for a track on its thread:
+  // a stale subscribe-path local forwarder under the same name is displaced
+  // here, and drains itself via the source-termination cascade (its identity-
+  // checked removal then no-ops, since this forwarder now owns the slot).
+  std::shared_ptr<moxygen::MoQForwarder>
+  set(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQForwarder> forwarder) {
+    auto prev = std::move(forwarders_[ftn]);
+    forwarders_[ftn] = std::move(forwarder);
+    return prev;
+  }
+
+  std::shared_ptr<moxygen::MoQForwarder> get(const moxygen::FullTrackName& ftn) const {
+    auto it = forwarders_.find(ftn);
+    return it != forwarders_.end() ? it->second : nullptr;
+  }
+
+  // Identity-checked removal: erase the entry for ftn only if it still points
+  // at `expected`. Called from a forwarder's onPublishDone, which fires on this
+  // thread. The identity check makes teardown order-independent: a terminated
+  // forwarder can only vacate its own slot, so it never clobbers a newer
+  // forwarder that has since claimed the same track name.
+  void remove(const moxygen::FullTrackName& ftn, const moxygen::MoQForwarder* expected) {
+    auto it = forwarders_.find(ftn);
+    if (it == forwarders_.end() || it->second.get() != expected) {
+      return;
+    }
+    forwarders_.erase(it);
+  }
+
+private:
+  folly::F14FastMap<
+      moxygen::FullTrackName,
+      std::shared_ptr<moxygen::MoQForwarder>,
+      moxygen::FullTrackName::hash>
+      forwarders_;
+};
+
+} // namespace openmoq::moqx

--- a/src/relay/PublisherCrossExecFilter.h
+++ b/src/relay/PublisherCrossExecFilter.h
@@ -17,7 +17,7 @@ namespace openmoq::moqx {
 // the result to the caller. goaway() is fire-and-forget.
 //
 // Requires targetExec_ to be a FIFO executor if call ordering matters.
-class PublisherCrossExecFilter final : public moxygen::Publisher {
+class PublisherCrossExecFilter : public moxygen::Publisher {
 public:
   PublisherCrossExecFilter(folly::Executor* targetExec, std::shared_ptr<moxygen::Publisher> inner)
       : targetExec_(targetExec), inner_(std::move(inner)) {}

--- a/src/relay/SubscriberCrossExecFilter.h
+++ b/src/relay/SubscriberCrossExecFilter.h
@@ -24,7 +24,7 @@ class CrossExecFilter;
 // goaway() is fire-and-forget.
 //
 // Requires targetExec_ to be a FIFO executor if call ordering matters.
-class SubscriberCrossExecFilter final : public moxygen::Subscriber {
+class SubscriberCrossExecFilter : public moxygen::Subscriber {
 public:
   SubscriberCrossExecFilter(folly::Executor* targetExec, std::shared_ptr<moxygen::Subscriber> inner)
       : targetExec_(targetExec), inner_(std::move(inner)) {}

--- a/src/relay/WeakRelayForwarderCallback.cpp
+++ b/src/relay/WeakRelayForwarderCallback.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "WeakRelayForwarderCallback.h"
+namespace openmoq::moqx {
+
+void WeakRelayForwarderCallback::onEmpty(moxygen::MoQForwarder* forwarder) {
+  if (auto r = relay_.lock()) {
+    r->onEmpty(forwarder);
+  }
+}
+
+void WeakRelayForwarderCallback::forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) {
+  if (auto r = relay_.lock()) {
+    r->forwardChanged(forwarder, forward);
+  }
+}
+
+void WeakRelayForwarderCallback::newGroupRequested(
+    moxygen::MoQForwarder* forwarder,
+    uint64_t group
+) {
+  if (auto r = relay_.lock()) {
+    r->newGroupRequested(forwarder, group);
+  }
+}
+
+} // namespace openmoq::moqx

--- a/src/relay/WeakRelayForwarderCallback.h
+++ b/src/relay/WeakRelayForwarderCallback.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <moxygen/relay/MoQForwarder.h>
+
+namespace openmoq::moqx {
+
+// Relay-side MoQForwarder::Callback target. Holds a weak_ptr to the relay
+// (as its MoQForwarder::Callback base) to avoid a reference cycle
+// (registry → forwarder → callback → relay). Intended to be used as the
+// downstream of CrossExecForwarderCallback, which handles cross-exec
+// dispatch and forwarder pointer recovery.
+class WeakRelayForwarderCallback final : public moxygen::MoQForwarder::Callback {
+public:
+  explicit WeakRelayForwarderCallback(std::weak_ptr<moxygen::MoQForwarder::Callback> relay)
+      : relay_(std::move(relay)) {}
+
+  void onEmpty(moxygen::MoQForwarder* forwarder) override;
+  void forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) override;
+  void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override;
+
+private:
+  std::weak_ptr<moxygen::MoQForwarder::Callback> relay_;
+};
+
+} // namespace openmoq::moqx

--- a/test/MoqxRelayNGRTests.cpp
+++ b/test/MoqxRelayNGRTests.cpp
@@ -286,6 +286,11 @@ TEST_P(MoQRelayTest, PublishOkNewNGRForwardedUpstream) {
   EXPECT_TRUE(driveUntil([&] { return updates.load() >= 2; }))
       << "NGR cascade incomplete: " << updates.load() << "/2 requestUpdates";
 
+  // Lock in the assertion before teardown: in LocalForwarderMT the trailing
+  // forwardChanged(false) → requestUpdate at subscriber removal lands
+  // asynchronously and would otherwise over-saturate the expectation.
+  ASSERT_TRUE(testing::Mock::VerifyAndClearExpectations(publishHandle.get()));
+
   removeSession(publisherSession);
   removeSession(subscriberSession);
   driveIfMultiThread();
@@ -364,6 +369,11 @@ TEST_P(MoQRelayTest, PublishOkDuplicateNGRNotForwardedUpstream) {
   // otherwise race in and over-saturate the expectation.
   EXPECT_TRUE(driveUntil([&] { return updates.load() >= 2; }))
       << "NGR cascade incomplete: " << updates.load() << "/2 requestUpdates";
+
+  // Lock in the assertion before teardown: in LocalForwarderMT the trailing
+  // forwardChanged(false) → requestUpdate at subscriber removal lands
+  // asynchronously and would otherwise over-saturate the expectation.
+  ASSERT_TRUE(testing::Mock::VerifyAndClearExpectations(publishHandle.get()));
 
   removeSession(publisherSession);
   removeSession(subscriber1);

--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -204,6 +204,7 @@ TEST_P(MoQRelayTest, PublishExtensionsForwardedToLateJoiners) {
   removeSession(subscriber1);
   removeSession(subscriber2);
   driveIfMultiThread(); // flush relay cleanup so it drops session refs before mocks are destroyed
+  driveIfMultiThread(); // flush relay cleanup so it drops session refs before mocks are destroyed
 }
 
 // Regression test: publisher reconnect after disconnect with active subscriber

--- a/test/MoqxRelaySubscribeTests.cpp
+++ b/test/MoqxRelaySubscribeTests.cpp
@@ -142,4 +142,66 @@ TEST_P(MoQRelayTest, Subscribe_SecondForwardingSubscriber_SingleRequestUpdate) {
   }
 }
 
+// Safety net for the planned attachLocalForwarderToPrimary reshape (and the merge
+// of the two primaryExec sorties): the first-subscriber path that issues an
+// upstream SUBSCRIBE, installs the relay chain, and wires the local/primary
+// forwarder must still deliver objects to the downstream subscriber in all three
+// modes. Data-plane tests only cover the published-track path (doPublish); this
+// covers announce-then-pull, where the relay subscribes upstream and the upstream
+// is the data source.
+TEST_P(MoQRelayTest, FirstSubscriberViaUpstreamSubscribeReceivesData) {
+  auto publisherSession = createMockSession();
+  auto subSession = createMockSession();
+
+  // Publisher announces the namespace but does NOT publish, so the first
+  // subscriber forces the relay to SUBSCRIBE upstream to pull the track.
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Capture the upstream consumer (the relay's writeback into the primary
+  // forwarder) so the test can act as the upstream source and push data.
+  std::shared_ptr<TrackConsumer> upstreamConsumer;
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(1);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce([&upstreamConsumer,
+                 upstreamOk](const SubscribeRequest&, std::shared_ptr<TrackConsumer> consumer) {
+        upstreamConsumer = std::move(consumer);
+        auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+        return folly::coro::makeTask<Publisher::SubscribeResult>(
+            folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(handle)
+        );
+      });
+
+  // First subscriber: drives the upstream subscribe + relay-chain wiring.
+  auto consumer = createMockConsumer();
+  auto sg = createMockSubgroupConsumer();
+  std::atomic<bool> gotSubgroup{false};
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&sg, &gotSubgroup](uint64_t, uint64_t, uint8_t, moxygen::BeginSubgroupOptions) {
+        gotSubgroup.store(true);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+
+  auto handle = subscribeToTrack(subSession, kTestTrackName, consumer, RequestID(0));
+  ASSERT_NE(handle, nullptr);
+  ASSERT_NE(upstreamConsumer, nullptr) << "relay should have issued an upstream subscribe";
+
+  // Act as the upstream source: push a subgroup. It must traverse the relay chain
+  // (and, in LocalForwarderMT, the primary->localFwd channel sub) to the downstream.
+  auto sgRes = upstreamConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(sgRes.hasValue());
+  EXPECT_TRUE(sgRes.value()->endOfSubgroup().hasValue());
+
+  EXPECT_TRUE(driveUntil([&] { return gotSubgroup.load(); }))
+      << "downstream subscriber should receive the upstream subgroup in mode "
+      << static_cast<int>(relayMode());
+
+  removeSession(publisherSession);
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
 } // namespace moxygen::test

--- a/test/MoqxRelayTestFixture.cpp
+++ b/test/MoqxRelayTestFixture.cpp
@@ -37,14 +37,14 @@ void TestMoQExecutor::driveFor(int n) {
 
 void MoQRelayTest::SetUp() {
   exec_ = std::make_shared<TestMoQExecutor>();
-  if (relayMode() == RelayMode::MultiThread) {
+  if (relayMode() == RelayMode::MultiThread || relayMode() == RelayMode::LocalForwarderMT) {
     relayThread_ = std::make_unique<folly::ScopedEventBaseThread>("relay-test");
     relayEvb_ = relayThread_->getEventBase();
     exec_->setRelayEvb(relayEvb_);
   }
   resetRelay(config::CacheConfig{.maxCachedTracks = 0});
   relay_->setAllowedNamespacePrefix(kAllowedPrefix);
-  if (relayMode() == RelayMode::MultiThread) {
+  if (relayMode() == RelayMode::MultiThread || relayMode() == RelayMode::LocalForwarderMT) {
     ASSERT_NE(relay_->getRelayExec(), nullptr);
   }
 }
@@ -54,10 +54,21 @@ void MoQRelayTest::resetRelay(config::CacheConfig cache, const std::string& rela
   if (relayEvb_) {
     relayExec = std::make_shared<moxygen::MoQFollyExecutorImpl>(relayEvb_);
   }
-  relay_ = std::make_shared<MoqxRelay>(std::move(cache), relayID, std::move(relayExec));
+  bool useLocalForwarders = relayEvb_ && relayMode() == RelayMode::LocalForwarderMT;
+  relay_ = std::make_shared<MoqxRelay>(
+      std::move(cache),
+      relayID,
+      std::move(relayExec),
+      useLocalForwarders
+  );
   if (relayEvb_) {
-    publisherInterface_ = std::make_shared<PublisherCrossExecFilter>(relayEvb_, relay_);
-    subscriberInterface_ = std::make_shared<SubscriberCrossExecFilter>(relayEvb_, relay_);
+    if (relayMode() == RelayMode::LocalForwarderMT) {
+      publisherInterface_ = relay_->createPublisherFilter();
+      subscriberInterface_ = relay_->createSubscriberFilter();
+    } else {
+      publisherInterface_ = std::make_shared<PublisherCrossExecFilter>(relayEvb_, relay_);
+      subscriberInterface_ = std::make_shared<SubscriberCrossExecFilter>(relayEvb_, relay_);
+    }
   }
 }
 

--- a/test/MoqxRelayTestFixture.h
+++ b/test/MoqxRelayTestFixture.h
@@ -35,7 +35,8 @@ namespace moxygen::test {
 enum class RelayMode {
   SingleThread,
   MultiThread,
-  // Future: Mode3 — add here, then add a branch in SetUp() and INSTANTIATE entry
+  LocalForwarderMT,
+  // Future: LocalForwarderMTCrossThread — separate publisherThread_ for pub/sub split
 };
 
 inline void PrintTo(RelayMode mode, std::ostream* os) {
@@ -45,6 +46,9 @@ inline void PrintTo(RelayMode mode, std::ostream* os) {
     return;
   case RelayMode::MultiThread:
     *os << "MultiThread";
+    return;
+  case RelayMode::LocalForwarderMT:
+    *os << "LocalForwarderMT";
     return;
   }
 }

--- a/test/MoqxRelayTestModes.cpp
+++ b/test/MoqxRelayTestModes.cpp
@@ -9,13 +9,15 @@ namespace moxygen::test {
 INSTANTIATE_TEST_SUITE_P(
     AllModes,
     MoQRelayTest,
-    ::testing::Values(RelayMode::SingleThread, RelayMode::MultiThread),
+    ::testing::Values(RelayMode::SingleThread, RelayMode::MultiThread, RelayMode::LocalForwarderMT),
     [](const ::testing::TestParamInfo<RelayMode>& info) -> std::string {
       switch (info.param) {
       case RelayMode::SingleThread:
         return "SingleThread";
       case RelayMode::MultiThread:
         return "MultiThread";
+      case RelayMode::LocalForwarderMT:
+        return "LocalForwarderMT";
       }
       return "Unknown";
     }

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -39,6 +39,7 @@ protected:
         config::CacheConfig{0, 0}, // no cache
         /*relayID=*/"",
         /*relayExec=*/nullptr,
+        /*useLocalForwarders=*/false,
         /*maxDeselected=*/0
     );
     relay_->setAllowedNamespacePrefix(kPrefix);
@@ -528,6 +529,7 @@ TEST_F(MoqxTrackFilterTest, FirstObjectCycle_DoesNotEvictSelectedTracksBeforeFir
       config::CacheConfig{0, 0},
       /*relayID=*/"",
       /*relayExec=*/nullptr,
+      /*useLocalForwarders=*/false,
       /*maxDeselected=*/0,
       /*idleTimeout=*/std::chrono::seconds(10),
       /*activityThreshold=*/std::chrono::milliseconds(1)
@@ -743,6 +745,7 @@ TEST_F(MoqxTrackFilterTest, DeselectedQueueEviction_EvictsOldestEntry) {
       config::CacheConfig{0, 0}, // no cache
       /*relayID=*/"",
       /*relayExec=*/nullptr,
+      /*useLocalForwarders=*/false,
       /*maxDeselected=*/2
   );
   relay_->setAllowedNamespacePrefix(kPrefix);
@@ -833,6 +836,7 @@ TEST_F(MoqxTrackFilterTest, IdleEviction_SilentTrackReplacedByActiveOutsider) {
       config::CacheConfig{0, 0}, // no cache
       /*relayID=*/"",
       /*relayExec=*/nullptr,
+      /*useLocalForwarders=*/false,
       /*maxDeselected=*/5,
       /*idleTimeout=*/std::chrono::milliseconds(10),
       /*activityThreshold=*/std::chrono::milliseconds(1)

--- a/test/test_relay_chain.sh
+++ b/test/test_relay_chain.sh
@@ -182,6 +182,7 @@ cat >"$UPSTREAM_CFG" <<EOF
 relay_id: "$UPSTREAM_RELAY_ID"
 threads: 2
 use_relay_thread: true
+use_local_forwarders: true
 listeners:
   - name: upstream
     udp:
@@ -210,6 +211,7 @@ cat >"$DOWNSTREAM_CFG" <<EOF
 relay_id: "$DOWNSTREAM_RELAY_ID"
 threads: 2
 use_relay_thread: true
+use_local_forwarders: true
 listeners:
   - name: downstream
     udp:


### PR DESCRIPTION

Adds an optional data-plane mode in which each I/O thread owns its own
MoQForwarder per track, so fanning objects out to subscribers on the same
thread needs no cross-thread hop. Gated by the new use_local_forwarders
option (which requires use_relay_thread); off by default.

Theory of operation
--------------------
The relay now runs in one of three modes, chosen per session by
createPublisherFilter()/createSubscriberFilter():

1. Single-threaded (relayExec_ unset): relay state and all forwarders live
   on the session I/O thread; MoqxRelay is the session handler directly.

2. Cross-exec (relayExec_ set, local forwarders off): relay state is
   isolated on a dedicated relay executor. Session handlers are
   Publisher/SubscriberCrossExecFilter, which hop to the relay exec before
   touching state. One primary forwarder per track lives on the relay exec
   and fans out to every subscriber via a per-callback cross-exec hop.

3. Local forwarders (relayExec_ set, local forwarders on): the primary
   forwarder for a track lives on its publisher's I/O thread. Each
   subscriber I/O thread keeps a thread-local forwarder (LocalForwarderRegistry
   in tlForwarders_) that attaches to the primary as a single channel
   subscriber. The primary thus hops once per subscriber *thread*; each local
   forwarder then fans out to its same-thread subscribers with no further hop.

Subscribe (local mode) is split so the relay-exec critical section stays
small: subscribeFromSubscriberThread orchestrates on the subscriber thread,
dispatching subscribeStatefulWork (registry lookup, first-vs-subsequent
decision) to the relay exec, then wiring the local->primary channel; for the
first subscriber, completeFirstSubscriber issues the upstream subscribe and
applies the SubscribeOk on the primary's exec. Publish (local mode) makes the
publisher's local forwarder the primary and registers it on the relay exec via
setupPublisherPrimary; the relay chain (TopNFilter -> termination -> cache)
attaches to it as a passive channel subscriber so it observes all objects
without counting as a forwarding subscriber.

Lifecycle callbacks flow LocalForwarderCallback -> CrossExecForwarderCallback
-> ChannelForwarderCallback (on the primary's exec), which propagates forward
and new-group-request changes upstream via requestUpdate and removes the
channel subscriber on onEmpty. LocalForwarderRegistry removal is
identity-checked so teardown is order-independent. PendingForwarderCallback
captures forwardChanged/newGroupRequested/onEmpty during the setup window for
replay once the real callback is installed. WeakRelayForwarderCallback breaks
the registry -> forwarder -> callback -> relay reference cycle and is now also
used by the cross-exec (non-local) mode.

Config and tests
----------------
- use_local_forwarders config field with ConfigResolver validation (requires
  use_relay_thread), threaded through MoqxRelayContext; --local-forwarders
  flag added to scripts/perf-test.sh.
- The relay test suite gains a third parameterized mode, LocalForwarderMT,
  run alongside SingleThread and MultiThread.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/365)
<!-- Reviewable:end -->
