### PR TITLE
ci(test-reporter): list only failed tests to avoid 64 KiB Check Run cap

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -132,6 +132,10 @@ jobs:
           path: ${{ matrix.build_dir }}/test-results.xml
           reporter: java-junit
           fail-on-empty: ${{ job.status == 'success' && 'true' || 'false' }}
+          # Only list failing tests in the Check Run summary. Listing all
+          # passing tests too blows GitHub's 64 KiB output-body cap on large
+          # suites; the per-suite pass/fail counts at the top still render.
+          list-tests: failed
 
   # ════════════════════════════════════════════════════════════════════════════
   # Conformance: mvfst × {d14, d16} × {Q, WT} + pico × {d14, d16} × Q

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -113,6 +113,10 @@ jobs:
           path: ${{ matrix.build_dir }}/test-results.xml
           reporter: java-junit
           fail-on-empty: ${{ job.status == 'success' && 'true' || 'false' }}
+          # Only list failing tests in the Check Run summary. Listing all
+          # passing tests too blows GitHub's 64 KiB output-body cap on large
+          # suites; the per-suite pass/fail counts at the top still render.
+          list-tests: failed
 
       - name: Note fork-PR reporter skip
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}


### PR DESCRIPTION
## Summary

The `test (macos)` Check Run on [PR #437](https://github.com/openmoq/moqx/pull/437) (and any other PR with a large test suite) hits GitHub's hard cap of 65 535 bytes on Check Run output bodies and gets trimmed:

> Report exceeded GitHub limit of 65535 bytes and has been trimmed

Cause: [`dorny/test-reporter`](https://github.com/dorny/test-reporter) defaults to `list-tests: all`, which emits every passing test name (672 of them in our case) alongside the 1 failing one. With 673 entries the markdown body sails past 64 KiB.

Fix: set `list-tests: failed` in both `ci-pr.yml` and `ci-main.yml`. Only failing tests get listed in the Check Run summary; the per-suite pass/fail/skip counts at the top still render, so reviewers still see "672 passed, 1 failed" at a glance — they just don't have to scroll through 600+ ✅ rows to find the ❌.

## What stays / what changes

| | Before | After |
|---|---|---|
| Per-suite header counts (passed/failed/skipped/time) | ✅ shown | ✅ shown |
| List of FAILING tests | ✅ shown | ✅ shown |
| List of PASSING tests | ✅ all 672 shown | ❌ hidden |
| Trimmed by GitHub | ⚠️ yes, at 64 KiB | ✅ no |

## Test plan

- [ ] Merge → next PR push triggers `test (linux/macos/asan debug)` jobs
- [ ] Confirm Check Run output is under 64 KiB and not annotated as trimmed
- [ ] Confirm failing tests (if any) still appear in the Check Run summary

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/448)
<!-- Reviewable:end -->
