### PR TITLE
Run PR CI (incl. asan) on all PR base branches

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -5,7 +5,6 @@ name: ci pr
 
 on:
   pull_request:
-    branches: [main, release/**]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What

Drop the `pull_request.branches` filter in [ci-pr.yml](.github/workflows/ci-pr.yml) so the full PR verification matrix — `linux`, `macos`, and **`asan debug`** — runs on **every** PR regardless of base branch, instead of only PRs targeting `main` or `release/**`.

```diff
 on:
   pull_request:
-    branches: [main, release/**]
```

## Why

Requested by Suhas: enable sanitizer CI on non-main PR branches too. Feature/fix branches and stacked PRs currently get **no CI at all** unless they target `main`/`release/**`, so sanitizer regressions only surface at merge-to-main time. Removing the filter (rather than enumerating `feature/**`/`fix/**`) covers any base branch with no future maintenance.

## Caveat (read before relying on it)

For `pull_request` events, GitHub runs the workflow definition from the PR's **base branch**, not the head. So:
- PRs targeting `main` / `release/**` — covered immediately.
- PRs targeting a long-lived `feature/**` base — only get the asan run once **this change is merged/rebased into that base branch**.

## Load note

The `asan debug` job runs on the shared `[self-hosted, linode]` runner. Opening it to all PRs increases load on that box; `cancel-in-progress` is per-ref, so concurrent feature PRs queue rather than collide.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/383)
<!-- Reviewable:end -->
