### PR TITLE
auth: per-session auth filters replace the session-keyed grants map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ add_library(moqx_core STATIC
   src/stats/QuicStatsCollector.cpp
   src/stats/EventBaseStatsCollector.cpp
   src/UpstreamProvider.cpp
+  src/relay/AuthFilters.cpp
   src/relay/TopNFilter.cpp
   src/relay/PropertyRanking.cpp
   src/relay/CrossExecFilter.cpp

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -95,84 +95,12 @@ void MoqxRelay::onUpstreamDisconnect() {
   upstreamSubNsHandle_.reset();
 }
 
-folly::Expected<folly::Unit, auth::AuthError> MoqxRelay::authenticateSession(
-    const ClientSetup& clientSetup,
-    std::shared_ptr<MoQSession> session
-) {
-  if (!authVerifier_.enabled()) {
-    return folly::unit;
-  }
-  auto token = auth::findAuthToken(clientSetup.params, authVerifier_.tokenType());
-  if (!token) {
-    if (!authVerifier_.requireSetupToken()) {
-      return folly::unit;
-    }
-    return folly::makeUnexpected(auth::AuthError::Missing);
-  }
-  auto grants = authVerifier_.verify(*token);
-  if (grants.hasError()) {
-    return folly::makeUnexpected(grants.error());
-  }
-  if (!auth::allows(grants.value(), auth::Action::ClientSetup, TrackNamespace{})) {
-    return folly::makeUnexpected(auth::AuthError::Forbidden);
-  }
-  sessionAuth_.insert_or_assign(session.get(), std::move(grants.value()));
-  return folly::unit;
+std::shared_ptr<Publisher> MoqxRelay::createPublisherFilter() {
+  return shared_from_this();
 }
 
-folly::Expected<folly::Unit, auth::AuthError> MoqxRelay::authorize(
-    auth::Action action,
-    const Parameters& params,
-    const TrackNamespace& ns,
-    const std::shared_ptr<MoQSession>& session,
-    std::optional<std::string_view> trackName
-) {
-  if (!authVerifier_.enabled()) {
-    return folly::unit;
-  }
-
-  auto token = auth::findAuthToken(params, authVerifier_.tokenType());
-  if (token && !authVerifier_.allowRequestTokenOverride()) {
-    // Request carried a per-request token but override is disabled, so the
-    // grants established at session setup govern. This is expected behavior;
-    // log at DBG1 for visibility rather than failing the request.
-    XLOG(DBG1) << "authorize: ignoring request AUTHORIZATION_TOKEN for action="
-               << static_cast<uint64_t>(action) << " (allow_request_token_override is disabled)";
-    token.reset();
-  }
-
-  // Resolve grants from exactly one source (request token or session), then run
-  // a single auth::allows() check below.
-  const auth::Grants* grants = nullptr;
-  auth::Grants verified;
-  if (token) {
-    auto res = authVerifier_.verify(*token);
-    if (res.hasError()) {
-      XLOG(DBG1) << "authorize: request token verification failed for action="
-                 << static_cast<uint64_t>(action) << ": " << auth::toString(res.error());
-      return folly::makeUnexpected(res.error());
-    }
-    verified = std::move(res.value());
-    grants = &verified;
-  } else {
-    auto it = sessionAuth_.find(session.get());
-    if (it == sessionAuth_.end()) {
-      XLOG(DBG1) << "authorize: no session grants for action=" << static_cast<uint64_t>(action)
-                 << " ns=" << ns;
-      return folly::makeUnexpected(auth::AuthError::Missing);
-    }
-    grants = &it->second;
-  }
-
-  const bool permitted =
-      trackName ? auth::allows(*grants, action, FullTrackName{ns, std::string(*trackName)})
-                : auth::allows(*grants, action, ns);
-  if (!permitted) {
-    XLOG(DBG1) << "authorize: action=" << static_cast<uint64_t>(action)
-               << " not permitted for ns=" << ns;
-    return folly::makeUnexpected(auth::AuthError::Forbidden);
-  }
-  return folly::unit;
+std::shared_ptr<Subscriber> MoqxRelay::createSubscriberFilter() {
+  return shared_from_this();
 }
 
 // Sends SUBSCRIBE_UPDATE to update forwarding state. Called from:
@@ -270,15 +198,6 @@ folly::coro::Task<Subscriber::PublishNamespaceResult> MoqxRelay::publishNamespac
   // TODO: store auth for forwarding on future SubscribeNamespace?
   auto session = MoQSession::getRequestSession();
   auto requestID = pubNs.requestID;
-  auto authRes =
-      authorize(auth::Action::PublishNamespace, pubNs.params, pubNs.trackNamespace, session);
-  if (authRes.hasError()) {
-    co_return folly::makeUnexpected(PublishNamespaceError{
-        requestID,
-        PublishNamespaceErrorCode::UNAUTHORIZED,
-        auth::toString(authRes.error())
-    });
-  }
   auto result = doPublishNamespace(std::move(pubNs), session, std::move(callback));
   if (!result) {
     co_return folly::makeUnexpected(
@@ -363,18 +282,6 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   XLOG(DBG1) << __func__ << " ftn=" << pub.fullTrackName;
   XCHECK(handle) << "Publish handle cannot be null";
   auto session = MoQSession::getRequestSession();
-  auto authRes = authorize(
-      auth::Action::Publish,
-      pub.params,
-      pub.fullTrackName.trackNamespace,
-      session,
-      pub.fullTrackName.trackName
-  );
-  if (authRes.hasError()) {
-    return folly::makeUnexpected(
-        PublishError{pub.requestID, PublishErrorCode::UNAUTHORIZED, auth::toString(authRes.error())}
-    );
-  }
   if (!pub.fullTrackName.trackNamespace.startsWith(allowedNamespacePrefix_)) {
     return folly::makeUnexpected(
         PublishError{pub.requestID, PublishErrorCode::UNINTERESTED, "bad namespace"}
@@ -654,21 +561,6 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
     // Fall through: register the peer as a normal subNs subscriber so it
     // receives namespace announcements as publishers connect.
   }
-  if (incomingPeerID.empty()) {
-    auto authRes = authorize(
-        auth::Action::SubscribeNamespace,
-        subNs.params,
-        subNs.trackNamespacePrefix,
-        session
-    );
-    if (authRes.hasError()) {
-      co_return folly::makeUnexpected(SubscribeNamespaceError{
-          subNs.requestID,
-          SubscribeNamespaceErrorCode::UNAUTHORIZED,
-          auth::toString(authRes.error())
-      });
-    }
-  }
   auto maybeNegotiatedVersion = session->getNegotiatedVersion();
   CHECK(maybeNegotiatedVersion.has_value());
 
@@ -812,20 +704,6 @@ MoqxRelay::PublishState MoqxRelay::findPublishState(const FullTrackName& ftn) {
 folly::coro::Task<Publisher::SubscribeResult>
 MoqxRelay::subscribe(SubscribeRequest subReq, std::shared_ptr<TrackConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
-  auto authRes = authorize(
-      auth::Action::Subscribe,
-      subReq.params,
-      subReq.fullTrackName.trackNamespace,
-      session,
-      subReq.fullTrackName.trackName
-  );
-  if (authRes.hasError()) {
-    co_return folly::makeUnexpected(SubscribeError{
-        subReq.requestID,
-        SubscribeErrorCode::UNAUTHORIZED,
-        auth::toString(authRes.error())
-    });
-  }
   const auto& ftn = subReq.fullTrackName;
 
   if (ftn.trackNamespace.empty()) {
@@ -948,18 +826,6 @@ folly::coro::Task<Publisher::FetchResult>
 MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
 
-  auto authRes = authorize(
-      auth::Action::Fetch,
-      fetch.params,
-      fetch.fullTrackName.trackNamespace,
-      session,
-      fetch.fullTrackName.trackName
-  );
-  if (authRes.hasError()) {
-    co_return folly::makeUnexpected(
-        FetchError({fetch.requestID, FetchErrorCode::UNAUTHORIZED, auth::toString(authRes.error())})
-    );
-  }
   if (fetch.fullTrackName.trackNamespace.empty()) {
     co_return folly::makeUnexpected(
         FetchError({fetch.requestID, FetchErrorCode::TRACK_NOT_EXIST, "namespace required"})
@@ -1026,20 +892,6 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatus(TrackStat
   XLOG(DBG1) << __func__ << " ftn=" << trackStatus.fullTrackName;
 
   auto session = MoQSession::getRequestSession();
-  auto authRes = authorize(
-      auth::Action::TrackStatus,
-      trackStatus.params,
-      trackStatus.fullTrackName.trackNamespace,
-      session,
-      trackStatus.fullTrackName.trackName
-  );
-  if (authRes.hasError()) {
-    co_return folly::makeUnexpected(TrackStatusError{
-        trackStatus.requestID,
-        TrackStatusErrorCode::UNAUTHORIZED,
-        auth::toString(authRes.error())
-    });
-  }
 
   if (trackStatus.fullTrackName.trackNamespace.empty()) {
     co_return folly::makeUnexpected(TrackStatusError(

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -12,7 +12,6 @@
 #include "NamespaceTree.h"
 #include "SubscriptionRegistry.h"
 #include "UpstreamProvider.h"
-#include "auth/Auth.h"
 #include "config/Config.h"
 #include "relay/PropertyRanking.h"
 #include <moxygen/MoQSession.h>
@@ -101,13 +100,12 @@ public:
   explicit MoqxRelay(
       config::CacheConfig cache = {},
       std::string relayID = {},
-      config::AuthConfig auth = {},
       uint64_t maxDeselected = kDefaultMaxDeselected,
       std::chrono::milliseconds idleTimeout = kDefaultIdleTimeout,
       std::chrono::milliseconds activityThreshold = kDefaultActivityThreshold
   )
-      : relayID_(std::move(relayID)), authVerifier_(std::move(auth)), maxDeselected_(maxDeselected),
-        idleTimeout_(idleTimeout), activityThreshold_(activityThreshold) {
+      : relayID_(std::move(relayID)), maxDeselected_(maxDeselected), idleTimeout_(idleTimeout),
+        activityThreshold_(activityThreshold) {
     if (cache.maxCachedTracks > 0) {
       cache_ = std::make_unique<MoqxCache>(cache.maxCachedTracks, cache.maxCachedGroupsPerTrack);
       cache_->setMaxCachedBytes(static_cast<size_t>(cache.maxCachedMb) * 1024 * 1024);
@@ -121,11 +119,10 @@ public:
     allowedNamespacePrefix_ = std::move(allowed);
   }
 
-  folly::Expected<folly::Unit, auth::AuthError> authenticateSession(
-      const moxygen::ClientSetup& clientSetup,
-      std::shared_ptr<moxygen::MoQSession> session
-  );
-  void removeSessionAuth(moxygen::MoQSession* session) { sessionAuth_.erase(session); }
+  // Per-session publish/subscribe handlers. Returns the relay itself today; the
+  // hook exists so cross-exec/data-plane wrapping can slot in here later.
+  std::shared_ptr<moxygen::Publisher> createPublisherFilter();
+  std::shared_ptr<moxygen::Subscriber> createSubscriberFilter();
 
   // Store the upstream provider. The provider must have been constructed with
   // publishHandler=this and subscribeHandler=this so that the upstream relay's
@@ -305,18 +302,8 @@ private:
   void
   onTrackEvicted(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQSession> session);
 
-  folly::Expected<folly::Unit, auth::AuthError> authorize(
-      auth::Action action,
-      const moxygen::Parameters& params,
-      const moxygen::TrackNamespace& ns,
-      const std::shared_ptr<moxygen::MoQSession>& session,
-      std::optional<std::string_view> trackName = std::nullopt
-  );
-
   moxygen::TrackNamespace allowedNamespacePrefix_;
   std::string relayID_;
-  auth::AuthTokenVerifier authVerifier_;
-  folly::F14FastMap<moxygen::MoQSession*, auth::Grants> sessionAuth_;
   std::shared_ptr<UpstreamProvider> upstream_;
 
   // Holds the peer subNs handle for the upstream (initiating) direction.

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "MoqxRelayContext.h"
+#include "relay/AuthFilters.h"
 #include "stats/MoQStatsCollector.h"
 #include <moxygen/events/MoQFollyExecutorImpl.h>
 #include <moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h>
@@ -24,7 +25,11 @@ MoqxRelayContext::MoqxRelayContext(
   for (const auto& [name, svc] : services) {
     services_.emplace(
         name,
-        ServiceEntry{svc, std::make_shared<MoqxRelay>(svc.cache, relayID, svc.auth)}
+        ServiceEntry{
+            svc,
+            std::make_shared<MoqxRelay>(svc.cache, relayID),
+            std::make_shared<const auth::AuthTokenVerifier>(svc.auth)
+        }
     );
   }
 }
@@ -141,13 +146,12 @@ void MoqxRelayContext::onNewSession(std::shared_ptr<MoQSession> clientSession) {
   }
 }
 
-void MoqxRelayContext::onSessionEnd(std::shared_ptr<MoQSession> session) {
+void MoqxRelayContext::onSessionEnd(std::shared_ptr<MoQSession> /*session*/) {
   if (statsCollector_) {
     statsCollector_->onSessionEnd();
   }
-  for (auto& [name, entry] : services_) {
-    entry.relay->removeSessionAuth(session.get());
-  }
+  // Per-session auth state lives on the session's AuthFilter and is released
+  // when the session drops it; no relay-side cleanup needed.
 }
 
 folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayContext::validateAuthority(
@@ -164,14 +168,15 @@ folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayContext::validateAu
     return folly::makeUnexpected(SessionCloseErrorCode::INVALID_AUTHORITY);
   }
 
-  // Route: set per-service relay as handler
+  // Route: verify the setup token, then install the session's filter handlers.
   auto it = services_.find(*matchedName);
   CHECK(it != services_.end()) << "Service '" << *matchedName << "' matched but no entry found";
-  auto authRes = it->second.relay->authenticateSession(clientSetup, session);
-  if (authRes.hasError()) {
+  auto& entry = it->second;
+  auto grants = auth::authenticateSetup(*entry.verifier, clientSetup.params);
+  if (grants.hasError()) {
     XLOG(ERR) << "Authorization failed for authority=" << authority << " path=" << path
-              << " reason=" << auth::toString(authRes.error());
-    switch (authRes.error()) {
+              << " reason=" << auth::toString(grants.error());
+    switch (grants.error()) {
     case auth::AuthError::Expired:
       return folly::makeUnexpected(SessionCloseErrorCode::EXPIRED_AUTH_TOKEN);
     case auth::AuthError::Malformed:
@@ -184,8 +189,21 @@ folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxRelayContext::validateAu
     }
     return folly::makeUnexpected(SessionCloseErrorCode::UNAUTHORIZED);
   }
-  session->setPublishHandler(it->second.relay);
-  session->setSubscribeHandler(it->second.relay);
+  // Wrap the relay's handlers in auth filters when grants are present (auth on);
+  // a null grants pointer means auth is disabled, so install the relay directly.
+  std::shared_ptr<Publisher> pub = entry.relay->createPublisherFilter();
+  std::shared_ptr<Subscriber> sub = entry.relay->createSubscriberFilter();
+  if (grants.value()) {
+    pub = std::make_shared<AuthPublisherFilter>(
+        std::move(pub),
+        entry.verifier,
+        grants.value(),
+        !relayID_.empty()
+    );
+    sub = std::make_shared<AuthSubscriberFilter>(std::move(sub), entry.verifier, grants.value());
+  }
+  session->setPublishHandler(std::move(pub));
+  session->setSubscribeHandler(std::move(sub));
   return folly::unit;
 }
 

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -12,6 +12,7 @@
 #include "MoqxRelay.h"
 #include "ServiceMatcher.h"
 #include "UpstreamProvider.h"
+#include "auth/Auth.h"
 #include "config/Config.h"
 #include "stats/MoQStatsCollector.h"
 #include "stats/StatsRegistry.h"
@@ -50,6 +51,7 @@ public:
   struct ServiceEntry {
     config::ServiceConfig config;
     std::shared_ptr<MoqxRelay> relay;
+    std::shared_ptr<const auth::AuthTokenVerifier> verifier;
   };
 
   MoqxRelayContext(

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -328,6 +328,77 @@ folly::Expected<Grants, AuthError> AuthTokenVerifier::verify(const AuthToken& to
   return grants;
 }
 
+folly::Expected<std::shared_ptr<const Grants>, AuthError>
+authenticateSetup(const AuthTokenVerifier& verifier, const Parameters& setupParams) {
+  if (!verifier.enabled()) {
+    return std::shared_ptr<const Grants>{};
+  }
+  if (auto token = findAuthToken(setupParams, verifier.tokenType())) {
+    auto verified = verifier.verify(*token);
+    if (verified.hasError()) {
+      return folly::makeUnexpected(verified.error());
+    }
+    if (!allows(verified.value(), Action::ClientSetup, TrackNamespace{})) {
+      return folly::makeUnexpected(AuthError::Forbidden);
+    }
+    return std::make_shared<const Grants>(std::move(verified.value()));
+  }
+  if (verifier.requireSetupToken()) {
+    return folly::makeUnexpected(AuthError::Missing);
+  }
+  // No setup token but not required: connect with empty grants; requests must
+  // then carry their own tokens to be authorized.
+  return std::make_shared<const Grants>();
+}
+
+folly::Expected<folly::Unit, AuthError> authorize(
+    const AuthTokenVerifier& verifier,
+    Action action,
+    const Parameters& params,
+    const TrackNamespace& ns,
+    const Grants& sessionGrants,
+    std::optional<std::string_view> trackName
+) {
+  if (!verifier.enabled()) {
+    return folly::unit;
+  }
+
+  auto token = findAuthToken(params, verifier.tokenType());
+  if (token && !verifier.allowRequestTokenOverride()) {
+    // Request carried a per-request token but override is disabled, so the
+    // session-setup grants govern; log rather than fail.
+    XLOG(DBG1) << "authorize: ignoring request AUTHORIZATION_TOKEN for action="
+               << static_cast<uint64_t>(action) << " (allow_request_token_override is disabled)";
+    token.reset();
+  }
+
+  // Resolve grants from exactly one source (request token or session).
+  const Grants* grants = nullptr;
+  Grants verified;
+  if (token) {
+    auto res = verifier.verify(*token);
+    if (res.hasError()) {
+      XLOG(DBG1) << "authorize: request token verification failed for action="
+                 << static_cast<uint64_t>(action) << ": " << toString(res.error());
+      return folly::makeUnexpected(res.error());
+    }
+    verified = std::move(res.value());
+    grants = &verified;
+  } else {
+    grants = &sessionGrants;
+  }
+
+  const bool permitted = trackName
+                             ? allows(*grants, action, FullTrackName{ns, std::string(*trackName)})
+                             : allows(*grants, action, ns);
+  if (!permitted) {
+    XLOG(DBG1) << "authorize: action=" << static_cast<uint64_t>(action)
+               << " not permitted for ns=" << ns;
+    return folly::makeUnexpected(AuthError::Forbidden);
+  }
+  return folly::unit;
+}
+
 std::string AuthTokenVerifier::signForTest(
     std::string_view keyID,
     std::string_view secret,

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -9,10 +9,12 @@
 #include "config/Config.h"
 
 #include <folly/Expected.h>
+#include <folly/Unit.h>
 #include <moxygen/MoQTypes.h>
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -100,5 +102,21 @@ bool allows(
 );
 
 const char* toString(AuthError error);
+
+// Verifies the setup AUTHORIZATION_TOKEN. Returns null grants when auth is
+// disabled; shared grants (possibly empty) to gate the session otherwise.
+folly::Expected<std::shared_ptr<const Grants>, AuthError>
+authenticateSetup(const AuthTokenVerifier& verifier, const moxygen::Parameters& setupParams);
+
+// Authorizes a request against session grants, or a per-request token when
+// allow_request_token_override is set. Returns Unit when permitted.
+folly::Expected<folly::Unit, AuthError> authorize(
+    const AuthTokenVerifier& verifier,
+    Action action,
+    const moxygen::Parameters& params,
+    const moxygen::TrackNamespace& ns,
+    const Grants& sessionGrants,
+    std::optional<std::string_view> trackName = std::nullopt
+);
 
 } // namespace openmoq::moqx::auth

--- a/src/relay/AuthFilters.cpp
+++ b/src/relay/AuthFilters.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/AuthFilters.h"
+
+#include "UpstreamProvider.h" // getPeerRelayID
+
+using namespace moxygen;
+
+namespace openmoq::moqx {
+
+folly::coro::Task<Publisher::SubscribeResult>
+AuthPublisherFilter::subscribe(SubscribeRequest sub, std::shared_ptr<TrackConsumer> consumer) {
+  auto ok = auth::authorize(
+      *verifier_,
+      auth::Action::Subscribe,
+      sub.params,
+      sub.fullTrackName.trackNamespace,
+      *grants_,
+      sub.fullTrackName.trackName
+  );
+  if (ok.hasError()) {
+    return folly::coro::makeTask<Publisher::SubscribeResult>(folly::makeUnexpected(
+        SubscribeError{sub.requestID, SubscribeErrorCode::UNAUTHORIZED, auth::toString(ok.error())}
+    ));
+  }
+  return downstream_->subscribe(std::move(sub), std::move(consumer));
+}
+
+folly::coro::Task<Publisher::FetchResult>
+AuthPublisherFilter::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
+  auto ok = auth::authorize(
+      *verifier_,
+      auth::Action::Fetch,
+      fetch.params,
+      fetch.fullTrackName.trackNamespace,
+      *grants_,
+      fetch.fullTrackName.trackName
+  );
+  if (ok.hasError()) {
+    return folly::coro::makeTask<Publisher::FetchResult>(folly::makeUnexpected(
+        FetchError{fetch.requestID, FetchErrorCode::UNAUTHORIZED, auth::toString(ok.error())}
+    ));
+  }
+  return downstream_->fetch(std::move(fetch), std::move(consumer));
+}
+
+folly::coro::Task<Publisher::SubscribeNamespaceResult> AuthPublisherFilter::subscribeNamespace(
+    SubscribeNamespace subNs,
+    std::shared_ptr<NamespacePublishHandle> handle
+) {
+  // Peer relays authenticate via their relay token, validated downstream;
+  // only non-peer subscribers go through grant-based auth here.
+  bool isPeer = peeringEnabled_ && getPeerRelayID(subNs).has_value();
+  if (!isPeer) {
+    auto ok = auth::authorize(
+        *verifier_,
+        auth::Action::SubscribeNamespace,
+        subNs.params,
+        subNs.trackNamespacePrefix,
+        *grants_
+    );
+    if (ok.hasError()) {
+      return folly::coro::makeTask<Publisher::SubscribeNamespaceResult>(
+          folly::makeUnexpected(SubscribeNamespaceError{
+              subNs.requestID,
+              SubscribeNamespaceErrorCode::UNAUTHORIZED,
+              auth::toString(ok.error())
+          })
+      );
+    }
+  }
+  return downstream_->subscribeNamespace(std::move(subNs), std::move(handle));
+}
+
+folly::coro::Task<Publisher::TrackStatusResult>
+AuthPublisherFilter::trackStatus(const TrackStatus req) {
+  auto ok = auth::authorize(
+      *verifier_,
+      auth::Action::TrackStatus,
+      req.params,
+      req.fullTrackName.trackNamespace,
+      *grants_,
+      req.fullTrackName.trackName
+  );
+  if (ok.hasError()) {
+    return folly::coro::makeTask<Publisher::TrackStatusResult>(
+        folly::makeUnexpected(TrackStatusError{
+            req.requestID,
+            TrackStatusErrorCode::UNAUTHORIZED,
+            auth::toString(ok.error())
+        })
+    );
+  }
+  return downstream_->trackStatus(req);
+}
+
+void AuthPublisherFilter::goaway(Goaway g) {
+  downstream_->goaway(std::move(g));
+}
+
+Subscriber::PublishResult
+AuthSubscriberFilter::publish(PublishRequest pub, std::shared_ptr<SubscriptionHandle> handle) {
+  auto ok = auth::authorize(
+      *verifier_,
+      auth::Action::Publish,
+      pub.params,
+      pub.fullTrackName.trackNamespace,
+      *grants_,
+      pub.fullTrackName.trackName
+  );
+  if (ok.hasError()) {
+    return folly::makeUnexpected(
+        PublishError{pub.requestID, PublishErrorCode::UNAUTHORIZED, auth::toString(ok.error())}
+    );
+  }
+  return downstream_->publish(std::move(pub), std::move(handle));
+}
+
+folly::coro::Task<Subscriber::PublishNamespaceResult> AuthSubscriberFilter::publishNamespace(
+    PublishNamespace pubNs,
+    std::shared_ptr<PublishNamespaceCallback> callback
+) {
+  auto ok = auth::authorize(
+      *verifier_,
+      auth::Action::PublishNamespace,
+      pubNs.params,
+      pubNs.trackNamespace,
+      *grants_
+  );
+  if (ok.hasError()) {
+    return folly::coro::makeTask<Subscriber::PublishNamespaceResult>(
+        folly::makeUnexpected(PublishNamespaceError{
+            pubNs.requestID,
+            PublishNamespaceErrorCode::UNAUTHORIZED,
+            auth::toString(ok.error())
+        })
+    );
+  }
+  return downstream_->publishNamespace(std::move(pubNs), std::move(callback));
+}
+
+void AuthSubscriberFilter::goaway(Goaway g) {
+  downstream_->goaway(std::move(g));
+}
+
+} // namespace openmoq::moqx

--- a/src/relay/AuthFilters.h
+++ b/src/relay/AuthFilters.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "auth/Auth.h"
+
+#include <moxygen/Publisher.h>
+#include <moxygen/Subscriber.h>
+
+#include <folly/coro/Task.h>
+#include <memory>
+
+namespace openmoq::moqx {
+
+// Per-session publisher-side auth gate: authorizes each request against the
+// session's grants, then forwards to the downstream publisher.
+class AuthPublisherFilter : public moxygen::Publisher {
+public:
+  AuthPublisherFilter(
+      std::shared_ptr<moxygen::Publisher> downstream,
+      std::shared_ptr<const auth::AuthTokenVerifier> verifier,
+      std::shared_ptr<const auth::Grants> grants,
+      bool peeringEnabled
+  )
+      : downstream_(std::move(downstream)), verifier_(std::move(verifier)),
+        grants_(std::move(grants)), peeringEnabled_(peeringEnabled) {}
+
+  folly::coro::Task<SubscribeResult> subscribe(
+      moxygen::SubscribeRequest sub,
+      std::shared_ptr<moxygen::TrackConsumer> consumer
+  ) override;
+
+  folly::coro::Task<FetchResult>
+  fetch(moxygen::Fetch fetch, std::shared_ptr<moxygen::FetchConsumer> consumer) override;
+
+  folly::coro::Task<SubscribeNamespaceResult> subscribeNamespace(
+      moxygen::SubscribeNamespace subNs,
+      std::shared_ptr<NamespacePublishHandle> handle
+  ) override;
+
+  folly::coro::Task<TrackStatusResult> trackStatus(const moxygen::TrackStatus req) override;
+
+  void goaway(moxygen::Goaway g) override;
+
+private:
+  std::shared_ptr<moxygen::Publisher> downstream_;
+  std::shared_ptr<const auth::AuthTokenVerifier> verifier_;
+  std::shared_ptr<const auth::Grants> grants_;
+  bool peeringEnabled_;
+};
+
+// Per-session subscriber-side auth gate: authorizes PUBLISH/PUBLISH_NAMESPACE,
+// then forwards to the downstream subscriber.
+class AuthSubscriberFilter : public moxygen::Subscriber {
+public:
+  AuthSubscriberFilter(
+      std::shared_ptr<moxygen::Subscriber> downstream,
+      std::shared_ptr<const auth::AuthTokenVerifier> verifier,
+      std::shared_ptr<const auth::Grants> grants
+  )
+      : downstream_(std::move(downstream)), verifier_(std::move(verifier)),
+        grants_(std::move(grants)) {}
+
+  PublishResult publish(
+      moxygen::PublishRequest pub,
+      std::shared_ptr<moxygen::SubscriptionHandle> handle
+  ) override;
+
+  folly::coro::Task<PublishNamespaceResult> publishNamespace(
+      moxygen::PublishNamespace pubNs,
+      std::shared_ptr<PublishNamespaceCallback> callback
+  ) override;
+
+  void goaway(moxygen::Goaway g) override;
+
+private:
+  std::shared_ptr<moxygen::Subscriber> downstream_;
+  std::shared_ptr<const auth::AuthTokenVerifier> verifier_;
+  std::shared_ptr<const auth::Grants> grants_;
+};
+
+} // namespace openmoq::moqx

--- a/test/MoqxTrackFilterTest.cpp
+++ b/test/MoqxTrackFilterTest.cpp
@@ -38,7 +38,6 @@ protected:
     relay_ = std::make_shared<MoqxRelay>(
         config::CacheConfig{0, 0}, // no cache
         /*relayID=*/"",
-        config::AuthConfig{},
         /*maxDeselected=*/0
     );
     relay_->setAllowedNamespacePrefix(kPrefix);
@@ -527,7 +526,6 @@ TEST_F(MoqxTrackFilterTest, FirstObjectCycle_DoesNotEvictSelectedTracksBeforeFir
   relay_ = std::make_shared<MoqxRelay>(
       config::CacheConfig{0, 0},
       /*relayID=*/"",
-      config::AuthConfig{},
       /*maxDeselected=*/0,
       /*idleTimeout=*/std::chrono::seconds(10),
       /*activityThreshold=*/std::chrono::milliseconds(1)
@@ -742,7 +740,6 @@ TEST_F(MoqxTrackFilterTest, DeselectedQueueEviction_EvictsOldestEntry) {
   relay_ = std::make_shared<MoqxRelay>(
       config::CacheConfig{0, 0}, // no cache
       /*relayID=*/"",
-      config::AuthConfig{},
       /*maxDeselected=*/2
   );
   relay_->setAllowedNamespacePrefix(kPrefix);
@@ -832,7 +829,6 @@ TEST_F(MoqxTrackFilterTest, IdleEviction_SilentTrackReplacedByActiveOutsider) {
   relay_ = std::make_shared<MoqxRelay>(
       config::CacheConfig{0, 0}, // no cache
       /*relayID=*/"",
-      config::AuthConfig{},
       /*maxDeselected=*/5,
       /*idleTimeout=*/std::chrono::milliseconds(10),
       /*activityThreshold=*/std::chrono::milliseconds(1)


### PR DESCRIPTION
Grants live on per-session AuthPublisherFilter/AuthSubscriberFilter (src/relay/AuthFilters.{h,cpp}) that wrap a downstream Publisher/Subscriber, gate each request, then forward. Removes the relay's F14FastMap<MoQSession*, Grants> and its onSessionEnd cleanup: no shared mutable auth state, no raw-pointer keys, data-race-free across IO threads.

auth::authenticateSetup/authorize are now free functions beside allows(), and AuthTokenVerifier is a pure token->grants verifier. MoqxRelay holds no auth; createPublisher/SubscriberFilter() return the relay (room to wrap a data-plane filter underneath). MoqxRelayContext owns a per-service verifier and wraps the relay handlers in the filters at session setup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/386)
<!-- Reviewable:end -->
