### PR TITLE
setup-deps-standalone: probe compiler for static Boost, not cmake --find-package

### DIFF
--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -100,31 +100,46 @@ fi
 # Boost linking: prefer static when available (more portable artifacts);
 # fall back to shared on distros that don't ship libboost_*.a (CentOS/RHEL).
 # Override via env: BOOST_USE_STATIC_LIBS={auto,on,off}
-#   auto (default) — ask cmake's own find_package whether static is findable
+#   auto (default) — probe the compiler for the static archives moxygen needs
 #   on             — force static (cmake configure fails loudly if missing)
-#   off            — force shared (omit the flag entirely)
-BOOST_STATIC_ARG=()
+#   off            — force shared
+#
+# The auto probe asks the compiler driver to resolve each required Boost
+# component's static archive via its own library search paths (no hardcoded
+# paths, no distro sniffing). -print-file-name echoes back an absolute path
+# when the archive exists and the bare name otherwise. We require *every*
+# component moxygen links (standalone/CMakeLists.txt) to be present, since a
+# single missing .a breaks the static link at ninja time -- which is what
+# `cmake --find-package -DMODE=EXIST` failed to catch (it only checks that
+# Boost is locatable at all and ignores Boost_USE_STATIC_LIBS).
+#
+# We always pass the flag explicitly (ON or OFF), never omit it: a re-run of
+# `setup` reuses the existing build dir, and omitting would leave a stale
+# Boost_USE_STATIC_LIBS=ON in CMakeCache.txt in force.
 case "${BOOST_USE_STATIC_LIBS:-auto}" in
     on|ON|1|true)
-        BOOST_STATIC_ARG=(-DBoost_USE_STATIC_LIBS=ON)
+        boost_static=ON
         ;;
     off|OFF|0|false)
-        ;; # explicitly shared
+        boost_static=OFF
+        ;;
     auto|Auto|AUTO|"")
-        # Use CMake's own find_package logic — same code path as the real
-        # configure step below, so the answer is definitive.
-        if cmake --find-package \
-                 -DNAME=Boost -DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=EXIST \
-                 -DBoost_USE_STATIC_LIBS=ON >/dev/null 2>&1; then
-            BOOST_STATIC_ARG=(-DBoost_USE_STATIC_LIBS=ON)
-        fi
+        boost_static=ON
+        for comp in context filesystem program_options regex; do
+            loc=$("${CXX:-c++}" -print-file-name="libboost_${comp}.a" 2>/dev/null)
+            if [[ "$loc" != /* ]]; then
+                boost_static=OFF
+                break
+            fi
+        done
         ;;
     *)
         echo "ERROR: BOOST_USE_STATIC_LIBS must be auto|on|off (got '${BOOST_USE_STATIC_LIBS}')" >&2
         exit 1
         ;;
 esac
-echo "==> Boost linking: ${BOOST_STATIC_ARG[*]:-shared (default)}"
+BOOST_STATIC_ARG=(-DBoost_USE_STATIC_LIBS="${boost_static}")
+echo "==> Boost linking: ${boost_static} (static libs)"
 
 echo "==> Configuring standalone moxygen build (profile: ${PROFILE})..."
 # BUILD_TESTS=ON: gates the GoogleTest FetchContent in moxygen's standalone


### PR DESCRIPTION
The auto Boost-linking probe from #388 used
`cmake --find-package ... -DMODE=EXIST -DBoost_USE_STATIC_LIBS=ON`, which is a false positive: that mode only checks whether Boost is locatable at all and ignores Boost_USE_STATIC_LIBS. On distros that ship only libboost_*.so (CentOS/RHEL), it reports "static found", the script selects static linking, and the build dies at ninja time with `libboost_context.a ... missing` -- the exact failure #388 meant to fix.

Replace the probe with one that asks the compiler driver to resolve each static archive moxygen actually links (context, filesystem, program_options, regex) via `c++ -print-file-name`. That returns an absolute path only when the .a exists in the compiler's own search paths -- definitive, no hardcoded paths, no distro sniffing.

Also always pass -DBoost_USE_STATIC_LIBS explicitly (ON or OFF) instead of omitting it for shared. A re-run of `setup` reuses the existing build dir; omitting would leave a stale Boost_USE_STATIC_LIBS=ON in CMakeCache.txt in force.

Verified: clean build picks shared and links; a poisoned =ON cache is overridden to OFF and still builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/389)
<!-- Reviewable:end -->
