### PR TITLE
test: serialize doPublishNamespaceDone cleanup onto relayExec_

### DIFF
--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -448,7 +448,9 @@ TEST_P(MoQRelayTest, PublishReconnectDuringSubscribeScopeGuardCrash) {
         {RequestID(0), PublishDoneStatusCode::SESSION_CLOSED, 0, "test cleanup"}
     );
   }
-  relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2);
+  // Relay state mutations must run on the relay executor; doPublishNamespaceDone
+  // touches the namespace tree, which publishDone also cleans up via relayEvb_.
+  verifyOnRelayExec([&] { relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2); });
 }
 
 // Same reconnect scenario but the upstream subscribe returns OK instead of an
@@ -526,7 +528,9 @@ TEST_P(MoQRelayTest, PublishReconnectDuringSubscribeSuccessPathCrash) {
         {RequestID(0), PublishDoneStatusCode::SESSION_CLOSED, 0, "test cleanup"}
     );
   }
-  relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2);
+  // Relay state mutations must run on the relay executor; doPublishNamespaceDone
+  // touches the namespace tree, which publishDone also cleans up via relayEvb_.
+  verifyOnRelayExec([&] { relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2); });
 }
 
 // Regression: after publishDone the namespace-tree node must be pruned when


### PR DESCRIPTION
The PublishReconnectDuringSubscribe* regression tests called
relay_->doPublishNamespaceDone() directly on the test thread right after
pub2Consumer->publishDone(), which in MT modes dispatches namespace-tree
cleanup onto relayEvb_. Both mutate NamespaceTree::children_ concurrently,
causing a flaky ASAN heap-buffer-overflow during the F14 swap-and-pop erase.
Wrap the call in verifyOnRelayExec so relay state mutations always run on
the relay executor, as they do everywhere else.

Fixes: #435

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/442)
<!-- Reviewable:end -->
