### PR TITLE
Add proxygen_qmux listener support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ add_library(moqx_core STATIC
   src/MoqxRelayContext.cpp
   src/MoqxRelayServer.cpp
   src/MoqxPicoRelayServer.cpp
+  src/MoqxQmuxRelayServer.cpp
   src/ServiceMatcher.cpp
   src/admin/AdminServer.cpp
   src/admin/BuiltinRoutes.cpp
@@ -158,6 +159,8 @@ target_link_libraries(moqx_core PUBLIC
   moxygen::moxygen_relay_moq_forwarder
   moxygen::moxygen_moq_relay_session
   moxygen::moxygen_moq_server
+  moxygen::moxygen_moq_qmux_server
+  moxygen::moxygen_qmux_utils
   moxygen::openmoq_pico_evb_server_transport
   proxygen::proxygenhttpserver
   # Workaround: wangle::wangle_acceptor_acceptor_core uses AsyncFdSocket from

--- a/src/MoqxQmuxRelayServer.cpp
+++ b/src/MoqxQmuxRelayServer.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MoqxQmuxRelayServer.h"
+
+#include "stats/EventBaseStatsCollector.h"
+#include <moxygen/MoQRelaySession.h>
+#include <moxygen/QmuxUtils.h>
+#include <proxygen/httpserver/samples/hq/FizzContext.h>
+
+#include <folly/logging/xlog.h>
+#include <quic/state/TransportSettings.h>
+
+using namespace moxygen;
+
+namespace openmoq::moqx {
+
+namespace {
+
+// qmux advertises only the MoQ ALPNs (no "h3" — that is for HTTP/3 WebTransport
+// on the QUIC path).
+std::vector<std::string> buildQmuxAlpns(const std::string& versions) {
+  return getMoqtProtocols(versions, /*useStandard=*/true);
+}
+
+std::shared_ptr<const fizz::server::FizzServerContext>
+buildFizzContext(const config::ListenerConfig& cfg) {
+  auto alpns = buildQmuxAlpns(cfg.moqtVersions);
+  return std::visit(
+      [&alpns](const auto& tls) -> std::shared_ptr<const fizz::server::FizzServerContext> {
+        using T = std::decay_t<decltype(tls)>;
+        if constexpr (std::is_same_v<T, config::Insecure>) {
+          return quic::samples::createFizzServerContextWithInsecureDefault(
+              alpns,
+              fizz::server::ClientAuthMode::None,
+              "",
+              ""
+          );
+        } else {
+          return quic::samples::createFizzServerContext(
+              alpns,
+              fizz::server::ClientAuthMode::Optional,
+              tls.certFile,
+              tls.keyFile
+          );
+        }
+      },
+      cfg.tlsMode
+  );
+}
+
+// Translate the QUIC flow-control / idle-timeout knobs into the QMUX transport
+// params advertised to the peer. mvfst-only tunables don't apply over TCP.
+MoQQmuxServer::Config buildQmuxConfig(const config::QuicConfig& quic) {
+  quic::TransportSettings ts;
+  ts.advertisedInitialConnectionFlowControlWindow = quic.maxData;
+  ts.advertisedInitialBidiLocalStreamFlowControlWindow = quic.maxStreamData;
+  ts.advertisedInitialBidiRemoteStreamFlowControlWindow = quic.maxStreamData;
+  ts.advertisedInitialUniStreamFlowControlWindow = quic.maxStreamData;
+  ts.advertisedInitialMaxStreamsBidi = quic.maxBidiStreams;
+  ts.advertisedInitialMaxStreamsUni = quic.maxUniStreams;
+  ts.idleTimeout = std::chrono::milliseconds(quic.idleTimeoutMs);
+
+  MoQQmuxServer::Config config;
+  config.selfTransportParams = qmuxParamsFromTransportSettings(ts);
+  return config;
+}
+
+} // namespace
+
+MoqxQmuxRelayServer::MoqxQmuxRelayServer(
+    const config::ListenerConfig& listenerCfg,
+    std::shared_ptr<MoqxRelayContext> context,
+    folly::IOThreadPoolExecutor* ioExecutor
+)
+    : MoQQmuxServer(
+          listenerCfg.endpoint,
+          buildFizzContext(listenerCfg),
+          buildQmuxConfig(listenerCfg.quic)
+      ),
+      listenerCfg_(listenerCfg), context_(std::move(context)), ioExecutor_(ioExecutor) {}
+
+MoqxQmuxRelayServer::~MoqxQmuxRelayServer() {
+  // Close incoming connections, drain worker EVBs, then destroy EVBs.
+  stop();
+}
+
+void MoqxQmuxRelayServer::stop() {
+  if (stopped_) {
+    return;
+  }
+  stopped_ = true;
+  // Keep context_ alive: terminateClientSession can run after stop() returns,
+  // from handleClientSession coroutines still draining on IO threads.
+  MoQQmuxServer::stop();
+}
+
+void MoqxQmuxRelayServer::setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry) {
+  context_->setStatsRegistry(registry);
+  for (auto& ka : ioExecutor_->getAllEventBases()) {
+    stats::EventBaseStatsCollector::create(registry, ka.get());
+  }
+  // No QuicStatsCollector: qmux runs over TCP, not the mvfst QUIC transport.
+}
+
+void MoqxQmuxRelayServer::start() {
+  auto evbKAs = ioExecutor_->getAllEventBases();
+  std::vector<folly::EventBase*> evbs;
+  evbs.reserve(evbKAs.size());
+  for (auto& ka : evbKAs) {
+    evbs.push_back(ka.get());
+  }
+  ioExecutor_ = nullptr;
+  MoQQmuxServer::start(listenerCfg_.address, std::move(evbs));
+}
+
+void MoqxQmuxRelayServer::start(const folly::SocketAddress& /*addr*/) {
+  start();
+}
+
+void MoqxQmuxRelayServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
+  context_->onNewSession(std::move(clientSession));
+}
+
+void MoqxQmuxRelayServer::terminateClientSession(std::shared_ptr<MoQSession> session) {
+  context_->onSessionEnd(session);
+  MoQQmuxServer::terminateClientSession(std::move(session));
+}
+
+folly::Expected<folly::Unit, SessionCloseErrorCode> MoqxQmuxRelayServer::validateAuthority(
+    const ClientSetup& clientSetup,
+    uint64_t negotiatedVersion,
+    std::shared_ptr<MoQSession> session
+) {
+  // Base class format validation (lives on MoQServerBase).
+  auto base = MoQQmuxServer::validateAuthority(clientSetup, negotiatedVersion, session);
+  if (!base.hasValue()) {
+    return base;
+  }
+  return context_->validateAuthority(clientSetup, negotiatedVersion, std::move(session));
+}
+
+std::shared_ptr<MoQSession> MoqxQmuxRelayServer::createSession(
+    folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+    std::shared_ptr<MoQExecutor> executor
+) {
+  return std::make_shared<MoQRelaySession>(
+      folly::MaybeManagedPtr<proxygen::WebTransport>(std::move(wt)),
+      *this,
+      std::move(executor)
+  );
+}
+
+} // namespace openmoq::moqx

