### PR TITLE
docker: parameterized relay config template (perf defaults + draft-18 fallback)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,11 +32,12 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libunwind8 libsodium23 libboost-context1.74.0 \
         libgoogle-glog0v6 libgflags2.2 libdouble-conversion3 \
-        curl \
+        curl gettext-base \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install/bin/moqx /usr/local/bin/moqx
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY docker/config.docker.yaml /usr/local/share/moqx/config.docker.yaml
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -20,8 +20,14 @@ listener_defaults:
     udp_socket_buffer_bytes: ${MOQX_UDP_BUFFER}
     ignore_path_mtu: ${MOQX_IGNORE_PATH_MTU}
 
+# Two listeners: mvfst on MOQX_PORT and (when enabled) picoquic on
+# MOQX_PICO_PORT — same cert/versions/endpoint, different stack + port.
+# entrypoint.sh fills the MOQX_PICO_LISTENER placeholder below with the pico
+# block, or leaves it empty when MOQX_PICO_ENABLE=false or MOQX_INSECURE=true
+# (picoquic needs real TLS).
 listeners:
-  - name: relay
+  - name: relay-mvfst
+    quic_stack: mvfst
     moqt_versions: ${MOQX_MOQT_VERSIONS}
     udp:
       socket:
@@ -32,6 +38,7 @@ listeners:
       key_file: "${MOQX_KEY}"
       insecure: ${MOQX_INSECURE}
     endpoint: "${MOQX_ENDPOINT}"
+${MOQX_PICO_LISTENER}
 
 services:
   default:

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -1,0 +1,48 @@
+# moqx relay — docker runtime config template.
+#
+# entrypoint.sh resolves the ${MOQX_*} placeholders from environment
+# variables (each with a default) via envsubst, then serves the result —
+# unless a full config is mounted at /etc/moqx/config.yaml.
+#
+# The performance defaults below are inherited by the CI deploy (which sets
+# no perf vars) and by the interop relay adapter. Override any value via its
+# MOQX_* env var; the default for each lives in docker/entrypoint.sh.
+
+threads: ${MOQX_THREADS}
+use_local_forwarders: ${MOQX_LOCAL_FWD}
+mvfst_bpf_steering: false
+
+listener_defaults:
+  mvfst:
+    enable_gso: true
+    max_conn_packets_sent_per_loop: ${MOQX_SEND_PKTS}
+    max_server_recv_packets_per_loop: ${MOQX_RECV_PKTS}
+    udp_socket_buffer_bytes: ${MOQX_UDP_BUFFER}
+    ignore_path_mtu: ${MOQX_IGNORE_PATH_MTU}
+
+listeners:
+  - name: relay
+    udp:
+      socket:
+        address: "${MOQX_BIND_ADDR}"
+        port: ${MOQX_PORT}
+    tls:
+      cert_file: "${MOQX_CERT}"
+      key_file: "${MOQX_KEY}"
+      insecure: ${MOQX_INSECURE}
+    endpoint: "${MOQX_ENDPOINT}"
+
+services:
+  default:
+    match:
+      - authority: {any: true}
+        path: {prefix: "/"}
+    cache:
+      enabled: ${MOQX_CACHE}
+      max_tracks: ${MOQX_MAX_TRACKS}
+      max_groups_per_track: ${MOQX_MAX_GROUPS}
+
+admin:
+  port: ${MOQX_ADMIN_PORT}
+  address: "${MOQX_BIND_ADDR}"
+  plaintext: true

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -22,6 +22,7 @@ listener_defaults:
 
 listeners:
   - name: relay
+    moqt_versions: ${MOQX_MOQT_VERSIONS}
     udp:
       socket:
         address: "${MOQX_BIND_ADDR}"

--- a/docker/config.docker.yaml
+++ b/docker/config.docker.yaml
@@ -43,6 +43,13 @@ ${MOQX_PICO_LISTENER}
 services:
   default:
     match:
+      # Two rules so both listeners + both transports work:
+      #   exact endpoint  → WebTransport on ${MOQX_ENDPOINT} (mvfst AND picoquic;
+      #                     pico only registers WT endpoints for exact-path rules)
+      #   prefix "/"      → raw QUIC (moqt://) on the base URL (mvfst). pico logs
+      #                     an "unsupported prefix" warning and ignores this rule.
+      - authority: {any: true}
+        path: {exact: "${MOQX_ENDPOINT}"}
       - authority: {any: true}
         path: {prefix: "/"}
     cache:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     restart: unless-stopped
     ports:
       - "${MOQX_PORT:-4433}:${MOQX_PORT:-4433}/udp"
+      - "${MOQX_PICO_PORT:-4434}:${MOQX_PICO_PORT:-4434}/udp"
       - "${MOQX_ADMIN_PORT:-8000}:${MOQX_ADMIN_PORT:-8000}/tcp"
     volumes:
       - ${MOQX_CERTS_DIR:-/etc/letsencrypt}:/certs:ro
@@ -35,6 +36,8 @@ services:
       MOQX_CERT: /certs/live/${DOMAIN}/fullchain.pem
       MOQX_KEY:  /certs/live/${DOMAIN}/privkey.pem
       MOQX_PORT: ${MOQX_PORT:-4433}
+      MOQX_PICO_PORT: ${MOQX_PICO_PORT:-4434}
+      MOQX_PICO_ENABLE: ${MOQX_PICO_ENABLE:-true}
       MOQX_ADMIN_PORT: ${MOQX_ADMIN_PORT:-8000}
       MOQX_MAX_TRACKS: ${MOQX_MAX_TRACKS:-1000}
       MOQX_MAX_GROUPS: ${MOQX_MAX_GROUPS:-100}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,7 +8,10 @@
 # Connection / TLS:
 #   MOQX_CERT       — TLS certificate PEM (required unless MOQX_INSECURE=true)
 #   MOQX_KEY        — TLS private key PEM  (required unless MOQX_INSECURE=true)
-#   MOQX_PORT       — UDP listen port (default: 4433)
+#   MOQX_PORT       — mvfst UDP listen port (default: 4433)
+#   MOQX_PICO_ENABLE— also run a picoquic listener (default: true; auto-off when
+#                     MOQX_INSECURE=true, since picoquic requires real TLS)
+#   MOQX_PICO_PORT  — picoquic UDP listen port (default: 4434)
 #   MOQX_ADMIN_PORT — admin HTTP port (default: 8000)
 #   MOQX_INSECURE   — use built-in dev cert (default: false)
 #   MOQX_BIND_ADDR  — listen address: 0.0.0.0 (default) or :: (dual-stack)
@@ -72,6 +75,38 @@ export MOQX_SEND_PKTS="${MOQX_SEND_PKTS:-16}"
 export MOQX_RECV_PKTS="${MOQX_RECV_PKTS:-256}"
 export MOQX_UDP_BUFFER="${MOQX_UDP_BUFFER:-$(cat /proc/sys/net/core/wmem_max 2>/dev/null || echo 1048576)}"
 export MOQX_IGNORE_PATH_MTU="${MOQX_IGNORE_PATH_MTU:-false}"
+
+# Second (picoquic) listener for dual-stack serving. Opt out with
+# MOQX_PICO_ENABLE=false. picoquic needs real TLS, so it is auto-disabled under
+# MOQX_INSECURE=true. The block is injected into config.docker.yaml's
+# ${MOQX_PICO_LISTENER} placeholder (empty when disabled). Values are expanded
+# here by the shell, so envsubst substitutes the block verbatim.
+export MOQX_PICO_ENABLE="${MOQX_PICO_ENABLE:-true}"
+export MOQX_PICO_PORT="${MOQX_PICO_PORT:-4434}"
+if [ "$MOQX_PICO_ENABLE" = "true" ] && [ "$MOQX_INSECURE" = "true" ]; then
+  echo "note: picoquic listener disabled — it requires real TLS (MOQX_INSECURE=true)" >&2
+  MOQX_PICO_ENABLE=false
+fi
+if [ "$MOQX_PICO_ENABLE" = "true" ]; then
+  MOQX_PICO_LISTENER=$(cat <<PICO
+  - name: relay-pico
+    quic_stack: picoquic
+    moqt_versions: ${MOQX_MOQT_VERSIONS}
+    udp:
+      socket:
+        address: "${MOQX_BIND_ADDR}"
+        port: ${MOQX_PICO_PORT}
+    tls:
+      cert_file: "${MOQX_CERT}"
+      key_file: "${MOQX_KEY}"
+      insecure: ${MOQX_INSECURE}
+    endpoint: "${MOQX_ENDPOINT}"
+PICO
+)
+else
+  MOQX_PICO_LISTENER=""
+fi
+export MOQX_PICO_LISTENER
 
 CONFIG=/tmp/relay.yaml
 envsubst < /usr/local/share/moqx/config.docker.yaml > "$CONFIG"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,21 +1,31 @@
 #!/bin/sh
 # Generate relay config from env vars and exec moqx.
 #
-# To use a custom config, mount it at /etc/moqx/config.yaml:
+# Resolves docker/config.docker.yaml (a ${MOQX_*} template) with envsubst,
+# unless a full config is mounted at /etc/moqx/config.yaml:
 #   docker run -v /path/to/config.yaml:/etc/moqx/config.yaml:ro ...
 #
-# Env vars (used only when no custom config is mounted):
-#   MOQX_CERT       — path to TLS certificate PEM (required unless MOQX_INSECURE=true)
-#   MOQX_KEY        — path to TLS private key PEM  (required unless MOQX_INSECURE=true)
+# Connection / TLS:
+#   MOQX_CERT       — TLS certificate PEM (required unless MOQX_INSECURE=true)
+#   MOQX_KEY        — TLS private key PEM  (required unless MOQX_INSECURE=true)
 #   MOQX_PORT       — UDP listen port (default: 4433)
 #   MOQX_ADMIN_PORT — admin HTTP port (default: 8000)
 #   MOQX_INSECURE   — use built-in dev cert (default: false)
+#   MOQX_BIND_ADDR  — listen address: 0.0.0.0 (default) or :: (dual-stack)
+#   MOQX_ENDPOINT   — WebTransport endpoint path (default: /moq-relay)
 #   MOQX_MAX_TRACKS — max cached tracks (default: 1000)
 #   MOQX_MAX_GROUPS — max groups per track in cache (default: 100)
-#   MOQX_BIND_ADDR  — listen address: "0.0.0.0" (IPv4, default) or "::" (IPv6/dual-stack)
-#   MOQX_ENDPOINT   — WebTransport endpoint path (default: /moq-relay)
+#   MOQX_CACHE      — relay object cache enabled (default: true)
 #
