### PR TITLE
config: add udp_socket_buffer_bytes listener config option

### DIFF
--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -34,6 +34,9 @@
 #                          locally.  The binary is expected at
 #                          /tmp/moqperf_test_client on the remote host.
 #                          HOST may include a user prefix (user@host).
+#   --udp-socket-buffer-bytes N
+#                          UDP socket send/recv buffer size in bytes for the
+#                          relay listener (defaults to net.core.wmem_max).
 #
 # Linux-only options (not supported on macOS):
 #   --metrics, --perf-duration, --perf-events, --perf-stat, --jemalloc,
@@ -62,6 +65,7 @@ PERF_DURATION=0
 PERF_EVENTS=""
 RUN_PERF_STAT=false
 REMOTE_CLIENT_HOST=""
+UDP_SOCKET_BUFFER_BYTES=$(cat /proc/sys/net/core/wmem_max 2>/dev/null || echo 1048576)
 TRACE_SCRIPT=""
 CLIENT_EXTRA_ARGS=()
 
@@ -93,6 +97,7 @@ while [[ $# -gt 0 ]]; do
     --trace-script)     TRACE_SCRIPT="$2";         shift 2 ;;
     --client-args)      read -ra CLIENT_EXTRA_ARGS <<< "$2"; shift 2 ;;
     --remote-client)    REMOTE_CLIENT_HOST="$2";  shift 2 ;;
+    --udp-socket-buffer-bytes) UDP_SOCKET_BUFFER_BYTES="$2"; shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -220,6 +225,7 @@ listeners:
       enable_gso: true
       max_conn_packets_sent_per_loop: 16
       max_server_recv_packets_per_loop: 256
+      udp_socket_buffer_bytes: $UDP_SOCKET_BUFFER_BYTES
       bbr2:
         exit_startup_on_loss: true
         enable_recovery_in_startup: true
@@ -260,6 +266,7 @@ cp "$RELAY_CFG" "$LOG_DIR/relay.yaml"
   echo "delivery_timeout: $DELIVERY_TIMEOUT"
   echo "client_threads:   $CLIENT_THREADS"
   echo "jemalloc:         ${JEMALLOC:-none}"
+  echo "udp_socket_buf:     $UDP_SOCKET_BUFFER_BYTES"
   echo "mvfst_bpf_steering: $BPF_STEERING"
   [[ "$PERF_DURATION" -gt 0 ]] && echo "perf_duration:    ${PERF_DURATION}s (delay=$(( 3 * SUBSCRIBER_MAX / RAMP ))s)" || true
   [[ -n "$PERF_EVENTS" ]] && echo "perf_events:      $PERF_EVENTS" || true

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -133,7 +133,11 @@ MoqxRelayServer::MoqxRelayServer(
     : MoQServer(
           buildFizzContext(listenerCfg),
           listenerCfg.endpoint,
-          buildTransportSettings(listenerCfg.quic, listenerCfg.mvfst)
+          MoQServer::Options{
+              .transportSettings = buildTransportSettings(listenerCfg.quic, listenerCfg.mvfst),
+              .udpSendBufferBytes = listenerCfg.mvfst.udpSocketBufferBytes,
+              .udpRecvBufferBytes = listenerCfg.mvfst.udpSocketBufferBytes,
+          }
       ),
       listenerCfg_(listenerCfg), context_(std::move(context)), ioExecutor_(ioExecutor) {}
 

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -128,6 +128,10 @@ struct MvfstConfig {
     float ceTarget{0.0f}; // 0 = disabled
   };
 
+  // UDP socket send/receive buffer size in bytes. 0 = use MoQServer default (1 MB).
+  // Increase when high fan-out causes EAGAIN bursts under load.
+  uint64_t udpSocketBufferBytes{0};
+
   BBR bbr;
   BBR2 bbr2;
   Cubic cubic;

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -508,6 +508,8 @@ void applyMvfstOverride(MvfstConfig& base, const ParsedMvfstConfig& overlay) {
     if (auto v = ls->ce_target.value())
       base.l4s.ceTarget = *v;
   }
+  if (auto v = overlay.udp_socket_buffer_bytes.value())
+    base.udpSocketBufferBytes = *v;
 }
 
 MvfstConfig mergeMvfstConfig(

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -225,6 +225,11 @@ struct ParsedMvfstConfig {
       "L4S tunables (ECN CE target). Usable alongside any ECN-aware CC algorithm.",
       std::optional<ParsedL4S>>
       l4s;
+  rfl::Description<
+      "UDP socket send and receive buffer size in bytes. Default: 0 (use MoQServer built-in "
+      "default of 1 MB). Increase to reduce EAGAIN errors under high fan-out burst load.",
+      std::optional<uint64_t>>
+      udp_socket_buffer_bytes;
 };
 
 struct ParsedListenerConfig {


### PR DESCRIPTION
Exposes udpSendBufferBytes/udpRecvBufferBytes via MoQServer::Options, plumbed through ParsedConfig → ConfigResolver → MoqxRelayServer. 0 (default) keeps the existing MoQServer built-in 1 MB behaviour. Also comments out reorderingThreshold (removed from moxygen API).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/374)
<!-- Reviewable:end -->
