### PR TITLE
moqx-run.sh utility script and template config

### DIFF
--- a/scripts/config.bench.yaml
+++ b/scripts/config.bench.yaml
@@ -1,20 +1,26 @@
-# moqx relay — production config template for ci.openmoq.org deployment
+# moqx relay — parameterized bench / scaling config template.
 #
-# Two listeners on separate ports:
-#   mvfst    :4433 — BBR with pacing
-#   picoquic :4434 — BBR
+# Filled by scripts/moqx-run.sh, which resolves the ${MOQX_*} / ${DOMAIN}
+# placeholders below from CLI flags > .env > built-in defaults, then serves
+# the resolved config. Two listeners: mvfst :4433 and picoquic :4434 (each
+# serves WebTransport via the endpoint path and raw QUIC moqt://).
 #
-# Each listener serves both WebTransport (via endpoint path) and raw
-# QUIC (moqt:// — no path, direct UDP+ALPN). Clients pick the port
-# matching their QUIC stack preference.
-#
-# Cert paths use /etc/letsencrypt convention — adjust for your deployment.
+# Tunable via env / CLI (defaults live in moqx-run.sh):
+#   MOQX_THREADS       IO worker threads; 0 = moqx autodetects one per CPU
+#   MOQX_LOCAL_FWD     per-subscriber-thread local forwarders (true|false)
+#   MOQX_BPF_STEERING  mvfst CID reuseport steering, Linux+mvfst (true|false)
+#   MOQX_SEND_PKTS     mvfst max_conn_packets_sent_per_loop
+#   MOQX_RECV_PKTS     mvfst max_server_recv_packets_per_loop
+#   MOQX_UDP_BUFFER    relay UDP socket buffer bytes; 0 = moxygen 1 MB default
+#   MOQX_CC            mvfst congestion control (bbr2|bbr|copa|cubic|...)
+#   MOQX_CACHE         relay object cache enabled (true|false)
+#   DOMAIN             TLS cert hostname under /etc/letsencrypt/live/
 
 relay_id: "moqx-000"
 
-threads: 6                    # was 1 — the master switch; set to your core count
-use_local_forwarders: true    # was false — the pr365 data-path optimization
-mvfst_bpf_steering: false     # was true — the pr365 data-path optimization; requires Linux + BPF support
+threads: ${MOQX_THREADS}
+use_local_forwarders: ${MOQX_LOCAL_FWD}
+mvfst_bpf_steering: ${MOQX_BPF_STEERING}
 
 listener_defaults:
   quic:
@@ -25,10 +31,11 @@ listener_defaults:
     idle_timeout_ms: 30000
     min_ack_delay_us: 1000
     max_ack_delay_us: 25000
-  mvfst:                                   # match Alan's perf-test.sh tuning
+  mvfst:
     enable_gso: true
-    max_conn_packets_sent_per_loop: 16     # perf-test value (code default: 48)
-    max_server_recv_packets_per_loop: 32   # perf-test value (code default: 64)
+    max_conn_packets_sent_per_loop: ${MOQX_SEND_PKTS}
+    max_server_recv_packets_per_loop: ${MOQX_RECV_PKTS}
+    udp_socket_buffer_bytes: ${MOQX_UDP_BUFFER}
     bbr2:
       exit_startup_on_loss: true
       enable_recovery_in_startup: true
@@ -47,7 +54,7 @@ listeners:
       insecure: false
     endpoint: "/moq-relay"
     quic:
-      cc_algo: bbr2                        # match perf-test.sh (was bbr)
+      cc_algo: ${MOQX_CC}
 
   - name: pico-relay
     quic_stack: picoquic
@@ -85,9 +92,7 @@ services:
 
 service_defaults:
   cache:
-    enabled: true                 # cache ON — serves late joiners and rides
-                                  # publisher blips from memory (Alan keeps it
-                                  # enabled too). Mirrors production serving.
+    enabled: ${MOQX_CACHE}
     max_tracks: 1000
     max_groups_per_track: 100
 

--- a/scripts/config.bench.yaml
+++ b/scripts/config.bench.yaml
@@ -12,6 +12,10 @@
 
 relay_id: "moqx-000"
 
+threads: 6                    # was 1 — the master switch; set to your core count
+use_local_forwarders: true    # was false — the pr365 data-path optimization
+mvfst_bpf_steering: false     # was true — the pr365 data-path optimization; requires Linux + BPF support
+
 listener_defaults:
   quic:
     max_data: 67108864            # 64 MB connection flow control
@@ -21,6 +25,14 @@ listener_defaults:
     idle_timeout_ms: 30000
     min_ack_delay_us: 1000
     max_ack_delay_us: 25000
+  mvfst:                                   # match Alan's perf-test.sh tuning
+    enable_gso: true
+    max_conn_packets_sent_per_loop: 16     # perf-test value (code default: 48)
+    max_server_recv_packets_per_loop: 32   # perf-test value (code default: 64)
+    bbr2:
+      exit_startup_on_loss: true
+      enable_recovery_in_startup: true
+      enable_recovery_in_probe_states: true
 
 listeners:
   - name: mvfst-relay
