### PR TITLE
 Run upstream-handle ops on the publisher exec; pin integration tests to draft 16

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -593,7 +593,10 @@ MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
     auto& evicted = *publishEntry.evicted;
     // Null handle => previous publisher already terminated and onPublishDone() tore it down; skip.
     if (evicted.handle) {
-      evicted.handle->unsubscribe();
+      // unsubscribe mutates the old publisher's session inline, so hop to its exec.
+      runOnSessionExec(relayExec_, evicted.publisherExec, [h = evicted.handle] {
+        h->unsubscribe();
+      });
       evicted.forwarder->publishDone(
           {RequestID(0),
            PublishDoneStatusCode::SUBSCRIPTION_ENDED,
@@ -2256,14 +2259,21 @@ void MoqxRelay::onEmptyImpl(const FullTrackName& ftn) {
     return;
   }
 
-  // Handle exists - just last subscriber left
+  // Handle exists - just last subscriber left. requestUpdate/unsubscribe mutate
+  // the upstream session inline (no self-hop), so they must run on publisherExec.
   XLOG(INFO) << "Last subscriber removed for " << ftn;
+  XCHECK(upstreamView->publisherExec);
   if (upstreamView->isPublish) {
     // if it's publish, don't unsubscribe, just subscribeUpdate forward=false
     XLOG(DBG1) << "Updating upstream subscription forward=false";
-    launchUpdate(relayExec(), doSubscribeUpdate(upstreamView->handle, /*forward=*/false));
+    launchUpdate(
+        upstreamView->publisherExec,
+        doSubscribeUpdate(upstreamView->handle, /*forward=*/false)
+    );
   } else {
-    upstreamView->handle->unsubscribe();
+    runOnSessionExec(relayExec_, upstreamView->publisherExec, [h = upstreamView->handle] {
+      h->unsubscribe();
+    });
     XLOG(DBG4) << "Erasing subscription to " << ftn;
     registry_.remove(ftn);
   }
@@ -2289,7 +2299,9 @@ void MoqxRelay::forwardChangedImpl(const FullTrackName& ftn, bool forward) {
   }
   XLOG(INFO) << "Updating forward for " << ftn << " forward=" << forward;
 
-  launchUpdate(relayExec(), doSubscribeUpdate(upstreamView->handle, forward));
+  // handle non-null (checked above) implies upstream is live, so publisherExec is set.
+  XCHECK(upstreamView->publisherExec);
+  launchUpdate(upstreamView->publisherExec, doSubscribeUpdate(upstreamView->handle, forward));
 }
 
 void MoqxRelay::newGroupRequested(MoQForwarder* forwarder, uint64_t group) {
@@ -2305,7 +2317,9 @@ void MoqxRelay::newGroupRequestedImpl(const FullTrackName& ftn, uint64_t group) 
   }
   XLOG(INFO) << "New group request detected for " << ftn;
 
-  launchUpdate(relayExec(), doNewGroupRequestUpdate(upstreamView->handle, group));
+  // handle non-null (checked above) implies upstream is live, so publisherExec is set.
+  XCHECK(upstreamView->publisherExec);
+  launchUpdate(upstreamView->publisherExec, doNewGroupRequestUpdate(upstreamView->handle, group));
 }
 
 // TRACK_FILTER support

--- a/src/SubscriptionRegistry.cpp
+++ b/src/SubscriptionRegistry.cpp
@@ -129,7 +129,9 @@ SubscriptionRegistry::PublishEntry SubscriptionRegistry::createFromPublish(
   // publishDone → onEmpty may fire during the erase.
   auto it = subscriptions_.find(ftn);
   if (it != subscriptions_.end()) {
-    evicted = Evicted{std::move(it->second.forwarder), std::move(it->second.handle)};
+    auto* oldPublisherExec = it->second.upstream ? it->second.upstream->getExecutor() : nullptr;
+    evicted =
+        Evicted{std::move(it->second.forwarder), std::move(it->second.handle), oldPublisherExec};
     subscriptions_.erase(it);
   }
 

--- a/src/SubscriptionRegistry.h
+++ b/src/SubscriptionRegistry.h
@@ -96,6 +96,7 @@ public:
   struct Evicted {
     std::shared_ptr<moxygen::MoQForwarder> forwarder;
     std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle; // may be null
+    folly::Executor* publisherExec{nullptr}; // old publisher's session exec, for handle teardown
   };
 
   struct PublishEntry {

--- a/test/make_test_config.sh
+++ b/test/make_test_config.sh
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/test_versions.sh"
+
 if [[ $# -lt 2 ]]; then
   echo "Usage: $0 <listen_port> <admin_port> [--cert <file> --key <file>]" >&2
   exit 1
@@ -37,6 +39,7 @@ listeners:
     tls:
       insecure: true
     endpoint: "/moq-relay"
+    moqt_versions: ${MOQT_TEST_VERSIONS}
 services:
   default:
     match:

--- a/test/test_admin_cache_purge_race.sh
+++ b/test/test_admin_cache_purge_race.sh
@@ -26,6 +26,8 @@ BINARY="${1:-$REPO/build/moqx}"
 MOQBIN="${MOQBIN:-$REPO/.scratch/moxygen-install/bin}"
 # shellcheck source=test_ports.sh
 source "$REPO/test/test_ports.sh"
+# shellcheck source=test_versions.sh
+source "$REPO/test/test_versions.sh"
 DATESERVER="$MOQBIN/moqdateserver"
 TEXTCLIENT="$MOQBIN/moqtextclient"
 
@@ -129,6 +131,7 @@ listeners:
     tls:
       insecure: true
     endpoint: "/moq-relay"
+    moqt_versions: ${MOQT_TEST_VERSIONS}
 services:
   default:
     match:

--- a/test/test_qmux_relay.sh
+++ b/test/test_qmux_relay.sh
@@ -28,6 +28,8 @@ fi
 MOQBIN="${MOQBIN:-$REPO/.scratch/moxygen-install/bin}"
 # shellcheck source=test_ports.sh
 source "$REPO/test/test_ports.sh"
+# shellcheck source=test_versions.sh
+source "$REPO/test/test_versions.sh"
 
 # Resolve a qmux-capable sample binary. Prefer MOQBIN's flat layout (the install
 # at .scratch/moxygen-install/bin); if that's a pre-qmux release, fall back to a
@@ -145,6 +147,7 @@ listeners:
     tls:
       insecure: true
     endpoint: "/moq-relay"
+    moqt_versions: ${MOQT_TEST_VERSIONS}
 services:
   default:
     match:

--- a/test/test_relay_chain.sh
+++ b/test/test_relay_chain.sh
@@ -20,6 +20,8 @@ BINARY="${1:-$REPO/build/moqx}"
 MOQBIN="${MOQBIN:-$REPO/.scratch/moxygen-install/bin}"
 # shellcheck source=test_ports.sh
 source "$REPO/test/test_ports.sh"
+# shellcheck source=test_versions.sh
+source "$REPO/test/test_versions.sh"
 
 # Parse --save-logs option (may appear anywhere in args)
 SAVE_LOGS=false
@@ -192,6 +194,7 @@ listeners:
     tls:
       insecure: true
     endpoint: "/moq-relay"
+    moqt_versions: ${MOQT_TEST_VERSIONS}
 services:
   default:
     match:
@@ -221,6 +224,7 @@ listeners:
     tls:
       insecure: true
     endpoint: "/moq-relay"
+    moqt_versions: ${MOQT_TEST_VERSIONS}
 services:
   default:
     match:

--- a/test/test_versions.sh
+++ b/test/test_versions.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Shared MoQT draft version(s) for shell integration tests.
+#
+# Pinning a single version forces the relay to exercise that draft instead of
+# silently negotiating down to an older one if the newest fails. Emitted into
+# generated relay configs as:  moqt_versions: ${MOQT_TEST_VERSIONS}
+#
+# Value is a YAML flow list, e.g. "[16]" or "[14, 16]".
+#
+# test_conformance.sh is intentionally exempt — it parameterizes the version
+# from its CLI arg so it can run against every supported draft.
+MOQT_TEST_VERSIONS="[16]"


### PR DESCRIPTION
Our integration tests are negotiating 14, because our alpn lists it first.  When testing 18, I discovered an MT bug from #362 / #365.  One commit here fixes the bug and the other pins the integration tests to 16 (which also demonstrated the bug), until 18 is ready.

Fixes a multi-threaded relay bug: `forwardChanged`, `newGroupRequested`, and
`onEmpty` operate on the upstream subscription handle (`requestUpdate` /
`unsubscribe`), which mutate the publisher's session inline without self-hopping,
so they must run on the publisher's executor, not the relay exec. Also covers the
publish-reconnect eviction path, which had the same latent bug against the old
publisher's session. No-op in single-threaded mode.

I considered wrapping the subscription handle so e.g. ->unsubscribe automatically jumps to the correct exec.  This was a little messier, so decided to go with a more bespoke solution for now.

Also pins the shell integration-test relays to a shared `MOQT_TEST_VERSIONS`
(`[16]`) so they exercise the chosen draft instead of silently negotiating down;
`test_conformance.sh` is left parameterized to keep running against all drafts.

Full ASan suite passes 655/655.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/424)
<!-- Reviewable:end -->