-# Env vars (always apply):
+# Performance (inherited by the CI deploy / interop adapter; override to tune):
+#   MOQX_THREADS          — IO worker threads (default: 4; must be >= 1)
+#   MOQX_LOCAL_FWD        — per-subscriber-thread local forwarders (default: true)
+#   MOQX_SEND_PKTS        — mvfst max_conn_packets_sent_per_loop (default: 16)
+#   MOQX_RECV_PKTS        — mvfst max_server_recv_packets_per_loop (default: 256)
+#   MOQX_UDP_BUFFER       — relay UDP socket buffer bytes (default: net.core.wmem_max)
+#   MOQX_IGNORE_PATH_MTU  — send full-size packets, skip PMTU (default: false)
+#
+# Logging (always apply):
 #   MOQX_LOG_LEVEL  — min log level: 0=INFO 1=WARNING 2=ERROR 3=FATAL (default: 0)
 #   MOQX_VERBOSE    — verbose/debug level: 0=off, 1-4=increasing detail (default: 0)
 set -e
@@ -30,42 +40,33 @@ if [ -d /var/coredumps ] && [ -w /proc/sys/kernel/core_pattern ]; then
   echo "/var/coredumps/core.%e.%p.%t" > /proc/sys/kernel/core_pattern
 fi
 
-# Use custom config if mounted, otherwise generate from env vars
+# Use custom config if mounted, otherwise render the template from env vars.
 CONFIG=/etc/moqx/config.yaml
 if [ -f "$CONFIG" ]; then
   echo "Using custom config: $CONFIG"
   exec /usr/local/bin/moqx --config "$CONFIG" "$@"
 fi
 
+# Defaults for every placeholder in config.docker.yaml (override via env).
+export MOQX_BIND_ADDR="${MOQX_BIND_ADDR:-0.0.0.0}"
+export MOQX_PORT="${MOQX_PORT:-4433}"
+export MOQX_ADMIN_PORT="${MOQX_ADMIN_PORT:-8000}"
+export MOQX_CERT="${MOQX_CERT:-}"
+export MOQX_KEY="${MOQX_KEY:-}"
+export MOQX_INSECURE="${MOQX_INSECURE:-false}"
+export MOQX_ENDPOINT="${MOQX_ENDPOINT:-/moq-relay}"
+export MOQX_MAX_TRACKS="${MOQX_MAX_TRACKS:-1000}"
+export MOQX_MAX_GROUPS="${MOQX_MAX_GROUPS:-100}"
+export MOQX_CACHE="${MOQX_CACHE:-true}"
+# Performance defaults (see header). MOQX_THREADS must be >= 1 (no autodetect).
+export MOQX_THREADS="${MOQX_THREADS:-4}"
+export MOQX_LOCAL_FWD="${MOQX_LOCAL_FWD:-true}"
+export MOQX_SEND_PKTS="${MOQX_SEND_PKTS:-16}"
+export MOQX_RECV_PKTS="${MOQX_RECV_PKTS:-256}"
+export MOQX_UDP_BUFFER="${MOQX_UDP_BUFFER:-$(cat /proc/sys/net/core/wmem_max 2>/dev/null || echo 1048576)}"
+export MOQX_IGNORE_PATH_MTU="${MOQX_IGNORE_PATH_MTU:-false}"
+
 CONFIG=/tmp/relay.yaml
-
-cat > "$CONFIG" <<EOF
-listeners:
-  - name: relay
-    udp:
-      socket:
-        address: "${MOQX_BIND_ADDR:-0.0.0.0}"
-        port: ${MOQX_PORT:-4433}
-    tls:
-      cert_file: "${MOQX_CERT:-}"
-      key_file: "${MOQX_KEY:-}"
-      insecure: ${MOQX_INSECURE:-false}
-    endpoint: "${MOQX_ENDPOINT:-/moq-relay}"
-
-services:
-  default:
-    match:
-      - authority: {any: true}
-        path: {prefix: "/"}
-    cache:
-      enabled: true
-      max_tracks: ${MOQX_MAX_TRACKS:-1000}
-      max_groups_per_track: ${MOQX_MAX_GROUPS:-100}
-
-admin:
-  port: ${MOQX_ADMIN_PORT:-8000}
-  address: "${MOQX_BIND_ADDR:-0.0.0.0}"
-  plaintext: true
-EOF
+envsubst < /usr/local/share/moqx/config.docker.yaml > "$CONFIG"
 
 exec /usr/local/bin/moqx --config "$CONFIG" "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,12 @@
 #   MOQX_INSECURE   — use built-in dev cert (default: false)
 #   MOQX_BIND_ADDR  — listen address: 0.0.0.0 (default) or :: (dual-stack)
 #   MOQX_ENDPOINT   — WebTransport endpoint path (default: /moq-relay)
+#   MOQX_MOQT_VERSIONS — advertised MoQT draft versions, YAML inline list
+#                     (default: [16, 14, 18]). The relay selects by server
+#                     preference — the first listed version the client also
+#                     supports — so draft 18 listed last is a fallback: only
+#                     d18-only clients negotiate 18; clients that also speak
+#                     14/16 settle on 16. Reorder to change preference.
 #   MOQX_MAX_TRACKS — max cached tracks (default: 1000)
 #   MOQX_MAX_GROUPS — max groups per track in cache (default: 100)
 #   MOQX_CACHE      — relay object cache enabled (default: true)
@@ -55,6 +61,7 @@ export MOQX_CERT="${MOQX_CERT:-}"
 export MOQX_KEY="${MOQX_KEY:-}"
 export MOQX_INSECURE="${MOQX_INSECURE:-false}"
 export MOQX_ENDPOINT="${MOQX_ENDPOINT:-/moq-relay}"
+export MOQX_MOQT_VERSIONS="${MOQX_MOQT_VERSIONS:-[16, 14, 18]}"
 export MOQX_MAX_TRACKS="${MOQX_MAX_TRACKS:-1000}"
 export MOQX_MAX_GROUPS="${MOQX_MAX_GROUPS:-100}"
 export MOQX_CACHE="${MOQX_CACHE:-true}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -221,7 +221,16 @@ require_system_deps() {
 check_submodule() {
   if [[ ! -e "$MOXYGEN_DIR/.git" ]]; then
     die "deps/moxygen submodule not initialized.
-  Run: git submodule update --init"
+  Run: git submodule update --init --recursive"
+  fi
+  # catapult and its own nested submodules (libcbor, nlohmann_json, spdlog,
+  # doctest) are required by the top-level build. A plain 'submodule update
+  # --init' without --recursive (or one scoped to deps/moxygen) leaves them
+  # empty, which fails configure with a missing-CMakeLists error. Auto-init
+  # recursively so a fresh or partial clone just works.
+  if [[ ! -f "$PROJECT_ROOT/deps/catapult/CMakeLists.txt" ]]; then
+    echo "==> Initializing catapult submodule (recursive)..."
+    git -C "$PROJECT_ROOT" submodule update --init --recursive deps/catapult
   fi
 }
 

--- a/scripts/config.bench.yaml
+++ b/scripts/config.bench.yaml
@@ -9,6 +9,7 @@
 #
 # Tunable via env / CLI (defaults live in moqx-run.sh):
 #   MOQX_STACK         quic stack for the listener: mvfst | picoquic (--quic-stack)
+#   MOQX_MOQT_VERSIONS advertised MoQT drafts, YAML inline list (default [16, 14])
 #   MOQX_PORT          UDP listen port
 #   MOQX_ADMIN_PORT    admin HTTP port
 #   MOQX_ENDPOINT      WebTransport endpoint path
@@ -61,6 +62,7 @@ listener_defaults:
 listeners:
   - name: relay
     quic_stack: ${MOQX_STACK}
+    moqt_versions: ${MOQX_MOQT_VERSIONS}
     udp:
       socket:
         address: "::"

--- a/scripts/config.bench.yaml
+++ b/scripts/config.bench.yaml
@@ -6,7 +6,7 @@
 # serves WebTransport via the endpoint path and raw QUIC moqt://).
 #
 # Tunable via env / CLI (defaults live in moqx-run.sh):
-#   MOQX_THREADS       IO worker threads; 0 = moqx autodetects one per CPU
+#   MOQX_THREADS       IO worker threads, must be >= 1
 #   MOQX_LOCAL_FWD     per-subscriber-thread local forwarders (true|false)
 #   MOQX_BPF_STEERING  mvfst CID reuseport steering, Linux+mvfst (true|false)
 #   MOQX_SEND_PKTS     mvfst max_conn_packets_sent_per_loop
@@ -14,6 +14,7 @@
 #   MOQX_UDP_BUFFER    relay UDP socket buffer bytes; 0 = moxygen 1 MB default
 #   MOQX_CC            mvfst congestion control (bbr2|bbr|copa|cubic|...)
 #   MOQX_CACHE         relay object cache enabled (true|false)
+#   MOQX_IGNORE_PATH_MTU  skip PMTU discovery, send full-size packets (true|false)
 #   DOMAIN             TLS cert hostname under /etc/letsencrypt/live/
 
 relay_id: "moqx-000"
@@ -36,6 +37,7 @@ listener_defaults:
     max_conn_packets_sent_per_loop: ${MOQX_SEND_PKTS}
     max_server_recv_packets_per_loop: ${MOQX_RECV_PKTS}
     udp_socket_buffer_bytes: ${MOQX_UDP_BUFFER}
+    ignore_path_mtu: ${MOQX_IGNORE_PATH_MTU}
     bbr2:
       exit_startup_on_loss: true
       enable_recovery_in_startup: true

--- a/scripts/config.bench.yaml
+++ b/scripts/config.bench.yaml
@@ -2,24 +2,37 @@
 #
 # Filled by scripts/moqx-run.sh, which resolves the ${MOQX_*} / ${DOMAIN}
 # placeholders below from CLI flags > .env > built-in defaults, then serves
-# the resolved config. Two listeners: mvfst :4433 and picoquic :4434 (each
-# serves WebTransport via the endpoint path and raw QUIC moqt://).
+# the resolved config. One listener at a time (mvfst or picoquic), selected
+# by MOQX_STACK (--quic-stack); it serves WebTransport via the endpoint path
+# and raw QUIC moqt://. To serve both stacks at once, use the docker config
+# template instead (docker/config.docker.yaml).
 #
 # Tunable via env / CLI (defaults live in moqx-run.sh):
