### PR TITLE
ci: pin benchmark macos runner to macos-15 (fix snapshot tarball 404)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -229,7 +229,10 @@ jobs:
           - name: linux
             runner: ubuntu-22.04
           - name: macos
-            runner: macos-latest
+            # Pinned to macos-15 to match the moxygen publish runner / tarball
+            # name (moxygen-macos-15-arm64.tar.gz), downloaded here with
+            # --no-fallback. See ci-pr.yml benchmark job for the full rationale.
+            runner: macos-15
     name: benchmark (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -206,7 +206,12 @@ jobs:
           - name: linux
             runner: ubuntu-22.04
           - name: macos
-            runner: macos-latest
+            # Pinned to match the moxygen publish runner: snapshot-latest ships
+            # moxygen-macos-15-arm64.tar.gz, and this job downloads it with
+            # --no-fallback. macos-latest now resolves to macOS 26 (gradual
+            # rollout), which requests a macos-26 tarball that 404s. Keep in
+            # lockstep with the build job above (also macos-15).
+            runner: macos-15
     name: benchmark (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
The `benchmark (macos)` job 404s downloading the prebuilt moxygen tarball, failing PR CI (e.g. [run 28048166972](https://github.com/openmoq/moxygen/actions/runs/28048166972)).

## Cause
- The job downloads `moxygen-macos-<ver>-arm64.tar.gz` from moxygen `snapshot-latest` with `--no-fallback`.
- moxygen publishes on **macos-15** → ships `moxygen-macos-15-arm64.tar.gz`.
- This job ran on **`macos-latest`**, which GitHub is rolling over to **macOS 26**. On a 26 runner the platform string becomes `macos-26-arm64` → tarball 404 → job fails.
- Intermittent, tracking the gradual `macos-latest` rollout (main was green earlier on a still-15 runner).

## Fix
Pin the benchmark `macos` matrix entry to `macos-15` in both `ci-pr.yml` and `ci-main.yml` — matching the moxygen publish runner **and** the already-pinned build/test `macos` job. Comment-only + one runner label per file.

Not a required check, so it does not block merges, but it leaves PR CI red.

## Follow-up (not this PR)
Decouple the tarball name from the macOS major version (version-agnostic `macos-arm64`) on both the moxygen publish and moqx consume sides, so future runner-image bumps stop breaking this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/433)
<!-- Reviewable:end -->