@@ -35,7 +47,7 @@ listeners:
       insecure: false
     endpoint: "/moq-relay"
     quic:
-      cc_algo: bbr
+      cc_algo: bbr2                        # match perf-test.sh (was bbr)
 
   - name: pico-relay
     quic_stack: picoquic
@@ -73,7 +85,9 @@ services:
 
 service_defaults:
   cache:
-    enabled: true
+    enabled: true                 # cache ON — serves late joiners and rides
+                                  # publisher blips from memory (Alan keeps it
+                                  # enabled too). Mirrors production serving.
     max_tracks: 1000
     max_groups_per_track: 100
 

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -24,11 +24,19 @@ Logging (override .env/defaults):
 
 Targeting:
       --subcmd CMD          moqx subcommand (default: serve)
-      --config FILE         config YAML template (default: docker/config.production.yaml)
-      --env FILE            alternate .env file (default: docker/.env)
+      --config FILE         config YAML template (default: scripts/config.bench.yaml)
+      --env FILE            alternate .env file (default: scripts/.env if present)
       --bin FILE            moqx binary path (default: <project>/build/moqx)
 
 Execution:
+  -j, --jemalloc [PATH]     LD_PRELOAD jemalloc for the relay (~10% speedup).
+                            Bare flag auto-detects libjemalloc.so.2; pass an
+                            explicit PATH to override. Warns and continues if
+                            not found. (apt install libjemalloc2)
+  -b, --bpf-steering        Force mvfst_bpf_steering: true in the config
+      --no-bpf-steering     Force mvfst_bpf_steering: false in the config
+                            (Linux + mvfst only; default: leave the config's
+                            own value untouched)
       --no-sudo             run without sudo (cert files must be user-readable)
   -n, --dry-run             print resolved env + command, don't exec
   -h, --help                this help
@@ -36,11 +44,15 @@ Execution:
 Environment overrides (via .env or shell):
   MOQX_BIN, MOQX_CONFIG, MOQX_ENV_FILE, MOQX_SUBCMD, MOQX_USE_SUDO
   MOQX_VERBOSE, MOQX_LOG_LEVEL, GLOG_vmodule, DOMAIN
+  MOQX_JEMALLOC       (auto|1|<path> — enable jemalloc preload)
+  MOQX_BPF_STEERING   (true|false — override mvfst_bpf_steering)
 
 Examples:
   $0                                       # serve with .env + defaults
   $0 -v 4                                  # GLOG_v=4
   $0 -m MoQSession=5,StreamPublisherImpl=5 # targeted trace
+  $0 -j                                    # serve with jemalloc preloaded
+  $0 --bpf-steering                        # force CID reuseport steering on
   $0 --subcmd validate-config --no-sudo    # just validate the config
   $0 -n                                    # show what would run
 EOF
@@ -55,6 +67,8 @@ CLI_CONFIG=""
 CLI_ENV_FILE=""
 CLI_BIN=""
 CLI_USE_SUDO=""    # "" = unset; "0"/"1" set
+CLI_JEMALLOC=""    # "" = unset; "auto" or explicit path
+CLI_BPF=""         # "" = unset (respect config); "true"/"false" = override
 DRY_RUN=0
 PASSTHRU=()
 
@@ -68,6 +82,16 @@ while (($#)); do
     --config)        CLI_CONFIG="$2"; shift 2 ;;
     --env)           CLI_ENV_FILE="$2"; shift 2 ;;
     --bin)           CLI_BIN="$2"; shift 2 ;;
+    -j|--jemalloc)
+      # Optional arg: a following token that isn't another flag is an
+      # explicit .so path; otherwise auto-detect.
+      if [[ -n "${2:-}" && "$2" != -* ]]; then
+        CLI_JEMALLOC="$2"; shift 2
+      else
+        CLI_JEMALLOC="auto"; shift
+      fi ;;
+    -b|--bpf-steering)   CLI_BPF=true;  shift ;;
+    --no-bpf-steering)   CLI_BPF=false; shift ;;
     --no-sudo)       CLI_USE_SUDO=0; shift ;;
     -n|--dry-run)    DRY_RUN=1; shift ;;
     -h|--help)       usage; exit 0 ;;
@@ -101,7 +125,7 @@ fi
 
 # ── Paths (CLI > env > defaults) ─────────────────────────────────────────
 MOQX_BIN="${CLI_BIN:-${MOQX_BIN:-$PROJECT_ROOT/build/moqx}}"
-CONFIG_TEMPLATE="${CLI_CONFIG:-${MOQX_CONFIG:-$SCRIPT_DIR/config.production.yaml}}"
+CONFIG_TEMPLATE="${CLI_CONFIG:-${MOQX_CONFIG:-$SCRIPT_DIR/config.bench.yaml}}"
 
 [[ -x "$MOQX_BIN" ]]        || { echo "moqx binary not found: $MOQX_BIN" >&2; exit 1; }
 [[ -f "$CONFIG_TEMPLATE" ]] || { echo "config not found: $CONFIG_TEMPLATE" >&2; exit 1; }
