### PR TITLE
relay: gate bidi NAMESPACE forward on negotiated draft >=16

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,7 +12,7 @@ listeners:
       # key_file: /path/to/key.pem     # Required when insecure: false
       insecure: true          # Skip TLS for local development
     endpoint: "/moq-relay"    # WebTransport endpoint path
-    # moqt_versions: [14, 16] # MOQT draft versions (empty = all supported)
+    # moqt_versions: [14, 16] # MOQT draft versions (empty = default 14,16)
     # quic:                   # Per-listener QUIC overrides (optional; inherits listener_defaults.quic)
     #   max_data: 33554432    # Override connection flow control window for this listener
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -62,7 +62,7 @@ listeners:
       key_file:  /etc/moqx/key.pem
     endpoint: /moq-relay
     quic_stack: mvfst         # optional; default mvfst
-    moqt_versions: []         # optional; empty = all supported versions
+    moqt_versions: []         # optional; empty = default [14, 16]
     quic: { ... }             # optional; overrides listener_defaults.quic
 ```
 

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -174,8 +174,11 @@ std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespac
   for (auto& [outSession, info] : sessions) {
     if (outSession != session && (info.options == SubscribeNamespaceOptions::NAMESPACE ||
                                   info.options == SubscribeNamespaceOptions::BOTH)) {
-      if (info.namespacePublishHandle) {
-        // Draft 16+: send NAMESPACE message on the bidi stream
+      // Bidi NAMESPACE is draft 16+ only; the handle is populated regardless of
+      // version, so gate on it (matching doPublishNamespaceDone).
+      auto maybeVersion = outSession->getNegotiatedVersion();
+      if (maybeVersion.has_value() && getDraftMajorVersion(*maybeVersion) >= 16 &&
+          info.namespacePublishHandle) {
         TrackNamespace suffix(std::vector<std::string>(
             pubNs.trackNamespace.trackNamespace.begin() + info.trackNamespacePrefix.size(),
             pubNs.trackNamespace.trackNamespace.end()

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -26,9 +26,13 @@ std::string matchRuleErrorLabel(const std::string& name, size_t j) {
   return "Service '" + name + "' match[" + std::to_string(j) + "]";
 }
 
+// Default versions when moqt_versions is unset. Excludes draft-18 (in moxygen's
+// kSupportedVersions but not yet interoperable); configure moqt_versions to opt in.
+constexpr const char* kDefaultMoqtVersions = "14,16";
+
 std::string moqtVersionsToString(const ParsedListenerConfig& listener) {
   if (!listener.moqt_versions.value().has_value() || listener.moqt_versions.value()->empty()) {
-    return "";
+    return kDefaultMoqtVersions;
   }
   return folly::join(',', *listener.moqt_versions.value());
 }

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -238,7 +238,7 @@ struct ParsedListenerConfig {
   rfl::Description<"TLS configuration", ParsedListenerTlsConfig> tls;
   rfl::Description<"WebTransport endpoint path", std::string> endpoint;
   rfl::Description<
-      "MOQT draft versions (empty = all supported)",
+      "MOQT draft versions (empty = default 14,16)",
       std::optional<std::vector<uint32_t>>>
       moqt_versions;
   rfl::Description<

--- a/test/MoqxRelaySubNsTests.cpp
+++ b/test/MoqxRelaySubNsTests.cpp
@@ -114,19 +114,34 @@ TEST_P(MoQRelayTest, SubscribeNamespaceEmptyPrefixAllowedV16) {
   // Override the negotiated version to draft-16
   ON_CALL(*session, getNegotiatedVersion())
       .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft16)));
+  auto publisher = createMockSession();
+
+  // A draft-16 subscriber receives announcements via the bidi NAMESPACE message
+  // (on the publish handle), not the separate-stream PUBLISH_NAMESPACE path.
+  auto handle = std::make_shared<NiceMock<MockNamespacePublishHandle>>();
+  EXPECT_CALL(*handle, namespaceMsg(_)).Times(1);
+  EXPECT_CALL(*session, publishNamespace(_, _)).Times(0);
 
   TrackNamespace emptyNs{{}};
-  doSubscribeNamespace(session, emptyNs);
+  doSubscribeNamespace(session, emptyNs, /*addToState=*/true, handle);
+  doPublishNamespace(publisher, kTestNamespace);
+  exec_->drive();
 
+  removeSession(publisher);
   removeSession(session);
 }
 
 TEST_P(MoQRelayTest, ExactNamespaceSubscriberReceivesPublishNamespace) {
-  auto subscriber = createMockSession();
+  auto subscriber = createMockSession(); // default kVersionDraftCurrent (< 16)
   auto publisher = createMockSession();
 
-  // Subscriber subscribes to exact namespace {"test", "namespace"}
-  doSubscribeNamespace(subscriber, kTestNamespace);
+  // Subscribe with a non-null publish handle, as MoQRelaySession always does.
+  // A draft <= 15 subscriber must forward via the separate-stream
+  // PUBLISH_NAMESPACE path, never the bidi handle (whose namespaceMsg is an
+  // unimplemented moxygen stub that aborts the relay).
+  auto handle = std::make_shared<NiceMock<MockNamespacePublishHandle>>();
+  EXPECT_CALL(*handle, namespaceMsg(_)).Times(0);
+  doSubscribeNamespace(subscriber, kTestNamespace, /*addToState=*/true, handle);
 
   // Expect the subscriber to receive a publishNamespace forwarding when
   // the publisher announces the same exact namespace

--- a/test/MoqxRelayTestFixture.cpp
+++ b/test/MoqxRelayTestFixture.cpp
@@ -204,12 +204,16 @@ std::shared_ptr<TrackConsumer> MoQRelayTest::doPublish(
 std::shared_ptr<Publisher::SubscribeNamespaceHandle> MoQRelayTest::doSubscribeNamespace(
     std::shared_ptr<MoQSession> session,
     const TrackNamespace& nsPrefix,
-    bool addToState
+    bool addToState,
+    std::shared_ptr<Publisher::NamespacePublishHandle> namespacePublishHandle
 ) {
   SubscribeNamespace subNs;
   subNs.trackNamespacePrefix = nsPrefix;
   return withSessionContext(session, [&]() {
-    auto task = publisherInterface()->subscribeNamespace(std::move(subNs), nullptr);
+    auto task = publisherInterface()->subscribeNamespace(
+        std::move(subNs),
+        std::move(namespacePublishHandle)
+    );
     auto res = folly::coro::blockingWait(std::move(task), exec_.get());
     EXPECT_TRUE(res.hasValue());
     if (res.hasValue()) {

--- a/test/MoqxRelayTestFixture.h
+++ b/test/MoqxRelayTestFixture.h
@@ -127,7 +127,8 @@ protected:
   std::shared_ptr<Publisher::SubscribeNamespaceHandle> doSubscribeNamespace(
       std::shared_ptr<MoQSession> session,
       const TrackNamespace& nsPrefix,
-      bool addToState = true
+      bool addToState = true,
+      std::shared_ptr<Publisher::NamespacePublishHandle> namespacePublishHandle = nullptr
   );
 
   std::shared_ptr<MockSubgroupConsumer> createMockSubgroupConsumer();

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -562,7 +562,7 @@ TEST(ResolveConfig, MinimalInsecure) {
   EXPECT_EQ(resolved.listeners[0].address.getPort(), 9668);
   EXPECT_TRUE(std::holds_alternative<Insecure>(resolved.listeners[0].tlsMode));
   EXPECT_EQ(resolved.listeners[0].endpoint, "/moq-relay");
-  EXPECT_EQ(resolved.listeners[0].moqtVersions, "");
+  EXPECT_EQ(resolved.listeners[0].moqtVersions, "14,16");
   EXPECT_THAT(result.value().warnings, IsEmpty());
 
   ASSERT_EQ(resolved.services.size(), 1);
@@ -830,7 +830,7 @@ TEST(ResolveConfig, VersionsEmpty) {
   auto cfg = makeMinimalInsecureConfig();
   auto result = resolveConfig(cfg);
   ASSERT_TRUE(result.hasValue());
-  EXPECT_EQ(result.value().config.listeners[0].moqtVersions, "");
+  EXPECT_EQ(result.value().config.listeners[0].moqtVersions, "14,16");
 }
 
 TEST(ResolveConfig, VersionsPopulated) {


### PR DESCRIPTION
doPublishNamespace chose the draft-16+ bidi NAMESPACE path versus the draft <=15 separate-stream PUBLISH_NAMESPACE path by testing whether the publish handle was present. The relay session populates that handle regardless of negotiated version, so a draft <=15 subscriber was routed into NamespacePublishHandle::namespaceMsg, which reaches an unimplemented moxygen SubNSReply stub (XLOG(FATAL)) and aborts the relay. Gate on the negotiated version instead, matching doPublishNamespaceDone.

Extend the existing SubNs tests to pass a non-null publish handle (as the relay session always does): ExactNamespaceSubscriberReceivesPublishNamespace now asserts a pre-v16 subscriber forwards via the separate stream and never the bidi handle (failing against the un-gated code), and EmptyPrefixAllowedV16 asserts a v16 subscriber forwards via the bidi handle.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/406)
<!-- Reviewable:end -->
