### PR TITLE
ci: benchmark jobs use snapshot tarball instead of source-building moxygen

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -255,7 +255,28 @@ jobs:
       - name: Setup dependencies
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: bash scripts/build.sh setup
+        run: |
+          # Three-mode setup resolution (mirrors the build/conformance jobs):
+          # 1. .moxygen-release file (release branches): use pinned tag.
+          # 2. Submodule SHA reachable from moxygen main: snapshot tarball
+          #    (avoids a slow from-source dep build when moxygen has advanced
+          #    past the local pin — the common case under the daily sync).
+          # 3. Submodule SHA diverged from main: source build.
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "==> Pinned moxygen tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            bash scripts/build.sh setup --no-fallback
+          else
+            SUB_SHA=$(git -C deps/moxygen rev-parse HEAD)
+            AHEAD=$(gh api "repos/openmoq/moxygen/compare/main...$SUB_SHA" --jq .ahead_by 2>/dev/null || echo "1")
+            if [ "$AHEAD" = "0" ]; then
+              echo "==> moxygen submodule $SUB_SHA on main → snapshot tarball"
+              bash scripts/build.sh setup --use-latest --no-fallback
+            else
+              echo "==> moxygen submodule $SUB_SHA $AHEAD commits diverged from main → source build"
+              bash scripts/build.sh setup
+            fi
+          fi
 
       - name: Build with benchmarks
         run: bash scripts/build.sh --benchmark

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -232,7 +232,28 @@ jobs:
       - name: Setup dependencies
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: bash scripts/build.sh setup
+        run: |
+          # Three-mode setup resolution (mirrors the build/conformance jobs):
+          # 1. .moxygen-release file (release branches): use pinned tag.
+          # 2. Submodule SHA reachable from moxygen main: snapshot tarball
+          #    (avoids a slow from-source dep build when moxygen has advanced
+          #    past the local pin — the common case under the daily sync).
+          # 3. Submodule SHA diverged from main: source build.
+          if [ -f .moxygen-release ]; then
+            export MOQX_MOXYGEN_RELEASE_TAG=$(cat .moxygen-release | tr -d '[:space:]')
+            echo "==> Pinned moxygen tag: $MOQX_MOXYGEN_RELEASE_TAG"
+            bash scripts/build.sh setup --no-fallback
+          else
+            SUB_SHA=$(git -C deps/moxygen rev-parse HEAD)
+            AHEAD=$(gh api "repos/openmoq/moxygen/compare/main...$SUB_SHA" --jq .ahead_by 2>/dev/null || echo "1")
+            if [ "$AHEAD" = "0" ]; then
+              echo "==> moxygen submodule $SUB_SHA on main → snapshot tarball"
+              bash scripts/build.sh setup --use-latest --no-fallback
+            else
+              echo "==> moxygen submodule $SUB_SHA $AHEAD commits diverged from main → source build"
+              bash scripts/build.sh setup
+            fi
+          fi
 
       - name: Build with benchmarks
         run: bash scripts/build.sh --benchmark


### PR DESCRIPTION
## Problem

Alan noticed the linux benchmark job sub-builds moxygen + all Meta deps **from source**. Root cause: the benchmark jobs in `ci-pr.yml` and `ci-main.yml` use a bare `bash scripts/build.sh setup`, which does an **exact submodule-SHA** tarball check and falls back to a from-source build whenever moxygen has advanced past the local pin — the common case, since the daily `moxygen-sync` moves the pin around merges.

This makes benchmark CI slow and, worse, produces **inconsistent dep builds run-to-run** (ad-hoc source builds vs. the publish pipeline's fixed RelWithDebInfo tarball).

## Fix

Both benchmark jobs now use the **same three-mode setup resolution** the `build` and `conformance` jobs already use:

1. `.moxygen-release` present (release branches) → pinned tag (`--no-fallback`)
2. submodule reachable from moxygen `main` (`ahead_by == 0`) → **snapshot tarball** (`--use-latest --no-fallback`)
3. submodule diverged from main → source build

No env changes needed — both benchmark jobs already export the app token as `GH_TOKEN`, which the `gh api .../compare` call requires.

## Verification

- Both files YAML-parse.
- Dry-ran the decision logic against the real submodule: `12b24a6` resolves `ahead_by=0` → snapshot tarball path. ✅
- Logic is copied verbatim from the already-proven build/conformance jobs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/419)
<!-- Reviewable:end -->
