### PR TITLE
tools: moq_decode.py — decode d18 SUBSCRIBER_PRIORITY/GROUP_ORDER/FORWARD as uint8 (§10.2.7/8/12)

### DIFF
--- a/tools/moq_decode.py
+++ b/tools/moq_decode.py
@@ -410,6 +410,12 @@ def p_params(cursor, annot, draft, count, param_keys):
             blob_start = cursor.pos
             raw = cursor.read_bytes(vlen)
             p_subscription_filter_blob(raw, blob_start, annot, i, draft)
+        elif draft >= 18 and abs_key in (0x10, 0x20, 0x22):
+            # d18 §10.2.7/8/12: FORWARD (0x10), SUBSCRIBER_PRIORITY (0x20) and
+            # GROUP_ORDER (0x22) values are a fixed uint8, overriding the
+            # generic even-key varint (§1.4.3). Diverges at value >= 64.
+            val, vs = cursor.read_uint8()
+            annot.add(vs, cursor.pos, f"param[{i}].value", str(val))
         elif abs_key % 2 == 0:
             # Even-keyed params are plain varints
             val, vs = cursor.read_varint()


### PR DESCRIPTION
`p_params` decoded the SUBSCRIBER_PRIORITY (0x20), GROUP_ORDER (0x22), and FORWARD (0x10) parameter values as varints (the generic §1.4.3 even-key rule). draft-18 §10.2.7 / §10.2.8 / §10.2.12 define each as a **uint8**, which §1.4.3 permits as a per-Type serialization override. The two forms are identical for values 0–63, so the bug was silent until a value ≥64 — most commonly the default `subscriber_priority=128`, which made the decoder read the uint8 `0x80` as the start of a 2-byte varint and mis-align the rest of the message.

This adds a `draft >= 18 and abs_key in (0x10, 0x20, 0x22)` branch using `read_uint8()`, placed before the generic even-key varint case — mirroring the existing per-key special-cases (`LARGEST_OBJECT`, `SUBSCRIPTION_FILTER`) and the file's `draft >=` version-gating. Drafts < 18 are unchanged (these stay varint there).

**Verification** — a draft-18 Standalone FETCH with `subscriber_priority=128`:
```
python tools/moq_decode.py --version 18 16 00 23 01 01 02 08 6d 6f 71 2d 74 65 73 74 07 69 6e 74 65 72 6f 70 05 66 65 74 63 68 00 00 00 00 02 20 80 02 01
```
Before: `! Error at offset 0x26: underflow reading MoQ varint`. After: `param[0].value 128`, `param[1].value 1`, clean — matching moxygen's `MoQFramer` (`paramEncodingV18 → Uint8`).

Fixes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/431)
<!-- Reviewable:end -->
