### PR TITLE
Fix MoQStatsCollector self-owning leak; fail integration tests on non-zero relay exit

### DIFF
--- a/src/stats/MoQStatsCollector.cpp
+++ b/src/stats/MoQStatsCollector.cpp
@@ -14,15 +14,6 @@ namespace openmoq::moqx::stats {
 std::shared_ptr<MoQStatsCollector>
 MoQStatsCollector::create_moq_stats_collector(std::shared_ptr<StatsRegistry> registry) {
   auto collector = std::shared_ptr<MoQStatsCollector>(new MoQStatsCollector());
-
-  // Build aliased shared_ptrs: they share the parent's refcount but point to
-  // the value-member inner objects.  Holding only an inner callback extends the
-  // parent's lifetime.
-  collector->pubCallbackPtr_ =
-      std::shared_ptr<moxygen::MoQPublisherStatsCallback>(collector, &collector->pubCallback_);
-  collector->subCallbackPtr_ =
-      std::shared_ptr<moxygen::MoQSubscriberStatsCallback>(collector, &collector->subCallback_);
-
   registry->registerCollector(collector);
   return collector;
 }
@@ -65,11 +56,17 @@ folly::Executor* MoQStatsCollector::owningExecutor() const {
 }
 
 std::shared_ptr<moxygen::MoQPublisherStatsCallback> MoQStatsCollector::publisherCallback() const {
-  return pubCallbackPtr_;
+  // Aliasing shared_ptr: shares this collector's refcount, points at the
+  // inner callback.
+  auto self = std::const_pointer_cast<MoQStatsCollector>(shared_from_this());
+  auto* cb = &self->pubCallback_;
+  return std::shared_ptr<moxygen::MoQPublisherStatsCallback>(std::move(self), cb);
 }
 
 std::shared_ptr<moxygen::MoQSubscriberStatsCallback> MoQStatsCollector::subscriberCallback() const {
-  return subCallbackPtr_;
+  auto self = std::const_pointer_cast<MoQStatsCollector>(shared_from_this());
+  auto* cb = &self->subCallback_;
+  return std::shared_ptr<moxygen::MoQSubscriberStatsCallback>(std::move(self), cb);
 }
 
 // --- Session lifecycle ---

--- a/src/stats/MoQStatsCollector.h
+++ b/src/stats/MoQStatsCollector.h
@@ -29,7 +29,8 @@ namespace openmoq::moqx::stats {
 //   SubscriberCallback – implements MoQSubscriberStatsCallback
 //                        Relay uses this when it is the *subscriber*
 //                        (consuming from upstream publishers).
-class MoQStatsCollector : public StatsCollectorBase {
+class MoQStatsCollector : public StatsCollectorBase,
+                          public std::enable_shared_from_this<MoQStatsCollector> {
 public:
   // --- Inner callback: publisher role ---
   class PublisherCallback : public moxygen::MoQPublisherStatsCallback {
@@ -116,8 +117,8 @@ public:
 
   void setExecutor(folly::Executor* executor);
 
-  // Returns aliased shared_ptrs whose reference count is shared with this
-  // MoQStatsCollector.  Holding only an inner callback keeps the parent alive.
+  // Aliased shared_ptrs sharing this collector's refcount; holding one keeps the
+  // collector alive.
   std::shared_ptr<moxygen::MoQPublisherStatsCallback> publisherCallback() const;
   std::shared_ptr<moxygen::MoQSubscriberStatsCallback> subscriberCallback() const;
 
@@ -138,10 +139,6 @@ private:
   // Value-member inner callbacks.
   PublisherCallback pubCallback_;
   SubscriberCallback subCallback_;
-
-  // Aliased shared_ptrs set up in create_moq_stats_collector().
-  std::shared_ptr<moxygen::MoQPublisherStatsCallback> pubCallbackPtr_;
-  std::shared_ptr<moxygen::MoQSubscriberStatsCallback> subCallbackPtr_;
 
   // --- Metric storage ---
 #define DEFINE_FIELD(type, name) type name##_{0};


### PR DESCRIPTION
MoQStatsCollector cached aliasing shared_ptrs to itself, so it never reached refcount 0 and leaked once per 
relay that saw a session. Builds the callbacks on demand from shared_from_this() instead, and hardens the 
relay integration tests to fail when a relay exits non-zero (which ASan does on a detected leak).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/423)
<!-- Reviewable:end -->