@@ -111,6 +135,22 @@ command -v envsubst >/dev/null || { echo "envsubst missing (apt install gettext-
 RESOLVED_CONFIG=/tmp/moqx-resolved.yaml
 envsubst < "$CONFIG_TEMPLATE" > "$RESOLVED_CONFIG"
 
+# ── Optional mvfst_bpf_steering override (CLI > env; unset = respect config) ─
+# Patches the resolved temp config only; the template is never modified.
+BPF_STEERING="${CLI_BPF:-${MOQX_BPF_STEERING:-}}"
+if [[ -n "$BPF_STEERING" ]]; then
+  case "$BPF_STEERING" in
+    1|true|yes|on)   BPF_STEERING=true ;;
+    0|false|no|off)  BPF_STEERING=false ;;
+    *) echo "invalid MOQX_BPF_STEERING/--bpf-steering value: $BPF_STEERING (want true/false)" >&2; exit 2 ;;
+  esac
+  if grep -qE '^[[:space:]]*mvfst_bpf_steering:' "$RESOLVED_CONFIG"; then
+    sed -i -E "s/^([[:space:]]*)mvfst_bpf_steering:.*/\1mvfst_bpf_steering: $BPF_STEERING/" "$RESOLVED_CONFIG"
+  else
+    printf '\nmvfst_bpf_steering: %s\n' "$BPF_STEERING" >> "$RESOLVED_CONFIG"
+  fi
+fi
+
 # ── GLOG — map MOQX_* → GLOG_* (matches docker/entrypoint.sh convention) ─
 # Precedence: CLI flag > .env/shell env > fallback default.
 export GLOG_logtostderr=1
@@ -118,6 +158,37 @@ export GLOG_colorlogtostderr=1
 export GLOG_minloglevel="${CLI_LOG_LEVEL:-${MOQX_LOG_LEVEL:-0}}"
 export GLOG_v="${CLI_VERBOSE:-${MOQX_VERBOSE:-0}}"
 export GLOG_vmodule="${CLI_VMODULE:-${GLOG_vmodule:-MoqxRelay=3,MoQSession=3,MoQForwarder=3,MoqxCache=2}}"
+
+# ── jemalloc resolution (CLI > env) ──────────────────────────────────────
+# moxygen/Meta production uses jemalloc; LD_PRELOAD gives ~10% throughput.
+# "auto"/"1"/"true" → search common locations + ldconfig; an explicit path
+# is used as-is. Resolves to empty (warn) when not found so the run still
+# proceeds with the system allocator.
+JEMALLOC_REQ="${CLI_JEMALLOC:-${MOQX_JEMALLOC:-}}"
+JEMALLOC=""
+if [[ -n "$JEMALLOC_REQ" ]]; then
+  case "$JEMALLOC_REQ" in
+    auto|1|true|yes)
+      for cand in \
+        /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+        /usr/lib/aarch64-linux-gnu/libjemalloc.so.2 \
+        /lib64/libjemalloc.so.2 \
+        /usr/lib64/libjemalloc.so.2 \
+        /usr/local/lib/libjemalloc.so.2; do
+        [[ -f "$cand" ]] && { JEMALLOC="$cand"; break; }
+      done
+      if [[ -z "$JEMALLOC" ]] && command -v ldconfig >/dev/null 2>&1; then
+        JEMALLOC="$(ldconfig -p 2>/dev/null | awk '/libjemalloc\.so\.2/ {print $NF; exit}')"
+      fi
+      [[ -n "$JEMALLOC" ]] || echo "WARNING: jemalloc requested but libjemalloc.so.2 not found; using system allocator (apt install libjemalloc2)" >&2 ;;
+    *)
+      if [[ -f "$JEMALLOC_REQ" ]]; then
+        JEMALLOC="$JEMALLOC_REQ"
+      else
+        echo "WARNING: jemalloc path not found: $JEMALLOC_REQ; using system allocator" >&2
+      fi ;;
+  esac
+fi
 
 # ── Run ──────────────────────────────────────────────────────────────────
 SUBCMD="${CLI_SUBCMD:-${MOQX_SUBCMD:-serve}}"
@@ -130,16 +201,21 @@ if (( DRY_RUN )); then
   echo "GLOG_minloglevel=$GLOG_minloglevel"
   echo "GLOG_v=$GLOG_v"
   echo "GLOG_vmodule=$GLOG_vmodule"
+  echo "LD_PRELOAD=${JEMALLOC:-<none>}"
+  echo "mvfst_bpf_steering=${BPF_STEERING:-<from config>} ($(grep -E '^[[:space:]]*mvfst_bpf_steering:' "$RESOLVED_CONFIG" | awk '{print $2}' || echo unset) in resolved config)"
   echo "# resolved config: $RESOLVED_CONFIG (from $CONFIG_TEMPLATE)"
   echo "# command"
   if (( USE_SUDO )); then
     printf '  sudo'
