### PR TITLE
feat: port SUBSCRIBE_TRACKS functionality for draft 18

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -664,6 +664,41 @@ MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
     }
   }
 
+  // Draft 18+: also fan out to SUBSCRIBE_TRACKS subscribers from the parallel
+  // tracks tree. They live in an independent overlap space and only want
+  // PUBLISH messages (no NAMESPACE / NAMESPACE_DONE).
+  NamespaceTree::SessionSubscriberList tracksSessions;
+  auto tracksNode = tracksTree_.findNode(
+      pub.fullTrackName.trackNamespace,
+      /*createMissingNodes=*/false,
+      NamespaceTree::MatchType::Exact,
+      &tracksSessions
+  );
+  if (tracksNode) {
+    tracksNode->forEachSubscriber(
+        [&](const std::shared_ptr<MoQSession>& outSession,
+            const NamespaceTree::NamespaceNode::NamespaceSubscriberInfo& info) {
+          tracksSessions.emplace_back(outSession, info);
+        }
+    );
+  }
+  for (auto& [outSession, info] : tracksSessions) {
+    if (outSession != session) {
+      nSubscribers++;
+      auto* publisherExec = relayExec_ ? session->getExecutor() : nullptr;
+      if (!addSubscriberAndPublish(
+              outSession,
+              forwarder,
+              info.forward,
+              /*pinned=*/true,
+              publisherExec
+          )) {
+        XLOG(ERR) << "addSubscriberAndPublish failed for " << forwarder->fullTrackName();
+        continue;
+      }
+    }
+  }
+
   // Forward if there are direct subscribers OR TRACK_FILTER subscribers
   // (PropertyRanking needs objects to evaluate property values for ranking).
   // When subscribers join later via subscribeNamespace, forwardChanged() sends REQUEST_UPDATE.
@@ -1169,6 +1204,45 @@ private:
   TrackNamespace trackNamespacePrefix_;
 };
 