+#   MOQX_STACK         quic stack for the listener: mvfst | picoquic (--quic-stack)
+#   MOQX_PORT          UDP listen port
+#   MOQX_ADMIN_PORT    admin HTTP port
+#   MOQX_ENDPOINT      WebTransport endpoint path
+#   MOQX_INSECURE      use built-in dev cert, ignore cert/key (true|false)
+#   MOQX_CERT          TLS certificate PEM (default: letsencrypt under DOMAIN)
+#   MOQX_KEY           TLS private key PEM  (default: letsencrypt under DOMAIN)
+#   MOQX_RELAY_THREAD  dedicated relay exec thread (true|false)
 #   MOQX_THREADS       IO worker threads, must be >= 1
 #   MOQX_LOCAL_FWD     per-subscriber-thread local forwarders (true|false)
 #   MOQX_BPF_STEERING  mvfst CID reuseport steering, Linux+mvfst (true|false)
 #   MOQX_SEND_PKTS     mvfst max_conn_packets_sent_per_loop
 #   MOQX_RECV_PKTS     mvfst max_server_recv_packets_per_loop
 #   MOQX_UDP_BUFFER    relay UDP socket buffer bytes; 0 = moxygen 1 MB default
-#   MOQX_CC            mvfst congestion control (bbr2|bbr|copa|cubic|...)
+#   MOQX_CC            congestion control; bbr works on both stacks (bbr|bbr2|cubic|...)
 #   MOQX_CACHE         relay object cache enabled (true|false)
+#   MOQX_MAX_TRACKS    cache max tracks (when cache enabled)
+#   MOQX_MAX_GROUPS    cache max groups per track (when cache enabled)
 #   MOQX_IGNORE_PATH_MTU  skip PMTU discovery, send full-size packets (true|false)
 #   DOMAIN             TLS cert hostname under /etc/letsencrypt/live/
 
 relay_id: "moqx-000"
 
 threads: ${MOQX_THREADS}
+use_relay_thread: ${MOQX_RELAY_THREAD}
 use_local_forwarders: ${MOQX_LOCAL_FWD}
 mvfst_bpf_steering: ${MOQX_BPF_STEERING}
 
@@ -43,44 +56,26 @@ listener_defaults:
       enable_recovery_in_startup: true
       enable_recovery_in_probe_states: true
 
+# Single listener; switch stacks with MOQX_STACK / --quic-stack. The mvfst
+# tuning under listener_defaults is a no-op when the picoquic stack is selected.
 listeners:
-  - name: mvfst-relay
-    quic_stack: mvfst
+  - name: relay
+    quic_stack: ${MOQX_STACK}
     udp:
       socket:
         address: "::"
-        port: 4433
+        port: ${MOQX_PORT}
     tls:
-      cert_file: "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
-      key_file: "/etc/letsencrypt/live/${DOMAIN}/privkey.pem"
-      insecure: false
-    endpoint: "/moq-relay"
+      cert_file: "${MOQX_CERT}"
+      key_file: "${MOQX_KEY}"
+      insecure: ${MOQX_INSECURE}
+    endpoint: "${MOQX_ENDPOINT}"
     quic:
       cc_algo: ${MOQX_CC}
-
-  - name: pico-relay
-    quic_stack: picoquic
-    udp:
-      socket:
-        address: "::"
-        port: 4434
-    tls:
-      cert_file: "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
-      key_file: "/etc/letsencrypt/live/${DOMAIN}/privkey.pem"
-      insecure: false
-    endpoint: "/moq-pico-relay"
-    quic:
-      cc_algo: bbr
 
 services:
   default:
     match:
-      - authority: {any: true}
-        path: {exact: "/moq-relay"}
-      - authority: {any: true}
-        path: {exact: "/moq-pico-relay"}
-      - authority: {any: true}
-        path: {exact: "/"}
       - authority: {any: true}
         path: {prefix: "/"}
 
@@ -95,10 +90,10 @@ services:
 service_defaults:
   cache:
     enabled: ${MOQX_CACHE}
-    max_tracks: 1000
-    max_groups_per_track: 100
+    max_tracks: ${MOQX_MAX_TRACKS}
+    max_groups_per_track: ${MOQX_MAX_GROUPS}
 
 admin:
-  port: 8000
+  port: ${MOQX_ADMIN_PORT}
   address: "::"
   plaintext: true

--- a/scripts/config.bench.yaml
+++ b/scripts/config.bench.yaml
@@ -80,6 +80,13 @@ listeners:
 services:
   default:
     match:
+      # Two rules so both transports work under either stack:
+      #   exact endpoint → WebTransport on ${MOQX_ENDPOINT} (mvfst AND picoquic;
+      #                    pico only registers WT endpoints for exact-path rules)
+      #   prefix "/"     → raw QUIC (moqt://) on the base URL (mvfst). A picoquic
+      #                    listener logs an "unsupported prefix" warning + ignores it.
+      - authority: {any: true}
+        path: {exact: "${MOQX_ENDPOINT}"}
       - authority: {any: true}
         path: {prefix: "/"}
 

--- a/scripts/config.bench.yaml
+++ b/scripts/config.bench.yaml
@@ -8,8 +8,10 @@
 # template instead (docker/config.docker.yaml).
 #
 # Tunable via env / CLI (defaults live in moqx-run.sh):
+#   MOQX_RELAY_ID      relay identity string in logs/metrics (default moqx-000)
 #   MOQX_STACK         quic stack for the listener: mvfst | picoquic (--quic-stack)
-#   MOQX_MOQT_VERSIONS advertised MoQT drafts, YAML inline list (default [16, 14])
+#   MOQX_MOQT_VERSIONS advertised MoQT drafts, YAML inline list, server-preference
+#                      order (default [16, 14, 18]; first listed wins)
 #   MOQX_PORT          UDP listen port
 #   MOQX_ADMIN_PORT    admin HTTP port
 #   MOQX_ENDPOINT      WebTransport endpoint path
@@ -30,7 +32,7 @@
 #   MOQX_IGNORE_PATH_MTU  skip PMTU discovery, send full-size packets (true|false)
 #   DOMAIN             TLS cert hostname under /etc/letsencrypt/live/
 
-relay_id: "moqx-000"
+relay_id: "${MOQX_RELAY_ID}"
 
 threads: ${MOQX_THREADS}
 use_relay_thread: ${MOQX_RELAY_THREAD}

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -33,6 +33,8 @@ Relay tuning (templated into the config; CLI > .env > default):
 
 Listener (templated into the config; CLI > .env > default):
       --quic-stack STACK    listener quic stack: mvfst|picoquic (default mvfst)
+      --moqt-versions LIST  advertised MoQT drafts, e.g. 16,14,18 (default 16,14;
+                            draft-18 is opt-in — not yet interoperable)
       --port N              UDP listen port (default 4433)
       --admin-port N        admin HTTP port (default 8000)
       --endpoint PATH       WebTransport endpoint path (default /moq-relay)
@@ -60,7 +62,7 @@ Environment overrides (via .env or shell):
   MOQX_VERBOSE, MOQX_LOG_LEVEL, GLOG_vmodule, MOQX_JEMALLOC
   MOQX_THREADS, MOQX_UDP_BUFFER, MOQX_RECV_PKTS, MOQX_SEND_PKTS, MOQX_CC,
   MOQX_LOCAL_FWD, MOQX_CACHE, MOQX_BPF_STEERING, MOQX_IGNORE_PATH_MTU,
-  MOQX_RELAY_THREAD, MOQX_STACK, MOQX_PORT, MOQX_ADMIN_PORT, MOQX_ENDPOINT,
+  MOQX_RELAY_THREAD, MOQX_STACK, MOQX_MOQT_VERSIONS, MOQX_PORT, MOQX_ADMIN_PORT, MOQX_ENDPOINT,
   MOQX_INSECURE, MOQX_CERT, MOQX_KEY, MOQX_MAX_TRACKS, MOQX_MAX_GROUPS
 
 Examples:
@@ -111,13 +113,17 @@ check_sysctl() {
 # normalize a boolean-ish value to true/false (or "INVALID")
 norm_bool() { case "${1,,}" in 1|true|yes|on) echo true ;; 0|false|no|off) echo false ;; *) echo INVALID ;; esac; }
 
+# normalize a MoQT versions value to a YAML inline list. Pass through an already
+# bracketed list (e.g. "[16, 14]"); wrap a comma list ("16,14" -> "[16, 14]").
+norm_versions() { local v="${1//[[:space:]]/}"; [[ "$v" == \[*\] ]] && echo "$v" || echo "[${v//,/, }]"; }
+
 CLI_VERBOSE="" CLI_LOG_LEVEL="" CLI_VMODULE="" CLI_XLOG=""
 CLI_SUBCMD="" CLI_CONFIG="" CLI_ENV_FILE="" CLI_BIN=""
 CLI_USE_SUDO=""   # "" = unset; "0"/"1" set
 CLI_JEMALLOC=""   # "" = unset; "auto" or explicit path
 CLI_THREADS="" CLI_UDP_BUFFER="" CLI_RECV_PKTS="" CLI_SEND_PKTS="" CLI_CC=""
 CLI_LOCAL_FWD="" CLI_CACHE="" CLI_RELAY_THREAD="" CLI_INSECURE=""   # tri-state booleans
-CLI_STACK="" CLI_PORT="" CLI_ADMIN_PORT="" CLI_ENDPOINT="" CLI_CERT="" CLI_KEY=""
+CLI_STACK="" CLI_MOQT_VERSIONS="" CLI_PORT="" CLI_ADMIN_PORT="" CLI_ENDPOINT="" CLI_CERT="" CLI_KEY=""
 CHECK_SYSCTL=0 DRY_RUN=0
 PASSTHRU=()
 
@@ -139,6 +145,7 @@ while (($#)); do
     --relay-thread)    CLI_RELAY_THREAD=true;  shift ;;
     --no-relay-thread) CLI_RELAY_THREAD=false; shift ;;
     --quic-stack)    CLI_STACK="$2"; shift 2 ;;
+    --moqt-versions) CLI_MOQT_VERSIONS="$2"; shift 2 ;;
     --port)          CLI_PORT="$2"; shift 2 ;;
     --admin-port)    CLI_ADMIN_PORT="$2"; shift 2 ;;
     --endpoint)      CLI_ENDPOINT="$2"; shift 2 ;;
@@ -195,27 +202,55 @@ export MOQX_CC="${CLI_CC:-${MOQX_CC:-bbr}}"
 MOQX_LOCAL_FWD="$(norm_bool "${CLI_LOCAL_FWD:-${MOQX_LOCAL_FWD:-true}}")"
 MOQX_CACHE="$(norm_bool "${CLI_CACHE:-${MOQX_CACHE:-true}}")"
 MOQX_RELAY_THREAD="$(norm_bool "${CLI_RELAY_THREAD:-${MOQX_RELAY_THREAD:-true}}")"