--- a/src/MoqxQmuxRelayServer.h
+++ b/src/MoqxQmuxRelayServer.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "MoqxRelayContext.h"
+#include "config/Config.h"
+#include "stats/StatsRegistry.h"
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <moxygen/MoQQmuxServer.h>
+
+namespace openmoq::moqx {
+
+// Relay server accepting MoQ sessions over QMUX-on-TCP + Fizz TLS.
+// Sibling to MoqxRelayServer (mvfst) / MoqxPicoRelayServer; shares MoqxRelayContext.
+class MoqxQmuxRelayServer : public moxygen::MoQQmuxServer {
+public:
+  MoqxQmuxRelayServer(
+      const config::ListenerConfig& listenerCfg,
+      std::shared_ptr<MoqxRelayContext> context,
+      folly::IOThreadPoolExecutor* ioExecutor
+  );
+
+  ~MoqxQmuxRelayServer() override;
+
+  // Idempotent; safe to call from main and again from ~MoqxQmuxRelayServer.
+  void stop() override;
+
+  void setStatsRegistry(std::shared_ptr<stats::StatsRegistry> registry);
+
+  // Preferred entry point: binds the address from the stored ListenerConfig.
+  void start();
+
+  // Satisfies MoQServerBase pure virtual; delegates to start().
+  void start(const folly::SocketAddress& addr) override;
+
+  void onNewSession(std::shared_ptr<moxygen::MoQSession> clientSession) override;
+
+  void terminateClientSession(std::shared_ptr<moxygen::MoQSession> session) override;
+
+  folly::Expected<folly::Unit, moxygen::SessionCloseErrorCode> validateAuthority(
+      const moxygen::ClientSetup& clientSetup,
+      uint64_t negotiatedVersion,
+      std::shared_ptr<moxygen::MoQSession> session
+  ) override;
+
+protected:
+  std::shared_ptr<moxygen::MoQSession> createSession(
+      folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+      std::shared_ptr<moxygen::MoQExecutor> executor
+  ) override;
+
+private:
+  config::ListenerConfig listenerCfg_;
+  std::shared_ptr<MoqxRelayContext> context_;
+  folly::IOThreadPoolExecutor* ioExecutor_;
+  bool stopped_{false};
+};
+
+} // namespace openmoq::moqx