+// Draft 18+: handle returned from subscribeTracks(). Calls unsubscribeTracks()
+// on destruction / explicit cancel, mirroring NamespaceSubscription above.
+class MoqxRelay::TracksSubscription : public Publisher::SubscribeTracksHandle {
+public:
+  TracksSubscription(
+      std::shared_ptr<MoqxRelay> relay,
+      std::shared_ptr<MoQSession> session,
+      RequestOk ok,
+      TrackNamespace trackNamespacePrefix
+  )
+      : Publisher::SubscribeTracksHandle(std::move(ok)), relay_(std::move(relay)),
+        session_(std::move(session)), trackNamespacePrefix_(std::move(trackNamespacePrefix)) {}
+
+  void unsubscribeTracks() override {
+    if (relay_) {
+      relay_->unsubscribeTracks(trackNamespacePrefix_, std::move(session_));
+      relay_.reset();
+    }
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(RequestUpdate reqUpdate) override {
+    // Draft-18 Section 10.9.2 allows REQUEST_UPDATE for SUBSCRIBE_TRACKS to update
+    // the TRACK_NAMESPACE_PREFIX parameter. However, moxygen's MoQSession::onRequestUpdate()
+    // only routes REQUEST_UPDATE to SUBSCRIBE and FETCH handles, not SUBSCRIBE_TRACKS.
+    // This is a moxygen limitation; when fixed upstream, we can implement prefix updates here
+    // by removing and re-adding the subscription with the new prefix, checking for overlaps.
+    co_return folly::makeUnexpected(RequestError{
+        reqUpdate.requestID,
+        RequestErrorCode::NOT_SUPPORTED,
+        "REQUEST_UPDATE not supported for relay SUBSCRIBE_TRACKS (moxygen limitation)"
+    });
+  }
+
+private:
+  std::shared_ptr<MoqxRelay> relay_;
+  std::shared_ptr<MoQSession> session_;
+  TrackNamespace trackNamespacePrefix_;
+};
+
 // Filter TrackConsumer that intercepts publishDone to clean up relay state.
 // Holds a weak_ptr to avoid a reference cycle: relay owns RelaySubscription
 // which owns the filter chain (TopNFilter→TerminationFilter), so a strong
@@ -1420,6 +1494,106 @@ void MoqxRelay::unsubscribeNamespace(
   auto result = namespaceTree_.removeNamespaceSubscriber(trackNamespacePrefix, session);
   if (result.hasError() && result.error() == NamespaceTree::Error::NotSubscribed) {
     XLOG(DBG1) << "Namespace prefix was not subscribed by this session";
+  }
+}
+
+// Draft 18+
+folly::coro::Task<Publisher::SubscribeTracksResult> MoqxRelay::subscribeTracks(
+    SubscribeTracks subTracks,
+    std::shared_ptr<PublishBlockedHandle> /*publishBlockedHandle*/
+) {
+  XLOG(DBG1) << __func__ << " nsp=" << subTracks.trackNamespacePrefix;
+
+  auto session = MoQSession::getRequestSession();
+  auto maybeNegotiatedVersion = session->getNegotiatedVersion();
+  XCHECK(maybeNegotiatedVersion.has_value());
+  if (getDraftMajorVersion(*maybeNegotiatedVersion) < 18) {
+    co_return folly::makeUnexpected(SubscribeTracksError{
+        subTracks.requestID,
+        SubscribeTracksErrorCode::NOT_SUPPORTED,
+        "SUBSCRIBE_TRACKS requires draft 18+"
+    });
+  }
+
+  if (tracksTree_.hasOverlappingTracksSubscription(subTracks.trackNamespacePrefix, session)) {
+    co_return folly::makeUnexpected(SubscribeTracksError{
+        subTracks.requestID,
+        SubscribeTracksErrorCode::PREFIX_OVERLAP,
+        "Overlapping SUBSCRIBE_TRACKS exists in this session"
+    });
+  }
+
+  // Register in the parallel tracks tree (independent overlap space).
+  // Tracks-tree entries always behave like PUBLISH-style subscribers;
+  // options is unused for this tree.
+  tracksTree_.addNamespaceSubscriber(
+      subTracks.trackNamespacePrefix,
+      session,
+      NamespaceTree::NamespaceNode::NamespaceSubscriberInfo{
+          subTracks.forward,
+          SubscribeNamespaceOptions::PUBLISH,
+          /*namespacePublishHandle=*/nullptr,
+          subTracks.trackNamespacePrefix,
+          /*trackFilter=*/std::nullopt
+      }
+  );
+
+  // Walk the existing publish tree and emit PUBLISH for each matching
+  // already-published track (backfill for new subscriber).
+  auto pubNode = namespaceTree_.findNode(
+      subTracks.trackNamespacePrefix,
+      /*createMissingNodes=*/false,
+      NamespaceTree::MatchType::Exact
+  );
+  if (pubNode) {
+    namespaceTree_.forEachNodeInSubtree(
+        subTracks.trackNamespacePrefix,
+        pubNode,
+        [&](const TrackNamespace& prefix, std::shared_ptr<NamespaceTree::NamespaceNode> node) {
+          node->forEachPublish([&](const std::string& trackName,
+                                   const std::shared_ptr<MoQSession>& publishSession) {
+            if (publishSession == session) {
+              // Don't echo the subscriber's own published tracks.
+              return;
+            }
+            FullTrackName ftn{prefix, trackName};
+            auto forwarder = registry_.getForwarder(ftn);
+            if (!forwarder) {
+              return;
+            }
+            auto* publisherExec = relayExec_ ? publishSession->getExecutor() : nullptr;
+            if (!addSubscriberAndPublish(
+                    session,
+                    forwarder,
+                    subTracks.forward,
+                    /*pinned=*/true,
+                    publisherExec
+                )) {
+              XLOG(ERR) << "addSubscriberAndPublish failed for " << ftn;
+              return;
+            }
+          });
+        }
+    );
+  }
+
+  RequestOk subTracksOk{.requestID = subTracks.requestID};
+  co_return std::make_shared<TracksSubscription>(
+      shared_from_this(),
+      std::move(session),
+      std::move(subTracksOk),
+      subTracks.trackNamespacePrefix
+  );
+}
+
+void MoqxRelay::unsubscribeTracks(
+    const TrackNamespace& trackNamespacePrefix,
+    std::shared_ptr<MoQSession> session
+) {
+  XLOG(DBG1) << __func__ << " nsp=" << trackNamespacePrefix;
+  auto result = tracksTree_.removeNamespaceSubscriber(trackNamespacePrefix, session);
+  if (result.hasError() && result.error() == NamespaceTree::Error::NotSubscribed) {
+    XLOG(DBG1) << "Tracks prefix was not subscribed by this session";
   }
 }
 

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -189,6 +189,11 @@ public:
       std::shared_ptr<NamespacePublishHandle> namespacePublishHandle
   ) override;
 