-MOQX_INSECURE="$(norm_bool "${CLI_INSECURE:-${MOQX_INSECURE:-false}}")"
 # bpf steering and ignore_path_mtu are experimental — env override only, no flag.
 MOQX_BPF_STEERING="$(norm_bool "${MOQX_BPF_STEERING:-false}")"
 MOQX_IGNORE_PATH_MTU="$(norm_bool "${MOQX_IGNORE_PATH_MTU:-false}")"
-for b in MOQX_LOCAL_FWD MOQX_CACHE MOQX_RELAY_THREAD MOQX_INSECURE MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU; do
+for b in MOQX_LOCAL_FWD MOQX_CACHE MOQX_RELAY_THREAD MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU; do
   [[ "${!b}" == INVALID ]] && { echo "invalid boolean for $b (want true/false)" >&2; exit 2; }
 done
-export MOQX_LOCAL_FWD MOQX_CACHE MOQX_RELAY_THREAD MOQX_INSECURE
+export MOQX_LOCAL_FWD MOQX_CACHE MOQX_RELAY_THREAD
 export MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU
 
 # ── Listener knobs (CLI > .env/env > default), exported for envsubst ──────
 export MOQX_STACK="${CLI_STACK:-${MOQX_STACK:-mvfst}}"
 case "$MOQX_STACK" in mvfst|picoquic) ;; *) echo "invalid --quic-stack: $MOQX_STACK (want mvfst|picoquic)" >&2; exit 2 ;; esac
+# MoQT drafts advertised by the listener (ALPN derives from these). Default
+# matches the relay's interoperable set; draft-18 is opt-in (--moqt-versions).
+export MOQX_MOQT_VERSIONS="$(norm_versions "${CLI_MOQT_VERSIONS:-${MOQX_MOQT_VERSIONS:-16,14}}")"
 export MOQX_PORT="${CLI_PORT:-${MOQX_PORT:-4433}}"
 export MOQX_ADMIN_PORT="${CLI_ADMIN_PORT:-${MOQX_ADMIN_PORT:-8000}}"
 export MOQX_ENDPOINT="${CLI_ENDPOINT:-${MOQX_ENDPOINT:-/moq-relay}}"
 export MOQX_MAX_TRACKS="${MOQX_MAX_TRACKS:-1000}"
 export MOQX_MAX_GROUPS="${MOQX_MAX_GROUPS:-100}"
+# Did the user explicitly ask for real TLS (a specific cert/key, or a DOMAIN to
+# locate one)? Capture before the defaults below overwrite MOQX_CERT/MOQX_KEY.
+CERT_EXPLICIT=0
+[[ -n "${CLI_CERT}${CLI_KEY}${MOQX_CERT:-}${MOQX_KEY:-}${DOMAIN:-}" ]] && CERT_EXPLICIT=1
+
 # TLS: cert/key default to letsencrypt under DOMAIN; --insecure ignores them.
 export MOQX_CERT="${CLI_CERT:-${MOQX_CERT:-/etc/letsencrypt/live/${DOMAIN:-}/fullchain.pem}}"
 export MOQX_KEY="${CLI_KEY:-${MOQX_KEY:-/etc/letsencrypt/live/${DOMAIN:-}/privkey.pem}}"
+
+# Insecure (built-in dev cert) resolution, in priority order:
+#   1. An explicit --insecure / MOQX_INSECURE always wins, whatever else is set.
+#   2. An explicit cert/key/DOMAIN means "use real TLS" — trust it even when the
+#      cert lives under a root-only path (e.g. /etc/letsencrypt) this user can't
+#      stat; the relay runs via sudo and reads it. moxygen errors if truly absent.
+#   3. Otherwise auto: serve real TLS if the default cert is readable here, else
+#      fall back to the dev cert so a bare local bench run needs no TLS setup.
+INSECURE_REQ="${CLI_INSECURE:-${MOQX_INSECURE:-}}"
+if [[ -n "$INSECURE_REQ" ]]; then
+  MOQX_INSECURE="$(norm_bool "$INSECURE_REQ")"
+  [[ "$MOQX_INSECURE" == INVALID ]] && { echo "invalid boolean for MOQX_INSECURE (want true/false)" >&2; exit 2; }
+elif (( CERT_EXPLICIT )); then
+  MOQX_INSECURE=false
+elif [[ -f "$MOQX_CERT" ]]; then
+  MOQX_INSECURE=false
+else
+  MOQX_INSECURE=true
+  echo "note: TLS cert not found ($MOQX_CERT); using built-in dev cert. Set DOMAIN or --cert/--key for real TLS, or pass --insecure to silence." >&2
+fi
+export MOQX_INSECURE
 
 # ── Resolve placeholders into a temp config ───────────────────────────────
 RESOLVED_CONFIG=/tmp/moqx-resolved.yaml
@@ -239,6 +274,7 @@ if [[ -n "$JEMALLOC_REQ" ]]; then
         /usr/lib/aarch64-linux-gnu/libjemalloc.so.2 \
         /lib64/libjemalloc.so.2 \
         /usr/lib64/libjemalloc.so.2 \
+        /usr/lib/libjemalloc.so.2 \
         /usr/local/lib/libjemalloc.so.2; do
         [[ -f "$cand" ]] && { JEMALLOC="$cand"; break; }
       done
@@ -259,7 +295,7 @@ CMD=("$MOQX_BIN" "$SUBCMD" --config "$RESOLVED_CONFIG" "${PASSTHRU[@]}")
 
 if (( DRY_RUN )); then
   echo "# relay knobs (templated into config)"
-  echo "stack=$MOQX_STACK port=$MOQX_PORT admin_port=$MOQX_ADMIN_PORT endpoint=$MOQX_ENDPOINT insecure=$MOQX_INSECURE"
+  echo "stack=$MOQX_STACK moqt_versions=$MOQX_MOQT_VERSIONS port=$MOQX_PORT admin_port=$MOQX_ADMIN_PORT endpoint=$MOQX_ENDPOINT insecure=$MOQX_INSECURE"
   echo "threads=$MOQX_THREADS relay_thread=$MOQX_RELAY_THREAD local_fwd=$MOQX_LOCAL_FWD bpf_steering=$MOQX_BPF_STEERING cache=$MOQX_CACHE"
   echo "cc=$MOQX_CC send_pkts=$MOQX_SEND_PKTS recv_pkts=$MOQX_RECV_PKTS udp_buffer=$MOQX_UDP_BUFFER ignore_path_mtu=$MOQX_IGNORE_PATH_MTU"
   echo "# resolved env"

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -21,7 +21,7 @@ Logging (override .env/defaults):
   -x, --xlog SPEC           folly XLOG config (passed as --logging=SPEC)
 
 Relay tuning (templated into the config; CLI > .env > default):
-      --threads N           IO worker threads; 0 = moqx autodetects 1/CPU (default 0)
+      --threads N           IO worker threads, must be >= 1 (default 4)
       --udp-buffer BYTES    relay UDP socket buffer; 0 = moxygen 1 MB default
                             (default: net.core.wmem_max)
       --recv-pkts N         mvfst max_server_recv_packets_per_loop (default 256)
@@ -29,8 +29,6 @@ Relay tuning (templated into the config; CLI > .env > default):
       --cc ALGO             mvfst congestion control (default bbr2)
       --local-forwarders / --no-local-forwarders   (default: on)
       --cache / --no-cache  relay object cache (default: on)
-  -b, --bpf-steering / --no-bpf-steering   mvfst CID reuseport steering
-                            (Linux + mvfst only; default: off)
 
 Targeting:
       --subcmd CMD          moqx subcommand (default: serve)
@@ -51,7 +49,7 @@ Environment overrides (via .env or shell):
   MOQX_BIN, MOQX_CONFIG, MOQX_ENV_FILE, MOQX_SUBCMD, MOQX_USE_SUDO, DOMAIN
   MOQX_VERBOSE, MOQX_LOG_LEVEL, GLOG_vmodule, MOQX_JEMALLOC
   MOQX_THREADS, MOQX_UDP_BUFFER, MOQX_RECV_PKTS, MOQX_SEND_PKTS, MOQX_CC,
-  MOQX_LOCAL_FWD, MOQX_CACHE, MOQX_BPF_STEERING
+  MOQX_LOCAL_FWD, MOQX_CACHE, MOQX_BPF_STEERING, MOQX_IGNORE_PATH_MTU
 
 Examples:
   $0                                       # serve with .env + defaults
@@ -106,7 +104,7 @@ CLI_SUBCMD="" CLI_CONFIG="" CLI_ENV_FILE="" CLI_BIN=""
 CLI_USE_SUDO=""   # "" = unset; "0"/"1" set
 CLI_JEMALLOC=""   # "" = unset; "auto" or explicit path
 CLI_THREADS="" CLI_UDP_BUFFER="" CLI_RECV_PKTS="" CLI_SEND_PKTS="" CLI_CC=""
-CLI_LOCAL_FWD="" CLI_CACHE="" CLI_BPF=""   # tri-state booleans
+CLI_LOCAL_FWD="" CLI_CACHE=""   # tri-state booleans
 CHECK_SYSCTL=0 DRY_RUN=0
 PASSTHRU=()
 
@@ -125,8 +123,6 @@ while (($#)); do
     --no-local-forwarders) CLI_LOCAL_FWD=false; shift ;;
     --cache)         CLI_CACHE=true;  shift ;;
     --no-cache)      CLI_CACHE=false; shift ;;
-    -b|--bpf-steering)   CLI_BPF=true;  shift ;;
-    --no-bpf-steering)   CLI_BPF=false; shift ;;
     --subcmd)        CLI_SUBCMD="$2"; shift 2 ;;
     --config)        CLI_CONFIG="$2"; shift 2 ;;
     --env)           CLI_ENV_FILE="$2"; shift 2 ;;
