### PR TITLE
stats: per-thread MoQStatsCollector for MT-safe collection

### DIFF
--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -173,25 +173,32 @@ folly::coro::Task<size_t> MoqxRelayContext::purgeCache(
   co_return total;
 }
 
+void MoqxRelayContext::initThreadStatsCollectors(folly::IOThreadPoolExecutor& ioExecutor) {
+  if (!statsRegistry_) {
+    return;
+  }
+  for (auto& ka : ioExecutor.getAllEventBases()) {
+    auto* evb = ka.get();
+    auto collector = stats::MoQStatsCollector::create_moq_stats_collector(statsRegistry_);
+    collector->setExecutor(evb);
+    statsCollectors_.push_back(collector);
+    // Bind on the owning thread; blocks so every thread is bound before serving.
+    evb->runInEventBaseThreadAndWait([this, collector] { *tlStatsCollector_ = collector; });
+  }
+}
+
 void MoqxRelayContext::onNewSession(std::shared_ptr<MoQSession> clientSession) {
-  if (statsRegistry_) {
-    if (!statsCollector_) {
-      statsCollector_ = stats::MoQStatsCollector::create_moq_stats_collector(statsRegistry_);
-    }
-    if (!statsCollector_->owningExecutor()) {
-      statsCollector_->setExecutor(clientSession->getExecutor());
-    }
-
-    clientSession->setPublisherStatsCallback(statsCollector_->publisherCallback());
-    clientSession->setSubscriberStatsCallback(statsCollector_->subscriberCallback());
-
-    statsCollector_->onSessionStart();
+  auto& collector = *tlStatsCollector_;
+  if (collector) {
+    clientSession->setPublisherStatsCallback(collector->publisherCallback());
+    clientSession->setSubscriberStatsCallback(collector->subscriberCallback());
+    collector->onSessionStart();
   }
 }
 
 void MoqxRelayContext::onSessionEnd(std::shared_ptr<MoQSession> /*session*/) {
-  if (statsCollector_) {
-    statsCollector_->onSessionEnd();
+  if (auto& collector = *tlStatsCollector_) {
+    collector->onSessionEnd();
   }
   // Per-session auth state lives on the session's AuthFilter and is released
   // when the session drops it; no relay-side cleanup needed.
@@ -257,10 +264,8 @@ std::vector<std::string> MoqxRelayContext::getExactServicePaths() const {
 }
 
 void MoqxRelayContext::dumpState(RelayContextVisitor& visitor) const {
+  // TODO: source active session count for /state (deferred to the /state rework).
   int64_t activeSessions = 0;
-  if (statsCollector_) {
-    activeSessions = statsCollector_->snapshot().moqActiveSessions;
-  }
 
   visitor.onRelayBegin(relayID_, activeSessions);
   for (const auto& [name, entry] : services_) {

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -20,10 +20,13 @@
 #include <moxygen/MoQSession.h>
 
 #include <folly/Expected.h>
+#include <folly/ThreadLocal.h>
 #include <folly/container/F14Map.h>
 #include <folly/coro/Task.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <folly/io/async/EventBase.h>
+
+#include <vector>
 
 #include <optional>
 
@@ -106,6 +109,9 @@ public:
   void onNewSession(std::shared_ptr<moxygen::MoQSession> session);
   void onSessionEnd(std::shared_ptr<moxygen::MoQSession> session);
 
+  // Must run after setStatsRegistry and before any listener accepts sessions.
+  void initThreadStatsCollectors(folly::IOThreadPoolExecutor& ioExecutor);
+
   folly::Expected<folly::Unit, moxygen::SessionCloseErrorCode> validateAuthority(
       const moxygen::ClientSetup& clientSetup,
       uint64_t negotiatedVersion,
@@ -123,7 +129,9 @@ private:
   std::string relayID_;
   folly::EventBase* cacheEvb_{nullptr};
   std::shared_ptr<stats::StatsRegistry> statsRegistry_;
-  std::shared_ptr<stats::MoQStatsCollector> statsCollector_;
+  // One collector per io thread; tlStatsCollector_ binds each to its own thread.
+  std::vector<std::shared_ptr<stats::MoQStatsCollector>> statsCollectors_;
+  folly::ThreadLocal<std::shared_ptr<stats::MoQStatsCollector>> tlStatsCollector_;
   folly::EventBase* workerEvb_{nullptr};
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,18 +143,20 @@ int main(int argc, char* argv[]) {
   admin::registerMetricsRoute(adminServer, statsRegistry);
   admin::registerCachePurgeRoute(adminServer, context);
   admin::registerStateRoute(adminServer, context);
+
+  // === 8. Start serving ===
+  for (auto& server : servers) {
+    // addr ignored — each server binds its own listenerCfg address
+    server->start(folly::SocketAddress{});
+  }
+
+  // Start admin after servers so every stats collector is registered before /metrics can read them.
   if (config.admin) {
     if (!adminServer.start(*config.admin)) {
       XLOG(FATAL) << "Failed to start admin server on " << config.admin->address.describe();
     }
 
     XLOG(INFO) << "Admin server listening on " << config.admin->address.describe();
-  }
-
-  // === 8. Start serving ===
-  for (auto& server : servers) {
-    // addr ignored — each server binds its own listenerCfg address
-    server->start(folly::SocketAddress{});
   }
 
   if (!servers.empty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,6 +134,7 @@ int main(int argc, char* argv[]) {
 
   if (!servers.empty()) {
     context->setCacheEvb(ioExecutor->getAllEventBases()[0].get());
+    context->initThreadStatsCollectors(*ioExecutor);
   }
 
   // === 7. Start health checks / admin endpoints ===

--- a/src/stats/StatsRegistry.cpp
+++ b/src/stats/StatsRegistry.cpp
@@ -161,19 +161,14 @@ folly::coro::Task<StatsSnapshot> StatsRegistry::aggregateAsync() {
   static auto snapshotTask = [](std::shared_ptr<StatsCollectorBase> c
                              ) -> folly::coro::Task<StatsSnapshot> { co_return c->snapshot(); };
 
-  // collectors_ is written only during startup; by the time aggregateAsync()
-  // is called it is effectively read-only.
+  // Lock-free read: collectors_ is fully registered before admin serves, and never compacted.
   std::vector<std::shared_ptr<StatsCollectorBase>> live;
   live.reserve(collectors_.size());
-  size_t write = 0;
-  for (size_t i = 0; i < collectors_.size(); ++i) {
-    auto s = collectors_[i].lock();
-    if (s) { // if collector is alive, keep it and move to next write slot
+  for (const auto& weak : collectors_) {
+    if (auto s = weak.lock()) {
       live.push_back(std::move(s));
-      collectors_[write++] = collectors_[i];
     }
   }
-  collectors_.resize(write);
 
   std::vector<folly::coro::TaskWithExecutor<StatsSnapshot>> tasks;
   tasks.reserve(live.size());


### PR DESCRIPTION
The stats collector predated multi-threading: one shared collector was wired to every session, so its plain counters/histograms were mutated concurrently from all io threads (TSAN-confirmed races in onSubscriptionEnd/onSessionEnd/etc.).

Pre-create one collector per io thread (initThreadStatsCollectors, called once at startup before serving), bound to its thread via a ThreadLocal. Each session wires its callbacks to its own thread's collector, so every mutation stays single-threaded. The StatsRegistry already aggregates across collectors for /metrics, so per-thread snapshots sum correctly.

/state's active-session read is stubbed to 0 for now (print-only, not asserted; deferred to the /state rework).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/444)
<!-- Reviewable:end -->