+  folly::coro::Task<SubscribeTracksResult> subscribeTracks(
+      moxygen::SubscribeTracks subTracks,
+      std::shared_ptr<PublishBlockedHandle> publishBlockedHandle = nullptr
+  ) override;
+
   folly::coro::Task<moxygen::Subscriber::PublishNamespaceResult>
   publishNamespace(moxygen::PublishNamespace pubNs, std::shared_ptr<moxygen::Subscriber::PublishNamespaceCallback>)
       override;
@@ -250,11 +255,24 @@ public:
 
 private:
   class NamespaceSubscription;
+  class TracksSubscription;
   class TerminationFilter;
   class LocalSubscribeFilter;
   class LocalPublishFilter;
 
+  // No-op NamespaceTree::Callback for the tracks-subscriber tree.
+  // The tracks tree never has publishers, so onPublishNamespaceDone never fires.
+  struct NullCallback : public NamespaceTree::Callback {
+    void onPublishNamespaceDone(const moxygen::TrackNamespace&) override {}
+  };
+
   void unsubscribeNamespace(
+      const moxygen::TrackNamespace& prefix,
+      std::shared_ptr<moxygen::MoQSession> session
+  );
+
+  // Draft 18+
+  void unsubscribeTracks(
       const moxygen::TrackNamespace& prefix,
       std::shared_ptr<moxygen::MoQSession> session
   );
@@ -264,6 +282,11 @@ private:
   void onPublishNamespaceDone(const moxygen::TrackNamespace& ns) override;
 
   NamespaceTree namespaceTree_{*this};
+
+  // Draft 18+: parallel tree for SUBSCRIBE_TRACKS. Independent overlap space;
+  // only `children` and `sessions` are populated (no publishers, no callbacks).
+  NullCallback tracksTreeCb_;
+  NamespaceTree tracksTree_{tracksTreeCb_};
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
   void forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) override;

--- a/src/NamespaceTree.cpp
+++ b/src/NamespaceTree.cpp
@@ -232,6 +232,44 @@ folly::Expected<folly::Unit, NamespaceTree::Error> NamespaceTree::removeNamespac
   return folly::unit;
 }
 
+bool NamespaceTree::hasTracksSubscriptionInSubtree(
+    const NamespaceNode& root,
+    const std::shared_ptr<moxygen::MoQSession>& session
+) const {
+  std::vector<const NamespaceNode*> nodesToVisit{&root};
+  while (!nodesToVisit.empty()) {
+    const auto* node = nodesToVisit.back();
+    nodesToVisit.pop_back();
+    if (node->subscribers_.find(session) != node->subscribers_.end()) {
+      return true;
+    }
+    for (const auto& [_, child] : node->children_) {
+      nodesToVisit.push_back(child.get());
+    }
+  }
+  return false;
+}
+
+bool NamespaceTree::hasOverlappingTracksSubscription(
+    const moxygen::TrackNamespace& trackNamespacePrefix,
+    const std::shared_ptr<moxygen::MoQSession>& session
+) const {
+  const NamespaceNode* node = &root_;
+  for (size_t i = 0; i < trackNamespacePrefix.size(); i++) {
+    // Nodes visited before the target prefix are strict ancestors.
+    if (node->subscribers_.find(session) != node->subscribers_.end()) {
+      return true;
+    }
+    auto it = node->children_.find(trackNamespacePrefix[i]);
+    if (it == node->children_.end()) {
+      return false;
+    }
+    node = it->second.get();
+  }
+  // The target subtree covers exact-prefix and descendant registrations.
+  return hasTracksSubscriptionInSubtree(*node, session);
+}
+
 std::shared_ptr<NamespaceTree::NamespaceNode> NamespaceTree::findNode(
     const TrackNamespace& ns,
     bool createMissingNodes,

--- a/src/NamespaceTree.h
+++ b/src/NamespaceTree.h
@@ -83,6 +83,12 @@ public:
       }
     }
 