@@ -169,18 +165,20 @@ command -v envsubst >/dev/null || { echo "envsubst missing (apt install gettext-
 
 # ── Relay tuning knobs (CLI > .env/env > default), exported for envsubst ──
 WMEM_MAX="$(cat /proc/sys/net/core/wmem_max 2>/dev/null || echo 1048576)"
-export MOQX_THREADS="${CLI_THREADS:-${MOQX_THREADS:-0}}"
+export MOQX_THREADS="${CLI_THREADS:-${MOQX_THREADS:-4}}"
 export MOQX_SEND_PKTS="${CLI_SEND_PKTS:-${MOQX_SEND_PKTS:-16}}"
 export MOQX_RECV_PKTS="${CLI_RECV_PKTS:-${MOQX_RECV_PKTS:-256}}"
 export MOQX_UDP_BUFFER="${CLI_UDP_BUFFER:-${MOQX_UDP_BUFFER:-$WMEM_MAX}}"
 export MOQX_CC="${CLI_CC:-${MOQX_CC:-bbr2}}"
 MOQX_LOCAL_FWD="$(norm_bool "${CLI_LOCAL_FWD:-${MOQX_LOCAL_FWD:-true}}")"
 MOQX_CACHE="$(norm_bool "${CLI_CACHE:-${MOQX_CACHE:-true}}")"
-MOQX_BPF_STEERING="$(norm_bool "${CLI_BPF:-${MOQX_BPF_STEERING:-false}}")"
-for b in MOQX_LOCAL_FWD MOQX_CACHE MOQX_BPF_STEERING; do
+# bpf steering and ignore_path_mtu are experimental — env override only, no flag.
+MOQX_BPF_STEERING="$(norm_bool "${MOQX_BPF_STEERING:-false}")"
+MOQX_IGNORE_PATH_MTU="$(norm_bool "${MOQX_IGNORE_PATH_MTU:-false}")"
+for b in MOQX_LOCAL_FWD MOQX_CACHE MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU; do
   [[ "${!b}" == INVALID ]] && { echo "invalid boolean for $b (want true/false)" >&2; exit 2; }
 done
-export MOQX_LOCAL_FWD MOQX_CACHE MOQX_BPF_STEERING
+export MOQX_LOCAL_FWD MOQX_CACHE MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU
 
 # ── Resolve placeholders into a temp config ───────────────────────────────
 RESOLVED_CONFIG=/tmp/moqx-resolved.yaml
@@ -225,7 +223,7 @@ CMD=("$MOQX_BIN" "$SUBCMD" --config "$RESOLVED_CONFIG" "${PASSTHRU[@]}")
 if (( DRY_RUN )); then
   echo "# relay knobs (templated into config)"
   echo "threads=$MOQX_THREADS local_fwd=$MOQX_LOCAL_FWD bpf_steering=$MOQX_BPF_STEERING cache=$MOQX_CACHE"
-  echo "cc=$MOQX_CC send_pkts=$MOQX_SEND_PKTS recv_pkts=$MOQX_RECV_PKTS udp_buffer=$MOQX_UDP_BUFFER"
+  echo "cc=$MOQX_CC send_pkts=$MOQX_SEND_PKTS recv_pkts=$MOQX_RECV_PKTS udp_buffer=$MOQX_UDP_BUFFER ignore_path_mtu=$MOQX_IGNORE_PATH_MTU"
   echo "# resolved env"
   echo "GLOG_minloglevel=$GLOG_minloglevel GLOG_v=$GLOG_v"
   echo "GLOG_vmodule=$GLOG_vmodule"

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -26,9 +26,19 @@ Relay tuning (templated into the config; CLI > .env > default):
                             (default: net.core.wmem_max)
       --recv-pkts N         mvfst max_server_recv_packets_per_loop (default 256)
       --send-pkts N         mvfst max_conn_packets_sent_per_loop (default 16)
-      --cc ALGO             mvfst congestion control (default bbr2)
+      --cc ALGO             congestion control; bbr works on both stacks (default bbr)
       --local-forwarders / --no-local-forwarders   (default: on)
       --cache / --no-cache  relay object cache (default: on)
+      --relay-thread / --no-relay-thread   dedicated relay exec thread (default: on)
+
+Listener (templated into the config; CLI > .env > default):
+      --quic-stack STACK    listener quic stack: mvfst|picoquic (default mvfst)
+      --port N              UDP listen port (default 4433)
+      --admin-port N        admin HTTP port (default 8000)
+      --endpoint PATH       WebTransport endpoint path (default /moq-relay)
+      --insecure            use a self-signed dev cert; ignore --cert/--key
+      --cert PATH           TLS cert PEM (default: letsencrypt under DOMAIN)
+      --key PATH            TLS key PEM  (default: letsencrypt under DOMAIN)
 
 Targeting:
       --subcmd CMD          moqx subcommand (default: serve)
@@ -49,7 +59,9 @@ Environment overrides (via .env or shell):
   MOQX_BIN, MOQX_CONFIG, MOQX_ENV_FILE, MOQX_SUBCMD, MOQX_USE_SUDO, DOMAIN
   MOQX_VERBOSE, MOQX_LOG_LEVEL, GLOG_vmodule, MOQX_JEMALLOC
   MOQX_THREADS, MOQX_UDP_BUFFER, MOQX_RECV_PKTS, MOQX_SEND_PKTS, MOQX_CC,
-  MOQX_LOCAL_FWD, MOQX_CACHE, MOQX_BPF_STEERING, MOQX_IGNORE_PATH_MTU
+  MOQX_LOCAL_FWD, MOQX_CACHE, MOQX_BPF_STEERING, MOQX_IGNORE_PATH_MTU,
+  MOQX_RELAY_THREAD, MOQX_STACK, MOQX_PORT, MOQX_ADMIN_PORT, MOQX_ENDPOINT,
+  MOQX_INSECURE, MOQX_CERT, MOQX_KEY, MOQX_MAX_TRACKS, MOQX_MAX_GROUPS
 
 Examples:
   $0                                       # serve with .env + defaults
@@ -104,7 +116,8 @@ CLI_SUBCMD="" CLI_CONFIG="" CLI_ENV_FILE="" CLI_BIN=""
 CLI_USE_SUDO=""   # "" = unset; "0"/"1" set
 CLI_JEMALLOC=""   # "" = unset; "auto" or explicit path
 CLI_THREADS="" CLI_UDP_BUFFER="" CLI_RECV_PKTS="" CLI_SEND_PKTS="" CLI_CC=""
-CLI_LOCAL_FWD="" CLI_CACHE=""   # tri-state booleans
+CLI_LOCAL_FWD="" CLI_CACHE="" CLI_RELAY_THREAD="" CLI_INSECURE=""   # tri-state booleans
+CLI_STACK="" CLI_PORT="" CLI_ADMIN_PORT="" CLI_ENDPOINT="" CLI_CERT="" CLI_KEY=""
 CHECK_SYSCTL=0 DRY_RUN=0
 PASSTHRU=()
 
@@ -123,6 +136,15 @@ while (($#)); do
     --no-local-forwarders) CLI_LOCAL_FWD=false; shift ;;
     --cache)         CLI_CACHE=true;  shift ;;
     --no-cache)      CLI_CACHE=false; shift ;;
+    --relay-thread)    CLI_RELAY_THREAD=true;  shift ;;
+    --no-relay-thread) CLI_RELAY_THREAD=false; shift ;;
+    --quic-stack)    CLI_STACK="$2"; shift 2 ;;
+    --port)          CLI_PORT="$2"; shift 2 ;;
+    --admin-port)    CLI_ADMIN_PORT="$2"; shift 2 ;;
+    --endpoint)      CLI_ENDPOINT="$2"; shift 2 ;;
+    --insecure)      CLI_INSECURE=true; shift ;;
+    --cert)          CLI_CERT="$2"; shift 2 ;;
+    --key)           CLI_KEY="$2"; shift 2 ;;
     --subcmd)        CLI_SUBCMD="$2"; shift 2 ;;
     --config)        CLI_CONFIG="$2"; shift 2 ;;
     --env)           CLI_ENV_FILE="$2"; shift 2 ;;
@@ -169,16 +191,31 @@ export MOQX_THREADS="${CLI_THREADS:-${MOQX_THREADS:-4}}"
 export MOQX_SEND_PKTS="${CLI_SEND_PKTS:-${MOQX_SEND_PKTS:-16}}"
 export MOQX_RECV_PKTS="${CLI_RECV_PKTS:-${MOQX_RECV_PKTS:-256}}"
 export MOQX_UDP_BUFFER="${CLI_UDP_BUFFER:-${MOQX_UDP_BUFFER:-$WMEM_MAX}}"
-export MOQX_CC="${CLI_CC:-${MOQX_CC:-bbr2}}"
+export MOQX_CC="${CLI_CC:-${MOQX_CC:-bbr}}"
 MOQX_LOCAL_FWD="$(norm_bool "${CLI_LOCAL_FWD:-${MOQX_LOCAL_FWD:-true}}")"
 MOQX_CACHE="$(norm_bool "${CLI_CACHE:-${MOQX_CACHE:-true}}")"
+MOQX_RELAY_THREAD="$(norm_bool "${CLI_RELAY_THREAD:-${MOQX_RELAY_THREAD:-true}}")"
+MOQX_INSECURE="$(norm_bool "${CLI_INSECURE:-${MOQX_INSECURE:-false}}")"
 # bpf steering and ignore_path_mtu are experimental — env override only, no flag.
 MOQX_BPF_STEERING="$(norm_bool "${MOQX_BPF_STEERING:-false}")"
 MOQX_IGNORE_PATH_MTU="$(norm_bool "${MOQX_IGNORE_PATH_MTU:-false}")"
-for b in MOQX_LOCAL_FWD MOQX_CACHE MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU; do
+for b in MOQX_LOCAL_FWD MOQX_CACHE MOQX_RELAY_THREAD MOQX_INSECURE MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU; do
   [[ "${!b}" == INVALID ]] && { echo "invalid boolean for $b (want true/false)" >&2; exit 2; }
 done
-export MOQX_LOCAL_FWD MOQX_CACHE MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU
+export MOQX_LOCAL_FWD MOQX_CACHE MOQX_RELAY_THREAD MOQX_INSECURE
+export MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU
+
+# ── Listener knobs (CLI > .env/env > default), exported for envsubst ──────
+export MOQX_STACK="${CLI_STACK:-${MOQX_STACK:-mvfst}}"
+case "$MOQX_STACK" in mvfst|picoquic) ;; *) echo "invalid --quic-stack: $MOQX_STACK (want mvfst|picoquic)" >&2; exit 2 ;; esac
+export MOQX_PORT="${CLI_PORT:-${MOQX_PORT:-4433}}"
+export MOQX_ADMIN_PORT="${CLI_ADMIN_PORT:-${MOQX_ADMIN_PORT:-8000}}"
+export MOQX_ENDPOINT="${CLI_ENDPOINT:-${MOQX_ENDPOINT:-/moq-relay}}"
+export MOQX_MAX_TRACKS="${MOQX_MAX_TRACKS:-1000}"
+export MOQX_MAX_GROUPS="${MOQX_MAX_GROUPS:-100}"
+# TLS: cert/key default to letsencrypt under DOMAIN; --insecure ignores them.
+export MOQX_CERT="${CLI_CERT:-${MOQX_CERT:-/etc/letsencrypt/live/${DOMAIN:-}/fullchain.pem}}"
+export MOQX_KEY="${CLI_KEY:-${MOQX_KEY:-/etc/letsencrypt/live/${DOMAIN:-}/privkey.pem}}"
 
 # ── Resolve placeholders into a temp config ───────────────────────────────
 RESOLVED_CONFIG=/tmp/moqx-resolved.yaml
