### PR TITLE
perf-test: increase packets read per loop to 256

### DIFF
--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -219,7 +219,7 @@ listeners:
     mvfst:
       enable_gso: true
       max_conn_packets_sent_per_loop: 16
-      max_server_recv_packets_per_loop: 32
+      max_server_recv_packets_per_loop: 256
       bbr2:
         exit_startup_on_loss: true
         enable_recovery_in_startup: true


### PR DESCRIPTION
For fan-out tests, most reads are ACKs, and reading more is better.  I can imagine scenarios where this might be too high, but let's roll with it for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/373)
<!-- Reviewable:end -->
