### PR TITLE
setup-deps-standalone: prefer static Boost when available, with env override

### DIFF
--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -97,6 +97,35 @@ if [[ -n "$CXX_FLAGS" ]]; then
   EXTRA_CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=${CXX_FLAGS}")
 fi
 
+# Boost linking: prefer static when available (more portable artifacts);
+# fall back to shared on distros that don't ship libboost_*.a (CentOS/RHEL).
+# Override via env: BOOST_USE_STATIC_LIBS={auto,on,off}
+#   auto (default) — ask cmake's own find_package whether static is findable
+#   on             — force static (cmake configure fails loudly if missing)
+#   off            — force shared (omit the flag entirely)
+BOOST_STATIC_ARG=()
+case "${BOOST_USE_STATIC_LIBS:-auto}" in
+    on|ON|1|true)
+        BOOST_STATIC_ARG=(-DBoost_USE_STATIC_LIBS=ON)
+        ;;
+    off|OFF|0|false)
+        ;; # explicitly shared
+    auto|Auto|AUTO|"")
+        # Use CMake's own find_package logic — same code path as the real
+        # configure step below, so the answer is definitive.
+        if cmake --find-package \
+                 -DNAME=Boost -DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=EXIST \
+                 -DBoost_USE_STATIC_LIBS=ON >/dev/null 2>&1; then
+            BOOST_STATIC_ARG=(-DBoost_USE_STATIC_LIBS=ON)
+        fi
+        ;;
+    *)
+        echo "ERROR: BOOST_USE_STATIC_LIBS must be auto|on|off (got '${BOOST_USE_STATIC_LIBS}')" >&2
+        exit 1
+        ;;
+esac
+echo "==> Boost linking: ${BOOST_STATIC_ARG[*]:-shared (default)}"
+
 echo "==> Configuring standalone moxygen build (profile: ${PROFILE})..."
 # BUILD_TESTS=ON: gates the GoogleTest FetchContent in moxygen's standalone
 # CMake. Without it, moxygen-install ships no GTest config and moqx's
@@ -109,7 +138,7 @@ cmake -S "$STANDALONE_SRC" -B "$BUILD_DIR" \
     -DBUILD_TESTS=ON \
     -DBUILD_SAMPLES=ON \
     -DBUILD_SHARED_LIBS=OFF \
-    -DBoost_USE_STATIC_LIBS=ON \
+    "${BOOST_STATIC_ARG[@]}" \
     "${EXTRA_CMAKE_ARGS[@]+"${EXTRA_CMAKE_ARGS[@]}"}"
 
 echo "==> Building ($NPROC jobs)..."


### PR DESCRIPTION
## Summary
#376 added `-DBoost_USE_STATIC_LIBS=ON` unconditionally, which fails the standalone moxygen dep build on distros that don't ship `libboost_*.a` (CentOS / RHEL — reported by devs using those systems). This restores the build on those distros while keeping the *"static when possible"* policy from #376.

## How it picks

The probe uses `cmake --find-package` so it consults CMake's own `find_package(Boost)` algorithm — no hardcoded library paths, no distro sniffing, no `pkg-config` (Boost's `.pc` files are inconsistent across distros). Same code path as the real configure step, so the answer is definitive.

| `BOOST_USE_STATIC_LIBS` env | behavior |
|---|---|
| `auto` (default — including unset/empty) | probe via `cmake --find-package`; pass the flag if static is findable |
| `on` / `ON` / `1` / `true` | force static — `cmake` configure fails loudly if static Boost is missing (useful in publish CI to catch env regressions) |
| `off` / `OFF` / `0` / `false` | force shared (omit the flag) |
| anything else | error + exit 1 with a usage hint |

A one-line `==> Boost linking: …` log makes the chosen mode visible in build output.

## Test plan
- [x] Smoke-tested each mode locally (unset, auto, on, off, empty, bogus) — all behave per spec.
- [ ] Verify on a CentOS / RHEL dev box that `auto` now selects shared and the build succeeds (was failing on `=ON`).
- [ ] Verify on Debian/Ubuntu that `auto` still selects static (no behavior change from #376).
- [ ] Spot-check `BOOST_USE_STATIC_LIBS=on` and `=off` produce the expected configure args.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/385)
<!-- Reviewable:end -->