+    template <typename Fn> void forEachSubscriber(Fn&& fn) const {
+      for (const auto& [session, info] : subscribers_) {
+        fn(session, info);
+      }
+    }
+
     void addDraft14PublishNamespaceHandle(
         std::shared_ptr<moxygen::MoQSession> session,
         std::shared_ptr<moxygen::Subscriber::PublishNamespaceHandle> handle
@@ -194,6 +200,14 @@ public:
   // Returns the PropertyRanking slot for propertyType at node, inserting null if absent.
   std::shared_ptr<PropertyRanking>& getOrInsertRanking(NamespaceNode& node, uint64_t propertyType);
 
+  // Draft 18+ helpers for the SUBSCRIBE_TRACKS parallel tree.
+  // Checks whether any existing subscriber entry in this tree for `session`
+  // overlaps the given prefix (exact, ancestor, or descendant match).
+  bool hasOverlappingTracksSubscription(
+      const moxygen::TrackNamespace& trackNamespacePrefix,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  ) const;
+
   // DFS walk. begin(childKey, node) is called on entry; end() on exit after
   // all children. childKey is empty for the root.
   template <typename BeginFn, typename EndFn> void walkTree(BeginFn&& begin, EndFn&& end) const {
@@ -263,6 +277,11 @@ private:
 
   // Called after content is removed: prunes node from its parent if now empty.
   void tryPruneSelf(NamespaceNode& node, bool hadContent, const moxygen::TrackNamespace& ns);
+
+  bool hasTracksSubscriptionInSubtree(
+      const NamespaceNode& node,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  ) const;
 
   void incrementActiveChildren(NamespaceNode& node);
   void tryPruneChild(NamespaceNode& parentNode, const std::string& childKey);

--- a/src/UpstreamProvider.cpp
+++ b/src/UpstreamProvider.cpp
@@ -56,6 +56,23 @@ public:
   PendingTrackConsumer() : TrackConsumerFilter(nullptr) {}
 };
 
+// Presents an upstream SUBSCRIBE_NAMESPACE(options=PUBLISH) handle as a
+// SubscribeTracksHandle, since subscribeTracks() maps onto subscribeNamespace().
+class UpstreamSubscribeTracksHandle : public Publisher::SubscribeTracksHandle {
+public:
+  explicit UpstreamSubscribeTracksHandle(std::shared_ptr<Publisher::SubscribeNamespaceHandle> inner)
+      : Publisher::SubscribeTracksHandle(inner->subscribeNamespaceOk()), inner_(std::move(inner)) {}
+
+  void unsubscribeTracks() override { inner_->unsubscribeNamespace(); }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(RequestUpdate update) override {
+    return inner_->requestUpdate(std::move(update));
+  }
+
+private:
+  std::shared_ptr<Publisher::SubscribeNamespaceHandle> inner_;
+};
+
 } // namespace
 
 UpstreamProvider::UpstreamProvider(
@@ -221,6 +238,27 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> UpstreamProvider::coSubsc
 ) {
   auto sess = co_await getOrConnectSession();
   co_return co_await sess->subscribeNamespace(std::move(subNs), std::move(handle));
+}
+
+folly::coro::Task<Publisher::SubscribeTracksResult> UpstreamProvider::subscribeTracks(
+    SubscribeTracks subTracks,
+    std::shared_ptr<PublishBlockedHandle> /*publishBlockedHandle*/
+) {
+  XLOG(DBG1) << "UpstreamProvider::subscribeTracks nsp=" << subTracks.trackNamespacePrefix;
+  // SUBSCRIBE_TRACKS == SUBSCRIBE_NAMESPACE with options=PUBLISH: both request
+  // PUBLISH for matching tracks under a prefix and want no NAMESPACE messages,
+  // so there is no namespace handle to forward.
+  SubscribeNamespace subNs;
+  subNs.requestID = subTracks.requestID;
+  subNs.trackNamespacePrefix = subTracks.trackNamespacePrefix;
+  subNs.forward = subTracks.forward;
+  subNs.params = std::move(subTracks.params);
+  subNs.options = SubscribeNamespaceOptions::PUBLISH;
+  auto result = co_await subscribeNamespace(std::move(subNs), /*handle=*/nullptr);
+  if (result.hasError()) {
+    co_return folly::makeUnexpected(std::move(result.error()));
+  }
+  co_return std::make_shared<UpstreamSubscribeTracksHandle>(std::move(result.value()));
 }
 
 // --- Subscriber interface ---

--- a/src/UpstreamProvider.h
+++ b/src/UpstreamProvider.h
@@ -97,6 +97,12 @@ public:
       std::shared_ptr<NamespacePublishHandle> handle
   ) override;
 
