### PR TITLE
relay: make stop() idempotent and keep context_ alive during teardown

### DIFF
--- a/src/MoqxPicoRelayServer.cpp
+++ b/src/MoqxPicoRelayServer.cpp
@@ -93,12 +93,14 @@ MoqxPicoRelayServer::~MoqxPicoRelayServer() {
 }
 
 void MoqxPicoRelayServer::stop() {
-  if (!context_) {
+  if (stopped_) {
     return;
   }
+  stopped_ = true;
+  // Keep context_ alive: terminateClientSession can run after stop() returns,
+  // from handleClientSession coroutines still draining on the evb.
   context_->stop();
   evb_->runImmediatelyOrRunInEventBaseThreadAndWait([this] { MoQPicoQuicEventBaseServer::stop(); });
-  context_.reset();
 }
 
 void MoqxPicoRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {

--- a/src/MoqxPicoRelayServer.h
+++ b/src/MoqxPicoRelayServer.h
@@ -64,6 +64,7 @@ private:
   config::ListenerConfig listenerCfg_;
   std::shared_ptr<MoqxRelayContext> context_;
   folly::EventBase* evb_;
+  bool stopped_{false};
 };
 
 } // namespace openmoq::moqx

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -143,12 +143,13 @@ MoqxRelayServer::~MoqxRelayServer() {
 }
 
 void MoqxRelayServer::stop() {
-  if (!context_) {
+  if (stopped_) {
     return;
   }
-  // QuicServer::shutdown drives terminateClientSession, which uses context_.
+  stopped_ = true;
+  // Keep context_ alive: terminateClientSession can run after stop() returns,
+  // from handleClientSession coroutines still draining on IO threads.
   MoQServer::stop();
-  context_.reset();
 }
 
 void MoqxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {

--- a/src/MoqxRelayServer.h
+++ b/src/MoqxRelayServer.h
@@ -57,6 +57,7 @@ private:
   config::ListenerConfig listenerCfg_;
   std::shared_ptr<MoqxRelayContext> context_;
   folly::IOThreadPoolExecutor* ioExecutor_;
+  bool stopped_{false};
 };
 
 } // namespace openmoq::moqx


### PR DESCRIPTION
Guard stop() with a stopped_ flag instead of context_ presence, and stop resetting context_. terminateClientSession can run after stop() returns, from handleClientSession coroutines still draining on the evb/IO threads, so context_ must outlive stop().

Calling stop with active sessions could lead to a null ptr deref on context_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/372)
<!-- Reviewable:end -->