@@ -222,7 +259,8 @@ CMD=("$MOQX_BIN" "$SUBCMD" --config "$RESOLVED_CONFIG" "${PASSTHRU[@]}")
 
 if (( DRY_RUN )); then
   echo "# relay knobs (templated into config)"
-  echo "threads=$MOQX_THREADS local_fwd=$MOQX_LOCAL_FWD bpf_steering=$MOQX_BPF_STEERING cache=$MOQX_CACHE"
+  echo "stack=$MOQX_STACK port=$MOQX_PORT admin_port=$MOQX_ADMIN_PORT endpoint=$MOQX_ENDPOINT insecure=$MOQX_INSECURE"
+  echo "threads=$MOQX_THREADS relay_thread=$MOQX_RELAY_THREAD local_fwd=$MOQX_LOCAL_FWD bpf_steering=$MOQX_BPF_STEERING cache=$MOQX_CACHE"
   echo "cc=$MOQX_CC send_pkts=$MOQX_SEND_PKTS recv_pkts=$MOQX_RECV_PKTS udp_buffer=$MOQX_UDP_BUFFER ignore_path_mtu=$MOQX_IGNORE_PATH_MTU"
   echo "# resolved env"
   echo "GLOG_minloglevel=$GLOG_minloglevel GLOG_v=$GLOG_v"

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -321,6 +321,22 @@ fi
 # ── Pre-flight: warn (don't block) if UDP sysctls are below recommended ───
 [[ "$SUBCMD" == serve ]] && { check_sysctl warn || true; }
 
+# ── Pre-flight: real-TLS cert/key must be readable by whoever runs the relay ─
+# moxygen SIGABRTs ("no certificates read") on a missing/unreadable cert (#173),
+# so probe with the same privilege the relay will use and fail cleanly instead.
+if [[ "$SUBCMD" == serve && "$MOQX_INSECURE" == false ]]; then
+  if (( USE_SUDO )); then probe=(sudo test -r); else probe=(test -r); fi
+  for f in "$MOQX_CERT" "$MOQX_KEY"; do
+    "${probe[@]}" "$f" 2>/dev/null || {
+      echo "error: TLS cert/key not readable: $f" >&2
+      echo "  - check DOMAIN spelling — it names the /etc/letsencrypt/live/<dir>, not the served host" >&2
+      echo "    (a wildcard *.example.com cert lives under the 'example.com' dir)" >&2
+      echo "  - or pass --cert/--key explicitly, or --insecure for the built-in dev cert" >&2
+      exit 1
+    }
+  done
+fi
+
 if (( USE_SUDO )); then
   # Pass GLOG_*/LD_PRELOAD explicitly: sudoers env_reset strips vars not in
   # env_keep, and exporting LD_PRELOAD would be dropped across the boundary.

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -30,11 +30,14 @@ Relay tuning (templated into the config; CLI > .env > default):
       --local-forwarders / --no-local-forwarders   (default: on)
       --cache / --no-cache  relay object cache (default: on)
       --relay-thread / --no-relay-thread   dedicated relay exec thread (default: on)
+      --ignore-path-mtu     send full-size pkts, skip PMTU discovery (default: off)
+      --bpf-steering        mvfst CID reuseport steering, Linux+mvfst (default: off)
 
 Listener (templated into the config; CLI > .env > default):
       --quic-stack STACK    listener quic stack: mvfst|picoquic (default mvfst)
-      --moqt-versions LIST  advertised MoQT drafts, e.g. 16,14,18 (default 16,14;
-                            draft-18 is opt-in — not yet interoperable)
+      --moqt-versions LIST  advertised MoQT drafts in server-preference order,
+                            e.g. 16,14,18 (default 16,14,18; first listed wins).
+                            Pass a single value (e.g. 18) to pin one draft.
       --port N              UDP listen port (default 4433)
       --admin-port N        admin HTTP port (default 8000)
       --endpoint PATH       WebTransport endpoint path (default /moq-relay)
@@ -63,7 +66,8 @@ Environment overrides (via .env or shell):
   MOQX_THREADS, MOQX_UDP_BUFFER, MOQX_RECV_PKTS, MOQX_SEND_PKTS, MOQX_CC,
   MOQX_LOCAL_FWD, MOQX_CACHE, MOQX_BPF_STEERING, MOQX_IGNORE_PATH_MTU,
   MOQX_RELAY_THREAD, MOQX_STACK, MOQX_MOQT_VERSIONS, MOQX_PORT, MOQX_ADMIN_PORT, MOQX_ENDPOINT,
-  MOQX_INSECURE, MOQX_CERT, MOQX_KEY, MOQX_MAX_TRACKS, MOQX_MAX_GROUPS
+  MOQX_INSECURE, MOQX_CERT, MOQX_KEY, MOQX_MAX_TRACKS, MOQX_MAX_GROUPS,
+  MOQX_RELAY_ID, MOQX_RESOLVED_CONFIG  (env-only; no CLI flag)
 
 Examples:
   $0                                       # serve with .env + defaults
@@ -123,6 +127,7 @@ CLI_USE_SUDO=""   # "" = unset; "0"/"1" set
 CLI_JEMALLOC=""   # "" = unset; "auto" or explicit path
 CLI_THREADS="" CLI_UDP_BUFFER="" CLI_RECV_PKTS="" CLI_SEND_PKTS="" CLI_CC=""
 CLI_LOCAL_FWD="" CLI_CACHE="" CLI_RELAY_THREAD="" CLI_INSECURE=""   # tri-state booleans
+CLI_IGNORE_PMTU="" CLI_BPF=""   # tri-state booleans
 CLI_STACK="" CLI_MOQT_VERSIONS="" CLI_PORT="" CLI_ADMIN_PORT="" CLI_ENDPOINT="" CLI_CERT="" CLI_KEY=""
 CHECK_SYSCTL=0 DRY_RUN=0
 PASSTHRU=()
@@ -144,6 +149,8 @@ while (($#)); do
     --no-cache)      CLI_CACHE=false; shift ;;
     --relay-thread)    CLI_RELAY_THREAD=true;  shift ;;
     --no-relay-thread) CLI_RELAY_THREAD=false; shift ;;
+    --ignore-path-mtu) CLI_IGNORE_PMTU=true; shift ;;
+    --bpf-steering)    CLI_BPF=true;         shift ;;
     --quic-stack)    CLI_STACK="$2"; shift 2 ;;
     --moqt-versions) CLI_MOQT_VERSIONS="$2"; shift 2 ;;
     --port)          CLI_PORT="$2"; shift 2 ;;
@@ -194,6 +201,7 @@ command -v envsubst >/dev/null || { echo "envsubst missing (apt install gettext-
 
 # ── Relay tuning knobs (CLI > .env/env > default), exported for envsubst ──
 WMEM_MAX="$(cat /proc/sys/net/core/wmem_max 2>/dev/null || echo 1048576)"
+export MOQX_RELAY_ID="${MOQX_RELAY_ID:-moqx-000}"
 export MOQX_THREADS="${CLI_THREADS:-${MOQX_THREADS:-4}}"
 export MOQX_SEND_PKTS="${CLI_SEND_PKTS:-${MOQX_SEND_PKTS:-16}}"
 export MOQX_RECV_PKTS="${CLI_RECV_PKTS:-${MOQX_RECV_PKTS:-256}}"
@@ -202,9 +210,9 @@ export MOQX_CC="${CLI_CC:-${MOQX_CC:-bbr}}"
 MOQX_LOCAL_FWD="$(norm_bool "${CLI_LOCAL_FWD:-${MOQX_LOCAL_FWD:-true}}")"
 MOQX_CACHE="$(norm_bool "${CLI_CACHE:-${MOQX_CACHE:-true}}")"
 MOQX_RELAY_THREAD="$(norm_bool "${CLI_RELAY_THREAD:-${MOQX_RELAY_THREAD:-true}}")"
-# bpf steering and ignore_path_mtu are experimental — env override only, no flag.
-MOQX_BPF_STEERING="$(norm_bool "${MOQX_BPF_STEERING:-false}")"
-MOQX_IGNORE_PATH_MTU="$(norm_bool "${MOQX_IGNORE_PATH_MTU:-false}")"
+# bpf steering and ignore_path_mtu are experimental (Linux+mvfst); default off.
+MOQX_BPF_STEERING="$(norm_bool "${CLI_BPF:-${MOQX_BPF_STEERING:-false}}")"
+MOQX_IGNORE_PATH_MTU="$(norm_bool "${CLI_IGNORE_PMTU:-${MOQX_IGNORE_PATH_MTU:-false}}")"
 for b in MOQX_LOCAL_FWD MOQX_CACHE MOQX_RELAY_THREAD MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU; do
   [[ "${!b}" == INVALID ]] && { echo "invalid boolean for $b (want true/false)" >&2; exit 2; }
 done
@@ -214,9 +222,10 @@ export MOQX_BPF_STEERING MOQX_IGNORE_PATH_MTU
 # ── Listener knobs (CLI > .env/env > default), exported for envsubst ──────
 export MOQX_STACK="${CLI_STACK:-${MOQX_STACK:-mvfst}}"
 case "$MOQX_STACK" in mvfst|picoquic) ;; *) echo "invalid --quic-stack: $MOQX_STACK (want mvfst|picoquic)" >&2; exit 2 ;; esac
-# MoQT drafts advertised by the listener (ALPN derives from these). Default
-# matches the relay's interoperable set; draft-18 is opt-in (--moqt-versions).
-export MOQX_MOQT_VERSIONS="$(norm_versions "${CLI_MOQT_VERSIONS:-${MOQX_MOQT_VERSIONS:-16,14}}")"
+# MoQT drafts advertised by the listener (ALPN derives from these), in
+# server-preference order — the relay picks the first listed version the client
+# also supports. Default offers d16, d14, then d18 as a fallback.
+export MOQX_MOQT_VERSIONS="$(norm_versions "${CLI_MOQT_VERSIONS:-${MOQX_MOQT_VERSIONS:-16,14,18}}")"
 export MOQX_PORT="${CLI_PORT:-${MOQX_PORT:-4433}}"
 export MOQX_ADMIN_PORT="${CLI_ADMIN_PORT:-${MOQX_ADMIN_PORT:-8000}}"
 export MOQX_ENDPOINT="${CLI_ENDPOINT:-${MOQX_ENDPOINT:-/moq-relay}}"
