### PR TITLE
relay: resolve joining fetch on subscriber exec in LF mode

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -143,6 +143,14 @@ public:
     return PublisherCrossExecFilter::trackStatus(std::move(req));
   }
 
+  folly::coro::Task<FetchResult>
+  fetch(moxygen::Fetch fetch, std::shared_ptr<moxygen::FetchConsumer> consumer) override {
+    auto session = moxygen::MoQSession::getRequestSession();
+    auto resolved = relay_->fetchOnSubscriberExec(std::move(fetch), session);
+    // Joining resolved/deferred on subscriberExec; base filter wraps + hops to relayExec_.
+    return PublisherCrossExecFilter::fetch(std::move(resolved), std::move(consumer));
+  }
+
 private:
   std::shared_ptr<MoqxRelay> relay_;
 };
@@ -2019,6 +2027,8 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
           attach.upstreamOk->largest->group,
           attach.upstreamOk->largest->object
       );
+      // Seed the subscriber snapshot so a post-SUBSCRIBE_OK joining fetch resolves.
+      sub->updateLargest(*attach.upstreamOk->largest);
     }
   }
   replayPendingFowarderEvents(localFwd.get(), attach.finalCallback, *pendingCb, forward);
@@ -2160,6 +2170,26 @@ MoqxRelay::trackStatusOnSubscriberExec(const TrackStatus& req) {
   return Publisher::TrackStatusResult(buildTrackStatusOk(*localFwd, /*hasHandle=*/true, req));
 }
 