+  // Mapped onto a draft-16 SUBSCRIBE_NAMESPACE with options=PUBLISH upstream.
+  folly::coro::Task<SubscribeTracksResult> subscribeTracks(
+      moxygen::SubscribeTracks subTracks,
+      std::shared_ptr<PublishBlockedHandle> publishBlockedHandle = nullptr
+  ) override;
+
   // --- Subscriber interface (forwarded to upstream session) ---
 
   folly::coro::Task<PublishNamespaceResult> publishNamespace(

--- a/src/relay/AuthFilters.cpp
+++ b/src/relay/AuthFilters.cpp
@@ -76,6 +76,32 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> AuthPublisherFilter::subs
   return downstream_->subscribeNamespace(std::move(subNs), std::move(handle));
 }
 
+folly::coro::Task<Publisher::SubscribeTracksResult> AuthPublisherFilter::subscribeTracks(
+    SubscribeTracks subTracks,
+    std::shared_ptr<PublishBlockedHandle> publishBlockedHandle
+) {
+  // SUBSCRIBE_TRACKS is namespace-level, like SUBSCRIBE_NAMESPACE; gate on the
+  // prefix. Unlike peering, which uses SUBSCRIBE_NAMESPACE, there is no peer
+  // bypass for SUBSCRIBE_TRACKS.
+  auto ok = auth::authorize(
+      *verifier_,
+      auth::Action::SubscribeNamespace,
+      subTracks.params,
+      subTracks.trackNamespacePrefix,
+      *grants_
+  );
+  if (ok.hasError()) {
+    return folly::coro::makeTask<Publisher::SubscribeTracksResult>(
+        folly::makeUnexpected(SubscribeTracksError{
+            subTracks.requestID,
+            SubscribeTracksErrorCode::UNAUTHORIZED,
+            auth::toString(ok.error())
+        })
+    );
+  }
+  return downstream_->subscribeTracks(std::move(subTracks), std::move(publishBlockedHandle));
+}
+
 folly::coro::Task<Publisher::TrackStatusResult>
 AuthPublisherFilter::trackStatus(const TrackStatus req) {
   auto ok = auth::authorize(

--- a/src/relay/AuthFilters.h
+++ b/src/relay/AuthFilters.h
@@ -42,6 +42,11 @@ public:
       std::shared_ptr<NamespacePublishHandle> handle
   ) override;
 
+  folly::coro::Task<SubscribeTracksResult> subscribeTracks(
+      moxygen::SubscribeTracks subTracks,
+      std::shared_ptr<PublishBlockedHandle> publishBlockedHandle = nullptr
+  ) override;
+
   folly::coro::Task<TrackStatusResult> trackStatus(const moxygen::TrackStatus req) override;
 
   void goaway(moxygen::Goaway g) override;

--- a/src/relay/PublisherCrossExecFilter.cpp
+++ b/src/relay/PublisherCrossExecFilter.cpp
@@ -118,6 +118,58 @@ private:
   folly::Executor* exec_;
 };
 
+// Wraps a PublishBlockedHandle so publishBlocked() dispatches back to the
+// caller's executor. Held by the inner session on targetExec_.
+class CrossExecPublishBlockedHandle : public moxygen::Publisher::PublishBlockedHandle {
+public:
+  CrossExecPublishBlockedHandle(
+      std::shared_ptr<moxygen::Publisher::PublishBlockedHandle> inner,
+      folly::Executor::KeepAlive<> exec
+  )
+      : inner_(std::move(inner)), exec_(std::move(exec)) {}
+
+  void publishBlocked(
+      const moxygen::TrackNamespace& trackNamespaceSuffix,
+      const std::string& trackName
+  ) override {
+    exec_->add([inner = inner_, trackNamespaceSuffix, trackName]() mutable {
+      inner->publishBlocked(trackNamespaceSuffix, trackName);
+    });
+  }
+
+private:
+  std::shared_ptr<moxygen::Publisher::PublishBlockedHandle> inner_;
+  folly::Executor::KeepAlive<> exec_;
+};
+
+class CrossExecSubscribeTracksHandle : public moxygen::Publisher::SubscribeTracksHandle {
+public:
+  CrossExecSubscribeTracksHandle(
+      std::shared_ptr<moxygen::Publisher::SubscribeTracksHandle> inner,
+      folly::Executor* exec
+  )
+      : inner_(std::move(inner)), exec_(exec) {}
+
+  const moxygen::SubscribeTracksOk& subscribeTracksOk() const override {
+    return inner_->subscribeTracksOk();
+  }
+
+  void unsubscribeTracks() override {
+    exec_->add([inner = inner_]() mutable { inner->unsubscribeTracks(); });
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate update) override {
+    co_return co_await folly::coro::co_withExecutor(
+        folly::getKeepAliveToken(exec_),
+        inner_->requestUpdate(std::move(update))
+    );
+  }
+
+private:
+  std::shared_ptr<moxygen::Publisher::SubscribeTracksHandle> inner_;
+  folly::Executor* exec_;
+};
+
 } // namespace
 
 folly::coro::Task<moxygen::Publisher::TrackStatusResult>
