### PR TITLE
Init folly XLOG (async by default) and root categories at moqx.*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,19 @@ FetchContent_Declare(reflectcpp
 )
 FetchContent_MakeAvailable(reflectcpp)
 
+# --- XLOG category rooting ---
+# Rewrite __FILE__ for moqx sources so folly XLOG categories render as moqx.*
+# (e.g. moqx.MoqxRelay) instead of src.* — sources live under src/, but the
+# user-facing logging API expects "moqx" as the top-level category. The
+# FOLLY_XLOG_STRIP_PREFIXES define handles paths the prefix-map doesn't touch
+# (notably generated headers under the build dir). Placed here so subsequent
+# moqx_* targets pick it up; yaml-cpp / reflectcpp above were declared before
+# this point and are unaffected.
+add_compile_options(-fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/src=moqx)
+add_compile_definitions(
+  "FOLLY_XLOG_STRIP_PREFIXES=\"${CMAKE_SOURCE_DIR}:${CMAKE_BINARY_DIR}\""
+)
+
 # --- Cache library (forked from moxygen) ---
 
 add_library(moqx_cache STATIC

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,10 +24,16 @@
 #include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <folly/init/Init.h>
 #include <folly/io/async/AsyncSignalHandler.h>
+#include <folly/logging/Init.h>
 #include <folly/logging/xlog.h>
 
 #include <iostream>
 #include <string_view>
+
+// Default folly logging config: root at INFO, async sink with WARN+ flushed
+// synchronously so we don't lose warnings/errors on crash. Overridable at
+// runtime via --logging=... or FOLLY_LOGGING= env var (folly::Init wires both).
+FOLLY_INIT_LOGGING_CONFIG(".=INFO; default:async=true,sync_level=WARN");
 
 DEFINE_string(config, "", "Path to config file (required)");
 DEFINE_bool(strict_config, false, "Reject unknown config fields");
@@ -89,8 +95,9 @@ int main(int argc, char* argv[]) {
   }
 
   // === 2. Set up logging/observability ===
-  // TODO: logging framework, log levels, structured logging
-  // (currently handled implicitly by folly::Init)
+  // folly logging is initialized by folly::Init above using the
+  // FOLLY_INIT_LOGGING_CONFIG default at file scope. Override with
+  // --logging=<config> or the FOLLY_LOGGING env var.
 
   // === 3. Set up signal handling ===
   folly::EventBase evb;


### PR DESCRIPTION
## Summary
Two small consumer-side changes that complete the moqx half of the logging normalization:

1. **`src/main.cpp`** — declare a compile-time baseline logging config so async writes are on by default:
   ```cpp
   FOLLY_INIT_LOGGING_CONFIG(".=INFO; default:async=true,sync_level=WARN");
   ```
   Keeps the relay off the log-I/O path; \`--logging=...\` and the \`FOLLY_LOGGING\` env var still override at startup.

2. **`CMakeLists.txt`** — root XLOG categories at \`moqx.*\` instead of \`src.*\`:
   ```cmake
   add_compile_options(-fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/src=moqx)
   add_compile_definitions(
     "FOLLY_XLOG_STRIP_PREFIXES=\"${CMAKE_SOURCE_DIR}:${CMAKE_BINARY_DIR}\""
   )
   ```
   moqx sources live under \`src/\`, but the user-facing logging API expects \`moqx\` as the top-level category. The macro-prefix-map rewrites \`__FILE__\` so xlog auto-derives \`moqx.MoqxRelay\` etc. The strip-prefixes define covers paths the prefix-map doesn't touch (generated headers under the build dir).

Pairs with upstream moxygen-side work landing the same FOLLY_XLOG_STRIP_PREFIXES pattern there and converting moxygen sources to XLOG.

## Test plan
- [ ] Build moqx; verify \`--logging moqx=DBG4\` selects moqx-rooted categories.
- [ ] Verify async writes (\`default:async=true,sync_level=WARN\`) — INFO/DBG don't block, WARN+ flushed synchronously.
- [ ] \`--logging=...\` runtime override still works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/370)
<!-- Reviewable:end -->
