### PR TITLE
fix: clean error instead of SIGABRT on unreadable TLS cert (#173)

### DIFF
--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -42,12 +42,24 @@ buildFizzContext(const config::ListenerConfig& cfg) {
               ""
           );
         } else {
-          return quic::samples::createFizzServerContext(
-              alpns,
-              fizz::server::ClientAuthMode::Optional,
-              tls.certFile,
-              tls.keyFile
-          );
+          // createFizzServerContext throws (deep in fizz) when the cert/key
+          // can't be read or contain no certificate. Enrich the message with
+          // the offending paths so the caller can report it cleanly instead of
+          // letting an opaque "no certificates read" escape to std::terminate.
+          try {
+            return quic::samples::createFizzServerContext(
+                alpns,
+                fizz::server::ClientAuthMode::Optional,
+                tls.certFile,
+                tls.keyFile
+            );
+          } catch (const std::exception& e) {
+            throw std::runtime_error(
+                "failed to load TLS certificate/key (cert='" + tls.certFile + "', key='" +
+                tls.keyFile + "'): " + e.what() +
+                " - check the paths exist and are readable by this process"
+            );
+          }
         }
       },
       cfg.tlsMode

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,8 +128,15 @@ int main(int argc, char* argv[]) {
   auto statsRegistry = std::make_shared<stats::StatsRegistry>();
 
   std::vector<std::shared_ptr<moxygen::MoQServerBase>> servers;
-  for (const auto& listenerCfg : config.listeners) {
-    servers.emplace_back(makeRelayServer(listenerCfg, context, ioExecutor.get(), statsRegistry));
+  try {
+    for (const auto& listenerCfg : config.listeners) {
+      servers.emplace_back(makeRelayServer(listenerCfg, context, ioExecutor.get(), statsRegistry));
+    }
+  } catch (const std::exception& e) {
+    // Listener setup (e.g. TLS cert loading) can throw. Report cleanly and exit
+    // non-zero rather than letting it reach std::terminate / SIGABRT (#173).
+    std::cerr << "Error: failed to initialize listener: " << e.what() << "\n";
+    return 1;
   }
 
   if (!servers.empty()) {


### PR DESCRIPTION
Closes #173.

## Problem
When the configured TLS cert/key cannot be read (missing file, or root-only Let's Encrypt key read by a non-root process), `createFizzServerContext` throws deep in `fizz` ("no certificates read"). The exception escaped through the `MoqxRelayServer` constructor to `std::terminate` → **SIGABRT / core dump**, with no indication of which path was at fault.

## Fix
- **`buildFizzContext`** ([src/MoqxRelayServer.cpp](src/MoqxRelayServer.cpp)): wrap the real-TLS `createFizzServerContext` call and rethrow a `std::runtime_error` enriched with the offending cert/key paths.
- **`main`** ([src/main.cpp](src/main.cpp)): wrap listener construction in try/catch; on failure print a clear `Error: …` and `return 1`. Deliberately a clean non-zero exit (not `XLOG(FATAL)`, which would `abort()`/core-dump).

## Verified locally
Incremental build is clean. Running the binary with a nonexistent cert (`insecure: false`):

```
Error: failed to initialize listener: failed to load TLS certificate/key
(cert='/tmp/nope-cert.pem', key='/tmp/nope-key.pem'): no certificates read
- check the paths exist and are readable by this process
```

Exit code **1** (was 134 / SIGABRT before). No core dump.

## Scope
The catch in `main` covers all listener-setup failures, not just TLS, so other startup config errors also exit cleanly instead of terminating.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/434)
<!-- Reviewable:end -->