+    [[ -n "$JEMALLOC" ]] && printf ' %s=%q' LD_PRELOAD "$JEMALLOC"
     printf ' %s=%q' \
       GLOG_v "$GLOG_v" \
       GLOG_vmodule "$GLOG_vmodule" \
       GLOG_minloglevel "$GLOG_minloglevel" \
       GLOG_logtostderr "$GLOG_logtostderr" \
       GLOG_colorlogtostderr "$GLOG_colorlogtostderr"
+  else
+    [[ -n "$JEMALLOC" ]] && printf '  LD_PRELOAD=%q' "$JEMALLOC"
   fi
   printf ' %q' "${CMD[@]}"
   printf '\n'
@@ -147,17 +223,21 @@ if (( DRY_RUN )); then
 fi
 
 if (( USE_SUDO )); then
-  # Pass GLOG_* explicitly: `sudo -E` is unreliable because sudoers
-  # env_reset (default on most distros) strips vars not listed in
-  # env_keep, and GLOG_* never is. Explicit name=value on the sudo
-  # command line bypasses env_reset entirely.
-  exec sudo \
-    GLOG_v="$GLOG_v" \
-    GLOG_vmodule="$GLOG_vmodule" \
-    GLOG_minloglevel="$GLOG_minloglevel" \
-    GLOG_logtostderr="$GLOG_logtostderr" \
-    GLOG_colorlogtostderr="$GLOG_colorlogtostderr" \
-    "${CMD[@]}"
+  # Pass GLOG_*/LD_PRELOAD explicitly: `sudo -E` is unreliable because
+  # sudoers env_reset (default on most distros) strips vars not listed in
+  # env_keep, and these never are. Explicit name=value on the sudo command
+  # line bypasses env_reset entirely. LD_PRELOAD especially: exporting it
+  # would be silently dropped across the sudo boundary.
+  SUDO_ENV=(
+    GLOG_v="$GLOG_v"
+    GLOG_vmodule="$GLOG_vmodule"
+    GLOG_minloglevel="$GLOG_minloglevel"
+    GLOG_logtostderr="$GLOG_logtostderr"
+    GLOG_colorlogtostderr="$GLOG_colorlogtostderr"
+  )
+  [[ -n "$JEMALLOC" ]] && SUDO_ENV+=("LD_PRELOAD=$JEMALLOC")
+  exec sudo "${SUDO_ENV[@]}" "${CMD[@]}"
 else
+  [[ -n "$JEMALLOC" ]] && export LD_PRELOAD="$JEMALLOC"
   exec "${CMD[@]}"
 fi

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Local moqx CLI launcher. Honors docker/.env for DOMAIN / MOQX_* / GLOG_*.
-# CLI flags win over .env. .env wins over script defaults.
+# Local moqx CLI launcher for bench/scaling runs.
+#
+# Resolves the ${MOQX_*}/${DOMAIN} placeholders in a config template
+# (default scripts/config.bench.yaml) from CLI flags > .env > built-in
+# defaults, then serves the resolved config. Reads a local .env if present.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,11 +19,18 @@ Logging (override .env/defaults):
   -L, --log-level N         GLOG_minloglevel (0=INFO 1=WARN 2=ERR 3=FATAL)
   -m, --vmodule SPEC        GLOG_vmodule (e.g. MoQSession=4,MoQForwarder=3)
   -x, --xlog SPEC           folly XLOG config (passed as --logging=SPEC)
