### PR TITLE
relay: deepen datagram send queue and drop oldest-first

### DIFF
--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -89,6 +89,10 @@ buildTransportSettings(const config::QuicConfig& quic, const config::MvfstConfig
   ts.advertisedInitialUniStreamFlowControlWindow = quic.maxStreamData;
   ts.advertisedInitialMaxStreamsBidi = quic.maxBidiStreams;
   ts.advertisedInitialMaxStreamsUni = quic.maxUniStreams;
+  // Deep datagram queue dropping oldest-first: a write stall sheds stale frames
+  // rather than rejecting new ones.
+  ts.datagramConfig.writeBufSize = 500;
+  ts.datagramConfig.sendDropOldDataFirst = true;
   ts.idleTimeout = std::chrono::milliseconds(quic.idleTimeoutMs);
   ts.minAckDelay = std::chrono::microseconds(quic.minAckDelayUs);
   if (quic.maxAckDelayUs != config::QuicConfig{}.maxAckDelayUs) {

--- a/src/UpstreamProvider.cpp
+++ b/src/UpstreamProvider.cpp
@@ -412,6 +412,10 @@ folly::coro::Task<void> UpstreamProvider::doConnect() {
 
   quic::TransportSettings ts;
   ts.orderedReadCallbacks = true;
+  // Deep datagram queue dropping oldest-first: a write stall sheds stale frames
+  // rather than rejecting new ones.
+  ts.datagramConfig.writeBufSize = 1000;
+  ts.datagramConfig.sendDropOldDataFirst = true;
 
   // Relay chaining requires draft 16+. Only offer standard draft-16 ALPN
   // ("moqt-16") so we fail fast if the upstream doesn't support it.


### PR DESCRIPTION
Raise the mvfst datagram send queue above the default of 75 and switch the full-queue policy from rejecting the incoming datagram to popping the oldest, so a momentary write stall sheds stale frames rather than failing new writes. Relay listeners use writeBufSize=500; the upstream client leg uses 1000.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/450)
<!-- Reviewable:end -->
