### PR TITLE
bpf: attach reuseport steering filter exactly once per group

### DIFF
--- a/src/bpf/QuicReuseportSteering.cpp
+++ b/src/bpf/QuicReuseportSteering.cpp
@@ -23,18 +23,54 @@
 #include <atomic>
 #include <cerrno>
 #include <cstring>
+#include <mutex>
 
 #include <linux/filter.h>
 #include <sys/socket.h>
 
+#include <folly/Indestructible.h>
+#include <folly/SocketAddress.h>
+#include <folly/ThreadLocal.h>
+#include <folly/container/F14Set.h>
 #include <folly/logging/xlog.h>
+#include <folly/net/NetworkSocket.h>
 
 namespace openmoq::moqx {
 
-static std::atomic<bool> gEnabled{true};
+// SO_ATTACH_REUSEPORT_CBPF is a property of the kernel reuseport group, not the
+// fd: re-attaching frees the group's single prog while sibling RX softirqs may
+// still run it. The hook fires per worker listener fd at bind() and per accepted
+// connection (site 2), so attach exactly once per group keyed by address:port.
+class ReuseportSteering {
+public:
+  void setEnabled(bool enabled) { enabled_.store(enabled, std::memory_order_relaxed); }
+
+  // The body of the mvfst_hook_on_socket_create weak-symbol override.
+  void maybeAttach(int fd);
+
+private:
+  std::atomic<bool> enabled_{true};
+
+  // Shared group set, guarded by mutex_. Touched only on the cold first-touch
+  // slow path.
+  std::mutex mutex_;
+  folly::F14FastSet<folly::SocketAddress> attachedGroups_;
+
+  // Lock-free, syscall-free fast path: fds this thread already resolved and
+  // confirmed attached. folly::ThreadLocal (not the native keyword, which can't
+  // be a non-static member) keeps the state instance-owned; safe because the
+  // Indestructible enclosing object never destructs, so neither does this.
+  folly::ThreadLocal<folly::F14FastSet<int>> tlSeenFds_;
+};
+
+// folly::Indestructible (constructs in place, never destructs) is required, not
+// a plain static: a late hook call from an IO thread draining during shutdown
+// (or terminateClientSession/site-2 work after stop(), see commit 8abbc20)
+// could otherwise touch an already-destroyed instance.
+static folly::Indestructible<ReuseportSteering> gSteering;
 
 void quicReuseportSetEnabled(bool enabled) {
-  gEnabled.store(enabled, std::memory_order_relaxed);
+  gSteering->setEnabled(enabled);
 }
 
 } // namespace openmoq::moqx
@@ -75,11 +111,52 @@ static const struct sock_fprog kProg = {
     .filter = const_cast<struct sock_filter*>(kFilter),
 };
 
-extern "C" void mvfst_hook_on_socket_create(int fd) {
-  if (!openmoq::moqx::gEnabled.load(std::memory_order_relaxed)) {
+void openmoq::moqx::ReuseportSteering::maybeAttach(int fd) {
+  if (!enabled_.load(std::memory_order_relaxed)) {
     return;
   }
-  if (setsockopt(fd, SOL_SOCKET, SO_ATTACH_REUSEPORT_CBPF, &kProg, sizeof(kProg)) != 0) {
-    XLOG(WARN) << "quic reuseport BPF steering: setsockopt failed: " << std::strerror(errno);
+
+  // Lock-free fast path: this thread already resolved this fd and the group was
+  // attached then. We never detach, so the skip is always correct.
+  if (tlSeenFds_->count(fd)) {
+    return;
   }
+
+  // Slow path (first time this thread sees this fd). Recover the group key
+  // outside the lock — getsockname reads only per-fd kernel state.
+  folly::SocketAddress addr;
+  try {
+    addr.setFromLocalAddress(folly::NetworkSocket::fromFd(fd));
+  } catch (const std::exception& ex) {
+    // Transient / unbound fd: log and return WITHOUT caching, so a later hook
+    // call retries.
+    XLOG_EVERY_N(WARN, 1000) << "quic reuseport BPF steering: getsockname failed: " << ex.what();
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> g(mutex_);
+    if (!attachedGroups_.count(addr)) {
+      // Hold the lock across check → setsockopt → insert so concurrent worker
+      // threads binding the same group at startup serialize and exactly one
+      // attaches.
+      if (setsockopt(fd, SOL_SOCKET, SO_ATTACH_REUSEPORT_CBPF, &kProg, sizeof(kProg)) != 0) {
+        // Return WITHOUT caching: a later hook retries a rare transient
+        // listener failure, and client sockets (where the option legitimately
+        // fails) re-run the rate-limited slow path per connection.
+        XLOG_EVERY_N(WARN, 1000) << "quic reuseport BPF steering: setsockopt failed: "
+                                 << std::strerror(errno);
+        return;
+      }
+      attachedGroups_.insert(addr);
+      XLOG(INFO) << "quic reuseport BPF steering: attached for group " << addr.describe();
+    }
+  }
+
+  // Cache only after the group is known-attached.
+  tlSeenFds_->insert(fd);
+}
+
+extern "C" void mvfst_hook_on_socket_create(int fd) {
+  openmoq::moqx::gSteering->maybeAttach(fd);
 }


### PR DESCRIPTION
SO_ATTACH_REUSEPORT_CBPF is a property of the kernel reuseport group, not the individual fd: re-attaching replaces and frees the group's single prog while sibling sockets' RX softirqs may still be running it. The mvfst_hook_on_socket_create hook fired on every invocation — once per worker listener fd at bind() and again per accepted connection at runtime (site 2 wraps the worker's same listener fd) — turning that into a hot, multi-threaded use-after-free.

Dedup attachment per reuseport group, keyed by the bound address:port (via getsockname). State is encapsulated in a ReuseportSteering class held in a folly::Indestructible singleton (never destructs, so a late hook call from a draining IO thread can't touch freed state on shutdown):

- A mutex-guarded F14 set of already-attached SocketAddresses. The lock is held across check -> setsockopt -> insert so concurrent workers binding the same group serialize and exactly one attaches.
- A per-thread folly::ThreadLocal F14 set of resolved fds as a lock-free, syscall-free fast path for the steady-state per-connection case.

getsockname/setsockopt failures return without caching so a later hook retries; client sockets (where the option legitimately fails) re-run the rate-limited slow path harmlessly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/371)
<!-- Reviewable:end -->
