### PR TITLE
feat: add mvfst ignore_path_mtu config option

### DIFF
--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -223,6 +223,7 @@ listeners:
     endpoint: "$ENDPOINT"
     mvfst:
       enable_gso: true
+      ignore_path_mtu: true
       max_conn_packets_sent_per_loop: 16
       max_server_recv_packets_per_loop: 256
       udp_socket_buffer_bytes: $UDP_SOCKET_BUFFER_BYTES

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -70,6 +70,7 @@ buildTransportSettings(const config::QuicConfig& quic, const config::MvfstConfig
   ts.maxServerRecvPacketsPerLoop = mvfst.maxServerRecvPacketsPerLoop;
   ts.maxRecvBatchSize = mvfst.maxServerRecvPacketsPerLoop;
   ts.numGROBuffers_ = mvfst.numGROBuffers;
+  ts.canIgnorePathMTU = mvfst.canIgnorePathMTU;
   ts.advertisedInitialConnectionFlowControlWindow = quic.maxData;
   ts.advertisedInitialBidiLocalStreamFlowControlWindow = quic.maxStreamData;
   ts.advertisedInitialBidiRemoteStreamFlowControlWindow = quic.maxStreamData;

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -83,6 +83,9 @@ struct MvfstConfig {
   uint16_t maxServerRecvPacketsPerLoop{64};
   // Number of UDP GRO buffers. 1 = disabled. > 1 enables kernel GRO coalescing.
   uint32_t numGROBuffers{1};
+  // Ignore the peer's path MTU and send full-size (max UDP payload) packets.
+  // Useful for testing / controlled networks; off by default to respect PMTU.
+  bool canIgnorePathMTU{false};
 
   // BBR (BBR1) congestion control tunables.
   // conservativeRecovery is shared with BBR2.

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -531,6 +531,8 @@ void applyMvfstOverride(MvfstConfig& base, const ParsedMvfstConfig& overlay) {
     base.maxServerRecvPacketsPerLoop = *v;
   if (auto v = overlay.num_gro_buffers.value())
     base.numGROBuffers = *v;
+  if (auto v = overlay.ignore_path_mtu.value())
+    base.canIgnorePathMTU = *v;
   if (const auto& b = overlay.bbr.value()) {
     if (auto v = b->conservative_recovery.value())
       base.bbr.conservativeRecovery = *v;

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -128,6 +128,12 @@ struct ParsedMvfstConfig {
       "overhead at high packet rates. Max 64. Requires kernel GRO support.",
       std::optional<uint32_t>>
       num_gro_buffers;
+  rfl::Description<
+      "Ignore the peer's path MTU and send full-size (max UDP payload) packets "
+      "(default: false). Useful for testing or controlled networks where the "
+      "path MTU is known; leave off to respect PMTU discovery.",
+      std::optional<bool>>
+      ignore_path_mtu;
 
   // BBR (BBR1) congestion control tunables.
   // conservative_recovery is shared with BBR2 — set it here when using either.

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -1637,6 +1637,7 @@ TEST(ResolveConfig, MvfstDefaultsRoundTrip) {
   EXPECT_TRUE(mvfst.useRecvmmsg);
   EXPECT_EQ(mvfst.maxServerRecvPacketsPerLoop, 64u);
   EXPECT_EQ(mvfst.numGROBuffers, 1u);
+  EXPECT_FALSE(mvfst.canIgnorePathMTU);
   EXPECT_DOUBLE_EQ(mvfst.copa.deltaParam, 0.05);
   EXPECT_FALSE(mvfst.bbr.conservativeRecovery);
   EXPECT_TRUE(mvfst.bbr2.exitStartupOnLoss);
@@ -1757,6 +1758,19 @@ TEST(ResolveConfig, MvfstBatchingModeRoundTrip) {
     auto result = resolveConfig(cfg);
     ASSERT_TRUE(result.hasValue()) << "enable_gso=" << gso;
     EXPECT_EQ(result.value().config.listeners[0].mvfst.enableGSO, gso);
+  }
+}
+
+// ignore_path_mtu toggles canIgnorePathMTU (default false).
+TEST(ResolveConfig, MvfstIgnorePathMtuRoundTrip) {
+  for (bool ignore : {true, false}) {
+    auto cfg = makeMinimalInsecureConfig();
+    ParsedMvfstConfig mvfst;
+    mvfst.ignore_path_mtu = std::optional<bool>{ignore};
+    setListenerMvfst(cfg, std::move(mvfst));
+    auto result = resolveConfig(cfg);
+    ASSERT_TRUE(result.hasValue()) << "ignore_path_mtu=" << ignore;
+    EXPECT_EQ(result.value().config.listeners[0].mvfst.canIgnorePathMTU, ignore);
   }
 }
 


### PR DESCRIPTION
Expose mvfst's canIgnorePathMTU as an mvfst.ignore_path_mtu config field, defaulting to false so packets stay at the conservative default size. When enabled, mvfst sends full max-UDP-payload packets, which improves throughput on networks where the path MTU is known to be large.

Enable it in perf-test.sh, where larger packets give a more representative best-case throughput number. This is a benchmarking knob and is left off by default for production safety.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/421)
<!-- Reviewable:end -->