@@ -253,7 +262,9 @@ fi
 export MOQX_INSECURE
 
 # ── Resolve placeholders into a temp config ───────────────────────────────
-RESOLVED_CONFIG=/tmp/moqx-resolved.yaml
+# Fixed path by default; override (e.g. per perf run, to avoid concurrent
+# clobber) with MOQX_RESOLVED_CONFIG.
+RESOLVED_CONFIG="${MOQX_RESOLVED_CONFIG:-/tmp/moqx-resolved.yaml}"
 envsubst < "$CONFIG_TEMPLATE" > "$RESOLVED_CONFIG"
 
 # ── GLOG — map MOQX_* → GLOG_* (matches docker/entrypoint.sh convention) ─
@@ -295,7 +306,8 @@ CMD=("$MOQX_BIN" "$SUBCMD" --config "$RESOLVED_CONFIG" "${PASSTHRU[@]}")
 
 if (( DRY_RUN )); then
   echo "# relay knobs (templated into config)"
-  echo "stack=$MOQX_STACK moqt_versions=$MOQX_MOQT_VERSIONS port=$MOQX_PORT admin_port=$MOQX_ADMIN_PORT endpoint=$MOQX_ENDPOINT insecure=$MOQX_INSECURE"
+  echo "relay_id=$MOQX_RELAY_ID stack=$MOQX_STACK moqt_versions=$MOQX_MOQT_VERSIONS port=$MOQX_PORT admin_port=$MOQX_ADMIN_PORT endpoint=$MOQX_ENDPOINT insecure=$MOQX_INSECURE"
+  echo "resolved_config=$RESOLVED_CONFIG"
   echo "threads=$MOQX_THREADS relay_thread=$MOQX_RELAY_THREAD local_fwd=$MOQX_LOCAL_FWD bpf_steering=$MOQX_BPF_STEERING cache=$MOQX_CACHE"
   echo "cc=$MOQX_CC send_pkts=$MOQX_SEND_PKTS recv_pkts=$MOQX_RECV_PKTS udp_buffer=$MOQX_UDP_BUFFER ignore_path_mtu=$MOQX_IGNORE_PATH_MTU"
   echo "# resolved env"

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -14,6 +14,10 @@
 #   --duration N           Test duration in seconds (default: 30)
 #   --delivery-timeout N   Delivery timeout in ms (default: 500)
 #   --transport TYPE       quic or webtransport (default: quic)
+#   --draft N              pin a single MoQ draft, e.g. 16, 14, 18 (default: relay
+#                          offers 16,14,18 and all three parties negotiate 16).
+#                          Sets the relay's offered versions AND the publisher/
+#                          subscriber --versions so all three agree.
 #   --no-relay-thread      Disable relay exec thread (use_relay_thread: false)
 #   --local-forwarders     Enable per-subscriber-thread local forwarders
 #                          (use_local_forwarders: true; requires relay thread)
@@ -56,6 +60,7 @@ RAMP=100
 DURATION=30
 DELIVERY_TIMEOUT=500
 TRANSPORT="quic"
+DRAFT=""
 USE_RELAY_THREAD="true"
 USE_LOCAL_FORWARDERS="false"
 IO_THREADS=1
@@ -86,6 +91,7 @@ while [[ $# -gt 0 ]]; do
     --duration)         DURATION="$2";          shift 2 ;;
     --delivery-timeout) DELIVERY_TIMEOUT="$2";  shift 2 ;;
     --transport)        TRANSPORT="$2";         shift 2 ;;
+    --draft)            DRAFT="$2";             shift 2 ;;
     --no-relay-thread)  USE_RELAY_THREAD="false"; shift ;;
     --local-forwarders) USE_LOCAL_FORWARDERS="true"; shift ;;
     --io-threads)       IO_THREADS="$2";          shift 2 ;;
@@ -174,9 +180,10 @@ else
   QUIC_FLAG="--quic_transport=false"
 fi
 
-# ── Temp dir for relay config ─────────────────────────────────────────────────
-TMPDIR_SCRIPT="$(mktemp -d)"
-RELAY_CFG="$TMPDIR_SCRIPT/relay.yaml"
+# Pin the MoQ draft on publisher + subscriber so all three parties negotiate the
+# same version the relay offers (--draft). Empty = parties use their defaults.
+VERSIONS_FLAG=()
+[[ -n "$DRAFT" ]] && VERSIONS_FLAG=(--versions="$DRAFT")
 
 # ── Cleanup ───────────────────────────────────────────────────────────────────
 PIDS=()
@@ -205,55 +212,12 @@ cleanup() {
   done
   [[ ${#PIDS[@]} -gt 0 ]] && wait ${PIDS[@]+"${PIDS[@]}"} 2>/dev/null || true
   [[ -n "$RELAY_PID" ]] && wait "$RELAY_PID" 2>/dev/null || true
-  rm -rf "$TMPDIR_SCRIPT"
   echo "Logs saved to $LOG_DIR"
 }
 trap cleanup EXIT
 
-# ── Relay config ──────────────────────────────────────────────────────────────
-cat >"$RELAY_CFG" <<EOF
-relay_id: "perf-test-relay"
-threads: $IO_THREADS
-use_relay_thread: $USE_RELAY_THREAD
-use_local_forwarders: $USE_LOCAL_FORWARDERS
-mvfst_bpf_steering: $BPF_STEERING
-listeners:
-  - name: perf
-    udp:
-      socket:
-        address: "::"
-        port: $RELAY_PORT
-    tls:
-      insecure: true
-    endpoint: "$ENDPOINT"
-    mvfst:
-      enable_gso: true
-      ignore_path_mtu: true
-      max_conn_packets_sent_per_loop: 16
-      max_server_recv_packets_per_loop: 256
-      udp_socket_buffer_bytes: $UDP_SOCKET_BUFFER_BYTES
-      bbr2:
-        exit_startup_on_loss: true
-        enable_recovery_in_startup: true
-        enable_recovery_in_probe_states: true
-    quic:
-      cc_algo: bbr2
-services:
-  default:
-    match:
-      - authority: {any: true}
-        path: {prefix: "/"}
-    cache:
-      enabled: false
-      max_tracks: 0
-      max_groups_per_track: 0
-admin:
-  port: $RELAY_ADMIN_PORT
-  address: "::"
-  plaintext: true
-EOF
-
-cp "$RELAY_CFG" "$LOG_DIR/relay.yaml"
+# The relay config is rendered by scripts/moqx-run.sh from config.bench.yaml at
+# launch (below) and written straight to $LOG_DIR/relay.yaml (MOQX_RESOLVED_CONFIG).
 
 # ── Run params ────────────────────────────────────────────────────────────────
 {
@@ -264,6 +228,7 @@ cp "$RELAY_CFG" "$LOG_DIR/relay.yaml"
   echo "moqbin:           $MOQBIN"
   echo "relay_url:        $RELAY_URL"
   echo "transport:        $TRANSPORT"
+  echo "draft:            ${DRAFT:-default (offers 16,14,18)}"
   echo "io_threads:       $IO_THREADS"
   echo "use_relay_thread: $USE_RELAY_THREAD"
   echo "local_forwarders: $USE_LOCAL_FORWARDERS"
@@ -281,18 +246,35 @@ cp "$RELAY_CFG" "$LOG_DIR/relay.yaml"
 } | tee "$LOG_DIR/run_params.txt"
 echo ""
 
-# ── Start relay ───────────────────────────────────────────────────────────────
+# ── Start relay (via scripts/moqx-run.sh + config.bench.yaml) ──────────────────
 ulimit -n 65536 2>/dev/null || true
 echo "Starting relay (use_relay_thread=$USE_RELAY_THREAD, local_forwarders=$USE_LOCAL_FORWARDERS, io_threads=$IO_THREADS, transport=$TRANSPORT, mvfst_bpf_steering=$BPF_STEERING)..."
-RELAY_LOGGING_ARG=()
-[[ -n "$RELAY_LOG_SPEC" ]] && RELAY_LOGGING_ARG=("--logging=$RELAY_LOG_SPEC")
-if [[ -n "$JEMALLOC" ]]; then
-  echo "Using jemalloc: $JEMALLOC"
-  LD_PRELOAD="$JEMALLOC" "$BINARY" --config="$RELAY_CFG" ${RELAY_LOGGING_ARG[@]+"${RELAY_LOGGING_ARG[@]}"} >"$RELAY_LOG" 2>&1 &
-else
-  "$BINARY" --config="$RELAY_CFG" ${RELAY_LOGGING_ARG[@]+"${RELAY_LOGGING_ARG[@]}"} >"$RELAY_LOG" 2>&1 &
-fi
-RELAY_PID=$!
+
+# Map perf knobs -> moqx-run.sh. --no-sudo is REQUIRED: moqx-run execs the relay,
+# so under sudo $! would be the sudo PID and perf -p would profile sudo, not moqx.
+RELAY_RUN_ARGS=(
+  --no-sudo --insecure --no-cache --ignore-path-mtu
+  --bin        "$BINARY"
+  --port       "$RELAY_PORT"
+  --admin-port "$RELAY_ADMIN_PORT"
+  --endpoint   "$ENDPOINT"
+  --threads    "$IO_THREADS"
+  --cc         bbr2
+  --udp-buffer "$UDP_SOCKET_BUFFER_BYTES"
+)
+[[ "$USE_RELAY_THREAD" == true ]]     && RELAY_RUN_ARGS+=(--relay-thread)     || RELAY_RUN_ARGS+=(--no-relay-thread)
+[[ "$USE_LOCAL_FORWARDERS" == true ]] && RELAY_RUN_ARGS+=(--local-forwarders) || RELAY_RUN_ARGS+=(--no-local-forwarders)
+[[ "$BPF_STEERING" == true ]] && RELAY_RUN_ARGS+=(--bpf-steering)
+[[ -n "$DRAFT" ]]             && RELAY_RUN_ARGS+=(--moqt-versions "$DRAFT")
+[[ -n "$RELAY_LOG_SPEC" ]]    && RELAY_RUN_ARGS+=(-x "$RELAY_LOG_SPEC")
+[[ -n "$JEMALLOC" ]]          && { echo "Using jemalloc: $JEMALLOC"; RELAY_RUN_ARGS+=(-j "$JEMALLOC"); }
+
+# Relay identity + render the resolved config straight into the run's log dir.
+export MOQX_RELAY_ID="perf-test-relay"
+export MOQX_RESOLVED_CONFIG="$LOG_DIR/relay.yaml"
+
+"$REPO/scripts/moqx-run.sh" "${RELAY_RUN_ARGS[@]}" >"$RELAY_LOG" 2>&1 &
+RELAY_PID=$!     # moqx-run execs moqx, so $! is the relay process itself
 
 deadline=$(( $(date +%s) + 10 ))
 until curl -sf "http://localhost:$RELAY_ADMIN_PORT/info" >/dev/null 2>&1; do
@@ -330,6 +312,7 @@ echo "Starting moqtest_server -> $RELAY_URL ..."
 "$MOQTEST_SERVER" \
   --relay_url="$RELAY_URL" \
   $QUIC_FLAG \
+  "${VERSIONS_FLAG[@]+"${VERSIONS_FLAG[@]}"}" \
   --include_timestamp_extension=true \
   >"$SERVER_LOG" 2>&1 &
 PIDS+=($!)
@@ -369,6 +352,7 @@ fi
 CLIENT_ARGS=(
   --relay_url="$RELAY_URL"
   $QUIC_FLAG
+  "${VERSIONS_FLAG[@]+"${VERSIONS_FLAG[@]}"}"
   --subscriber_max="$SUBSCRIBER_MAX"
   --subscriber_ramp="$RAMP"
   --duration="$DURATION"

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -26,7 +26,7 @@
 #   --relay-log SPEC       folly XLOG config passed as --logging=SPEC to relay
 #   --bpf-steering         Enable mvfst BPF reuseport steering (requires MOQX_ENABLE_BPF_STEERING build)
 #   --no-bpf-steering      Disable mvfst BPF reuseport steering (default)
-#   --jemalloc             LD_PRELOAD jemalloc (auto-detected from /lib64/libjemalloc.so.2)
+#   -j, --jemalloc         LD_PRELOAD jemalloc for the relay (moqx-run auto-detects the lib)
 #   --metrics              Run perf-metrics.sh alongside the relay; logs to LOG_DIR/metrics.log
 #   --perf-duration N      Run perf record -F 499 -g -e cycles on relay for N seconds; starts after
 #                          subscribers finish ramping (delay = 3*max/ramp s); saves to LOG_DIR/
@@ -99,7 +99,7 @@ while [[ $# -gt 0 ]]; do
     --relay-log)        RELAY_LOG_SPEC="$2";      shift 2 ;;
     --bpf-steering)     BPF_STEERING="true";      shift ;;
     --no-bpf-steering)  BPF_STEERING="false";     shift ;;
-    --jemalloc)         JEMALLOC="auto";           shift ;;
+    -j|--jemalloc)      JEMALLOC="auto";           shift ;;
     --metrics)          RUN_METRICS=true;          shift ;;
     --perf-duration)    PERF_DURATION="$2";        shift 2 ;;
     --perf-events)      PERF_EVENTS="$2";          shift 2 ;;
