### PR TITLE
Remove CODEOWNERS (advisory-only, no merge gating)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,0 @@
-# CODEOWNERS — gates merging via branch protection.
-#
-# An approving review from at least one code owner is required for any PR
-# that touches this repository. The merge button itself is restricted (via
-# branch protection `restrictions`) to the same set of users.
-
-* @afrind @akash-a-n @gmarzot @michalhosna @mondain @Oxyd @peterchave @suhasHere @TimEvens

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ The following is a list of ideals for PR content — developer discretion and so
 
 PRs with all checks passing may be merged by maintainers at unpredictable times based on availability and relative priority. The author can signal merge intent in the following ways:
 
-- **Draft** — not ready for review. No auto-reviewer request; CI still runs.
+- **Draft** — not ready for review; CI still runs.
 - **`WIP:` prefix** — ready for review and CI, not ready for merge.
 - **Ready** (non-draft, no `WIP:` prefix) — merge when all checks pass (manual for now).
 


### PR DESCRIPTION
## What

- Delete `CODEOWNERS`.
- Drop the stale "no auto-reviewer request" note from the Draft bullet in `CONTRIBUTING.md` (with CODEOWNERS gone, no PR triggers an auto-reviewer request, so it's no longer a draft-only distinction).

## Why

Branch protection on `main` has **`require_code_owner_reviews: false`**, so `CODEOWNERS` never gated merges. Its only live effect was auto-requesting review from all **nine** listed owners on every PR — review noise with no compensating enforcement.

Nothing about how merges actually work changes:

- The required **single approving review** can still come from any collaborator with write access.
- The **merge button** stays independently restricted via branch-protection `restrictions` (`suhasHere`, `afrind`, `gmarzot`, + the sync bot app); admins can still `--admin` override.
- No workflow or tooling reads `CODEOWNERS` (the auto-merge workflow gates on an existing approval + green checks, not code owners).

Note: the deleted file's header comment claimed code-owner review was *required* and that the merge button was restricted to all nine listed users — both were inaccurate (review was advisory, merge is restricted to three). Dropping the file removes that misleading doc as well.

Reviewers can still be assigned per-PR as needed; this just drops the noisy auto-assignment default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/396)
<!-- Reviewable:end -->