@@ -183,6 +235,30 @@ PublisherCrossExecFilter::subscribeNamespace(
   );
   if (result.hasValue()) {
     co_return std::make_shared<CrossExecSubscribeNamespaceHandle>(
+        std::move(result.value()),
+        targetExec_
+    );
+  }
+  co_return result;
+}
+
+folly::coro::Task<moxygen::Publisher::SubscribeTracksResult>
+PublisherCrossExecFilter::subscribeTracks(
+    moxygen::SubscribeTracks subTracks,
+    std::shared_ptr<PublishBlockedHandle> publishBlockedHandle
+) {
+  auto callerExec = co_await folly::coro::co_current_executor;
+  auto wrappedHandle = publishBlockedHandle ? std::make_shared<CrossExecPublishBlockedHandle>(
+                                                  std::move(publishBlockedHandle),
+                                                  std::move(callerExec)
+                                              )
+                                            : nullptr;
+  auto result = co_await folly::coro::co_withExecutor(
+      folly::getKeepAliveToken(targetExec_),
+      inner_->subscribeTracks(std::move(subTracks), std::move(wrappedHandle))
+  );
+  if (result.hasValue()) {
+    co_return std::make_shared<CrossExecSubscribeTracksHandle>(
         std::move(result.value()),
         targetExec_
     );

--- a/src/relay/PublisherCrossExecFilter.h
+++ b/src/relay/PublisherCrossExecFilter.h
@@ -37,6 +37,11 @@ public:
       std::shared_ptr<NamespacePublishHandle> namespacePublishHandle
   ) override;
 
+  folly::coro::Task<SubscribeTracksResult> subscribeTracks(
+      moxygen::SubscribeTracks subTracks,
+      std::shared_ptr<PublishBlockedHandle> publishBlockedHandle = nullptr
+  ) override;
+
   void goaway(moxygen::Goaway goaway) override;
 
 private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(moqx_relay_test
   MoqxRelayTrackStatusTests.cpp
   MoqxRelayNGRTests.cpp
   MoqxRelayPeerTests.cpp
+  MoqxRelayTracksTests.cpp
   MoqxRelayTestModes.cpp
 )
 target_link_libraries(moqx_relay_test PRIVATE

--- a/test/MoqxRelayTracksTests.cpp
+++ b/test/MoqxRelayTracksTests.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Originally from github.com/facebookexperimental/moxygen.
+ * See deps/moxygen/LICENSE for the original license terms.
+ *
+ * Copyright (c) OpenMOQ contributors.
+ */
+
+// Draft 18+: SUBSCRIBE_TRACKS relay tests.
+// Ported from deps/moxygen/moxygen/relay/test/MoQRelayTest.cpp
+
+#include "MoqxRelayTestFixture.h"
+
+namespace moxygen::test {
+
+// ============================================================================
+// MoqxRelayTracksTest fixture
+// ============================================================================
+
+class MoqxRelayTracksTest : public MoQRelayTest {
+protected:
+  // Like createMockSession() but reports draft 18 for the negotiated version.
+  std::shared_ptr<MockMoQSession> createV18Session() {
+    auto session = std::make_shared<NiceMock<MockMoQSession>>(exec_);
+    ON_CALL(*session, getNegotiatedVersion())
+        .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft18)));
+    getOrCreateMockState(session);
+    return session;
+  }
+
+  Publisher::SubscribeTracksResult subscribeTracks(
+      std::shared_ptr<MoQSession> session,
+      const TrackNamespace& nsPrefix,
+      bool forward = true
+  ) {
+    SubscribeTracks subTracks;
+    subTracks.trackNamespacePrefix = nsPrefix;
+    subTracks.forward = forward;
+    return withSessionContext(session, [&]() {
+      auto task = publisherInterface()->subscribeTracks(std::move(subTracks));
+      return folly::coro::blockingWait(std::move(task), exec_.get());
+    });
+  }
+
+  // Helper mirroring doSubscribeNamespace but for SUBSCRIBE_TRACKS.
+  // The handle is stashed for cleanup so unsubscribeTracks() fires before
+  // the relay is torn down.
+  std::shared_ptr<Publisher::SubscribeTracksHandle>
+  doSubscribeTracks(std::shared_ptr<MoQSession> session, const TrackNamespace& nsPrefix) {
+    auto res = subscribeTracks(session, nsPrefix);
+    EXPECT_TRUE(res.hasValue());
+    if (!res.hasValue()) {
+      return nullptr;
+    }
+    auto handle = *res;
+    cleanupHandles_.push_back(handle);
+    return handle;
+  }
+
+  void TearDown() override {
+    // Drop handle refs before MoQRelayTest tears down the relay.
+    for (auto& handle : cleanupHandles_) {
+      if (handle) {
+        handle->unsubscribeTracks();
+      }
+    }
+    cleanupHandles_.clear();
+    MoQRelayTest::TearDown();
+  }
+
+  // Stash handles here for automatic cleanup in TearDown.
+  // Tests that manually call unsubscribeTracks() should clear this.
+  std::vector<std::shared_ptr<Publisher::SubscribeTracksHandle>> cleanupHandles_;
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+// Pre-draft-18 sessions can't issue SUBSCRIBE_TRACKS at all.
+TEST_P(MoqxRelayTracksTest, SubscribeTracksRejectsPreV18) {
+  // createMockSession() defaults to kVersionDraftCurrent (draft-14).
+  auto session = createMockSession();
+  auto res = subscribeTracks(session, TrackNamespace{{"test"}});
+  ASSERT_FALSE(res.hasValue());
+  EXPECT_EQ(res.error().errorCode, SubscribeTracksErrorCode::NOT_SUPPORTED);
+  removeSession(session);
+}
+
+// SUBSCRIBE_TRACKS and SUBSCRIBE_NAMESPACE live in independent overlap spaces,
+// so the same prefix in both trees must be allowed simultaneously.
+TEST_P(MoqxRelayTracksTest, SamePrefixInBothTreesAllowed) {
+  auto session = createV18Session();
+  TrackNamespace prefix{{"test", "live"}};
+  doSubscribeNamespace(session, prefix);
+  auto tracksHandle = doSubscribeTracks(session, prefix);
+  EXPECT_NE(tracksHandle, nullptr);
+  removeSession(session);
+}
+
+// New tracks published after a SUBSCRIBE_TRACKS are forwarded to the
+// subscribing session as PUBLISH messages.
+TEST_P(MoqxRelayTracksTest, NewPublishFanoutToTracksSubscriber) {
+  auto subscriber = createV18Session();
+  auto publisher = createMockSession();
+  setupPublishSucceeds(subscriber);
+
+  doSubscribeTracks(subscriber, kTestNamespace);
+
+  // The relay must issue exactly one PUBLISH to subscriber when the
+  // matching track appears.
+  EXPECT_CALL(*subscriber, publish(_, _)).Times(1);
+
+  doPublish(publisher, kTestTrackName);
+  exec_->driveFor(5);
+
+  ASSERT_TRUE(testing::Mock::VerifyAndClearExpectations(subscriber.get()));
+  removeSession(subscriber);
+  removeSession(publisher);
+  // Flush the async forwarder teardown onto the relay exec (MT modes), else
+  // the forwarder keeps the subscriber session + consumer alive past exit.
+  driveIfMultiThread();
+}
+
+// Draft 18 §10.19: a SUBSCRIBE_TRACKS from a session that already has a
+// registration at an exact / ancestor / descendant prefix must be rejected
+// with PREFIX_OVERLAP. Cross-session overlap is permitted.
+TEST_P(MoqxRelayTracksTest, OverlappingSubscribeTracksRejected) {
+  auto session = createV18Session();
+  const TrackNamespace base{{"a", "b"}};
+  const TrackNamespace ancestor{{"a"}};
+  const TrackNamespace descendant{{"a", "b", "c"}};
+
+  // Establish the base registration.
+  auto baseHandle = doSubscribeTracks(session, base);
+  ASSERT_NE(baseHandle, nullptr);
+
+  // Exact duplicate, ancestor, and descendant must all fail.
+  for (const auto& [label, prefix] : std::vector<std::pair<std::string, TrackNamespace>>{
+           {"exact", base},
+           {"ancestor", ancestor},
+           {"descendant", descendant},
+       }) {
+    SCOPED_TRACE(label);
+    auto res = subscribeTracks(session, prefix);
+    ASSERT_FALSE(res.hasValue());
+    EXPECT_EQ(res.error().errorCode, SubscribeTracksErrorCode::PREFIX_OVERLAP);
+  }
+
+  // A different session subscribing to the same prefix is fine — the
+  // overlap check is per-session.
+  auto otherSession = createV18Session();
+  auto otherHandle = doSubscribeTracks(otherSession, base);
+  EXPECT_NE(otherHandle, nullptr);
+
+  removeSession(session);
+  removeSession(otherSession);
+}
+
+// A SUBSCRIBE_TRACKS that arrives after a track is already published must
+// receive the existing track immediately via PUBLISH (backfill).
+TEST_P(MoqxRelayTracksTest, ExistingPublishEchoedToNewTracksSubscriber) {
+  auto subscriber = createV18Session();
+  auto publisher = createMockSession();
+  setupPublishSucceeds(subscriber);
+
+  doPublish(publisher, kTestTrackName);
+
+  EXPECT_CALL(*subscriber, publish(_, _)).Times(1);
+  doSubscribeTracks(subscriber, kTestNamespace);
+  exec_->driveFor(5);
+
+  ASSERT_TRUE(testing::Mock::VerifyAndClearExpectations(subscriber.get()));
+  removeSession(subscriber);
+  removeSession(publisher);
+  driveIfMultiThread();
+}
+
+// The publisher's own tracks must NOT be echoed back when it issues
+// SUBSCRIBE_TRACKS on the same namespace prefix it publishes into.
+TEST_P(MoqxRelayTracksTest, NoSelfEchoOnSubscribeTracks) {
+  auto publisherSubscriber = createV18Session();
+  setupPublishSucceeds(publisherSubscriber);
+
+  doPublish(publisherSubscriber, kTestTrackName);
+
+  // Even though the session subscribes to the namespace it published into,
+  // publish() must NOT be called on that session.
+  EXPECT_CALL(*publisherSubscriber, publish(_, _)).Times(0);
+  doSubscribeTracks(publisherSubscriber, kTestNamespace);
+  exec_->driveFor(5);
+
+  ASSERT_TRUE(testing::Mock::VerifyAndClearExpectations(publisherSubscriber.get()));
+  removeSession(publisherSubscriber);
+  driveIfMultiThread();
+}
+
+// Verify that unsubscribeTracks() stops future fan-out to that session.
+TEST_P(MoqxRelayTracksTest, UnsubscribeTracksStopsFanout) {
+  auto subscriber = createV18Session();
+  auto publisher = createMockSession();
+  setupPublishSucceeds(subscriber);
+
+  auto handle = doSubscribeTracks(subscriber, kTestNamespace);
+  ASSERT_NE(handle, nullptr);
+
+  // Unsubscribe before any publish arrives.
+  withSessionContext(subscriber, [&]() { handle->unsubscribeTracks(); });
+  // Remove from cleanupHandles_ since we already unsubscribed manually.
+  cleanupHandles_.clear();
+
+  // No PUBLISH should reach subscriber after unsubscribe.
+  EXPECT_CALL(*subscriber, publish(_, _)).Times(0);
+  doPublish(publisher, kTestTrackName);
+  exec_->driveFor(5);
+
+  ASSERT_TRUE(testing::Mock::VerifyAndClearExpectations(subscriber.get()));
+  removeSession(subscriber);
+  removeSession(publisher);
+  driveIfMultiThread();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllModes,
+    MoqxRelayTracksTest,
+    ::testing::Values(RelayMode::SingleThread, RelayMode::MultiThread, RelayMode::LocalForwarderMT),
+    [](const ::testing::TestParamInfo<RelayMode>& info) -> std::string {
+      switch (info.param) {
+      case RelayMode::SingleThread:
+        return "SingleThread";
+      case RelayMode::MultiThread:
+        return "MultiThread";
+      case RelayMode::LocalForwarderMT:
+        return "LocalForwarderMT";
+      }
+      return "Unknown";
+    }
+);
+
+} // namespace moxygen::test


### PR DESCRIPTION
- Added support for SUBSCRIBE_TRACKS in MoqxRelay, allowing sessions to subscribe to track updates.
- Introduced TracksSubscription class to manage track subscriptions and handle unsubscriptions.
- Updated NamespaceTree with methods to check for overlapping track subscriptions.
- Added tests for SUBSCRIBE_TRACKS functionality, ensuring correct behavior for various scenarios.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/411)
<!-- Reviewable:end -->