--- a/src/MoqxServerFactory.h
+++ b/src/MoqxServerFactory.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "MoqxPicoRelayServer.h"
+#include "MoqxQmuxRelayServer.h"
 #include "MoqxRelayContext.h"
 #include "MoqxRelayServer.h"
 #include "config/Config.h"
@@ -28,6 +29,12 @@ inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
   if (listenerCfg.quicStack == config::QuicStack::Picoquic) {
     auto server =
         std::make_shared<MoqxPicoRelayServer>(listenerCfg, std::move(context), ioExecutor);
+    server->setStatsRegistry(std::move(statsRegistry));
+    return server;
+  }
+  if (listenerCfg.quicStack == config::QuicStack::ProxygenQmux) {
+    auto server =
+        std::make_shared<MoqxQmuxRelayServer>(listenerCfg, std::move(context), ioExecutor);
     server->setStatsRegistry(std::move(statsRegistry));
     return server;
   }

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -39,7 +39,8 @@ struct CacheConfig {
       defaultMaxCacheDuration; // nullopt = use maxCacheDuration; 0ms = opt-in only
 };
 
-enum class QuicStack { Mvfst, Picoquic };
+// ProxygenQmux carries MoQ over QMUX-on-TCP + Fizz TLS, not QUIC/UDP.
+enum class QuicStack { Mvfst, Picoquic, ProxygenQmux };
 
 struct QuicConfig {
   // Flow control

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -20,6 +20,18 @@ namespace {
 
 constexpr const char* kStackMvfst = "mvfst";
 constexpr const char* kStackPicoquic = "picoquic";
+// Named proxygen_qmux (not bare "qmux") so a second qmux impl can be added later.
+constexpr const char* kStackProxygenQmux = "proxygen_qmux";
+
+QuicStack parseQuicStack(const std::string& stackStr) {
+  if (stackStr == kStackPicoquic) {
+    return QuicStack::Picoquic;
+  }
+  if (stackStr == kStackProxygenQmux) {
+    return QuicStack::ProxygenQmux;
+  }
+  return QuicStack::Mvfst;
+}
 
 // Format a label for error messages: "Service 'name' match[j]"
 std::string matchRuleErrorLabel(const std::string& name, size_t j) {
@@ -176,10 +188,11 @@ void validateListener(
 
   // quic_stack validation
   const auto& stackOpt = listener.quic_stack.value();
-  if (stackOpt.has_value() && *stackOpt != kStackMvfst && *stackOpt != kStackPicoquic) {
+  if (stackOpt.has_value() && *stackOpt != kStackMvfst && *stackOpt != kStackPicoquic &&
+      *stackOpt != kStackProxygenQmux) {
     errors.push_back(
         "Listener '" + listener.name.value() + "': unknown quic_stack '" + *stackOpt +
-        "' (expected \"mvfst\" or \"picoquic\")"
+        "' (expected \"mvfst\", \"picoquic\", or \"proxygen_qmux\")"
     );
   }
   if (stackOpt.value_or(kStackMvfst) == kStackPicoquic && listener.tls.value().insecure.value()) {
@@ -636,6 +649,10 @@ void validateQuicConfig(
         ") must be >= min_ack_delay_us (" + std::to_string(quic.minAckDelayUs) + ")"
     );
   }
+  // qmux runs over TCP, so QUIC congestion-control selection does not apply.
+  if (stack == QuicStack::ProxygenQmux) {
+    return;
+  }
   // (excluded: mvfst "custom"/"staticcwnd" require programmatic setup)
   static const std::unordered_set<std::string> kPicoCcAlgos =
       {"bbr", "bbr1", "c4", "cubic", "dcubic", "fast", "newreno", "prague", "reno"};
@@ -747,7 +764,7 @@ ListenerConfig resolveListener(
   }
 
   const auto& stackStr = listener.quic_stack.value().value_or(kStackMvfst);
-  auto quicStack = (stackStr == kStackPicoquic) ? QuicStack::Picoquic : QuicStack::Mvfst;
+  auto quicStack = parseQuicStack(stackStr);
 
   return ListenerConfig{
       .name = listener.name.value(),
@@ -841,24 +858,28 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
       }
       auto quic = mergeQuicConfig(quicDefaults, listener.quic.value());
       const auto stackStr = listener.quic_stack.value().value_or(kStackMvfst);
-      const auto stack = (stackStr == kStackPicoquic) ? QuicStack::Picoquic : QuicStack::Mvfst;
+      const auto stack = parseQuicStack(stackStr);
       validateQuicConfig(quic, stack, "Listener '" + listener.name.value() + "'", errors, warnings);
       mergedQuicConfigs.push_back(quic);
       mergedMvfstConfigs.push_back(mergeMvfstConfig(mvfstDefaults, listener.mvfst.value()));
-      validateMvfstConfig(
-          mergedMvfstConfigs.back(),
-          "Listener '" + listener.name.value() + "'",
-          errors,
-          warnings
-      );
-      if (!mergedMvfstConfigs.back().pacingEnabled) {
-        const auto& cc = quic.ccAlgo;
-        if (cc == "bbr" || cc == "bbr2" || cc == "bbr2modular") {
-          errors.push_back(
-              "Listener '" + listener.name.value() +
-              "': mvfst: pacing_enabled: false is incompatible with cc_algo '" + cc +
-              "' (bbr, bbr2, and bbr2modular require pacing)"
-          );
+      // mvfst tunables don't apply to picoquic (PicoTransportConfig) or qmux
+      // (TCP); validating them on those stacks only yields spurious errors.
+      if (stack == QuicStack::Mvfst) {
+        validateMvfstConfig(
+            mergedMvfstConfigs.back(),
+            "Listener '" + listener.name.value() + "'",
+            errors,
+            warnings
+        );
+        if (!mergedMvfstConfigs.back().pacingEnabled) {
+          const auto& cc = quic.ccAlgo;
+          if (cc == "bbr" || cc == "bbr2" || cc == "bbr2modular") {
+            errors.push_back(
+                "Listener '" + listener.name.value() +
+                "': mvfst: pacing_enabled: false is incompatible with cc_algo '" + cc +
+                "' (bbr, bbr2, and bbr2modular require pacing)"
+            );
+          }
         }
       }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -190,6 +190,16 @@ set_tests_properties(relay_chain PROPERTIES
 )
 
 add_test(
+  NAME qmux_relay
+  COMMAND bash ${PROJECT_SOURCE_DIR}/test/test_qmux_relay.sh $<TARGET_FILE:moqx>
+)
+set_tests_properties(qmux_relay PROPERTIES
+  TIMEOUT 60
+  SKIP_RETURN_CODE 77
+  ENVIRONMENT "MOQBIN=${PROJECT_SOURCE_DIR}/.scratch/moxygen-install/bin"
+)
+
+add_test(
   NAME admin_info_endpoint
   COMMAND bash ${PROJECT_SOURCE_DIR}/test/test_admin_info.sh $<TARGET_FILE:moqx>
 )

--- a/test/test_ports.sh
+++ b/test/test_ports.sh
@@ -39,3 +39,8 @@ TEST_RELAY_CHAIN_DOWNSTREAM_ADMIN=19671
 # test_admin_cache_purge_race.sh
 TEST_CACHE_PURGE_RACE_RELAY=19678
 TEST_CACHE_PURGE_RACE_ADMIN=19679
+
+# test_qmux_relay.sh  (relay listener + admin, plus a throwaway dateserver listener)
+TEST_QMUX_RELAY_LISTEN=19680
+TEST_QMUX_RELAY_ADMIN=19681
+TEST_QMUX_DATESERVER_LISTEN=19682

--- a/test/test_qmux_relay.sh
+++ b/test/test_qmux_relay.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# test_qmux_relay.sh — end-to-end test of a moqx relay's proxygen_qmux listener.
+#
+# Starts one moqx relay with a single quic_stack: proxygen_qmux listener
+# (QMUX-on-TCP + Fizz, insecure), a moqdateserver publishing to it over qmux,
+# and a moqtextclient subscribing from it over qmux. Passes if at least one
+# date object flows through the relay within the timeout.
+#
+# The moqtest_* binaries can't drive this: their client side speaks only
+# QUIC/WebTransport. moqdateserver/moqtextclient have a real client-side
+# --qmux (makeRelayClientTransport TransportType::QMUX), so they're used here.
+#
+# moqdateserver/moqtextclient must be at:
+#   .scratch/moxygen-install/bin/  (relative to repo root)
+#
+# Usage: bash test/test_qmux_relay.sh [path/to/moqx]
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+# Explicit arg wins; otherwise pick the most recently built moqx, so a fresh
+# build-san/ is preferred over a stale build/ that may predate proxygen_qmux.
+BINARY="${1:-}"
+if [[ -z "$BINARY" ]]; then
+  BINARY="$(ls -t "$REPO"/build*/moqx 2>/dev/null | head -1 || true)"
+  BINARY="${BINARY:-$REPO/build/moqx}"
+fi
+MOQBIN="${MOQBIN:-$REPO/.scratch/moxygen-install/bin}"
+# shellcheck source=test_ports.sh
+source "$REPO/test/test_ports.sh"
+
+# Resolve a qmux-capable sample binary. Prefer MOQBIN's flat layout (the install
+# at .scratch/moxygen-install/bin); if that's a pre-qmux release, fall back to a
+# from-source build under .scratch/standalone-build*/moxygen/samples (e.g. the
+# asan build), where samples live in per-tool subdirs. Empty if none found.
+# $1 = binary name, $2 = samples subdir for the fallback layout.
+resolve_qmux_bin() {
+  local name="$1" sub="$2" cand
+  for cand in "$MOQBIN/$name" \
+              "$REPO"/.scratch/standalone-build*/moxygen/samples/"$sub/$name"; do
+    if [[ -x "$cand" ]] && grep -q "qmux" <<<"$("$cand" --help 2>&1 || true)"; then
+      echo "$cand"
+      return
+    fi
+  done
+}
+
+DATESERVER="$(resolve_qmux_bin moqdateserver date)"
+TEXTCLIENT="$(resolve_qmux_bin moqtextclient text-client)"
+
+RELAY_PORT=$TEST_QMUX_RELAY_LISTEN
+ADMIN_PORT=$TEST_QMUX_RELAY_ADMIN
+DATESERVER_PORT=$TEST_QMUX_DATESERVER_LISTEN
+NAMESPACE="moq-date"
+TIMEOUT=3   # seconds to wait for data
+
+# ── Prereq checks ───────────────────────────────────────────────────────────────
+if [[ ! -x "$BINARY" ]]; then
+  echo "ERROR: not found or not executable: $BINARY" >&2
+  exit 1
+fi
+
+# Skip (ctest SKIP_RETURN_CODE 77) when no qmux-capable moqdateserver/moqtextclient
+# is available — the sample binaries only gained client-side --qmux after moxygen's
+# qmux work, so a pre-qmux install (and no from-source build) can't drive this.
+if [[ -z "$DATESERVER" || -z "$TEXTCLIENT" ]]; then
+  echo "SKIP: no qmux-capable moqdateserver/moqtextclient found (pre-qmux build)" >&2
+  exit 77
+fi
+echo "Using publisher: $DATESERVER"
+echo "Using subscriber: $TEXTCLIENT"
+
+# qmux is TCP — check TCP listeners (relay chain checks UDP).
+for port in "$RELAY_PORT" "$ADMIN_PORT" "$DATESERVER_PORT"; do
+  if ss -tlnp 2>/dev/null | grep -q ":$port "; then
+    echo "ERROR: port $port already in use (stale process?)" >&2
+    exit 1
+  fi
+done
+
+# ── Temp files / cleanup ────────────────────────────────────────────────────────
+TMPDIR_SCRIPT="$(mktemp -d)"
+RELAY_CFG="$TMPDIR_SCRIPT/relay.yaml"
+CLIENT_OUT="$TMPDIR_SCRIPT/client.out"
+DATESERVER_LOG="$TMPDIR_SCRIPT/dateserver.log"
+
+PIDS=()        # helpers — 2s grace then SIGKILL
+RELAY_PIDS=()  # relay — wait indefinitely (relay has a hard shutdown watchdog)
+cleanup() {
+  for pid in "${PIDS[@]:-}" "${RELAY_PIDS[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  local deadline=$(( $(date +%s) + 2 ))
+  while true; do
+    local any_alive=false
+    for pid in "${PIDS[@]:-}"; do
+      kill -0 "$pid" 2>/dev/null && { any_alive=true; break; }
+    done
+    [[ "$any_alive" == true ]] || break
+    (( $(date +%s) >= deadline )) && break
+    sleep 0.2
+  done
+  for pid in "${PIDS[@]:-}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  wait "${PIDS[@]:-}" "${RELAY_PIDS[@]:-}" 2>/dev/null || true
+  rm -rf "$TMPDIR_SCRIPT"
+}
+trap cleanup EXIT
+
+# ── Readiness helpers ───────────────────────────────────────────────────────────
+wait_ready() {
+  local port="$1" label="$2"
+  local deadline=$(( $(date +%s) + 10 ))
+  until curl -sf "http://localhost:$port/info" >/dev/null 2>&1; do
+    (( $(date +%s) >= deadline )) && { echo "ERROR: $label not ready after 10s" >&2; exit 1; }
+    sleep 0.1
+  done
+}
+
+wait_sessions() {
+  local port="$1" min="$2" label="$3"
+  local deadline=$(( $(date +%s) + 10 ))
+  local val
+  until val=$(curl -sf "http://localhost:$port/metrics" 2>/dev/null \
+        | grep "^moqx_moqActiveSessions " | awk '{print $2}') \
+        && [[ -n "$val" && "$val" -ge "$min" ]]; do
+    (( $(date +%s) >= deadline )) && {
+      echo "ERROR: $label: moqActiveSessions=${val:-?} < $min after 10s" >&2; exit 1;
+    }
+    sleep 0.1
+  done
+}
+
+# ── Relay config: a single proxygen_qmux listener, insecure ─────────────────────
+cat >"$RELAY_CFG" <<EOF
+relay_id: "qmux-test"
+listeners:
+  - name: qmux
+    quic_stack: proxygen_qmux
+    udp:
+      socket:
+        address: "::"
+        port: $RELAY_PORT
+    tls:
+      insecure: true
+    endpoint: "/moq-relay"
+services:
+  default:
+    match:
+      - authority: {any: true}
+        path: {prefix: "/"}
+    cache:
+      enabled: false
+      max_tracks: 100
+      max_groups_per_track: 3
+admin:
+  port: $ADMIN_PORT
+  address: "::"
+  plaintext: true
+EOF
+
+echo "Starting moqx relay (proxygen_qmux) on port $RELAY_PORT..."
+"$BINARY" --config="$RELAY_CFG" >/dev/null 2>&1 &
+RELAY_PIDS+=($!)
+wait_ready "$ADMIN_PORT" "relay"
+
+# ── Publisher: moqdateserver connects to the relay over qmux ────────────────────
+# --quic=false so only a throwaway qmux listener binds; --qmux selects QMUX as
+# the relay-client transport (makeRelayClientTransport).
+echo "Starting moqdateserver (qmux publisher)..."
+"$DATESERVER" \
+  --relay_url="https://localhost:$RELAY_PORT/moq-relay" \
+  --ns="$NAMESPACE" --qmux --quic=false --port="$DATESERVER_PORT" --insecure \
+  >"$DATESERVER_LOG" 2>&1 &
+PIDS+=($!)
+wait_sessions "$ADMIN_PORT" 1 "publisher"
+
+# ── Subscriber: moqtextclient subscribes from the relay over qmux ───────────────
+# Poll the output and stop as soon as the first object (or an error) appears,
+# rather than waiting the full timeout — the date track emits one object/sec.
+echo "Starting moqtextclient (qmux subscriber)..."
+"$TEXTCLIENT" \
+  --connect_url="https://localhost:$RELAY_PORT/moq-relay" \
+  --track_namespace="$NAMESPACE" --track_name="date" --qmux --insecure \
+  >"$CLIENT_OUT" 2>&1 &
+TCPID=$!
+PIDS+=($TCPID)
+deadline=$(( $(date +%s) + TIMEOUT ))
+while (( $(date +%s) < deadline )); do
+  grep -qE "^[0-9]|SubscribeError" "$CLIENT_OUT" 2>/dev/null && break
+  kill -0 "$TCPID" 2>/dev/null || break
+  sleep 0.1
+done
+kill "$TCPID" 2>/dev/null || true
+
+# ── Verify ──────────────────────────────────────────────────────────────────────
+if grep -q "SubscribeError" "$CLIENT_OUT" 2>/dev/null; then
+  echo "FAIL [qmux relay]: SubscribeError" >&2
+  cat "$CLIENT_OUT" >&2
+  echo "--- dateserver log ---" >&2; cat "$DATESERVER_LOG" >&2 || true
+  exit 1
+elif grep -qE "^[0-9]" "$CLIENT_OUT" 2>/dev/null; then
+  echo "PASS [qmux relay]: received '$(grep -E "^[0-9]" "$CLIENT_OUT" | head -1)'"
+  exit 0
+else
+  echo "FAIL [qmux relay]: no data received over qmux" >&2
+  cat "$CLIENT_OUT" >&2
+  echo "--- dateserver log ---" >&2; cat "$DATESERVER_LOG" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
A listener with quic_stack: proxygen_qmux now accepts MoQ sessions over QMUX-on-TCP+Fizz via MoqxQmuxRelayServer, feeding the same relay context as the mvfst/picoquic listeners. mvfst-only transport validation is gated to the mvfst stack so picoquic and qmux no longer trip QUIC-only errors.

test_qmux_relay.sh exercises publish->relay->subscribe over qmux end to end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/420)
<!-- Reviewable:end -->