-                            Bare LEVEL sets root: -x DBG6 = everything
-                            CSV for category-specific:
-                              -x moxygen=DBG6,quic=INFO
-                            Levels: DBG0..DBG9, INFO, WARN, ERR, FATAL
-                            (moxygen uses folly XLOG; GLOG_* doesn't apply)
+
+Relay tuning (templated into the config; CLI > .env > default):
+      --threads N           IO worker threads; 0 = moqx autodetects 1/CPU (default 0)
+      --udp-buffer BYTES    relay UDP socket buffer; 0 = moxygen 1 MB default
+                            (default: net.core.wmem_max)
+      --recv-pkts N         mvfst max_server_recv_packets_per_loop (default 256)
+      --send-pkts N         mvfst max_conn_packets_sent_per_loop (default 16)
+      --cc ALGO             mvfst congestion control (default bbr2)
+      --local-forwarders / --no-local-forwarders   (default: on)
+      --cache / --no-cache  relay object cache (default: on)
+  -b, --bpf-steering / --no-bpf-steering   mvfst CID reuseport steering
+                            (Linux + mvfst only; default: off)
 
 Targeting:
       --subcmd CMD          moqx subcommand (default: serve)
@@ -30,46 +40,74 @@ Targeting:
 
 Execution:
   -j, --jemalloc [PATH]     LD_PRELOAD jemalloc for the relay (~10% speedup).
-                            Bare flag auto-detects libjemalloc.so.2; pass an
-                            explicit PATH to override. Warns and continues if
-                            not found. (apt install libjemalloc2)
-  -b, --bpf-steering        Force mvfst_bpf_steering: true in the config
-      --no-bpf-steering     Force mvfst_bpf_steering: false in the config
-                            (Linux + mvfst only; default: leave the config's
-                            own value untouched)
+                            Bare flag auto-detects libjemalloc.so.2.
+      --check-sysctl        report current vs recommended UDP/network sysctls
+                            (with the commands to raise them) and exit
       --no-sudo             run without sudo (cert files must be user-readable)
   -n, --dry-run             print resolved env + command, don't exec
   -h, --help                this help
 
 Environment overrides (via .env or shell):
-  MOQX_BIN, MOQX_CONFIG, MOQX_ENV_FILE, MOQX_SUBCMD, MOQX_USE_SUDO
-  MOQX_VERBOSE, MOQX_LOG_LEVEL, GLOG_vmodule, DOMAIN
-  MOQX_JEMALLOC       (auto|1|<path> — enable jemalloc preload)
-  MOQX_BPF_STEERING   (true|false — override mvfst_bpf_steering)
+  MOQX_BIN, MOQX_CONFIG, MOQX_ENV_FILE, MOQX_SUBCMD, MOQX_USE_SUDO, DOMAIN
+  MOQX_VERBOSE, MOQX_LOG_LEVEL, GLOG_vmodule, MOQX_JEMALLOC
+  MOQX_THREADS, MOQX_UDP_BUFFER, MOQX_RECV_PKTS, MOQX_SEND_PKTS, MOQX_CC,
+  MOQX_LOCAL_FWD, MOQX_CACHE, MOQX_BPF_STEERING
 
 Examples:
   $0                                       # serve with .env + defaults
-  $0 -v 4                                  # GLOG_v=4
-  $0 -m MoQSession=5,StreamPublisherImpl=5 # targeted trace
-  $0 -j                                    # serve with jemalloc preloaded
-  $0 --bpf-steering                        # force CID reuseport steering on
+  $0 --threads 8 --udp-buffer 16777216     # 8 IO threads, 16 MB socket buffer
+  $0 --recv-pkts 256 -j                    # Alan's recv loop + jemalloc
+  $0 --check-sysctl                        # audit kernel UDP buffers, then exit
   $0 --subcmd validate-config --no-sudo    # just validate the config
   $0 -n                                    # show what would run
 EOF
 }
 
-CLI_VERBOSE=""
-CLI_LOG_LEVEL=""
-CLI_VMODULE=""
-CLI_XLOG=""
-CLI_SUBCMD=""
-CLI_CONFIG=""
-CLI_ENV_FILE=""
-CLI_BIN=""
-CLI_USE_SUDO=""    # "" = unset; "0"/"1" set
-CLI_JEMALLOC=""    # "" = unset; "auto" or explicit path
-CLI_BPF=""         # "" = unset (respect config); "true"/"false" = override
-DRY_RUN=0
+# ── sysctl probe — report current vs recommended; print fix commands ───────
+# Reports only; never changes anything. Recommended values target a
+# high-fan-out UDP relay (the #1 source of silent packet drops).
+check_sysctl() {
+  local mode="${1:-report}"          # report = full table; warn = only if low
+  local keys=(net.core.rmem_max net.core.wmem_max net.core.rmem_default \
+              net.core.wmem_default net.core.netdev_max_backlog \
+              net.core.optmem_max net.ipv4.udp_rmem_min net.ipv4.udp_wmem_min)
+  local rec=(16777216 16777216 4194304 4194304 65536 1048576 262144 262144)
+  local i key r cur status low_cmd=""
+  [[ "$mode" == report ]] && printf '%-30s %-14s %-14s %s\n' SYSCTL CURRENT RECOMMENDED STATUS
+  for i in "${!keys[@]}"; do
+    key="${keys[$i]}"; r="${rec[$i]}"
+    cur="$(sysctl -n "$key" 2>/dev/null || true)"
+    if [[ -z "$cur" ]]; then
+      status="n/a"
+    elif [[ "$cur" =~ ^[0-9]+$ ]] && (( cur < r )); then
+      status="LOW"; low_cmd+=" $key=$r"
+    else
+      status="ok"
+    fi
+    [[ "$mode" == report ]] && printf '%-30s %-14s %-14s %s\n' "$key" "${cur:-?}" "$r" "$status"
+  done
+  if [[ -n "$low_cmd" ]]; then
+    [[ "$mode" == report ]] && echo
+    echo "WARNING: UDP buffer/backlog sysctls below recommended for high fan-out." >&2
+    echo "  raise (run yourself — NOT executed here):" >&2
+    echo "    sudo sysctl -w$low_cmd" >&2
+    echo "  persist: put those KEY=VALUE lines in /etc/sysctl.d/99-moqx.conf, then 'sudo sysctl --system'" >&2
+    return 1
+  fi
+  [[ "$mode" == report ]] && echo "All recommended sysctls satisfied."
+  return 0
+}
+
+# normalize a boolean-ish value to true/false (or "INVALID")
+norm_bool() { case "${1,,}" in 1|true|yes|on) echo true ;; 0|false|no|off) echo false ;; *) echo INVALID ;; esac; }
+
+CLI_VERBOSE="" CLI_LOG_LEVEL="" CLI_VMODULE="" CLI_XLOG=""
+CLI_SUBCMD="" CLI_CONFIG="" CLI_ENV_FILE="" CLI_BIN=""
+CLI_USE_SUDO=""   # "" = unset; "0"/"1" set
+CLI_JEMALLOC=""   # "" = unset; "auto" or explicit path
+CLI_THREADS="" CLI_UDP_BUFFER="" CLI_RECV_PKTS="" CLI_SEND_PKTS="" CLI_CC=""
+CLI_LOCAL_FWD="" CLI_CACHE="" CLI_BPF=""   # tri-state booleans
+CHECK_SYSCTL=0 DRY_RUN=0
 PASSTHRU=()
 
 while (($#)); do
@@ -78,20 +116,26 @@ while (($#)); do
     -L|--log-level)  CLI_LOG_LEVEL="$2"; shift 2 ;;
     -m|--vmodule)    CLI_VMODULE="$2"; shift 2 ;;
     -x|--xlog)       CLI_XLOG="$2"; shift 2 ;;
+    --threads)       CLI_THREADS="$2"; shift 2 ;;
+    --udp-buffer)    CLI_UDP_BUFFER="$2"; shift 2 ;;
+    --recv-pkts)     CLI_RECV_PKTS="$2"; shift 2 ;;
+    --send-pkts)     CLI_SEND_PKTS="$2"; shift 2 ;;
+    --cc)            CLI_CC="$2"; shift 2 ;;
+    --local-forwarders)    CLI_LOCAL_FWD=true;  shift ;;
+    --no-local-forwarders) CLI_LOCAL_FWD=false; shift ;;
+    --cache)         CLI_CACHE=true;  shift ;;
+    --no-cache)      CLI_CACHE=false; shift ;;
+    -b|--bpf-steering)   CLI_BPF=true;  shift ;;
+    --no-bpf-steering)   CLI_BPF=false; shift ;;
     --subcmd)        CLI_SUBCMD="$2"; shift 2 ;;
     --config)        CLI_CONFIG="$2"; shift 2 ;;
     --env)           CLI_ENV_FILE="$2"; shift 2 ;;
     --bin)           CLI_BIN="$2"; shift 2 ;;
     -j|--jemalloc)
