### PR TITLE
config: default MOQT versions to 14,16, excluding draft-18

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,7 +12,7 @@ listeners:
       # key_file: /path/to/key.pem     # Required when insecure: false
       insecure: true          # Skip TLS for local development
     endpoint: "/moq-relay"    # WebTransport endpoint path
-    # moqt_versions: [14, 16] # MOQT draft versions (empty = all supported)
+    # moqt_versions: [14, 16] # MOQT draft versions (empty = default 14,16)
     # quic:                   # Per-listener QUIC overrides (optional; inherits listener_defaults.quic)
     #   max_data: 33554432    # Override connection flow control window for this listener
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -62,7 +62,7 @@ listeners:
       key_file:  /etc/moqx/key.pem
     endpoint: /moq-relay
     quic_stack: mvfst         # optional; default mvfst
-    moqt_versions: []         # optional; empty = all supported versions
+    moqt_versions: []         # optional; empty = default [14, 16]
     quic: { ... }             # optional; overrides listener_defaults.quic
 ```
 

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -26,9 +26,13 @@ std::string matchRuleErrorLabel(const std::string& name, size_t j) {
   return "Service '" + name + "' match[" + std::to_string(j) + "]";
 }
 
+// Default versions when moqt_versions is unset. Excludes draft-18 (in moxygen's
+// kSupportedVersions but not yet interoperable); configure moqt_versions to opt in.
+constexpr const char* kDefaultMoqtVersions = "14,16";
+
 std::string moqtVersionsToString(const ParsedListenerConfig& listener) {
   if (!listener.moqt_versions.value().has_value() || listener.moqt_versions.value()->empty()) {
-    return "";
+    return kDefaultMoqtVersions;
   }
   return folly::join(',', *listener.moqt_versions.value());
 }

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -238,7 +238,7 @@ struct ParsedListenerConfig {
   rfl::Description<"TLS configuration", ParsedListenerTlsConfig> tls;
   rfl::Description<"WebTransport endpoint path", std::string> endpoint;
   rfl::Description<
-      "MOQT draft versions (empty = all supported)",
+      "MOQT draft versions (empty = default 14,16)",
       std::optional<std::vector<uint32_t>>>
       moqt_versions;
   rfl::Description<

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -562,7 +562,7 @@ TEST(ResolveConfig, MinimalInsecure) {
   EXPECT_EQ(resolved.listeners[0].address.getPort(), 9668);
   EXPECT_TRUE(std::holds_alternative<Insecure>(resolved.listeners[0].tlsMode));
   EXPECT_EQ(resolved.listeners[0].endpoint, "/moq-relay");
-  EXPECT_EQ(resolved.listeners[0].moqtVersions, "");
+  EXPECT_EQ(resolved.listeners[0].moqtVersions, "14,16");
   EXPECT_THAT(result.value().warnings, IsEmpty());
 
   ASSERT_EQ(resolved.services.size(), 1);
@@ -830,7 +830,7 @@ TEST(ResolveConfig, VersionsEmpty) {
   auto cfg = makeMinimalInsecureConfig();
   auto result = resolveConfig(cfg);
   ASSERT_TRUE(result.hasValue());
-  EXPECT_EQ(result.value().config.listeners[0].moqtVersions, "");
+  EXPECT_EQ(result.value().config.listeners[0].moqtVersions, "14,16");
 }
 
 TEST(ResolveConfig, VersionsPopulated) {


### PR DESCRIPTION
moxygen added draft-18 to kSupportedVersions, but neither moxygen nor moqx interoperate with it yet. An unset moqt_versions resolved to "", which getMoqtProtocols expands to all supported versions, silently advertising draft-18. Default to "14,16" instead; opt into draft-18 by configuring moqt_versions explicitly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/405)
<!-- Reviewable:end -->
