### PR TITLE
fix macOS deps build with Apple Clang 21+ and tidy sanitizer flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _CPack_Packages/
 .vscode/
 .claude/
 .cache/
+.idea/
 
 # Docker secrets (never commit)
 docker/.env

--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -57,15 +57,15 @@ NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 # Profile-specific cmake flags
 CMAKE_BUILD_TYPE="RelWithDebInfo"
 EXTRA_CMAKE_ARGS=()
+CXX_FLAGS=""
 if [[ "$PROFILE" == "san" ]]; then
   CMAKE_BUILD_TYPE="Debug"
   # ASAN only (no UBSAN): folly uses static_assert on syscall function addresses
   # (recvmmsg, sendmmsg) which become non-constant under UBSAN's function
   # interposition. ASAN alone is sufficient for memory safety in deps.
-  SAN_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+  CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
   EXTRA_CMAKE_ARGS+=(
-    "-DCMAKE_C_FLAGS=${SAN_FLAGS}"
-    "-DCMAKE_CXX_FLAGS=${SAN_FLAGS}"
+    "-DCMAKE_C_FLAGS=${CXX_FLAGS}"
     "-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address"
     "-DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=address"
   )
@@ -74,13 +74,27 @@ elif [[ "$PROFILE" == "tsan" ]]; then
   # TSan must instrument the full dep chain: folly/mvfst atomics and EventBase
   # internals are invisible to TSan without instrumentation, causing false positives
   # on every lock operation.
-  SAN_FLAGS="-fsanitize=thread -fno-omit-frame-pointer"
+  CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer"
   EXTRA_CMAKE_ARGS+=(
-    "-DCMAKE_C_FLAGS=${SAN_FLAGS}"
-    "-DCMAKE_CXX_FLAGS=${SAN_FLAGS}"
+    "-DCMAKE_C_FLAGS=${CXX_FLAGS}"
     "-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=thread"
     "-DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=thread"
   )
+fi
+
+# moxygen pins fmt 10.2.1; Apple Clang 21+ (Xcode 26 / recent CLT) rejects its
+# C++20 consteval format-string validation (fmtlib/fmt#4740). Define
+# FMT_CONSTEVAL empty so fmt falls back to runtime checking for this dep build.
+if [[ "$(uname -s)" == "Darwin" ]] && command -v c++ >/dev/null 2>&1; then
+  _apple_clang_ver="$(c++ --version 2>/dev/null \
+    | sed -En 's/.*clang version ([0-9]+).*/\1/p' | head -1)"
+  if [[ -n "${_apple_clang_ver:-}" && "${_apple_clang_ver}" -ge 21 ]]; then
+    CXX_FLAGS+=" -DFMT_CONSTEVAL="
+  fi
+fi
+if [[ -n "$CXX_FLAGS" ]]; then
+  # shellcheck disable=SC2086
+  EXTRA_CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=${CXX_FLAGS}")
 fi
 
 echo "==> Configuring standalone moxygen build (profile: ${PROFILE})..."


### PR DESCRIPTION
- Work around Apple Clang 21+ (Xcode 26 / recent CLT) rejecting fmt 10.2.1's C++20 consteval format-string validation (fmtlib/fmt#4740) by defining `FMT_CONSTEVAL` empty for the standalone moxygen dep build on Darwin when the detected clang major version is >= 21. This unblocks `setup-deps-standalone.sh` on current macOS toolchains.
- Refactor the `san` / `tsan` profiles in `scripts/setup-deps-standalone.sh` to accumulate C++ compile flags in a single `CXX_FLAGS` variable, so the macOS workaround composes cleanly with sanitizer builds, and only emit `-DCMAKE_CXX_FLAGS=...` when there is something to set.
- Ignore `.idea/` in `.gitignore`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/377)
<!-- Reviewable:end -->