-      # Optional arg: a following token that isn't another flag is an
-      # explicit .so path; otherwise auto-detect.
-      if [[ -n "${2:-}" && "$2" != -* ]]; then
-        CLI_JEMALLOC="$2"; shift 2
-      else
-        CLI_JEMALLOC="auto"; shift
-      fi ;;
-    -b|--bpf-steering)   CLI_BPF=true;  shift ;;
-    --no-bpf-steering)   CLI_BPF=false; shift ;;
+      # Optional arg: a following token that isn't another flag is a path.
+      if [[ -n "${2:-}" && "$2" != -* ]]; then CLI_JEMALLOC="$2"; shift 2
+      else CLI_JEMALLOC="auto"; shift; fi ;;
+    --check-sysctl)  CHECK_SYSCTL=1; shift ;;
     --no-sudo)       CLI_USE_SUDO=0; shift ;;
     -n|--dry-run)    DRY_RUN=1; shift ;;
     -h|--help)       usage; exit 0 ;;
@@ -100,21 +144,13 @@ while (($#)); do
   esac
 done
 
-# ── Folly XLOG passthrough ────────────────────────────────────────────────
-# moxygen uses folly::XLOG (not glog VLOG), which ignores GLOG_*. folly
-# is initialized via folly::Init in moqx main.cpp and respects the
-# --logging=<config> gflag. Bare -x LEVEL sets the ROOT category — all
-# XLOGs at that level or higher fire. Pass `cat=LEVEL[,cat=LEVEL...]`
-# (a string containing `=`) for category-specific levels.
-#   -x DBG6                       → --logging=DBG6           (everything)
-#   -x moxygen=DBG6               → --logging=moxygen=DBG6   (one category)
-#   -x moxygen=DBG6,quic=INFO     → --logging=moxygen=DBG6,quic=INFO
-if [[ -n "$CLI_XLOG" ]]; then
-  PASSTHRU+=("--logging=$CLI_XLOG")
-fi
+# --check-sysctl: report and exit (no .env / binary needed)
+if (( CHECK_SYSCTL )); then check_sysctl report; exit $?; fi
 
-# ── Source .env if present ───────────────────────────────────────────────
-# set -a exports every KEY=VALUE it parses (shell-compatible .env format).
+# ── Folly XLOG passthrough (moxygen uses folly::XLOG, ignores GLOG_*) ──────
+[[ -n "$CLI_XLOG" ]] && PASSTHRU+=("--logging=$CLI_XLOG")
+
+# ── Source local .env if present (set -a exports each KEY=VALUE) ───────────
 ENV_FILE="${CLI_ENV_FILE:-${MOQX_ENV_FILE:-$SCRIPT_DIR/.env}}"
 if [[ -f "$ENV_FILE" ]]; then
   set -a
@@ -131,28 +167,26 @@ CONFIG_TEMPLATE="${CLI_CONFIG:-${MOQX_CONFIG:-$SCRIPT_DIR/config.bench.yaml}}"
 [[ -f "$CONFIG_TEMPLATE" ]] || { echo "config not found: $CONFIG_TEMPLATE" >&2; exit 1; }
 command -v envsubst >/dev/null || { echo "envsubst missing (apt install gettext-base)" >&2; exit 1; }
 
-# ── Resolve ${…} placeholders (DOMAIN, ports, etc.) into a temp config ──
+# ── Relay tuning knobs (CLI > .env/env > default), exported for envsubst ──
+WMEM_MAX="$(cat /proc/sys/net/core/wmem_max 2>/dev/null || echo 1048576)"
+export MOQX_THREADS="${CLI_THREADS:-${MOQX_THREADS:-0}}"
+export MOQX_SEND_PKTS="${CLI_SEND_PKTS:-${MOQX_SEND_PKTS:-16}}"
+export MOQX_RECV_PKTS="${CLI_RECV_PKTS:-${MOQX_RECV_PKTS:-256}}"
+export MOQX_UDP_BUFFER="${CLI_UDP_BUFFER:-${MOQX_UDP_BUFFER:-$WMEM_MAX}}"
+export MOQX_CC="${CLI_CC:-${MOQX_CC:-bbr2}}"
+MOQX_LOCAL_FWD="$(norm_bool "${CLI_LOCAL_FWD:-${MOQX_LOCAL_FWD:-true}}")"
+MOQX_CACHE="$(norm_bool "${CLI_CACHE:-${MOQX_CACHE:-true}}")"
+MOQX_BPF_STEERING="$(norm_bool "${CLI_BPF:-${MOQX_BPF_STEERING:-false}}")"
+for b in MOQX_LOCAL_FWD MOQX_CACHE MOQX_BPF_STEERING; do
+  [[ "${!b}" == INVALID ]] && { echo "invalid boolean for $b (want true/false)" >&2; exit 2; }
+done
+export MOQX_LOCAL_FWD MOQX_CACHE MOQX_BPF_STEERING
+
+# ── Resolve placeholders into a temp config ───────────────────────────────
 RESOLVED_CONFIG=/tmp/moqx-resolved.yaml
 envsubst < "$CONFIG_TEMPLATE" > "$RESOLVED_CONFIG"
 
-# ── Optional mvfst_bpf_steering override (CLI > env; unset = respect config) ─
-# Patches the resolved temp config only; the template is never modified.
-BPF_STEERING="${CLI_BPF:-${MOQX_BPF_STEERING:-}}"
-if [[ -n "$BPF_STEERING" ]]; then
-  case "$BPF_STEERING" in
-    1|true|yes|on)   BPF_STEERING=true ;;
-    0|false|no|off)  BPF_STEERING=false ;;
-    *) echo "invalid MOQX_BPF_STEERING/--bpf-steering value: $BPF_STEERING (want true/false)" >&2; exit 2 ;;
-  esac
-  if grep -qE '^[[:space:]]*mvfst_bpf_steering:' "$RESOLVED_CONFIG"; then
-    sed -i -E "s/^([[:space:]]*)mvfst_bpf_steering:.*/\1mvfst_bpf_steering: $BPF_STEERING/" "$RESOLVED_CONFIG"
-  else
-    printf '\nmvfst_bpf_steering: %s\n' "$BPF_STEERING" >> "$RESOLVED_CONFIG"
-  fi
-fi
-
 # ── GLOG — map MOQX_* → GLOG_* (matches docker/entrypoint.sh convention) ─