+Fetch MoqxRelay::fetchOnSubscriberExec(Fetch fetch, const std::shared_ptr<MoQSession>& session) {
+  auto [standalone, joining] = fetchType(fetch);
+  if (!joining) {
+    return fetch;
+  }
+  auto* localReg = tlForwarders_.get();
+  auto localFwd = localReg ? localReg->get(fetch.fullTrackName) : nullptr;
+  if (localFwd) {
+    auto res = localFwd->resolveJoiningFetch(session, *joining);
+    if (res.hasValue()) {
+      fetch.args = StandaloneFetch(res.value().start, res.value().end);
+      return fetch;
+    }
+  }
+  // Not resolvable yet (no largest, or pre-PUBLISH_OK on draft-18's separate
+  // stream): defer upstream by track name. Rare; fails if there's no upstream.
+  joining->joiningRequestID = std::nullopt;
+  return fetch;
+}
+
 folly::coro::Task<Publisher::FetchResult>
 MoqxRelay::fetchImpl(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
@@ -2171,7 +2201,8 @@ MoqxRelay::fetchImpl(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   }
 
   auto [standalone, joining] = fetchType(fetch);
-  if (joining) {
+  // LF mode resolves/defers joining in fetchOnSubscriberExec on the subscriber exec.
+  if (joining && mode() != Mode::LocalForwarder) {
     auto fetchView = registry_.getFetchView(fetch.fullTrackName);
     if (!fetchView) {
       XLOG(ERR) << "No subscription for joining fetch";

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -496,6 +496,11 @@ private:
   std::optional<moxygen::Publisher::TrackStatusResult>
   trackStatusOnSubscriberExec(const moxygen::TrackStatus& req);
 
+  // Resolves a joining fetch against this thread's local forwarder (race-free). Rewrites to a
+  // standalone Fetch when largest is known, else clears joiningRequestID to defer to upstream.
+  moxygen::Fetch
+  fetchOnSubscriberExec(moxygen::Fetch fetch, const std::shared_ptr<moxygen::MoQSession>& session);
+
   // Impl methods — run on relayExec_ when set, or inline when relayExec_==nullptr.
   folly::coro::Task<SubscribeResult>
   subscribeImpl(moxygen::SubscribeRequest subReq, std::shared_ptr<moxygen::TrackConsumer> consumer);

--- a/test/MoqxRelayFetchTests.cpp
+++ b/test/MoqxRelayFetchTests.cpp
@@ -65,4 +65,95 @@ TEST_P(MoQRelayTest, FetchAfterPublisherTermination) {
   removeSession(fetchSession);
 }
 
+// Joining fetch referencing a PUBLISH: onPublishOk must store the PUBLISH_OK
+// request id so the fetch matches the fanned-out subscription and resolves.
+TEST_P(MoQRelayTest, JoiningFetchAgainstPublish) {
+  auto publisherSession = createMockSession();
+  auto subscriber = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  std::atomic<bool> published{false};
+  auto mockConsumer = createMockConsumer();
+  EXPECT_CALL(*subscriber, publish(_, _))
+      .WillOnce([&mockConsumer, &published](const PublishRequest&, auto) {
+        published.store(true);
+        return Subscriber::PublishResult(Subscriber::PublishConsumerAndReplyTask{
+            mockConsumer,
+            []() -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
+              co_return PublishOk{
+                  RequestID(7),
+                  /*forward=*/true,
+                  0,
+                  GroupOrder::OldestFirst,
+                  LocationType::LargestObject,
+                  std::nullopt,
+                  std::nullopt
+              };
+            }()
+        });
+      });
+
+  doSubscribeNamespace(subscriber, kTestNamespace);
+
+  // Publish the track with an initial largest so the fanned-out subscriber
+  // snapshots a join point.
+  PublishRequest pub;
+  pub.fullTrackName = kTestTrackName;
+  pub.largest = AbsoluteLocation{0, 0};
+  withSessionContext(publisherSession, [&]() {
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
+    ASSERT_TRUE(res.hasValue());
+    getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
+    co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(res->reply))
+        .start();
+  });
+  exec_->drive();
+  ASSERT_TRUE(driveUntil([&] { return published.load(); }))
+      << "publish was not forwarded to the subscriber";
+  // Flush the PUBLISH_OK reply so onPublishOk stores the request id before the fetch.
+  for (int i = 0; i < 5; ++i) {
+    exec_->drive();
+  }
+
+  std::atomic<bool> upstreamFetched{false};
+  auto capturedFetch = std::make_shared<Fetch>();
+  EXPECT_CALL(*publisherSession, fetch(_, _))
+      .WillOnce([capturedFetch,
+                 &upstreamFetched](Fetch f, std::shared_ptr<FetchConsumer> consumer) {
+        *capturedFetch = std::move(f);
+        upstreamFetched.store(true);
+        // Terminate the fetch so the cross-exec consumer drops its self-anchor;
+        // a real upstream always ends the fetch (here the resolved range is empty).
+        consumer->endOfFetch();
+        return folly::coro::makeTask<Publisher::FetchResult>(std::make_shared<MockFetchHandle>(
+            FetchOk{RequestID(0), GroupOrder::OldestFirst, 0, AbsoluteLocation{0, 0}, {}}
+        ));
+      });
+
+  Fetch joiningFetch(RequestID(0), RequestID(7), /*joiningStart=*/0, FetchType::RELATIVE_JOINING);
+  joiningFetch.fullTrackName = kTestTrackName;
+  auto fetchConsumer = std::make_shared<NiceMock<MockFetchConsumer>>();
+  EXPECT_CALL(*fetchConsumer, endOfFetch()).WillOnce([]() {
+    return folly::Expected<folly::Unit, MoQPublishError>(folly::unit);
+  });
+  withSessionContext(subscriber, [&]() {
+    auto task = publisherInterface()->fetch(std::move(joiningFetch), fetchConsumer);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    EXPECT_TRUE(res.hasValue());
+  });
+  ASSERT_TRUE(driveUntil([&] { return upstreamFetched.load(); }))
+      << "joining fetch was not resolved/forwarded upstream";
+
+  auto [standalone, joining] = fetchType(*capturedFetch);
+  EXPECT_EQ(joining, nullptr) << "joining fetch was not resolved to standalone";
+  ASSERT_NE(standalone, nullptr);
+  EXPECT_EQ(standalone->start, (AbsoluteLocation{0, 0}));
+  EXPECT_EQ(standalone->end, (AbsoluteLocation{0, 1}));
+
+  removeSession(publisherSession);
+  removeSession(subscriber);
+  driveIfMultiThread();
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
A joining fetch read the publisher forwarder's subscribers_ on relayExec_ while addChannelSubscriber wrote it on the publisher exec — an F14 data race. The read also never matched (the publisher forwarder keys channel subscribers by exec, not session), so LF joining fetches returned DOES_NOT_EXIST regardless.

Resolve the join against the thread-local local forwarder on the subscriber exec before the relay hop (fetchOnSubscriberExec + LocalSubscribeFilter::fetch). Seed the subscribe-path subscriber's largest from the upstream OK so a post-SUBSCRIBE_OK joining fetch resolves; when it can't resolve yet (subscribe in progress, or pre-PUBLISH_OK), defer to upstream by track name. fetchImpl's joining block is now non-LF only.

Bumps moxygen: onPublishOk stores the PUBLISH_OK requestID, plus a MockMoQSession fetch mock for the new test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/445)
<!-- Reviewable:end -->
