### PR TITLE
tools: moq_decode.py — drop Existing Request ID from REQUEST_UPDATE at draft-18

### DIFF
--- a/tools/moq_decode.py
+++ b/tools/moq_decode.py
@@ -489,7 +489,9 @@ def parse_request_update(cursor, annot, draft, payload_end):
     val, s = cursor.read_varint()
     annot.add(s, cursor.pos, "request_id", str(val))
 
-    if draft >= 14:
+    # d18 §10.9 (Figure 12) removed Existing Request ID from REQUEST_UPDATE;
+    # d14-16 still carry it.
+    if 14 <= draft < 18:
         val, s = cursor.read_varint()
         annot.add(s, cursor.pos, "existing_request_id", str(val))
 


### PR DESCRIPTION
Fixes #439.

draft-18 §10.9 (Figure 12) removed the **Existing Request ID** field from `REQUEST_UPDATE` — the d18 body is `Request ID + Number of Parameters + Parameters`. draft-14..16 still carry it.

`parse_request_update()` read `existing_request_id` for every `draft >= 14`, so a real draft-18 `REQUEST_UPDATE` misaligned: the extra `read_varint()` consumed the Number-of-Parameters byte, and the following delta-coded parameter key was then read as a count → `Unknown parameter key …`.

**Fix:** gate the read to `14 <= draft < 18` (one line + comment).

**Verified** against a real moxygen draft-18 `REQUEST_UPDATE` (relay → publisher on a `forward=1` flip):

```
# v18 (after fix): clean
02  REQUEST_UPDATE
01  request_id = 1
02  num_params = 2
10  param[0].key 16 [FORWARD]
11  param[1].key 33 (Δ=17) [SUBSCRIPTION_FILTER]
```

```
# v16 (unchanged): Existing Request ID still decoded
02  REQUEST_UPDATE
01  request_id = 1
02  existing_request_id = 2
00  num_params = 0
```

Same per-draft-divergence class as #430/#431 (uint8 params).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/440)
<!-- Reviewable:end -->