-# Precedence: CLI flag > .env/shell env > fallback default.
 export GLOG_logtostderr=1
 export GLOG_colorlogtostderr=1
 export GLOG_minloglevel="${CLI_LOG_LEVEL:-${MOQX_LOG_LEVEL:-0}}"
@@ -160,10 +194,6 @@ export GLOG_v="${CLI_VERBOSE:-${MOQX_VERBOSE:-0}}"
 export GLOG_vmodule="${CLI_VMODULE:-${GLOG_vmodule:-MoqxRelay=3,MoQSession=3,MoQForwarder=3,MoqxCache=2}}"
 
 # ── jemalloc resolution (CLI > env) ──────────────────────────────────────
-# moxygen/Meta production uses jemalloc; LD_PRELOAD gives ~10% throughput.
-# "auto"/"1"/"true" → search common locations + ldconfig; an explicit path
-# is used as-is. Resolves to empty (warn) when not found so the run still
-# proceeds with the system allocator.
 JEMALLOC_REQ="${CLI_JEMALLOC:-${MOQX_JEMALLOC:-}}"
 JEMALLOC=""
 if [[ -n "$JEMALLOC_REQ" ]]; then
@@ -182,52 +212,46 @@ if [[ -n "$JEMALLOC_REQ" ]]; then
       fi
       [[ -n "$JEMALLOC" ]] || echo "WARNING: jemalloc requested but libjemalloc.so.2 not found; using system allocator (apt install libjemalloc2)" >&2 ;;
     *)
