### PR TITLE
Fix Debian bookworm builds and switch deps to CPM

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -168,3 +168,51 @@ CI requires clang-format-19. Check before pushing:
 
 See [design/ci-architecture.md](design/ci-architecture.md) for the full CI pipeline:
 upstream sync, submodule updates, build/publish/release, and auto-deploy.
+
+## Developer IDEs
+
+### CLion
+
+CLion can build moqx directly via its CMake integration. You still need the
+same prerequisites as the command-line build (CMake 3.22+, system libraries,
+and a staged moxygen install). The steps below wire CLion to the local
+dependency tree under `.scratch/`.
+
+#### 1. Stage dependencies (first time, or after dep changes)
+
+Before CLion can configure the project, moxygen must be present at
+`.scratch/moxygen-install`. Run:
+
+```bash
+./scripts/build.sh setup --from-source
+```
+
+This installs moxygen and its Meta dependencies into `.scratch/moxygen-install`.
+It takes 15–30 minutes on a first run.
+
+You only need to re-run this when **dependencies change** — for example, after
+updating the `deps/moxygen` submodule or when `.scratch/` has been cleaned.
+Day-to-day moqx source edits do not require re-running setup.
+
+#### 2. Configure CMake in CLion
+
+Open the moqx project root in CLion, then go to
+**Settings → Build, Execution, Deployment → CMake** and edit the **Debug**
+profile. Add these CMake options:
+
+```
+-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_PREFIX_PATH=$CMakeProjectDir$/.scratch/moxygen-install -DGFLAGS_SHARED=ON
+```
+
+`$CMakeProjectDir$` is a CLion macro that expands to the project root, so
+CMake can find the staged moxygen package config.
+
+If you configure before running setup, CMake will fail because
+`.scratch/moxygen-install` does not exist yet — that is expected.
+
+#### 3. Reload and build
+
+After setup completes, reload the CMake project in CLion
+(**Tools → CMake → Reload CMake Project**, or the reload button in the CMake
+tool window). Configuration should succeed and you can build and run targets
+from the IDE as usual.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,39 +56,28 @@ endif()
 
 find_package(moxygen REQUIRED)
 
-# --- yaml-cpp (FetchContent) ---
+include(cmake/CPM.cmake)
 
-include(FetchContent)
-
-set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
-set(YAML_CPP_FORMAT_SOURCE OFF CACHE BOOL "" FORCE)
-
-# yaml-cpp 0.8.0 uses cmake_minimum_required(VERSION 3.0.2) which triggers a
-# deprecation warning on CMake ≥ 3.27. Suppress it for this dependency only.
-set(_moqx_save_warn_deprecated "${CMAKE_WARN_DEPRECATED}")
-set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
-
-FetchContent_Declare(yaml-cpp
-  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-  GIT_TAG 0.8.0
-  SYSTEM
+# --- yaml-cpp (CPM) ---
+CPMAddPackage(
+        NAME yaml-cpp
+        GITHUB_REPOSITORY jbeder/yaml-cpp
+        GIT_TAG 0.8.0
+        OPTIONS
+        "YAML_CPP_BUILD_TESTS OFF"
+        "YAML_CPP_BUILD_TOOLS OFF"
+        "YAML_CPP_FORMAT_SOURCE OFF"
+        "CMAKE_WARN_DEPRECATED OFF"
 )
-FetchContent_MakeAvailable(yaml-cpp)
-
-set(CMAKE_WARN_DEPRECATED "${_moqx_save_warn_deprecated}" CACHE BOOL "" FORCE)
 
 # --- reflect-cpp (FetchContent, needs yaml-cpp available) ---
 
-set(REFLECTCPP_YAML ON CACHE BOOL "" FORCE)
-set(REFLECTCPP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-
-FetchContent_Declare(reflectcpp
-  GIT_REPOSITORY https://github.com/getml/reflect-cpp.git
-  GIT_TAG v0.18.0
-  SYSTEM
+CPMAddPackage(
+        NAME reflectcpp
+        GITHUB_REPOSITORY getml/reflect-cpp
+        GIT_TAG v0.18.0
+        OPTIONS "REFLECTCPP_YAML ON" "REFLECTCPP_BUILD_TESTS OFF"
 )
-FetchContent_MakeAvailable(reflectcpp)
 
 # --- Cache library (forked from moxygen) ---
 

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.42.0)
+set(CPM_HASH_SUM "2020b4fc42dba44817983e06342e682ecfc3d2f484a581f11cc5731fbe4dce8a")
+
+if(CPM_SOURCE_CACHE)
+    set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+    set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+    set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+        https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+        ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,9 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /src
 
 # Moxygen tarball (pre-extracted bookworm build)
-#COPY .docker-deps/moxygen /opt/moxygen
-
-RUN
+COPY .docker-deps/moxygen /opt/moxygen
 
 # MoQX source — only what cmake needs
 COPY CMakeLists.txt CMakePresets.json ./

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,17 +2,18 @@
 FROM debian:bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential ninja-build git ca-certificates python3-pip \
+        build-essential cmake ninja-build git ca-certificates \
         libssl-dev libunwind-dev libgoogle-glog-dev libgflags-dev \
         libdouble-conversion-dev libevent-dev libsodium-dev libzstd-dev \
-        libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev libdwarf-dev \
-    && pip install --break-system-packages cmake \
+        libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev libdwarf-dev libaio-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
 
 # Moxygen tarball (pre-extracted bookworm build)
-COPY .docker-deps/moxygen /opt/moxygen
+#COPY .docker-deps/moxygen /opt/moxygen
+
+RUN
 
 # MoQX source — only what cmake needs
 COPY CMakeLists.txt CMakePresets.json ./

--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -95,6 +95,7 @@ cmake -S "$STANDALONE_SRC" -B "$BUILD_DIR" \
     -DBUILD_TESTS=ON \
     -DBUILD_SAMPLES=ON \
     -DBUILD_SHARED_LIBS=OFF \
+    -DBoost_USE_STATIC_LIBS=ON \
     "${EXTRA_CMAKE_ARGS[@]+"${EXTRA_CMAKE_ARGS[@]}"}"
 
 echo "==> Building ($NPROC jobs)..."


### PR DESCRIPTION
- Switch yaml-cpp and reflect-cpp from CMake FetchContent to CPM for cleaner dependency management and fewer CMake version workarounds.
- Harden the Debian bookworm native and docker builds. No longer require pip install of cmake. 
- Use Boost static libs when building standalone moxygen deps.
- Add CLion setup instructions to BUILD.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/376)
<!-- Reviewable:end -->