@@ -116,15 +116,9 @@ MOQTEST_SERVER="$MOQBIN/moqtest_server"
 MOQPERF_CLIENT="$MOQBIN/moqperf_test_client"
 METRICS_SCRIPT="$REPO/scripts/perf-metrics.sh"
 
-# ── jemalloc resolution ───────────────────────────────────────────────────────
-if [[ "$JEMALLOC" == "auto" ]]; then
-  if [[ -f /lib64/libjemalloc.so.2 ]]; then
-    JEMALLOC=/lib64/libjemalloc.so.2
-  else
-    echo "WARNING: --jemalloc requested but /lib64/libjemalloc.so.2 not found; ignoring" >&2
-    JEMALLOC=""
-  fi
-fi
+# jemalloc detection is delegated to moqx-run.sh (-j auto): it probes the common
+# multiarch + /lib64 paths and LD_PRELOADs the lib for the relay, warning (in the
+# relay log) if none is found. JEMALLOC is just the request flag here.
 
 # ── Log directory (always on) ─────────────────────────────────────────────────
 LOG_DIR="/tmp/moqx-perf-$(date +%Y%m%d-%H%M%S)"
@@ -267,7 +261,7 @@ RELAY_RUN_ARGS=(
 [[ "$BPF_STEERING" == true ]] && RELAY_RUN_ARGS+=(--bpf-steering)
 [[ -n "$DRAFT" ]]             && RELAY_RUN_ARGS+=(--moqt-versions "$DRAFT")
 [[ -n "$RELAY_LOG_SPEC" ]]    && RELAY_RUN_ARGS+=(-x "$RELAY_LOG_SPEC")
-[[ -n "$JEMALLOC" ]]          && { echo "Using jemalloc: $JEMALLOC"; RELAY_RUN_ARGS+=(-j "$JEMALLOC"); }
+[[ -n "$JEMALLOC" ]]          && RELAY_RUN_ARGS+=(-j auto)   # moqx-run resolves + LD_PRELOADs
 
 # Relay identity + render the resolved config straight into the run's log dir.
 export MOQX_RELAY_ID="perf-test-relay"

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -9,11 +9,11 @@
 #   --relay PATH           Path to moqx binary (default: build/moqx)
 #   --moqbin PATH          Path to moxygen bin dir
 #                          (default: .scratch/moxygen-install/bin)
-#   --subscriber-max N     Max total subscribers (default: 500)
+#   -s, --subscriber-max N Max total subscribers (default: 500)
 #   --ramp N               Subscribers added per second (default: 100)
-#   --duration N           Test duration in seconds (default: 30)
+#   -d, --duration N       Test duration in seconds (default: 30)
 #   --delivery-timeout N   Delivery timeout in ms (default: 500)
-#   --transport TYPE       quic or webtransport (default: quic)
+#   -t, --transport TYPE   quic or webtransport (default: quic)
 #   --draft N              pin a single MoQ draft, e.g. 16, 14, 18 (default: relay
 #                          offers 16,14,18 and all three parties negotiate 16).
 #                          Sets the relay's offered versions AND the publisher/
@@ -23,7 +23,7 @@
 #                          (use_local_forwarders: true; requires relay thread)
 #   --io-threads N         Number of relay IO threads (default: 1)
 #   --threads N            Number of perf client threads (default: 2)
-#   --relay-log SPEC       folly XLOG config passed as --logging=SPEC to relay
+#   -l, --relay-log SPEC   folly XLOG config passed as --logging=SPEC to relay
 #   --bpf-steering         Enable mvfst BPF reuseport steering (requires MOQX_ENABLE_BPF_STEERING build)
 #   --no-bpf-steering      Disable mvfst BPF reuseport steering (default)
 #   -j, --jemalloc         LD_PRELOAD jemalloc for the relay (moqx-run auto-detects the lib)
@@ -86,17 +86,17 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --relay)            BINARY="$2";            shift 2 ;;
     --moqbin)           MOQBIN="$2";            shift 2 ;;
-    --subscriber-max)   SUBSCRIBER_MAX="$2";    shift 2 ;;
+    -s|--subscriber-max) SUBSCRIBER_MAX="$2";   shift 2 ;;
     --ramp)             RAMP="$2";              shift 2 ;;
-    --duration)         DURATION="$2";          shift 2 ;;
+    -d|--duration)      DURATION="$2";          shift 2 ;;
     --delivery-timeout) DELIVERY_TIMEOUT="$2";  shift 2 ;;
-    --transport)        TRANSPORT="$2";         shift 2 ;;
+    -t|--transport)     TRANSPORT="$2";         shift 2 ;;
     --draft)            DRAFT="$2";             shift 2 ;;
     --no-relay-thread)  USE_RELAY_THREAD="false"; shift ;;
     --local-forwarders) USE_LOCAL_FORWARDERS="true"; shift ;;
     --io-threads)       IO_THREADS="$2";          shift 2 ;;
     --threads)          CLIENT_THREADS="$2";      shift 2 ;;
-    --relay-log)        RELAY_LOG_SPEC="$2";      shift 2 ;;
+    -l|--relay-log)     RELAY_LOG_SPEC="$2";      shift 2 ;;
     --bpf-steering)     BPF_STEERING="true";      shift ;;
     --no-bpf-steering)  BPF_STEERING="false";     shift ;;
     -j|--jemalloc)      JEMALLOC="auto";           shift ;;

--- a/test/test.config.yaml
+++ b/test/test.config.yaml
@@ -1,6 +1,7 @@
 # Minimal config for integration tests (insecure, no TLS).
 listeners:
   - name: main
+    moqt_versions: [16, 14, 18]   # d18 last = forward-looking fallback
     udp:
       socket:
         address: "::"


### PR DESCRIPTION
Parameterizes the docker relay config so the published `ghcr.io/openmoq/moqx` image, the moqx-main.ci.openmoq.org deploy, and the interop relay all share one `${MOQX_*}` template ([config.docker.yaml](docker/config.docker.yaml)) resolved by [entrypoint.sh](docker/entrypoint.sh) via envsubst. A full config mounted at `/etc/moqx/config.yaml` still wins.

## What's templated
- Connection/TLS: bind addr, port, admin port, endpoint, cert/key, insecure
- Cache: enabled, max tracks/groups
- Performance (inherited by CI deploy + interop adapter): threads, local forwarders, send/recv packets-per-loop, UDP buffer, `ignore_path_mtu`
- **MoQT versions** (new): `MOQX_MOQT_VERSIONS`, default `[16, 14, 18]`

## Draft 18 as a negotiation *fallback*
The relay's advertised version comes from TLS ALPN, and fizz negotiates by **server preference** (client preference is ignored — `fizz/server/Negotiator.h`): it returns the first of the relay's listed versions that the client also supports. Listing draft 18 **last** makes it a fallback:

- client supports {14,16,18} → negotiates **16** (avoids the less-mature d18 path)
- client supports only {18} → negotiates **18** (d18-only clients can still connect)

So the same default is safe for the published image and the interop runner (no surprise d18 against dual-capable peers) while not locking out d18-only clients. Reorder `MOQX_MOQT_VERSIONS` (e.g. `[18, 16, 14]`) to prefer d18 where you want to actively test it.

## Verification
- Template renders to valid YAML (`moqt_versions` parses as a list of ints).
- `moqx validate-config` accepts the rendered config with `[16, 14, 18]`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/428)
<!-- Reviewable:end -->