-      if [[ -f "$JEMALLOC_REQ" ]]; then
-        JEMALLOC="$JEMALLOC_REQ"
-      else
-        echo "WARNING: jemalloc path not found: $JEMALLOC_REQ; using system allocator" >&2
-      fi ;;
+      if [[ -f "$JEMALLOC_REQ" ]]; then JEMALLOC="$JEMALLOC_REQ"
+      else echo "WARNING: jemalloc path not found: $JEMALLOC_REQ; using system allocator" >&2; fi ;;
   esac
 fi
 
 # ── Run ──────────────────────────────────────────────────────────────────
 SUBCMD="${CLI_SUBCMD:-${MOQX_SUBCMD:-serve}}"
 USE_SUDO="${CLI_USE_SUDO:-${MOQX_USE_SUDO:-1}}"
-
 CMD=("$MOQX_BIN" "$SUBCMD" --config "$RESOLVED_CONFIG" "${PASSTHRU[@]}")
 
 if (( DRY_RUN )); then
+  echo "# relay knobs (templated into config)"
+  echo "threads=$MOQX_THREADS local_fwd=$MOQX_LOCAL_FWD bpf_steering=$MOQX_BPF_STEERING cache=$MOQX_CACHE"
+  echo "cc=$MOQX_CC send_pkts=$MOQX_SEND_PKTS recv_pkts=$MOQX_RECV_PKTS udp_buffer=$MOQX_UDP_BUFFER"
   echo "# resolved env"
-  echo "GLOG_minloglevel=$GLOG_minloglevel"
-  echo "GLOG_v=$GLOG_v"
+  echo "GLOG_minloglevel=$GLOG_minloglevel GLOG_v=$GLOG_v"
   echo "GLOG_vmodule=$GLOG_vmodule"
   echo "LD_PRELOAD=${JEMALLOC:-<none>}"
-  echo "mvfst_bpf_steering=${BPF_STEERING:-<from config>} ($(grep -E '^[[:space:]]*mvfst_bpf_steering:' "$RESOLVED_CONFIG" | awk '{print $2}' || echo unset) in resolved config)"
   echo "# resolved config: $RESOLVED_CONFIG (from $CONFIG_TEMPLATE)"
   echo "# command"
   if (( USE_SUDO )); then
     printf '  sudo'
     [[ -n "$JEMALLOC" ]] && printf ' %s=%q' LD_PRELOAD "$JEMALLOC"
     printf ' %s=%q' \
-      GLOG_v "$GLOG_v" \
-      GLOG_vmodule "$GLOG_vmodule" \
+      GLOG_v "$GLOG_v" GLOG_vmodule "$GLOG_vmodule" \
       GLOG_minloglevel "$GLOG_minloglevel" \
-      GLOG_logtostderr "$GLOG_logtostderr" \
-      GLOG_colorlogtostderr "$GLOG_colorlogtostderr"
+      GLOG_logtostderr "$GLOG_logtostderr" GLOG_colorlogtostderr "$GLOG_colorlogtostderr"
   else
     [[ -n "$JEMALLOC" ]] && printf '  LD_PRELOAD=%q' "$JEMALLOC"
   fi
-  printf ' %q' "${CMD[@]}"
-  printf '\n'
+  printf ' %q' "${CMD[@]}"; printf '\n'
   exit 0
 fi
 
+# ── Pre-flight: warn (don't block) if UDP sysctls are below recommended ───
+[[ "$SUBCMD" == serve ]] && { check_sysctl warn || true; }
+
 if (( USE_SUDO )); then
-  # Pass GLOG_*/LD_PRELOAD explicitly: `sudo -E` is unreliable because
-  # sudoers env_reset (default on most distros) strips vars not listed in
-  # env_keep, and these never are. Explicit name=value on the sudo command
-  # line bypasses env_reset entirely. LD_PRELOAD especially: exporting it
-  # would be silently dropped across the sudo boundary.
+  # Pass GLOG_*/LD_PRELOAD explicitly: sudoers env_reset strips vars not in
+  # env_keep, and exporting LD_PRELOAD would be dropped across the boundary.
   SUDO_ENV=(
     GLOG_v="$GLOG_v"
     GLOG_vmodule="$GLOG_vmodule"


### PR DESCRIPTION
Separates roles: the local bench launcher `moqx-run.sh` and the high-scale bench config move out of `docker/` into `scripts/`, alongside `perf-test.sh`/`perf-metrics.sh`.

- **`scripts/moqx-run.sh`** — local moqx CLI launcher with jemalloc (`-j`) and mvfst bpf-steering (`--bpf-steering`) toggles. Default config is now `scripts/config.bench.yaml`; reads a local `scripts/.env` if present, else built-in defaults, CLI args override.
- **`scripts/config.bench.yaml`** — high-scale / high-fan-out tuning (bbr2 + recovery, mvfst recv/send loop limits, cache) for scaling tests.

The docker image never used `config.production.yaml` — `entrypoint.sh` generates its config from env vars — so this is a **pure relocation with no change to the docker path**. Parameterized docker config templating is left for a follow-up PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/416)
<!-- Reviewable:end -->
