### PR TITLE
relay: don't inspect the publisher forwarder from relayExec_ on publishDone (LF mode)

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -408,10 +408,16 @@ void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
     namespaceTree_.unpublishTrack(ftn.trackNamespace, ftn.trackName);
   }
 
-  // Clears handle + upstream; erases if no subscribers remain.
-  auto forwarder = registry_.onPublisherTerminated(ftn);
-  if (!forwarder) {
-    XLOG(DBG1) << "Publisher terminated with no subscribers, cleaning up " << ftn;
+  if (mode() == Mode::LocalForwarder) {
+    // The publisher forwarder is [Pub]-owned — never inspect it from relayExec_.
+    // The entry only indexes a live publisher, so drop it outright.
+    registry_.remove(ftn);
+  } else {
+    // Clears handle + upstream; erases if no subscribers remain.
+    auto forwarder = registry_.onPublisherTerminated(ftn);
+    if (!forwarder) {
+      XLOG(DBG1) << "Publisher terminated with no subscribers, cleaning up " << ftn;
+    }
   }
 }
 


### PR DESCRIPTION
In LocalForwarder mode the publisher's forwarder is owned by the publisher's executor ([Pub]), but onPublishDone runs on relayExec_ via the passive relay chain. Its call to registry_.onPublisherTerminated() did rsub.forwarder->empty(), reading the [Pub]-owned forwarder's subscribers_ map from relayExec_ while the publisher mutated it — a data race (TSAN-confirmed; intermittent ASan heap-buffer-overflow).

The registry entry in LF mode only indexes a live publisher for subscriber discovery; existing subscribers are served off-relay via channel subs and the relay chain is held by the passive pigtail, so neither depends on the entry. Drop the entry outright in LF mode without touching the forwarder. Non-LF modes keep the empty()-conditional erase (single-exec, safe).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/443)
<!-- Reviewable:end -->
