### PR TITLE
relay: answer trackStatus without touching registry forwarder in LF mode

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -135,6 +135,14 @@ public:
     );
   }
 
+  folly::coro::Task<TrackStatusResult> trackStatus(moxygen::TrackStatus req) override {
+    // Answer from the local forwarder on this exec; else hop to relayExec_ + upstream.
+    if (auto local = relay_->trackStatusOnSubscriberExec(req)) {
+      return folly::coro::makeTask<TrackStatusResult>(std::move(*local));
+    }
+    return PublisherCrossExecFilter::trackStatus(std::move(req));
+  }
+
 private:
   std::shared_ptr<MoqxRelay> relay_;
 };
@@ -2108,6 +2116,37 @@ MoqxRelay::fetch(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   return fetchImpl(std::move(fetch), std::move(consumer));
 }
 
+namespace {
+TrackStatusOk buildTrackStatusOk(MoQForwarder& fwd, bool hasHandle, const TrackStatus& req) {
+  TrackStatusCode statusCode = TrackStatusCode::TRACK_NOT_STARTED;
+  // largest() set means an object arrived; hasHandle means the upstream sub is still live.
+  if (fwd.largest()) {
+    statusCode = hasHandle ? TrackStatusCode::IN_PROGRESS : TrackStatusCode::UNKNOWN;
+  }
+  TrackStatusOk ok;
+  ok.requestID = req.requestID;
+  ok.groupOrder = fwd.groupOrder();
+  ok.largest = fwd.largest();
+  ok.fullTrackName = req.fullTrackName;
+  ok.statusCode = statusCode;
+  return ok;
+}
+} // namespace
+
+std::optional<Publisher::TrackStatusResult>
+MoqxRelay::trackStatusOnSubscriberExec(const TrackStatus& req) {
+  if (req.fullTrackName.trackNamespace.empty()) {
+    return std::nullopt;
+  }
+  auto* localReg = tlForwarders_.get();
+  auto localFwd = localReg ? localReg->get(req.fullTrackName) : nullptr;
+  if (!localFwd || localFwd->numForwardingSubscribers() == 0) {
+    return std::nullopt;
+  }
+  // A forwarding local subscriber implies the upstream sub is live.
+  return Publisher::TrackStatusResult(buildTrackStatusOk(*localFwd, /*hasHandle=*/true, req));
+}
+
 folly::coro::Task<Publisher::FetchResult>
 MoqxRelay::fetchImpl(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
@@ -2172,6 +2211,16 @@ MoqxRelay::fetchImpl(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
       ->fetch(std::move(fetch), std::move(consumer), std::move(upstreamPublisher));
 }
 
+folly::coro::Task<std::optional<TrackStatusOk>>
+MoqxRelay::readPublisherForwarderStatus(bool hasHandle, TrackStatus req) {
+  auto* localReg = tlForwarders_.get();
+  auto forwarder = localReg ? localReg->get(req.fullTrackName) : nullptr;
+  if (!forwarder || forwarder->numForwardingSubscribers() == 0) {
+    co_return std::nullopt;
+  }
+  co_return buildTrackStatusOk(*forwarder, hasHandle, req);
+}
+
 folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatus(TrackStatus trackStatus) {
   return trackStatusImpl(std::move(trackStatus));
 }
@@ -2189,34 +2238,29 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatusImpl(Track
   }
 
   auto upstreamView = registry_.getUpstreamView(trackStatus.fullTrackName);
-  if (upstreamView && upstreamView->forwarder->numForwardingSubscribers() > 0) {
-    // We have active subscription - answer directly from local forwarder state
-    auto& forwarder = upstreamView->forwarder;
-
-    TrackStatusCode statusCode = TrackStatusCode::TRACK_NOT_STARTED;
-    // forwarder->largest() being set means: we have actually
-    // received at least one object for this track.
-    // upstreamView->handle being non-null means: the relay still has a
-    // live upstream Publisher::SubscriptionHandle for this track
-    if (forwarder->largest()) {
-      if (upstreamView->handle) {
-        statusCode = TrackStatusCode::IN_PROGRESS;
-      } else {
-        statusCode = TrackStatusCode::UNKNOWN;
-      }
+  // Active subscription: answer from the publisher forwarder's state instead of going upstream.
+  std::optional<TrackStatusOk> trackStatusOk;
+  if (mode() == Mode::LocalForwarder) {
+    // LF mode never touches registry->forwarder; read it via tlForwarders_ on the publisher exec.
+    if (upstreamView && upstreamView->publisherExec) {
+      trackStatusOk = co_await folly::coro::co_withExecutor(
+          folly::getKeepAliveToken(upstreamView->publisherExec),
+          readPublisherForwarderStatus((bool)upstreamView->handle, trackStatus)
+      );
     }
-
-    TrackStatusOk trackStatusOk;
-    trackStatusOk.requestID = trackStatus.requestID;
-    trackStatusOk.groupOrder = forwarder->groupOrder();
-    trackStatusOk.largest = forwarder->largest();
-    trackStatusOk.fullTrackName = trackStatus.fullTrackName;
-    trackStatusOk.statusCode = statusCode;
-
+  } else if (upstreamView && upstreamView->forwarder &&
+             upstreamView->forwarder->numForwardingSubscribers() > 0) {
+    // Non-LF: relayExec_ (or the single thread) owns the sole forwarder; read it inline.
+    trackStatusOk =
+        buildTrackStatusOk(*upstreamView->forwarder, (bool)upstreamView->handle, trackStatus);
+  }
+  if (trackStatusOk) {
     XLOG(DBG1) << "Returning local track status for " << trackStatus.fullTrackName
-               << " statusCode=" << (uint32_t)statusCode;
-    co_return trackStatusOk;
-  } else {
+               << " statusCode=" << (uint32_t)trackStatusOk->statusCode;
+    co_return std::move(*trackStatusOk);
+  }
+  // No active subscription — fall through to the upstream path.
+  {
     // No active subscription — try registry publisher first, then namespace tree
     std::shared_ptr<Publisher> upstreamPublisher;
     if (upstreamView) {

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -492,6 +492,10 @@ private:
       folly::Executor* subscriberExec
   );
 
+  // Answers from this thread's local forwarder (race-free); nullopt defers to trackStatusImpl.
+  std::optional<moxygen::Publisher::TrackStatusResult>
+  trackStatusOnSubscriberExec(const moxygen::TrackStatus& req);
+
   // Impl methods — run on relayExec_ when set, or inline when relayExec_==nullptr.
   folly::coro::Task<SubscribeResult>
   subscribeImpl(moxygen::SubscribeRequest subReq, std::shared_ptr<moxygen::TrackConsumer> consumer);
@@ -507,6 +511,10 @@ private:
   );
   folly::coro::Task<moxygen::Publisher::TrackStatusResult> trackStatusImpl(moxygen::TrackStatus req
   );
+  // Must be scheduled on the publisher exec; looks the forwarder up in tlForwarders_ by FTN.
+  // nullopt means no active sub, defer upstream.
+  folly::coro::Task<std::optional<moxygen::TrackStatusOk>>
+  readPublisherForwarderStatus(bool hasHandle, moxygen::TrackStatus req);
   folly::coro::Task<void> onUpstreamConnectImpl(std::shared_ptr<moxygen::MoQSession> session);
 
   // Synchronous result of publishWithSession: the consumer the publisher writes

--- a/test/MoqxRelayTrackStatusTests.cpp
+++ b/test/MoqxRelayTrackStatusTests.cpp
@@ -108,4 +108,56 @@ TEST_P(MoQRelayTest, TrackStatusViaPrefixMatching) {
   removeSession(requester);
 }
 
+// An unsubscribed requester is answered from the relay's forwarder state (kept alive by
+// another subscriber), never an upstream round-trip.
+TEST_P(MoQRelayTest, TrackStatusUnsubscribedRequesterReadsForwarder) {
+  auto publisherSession = createMockSession();
+  auto subscriber = createMockSession();
+  auto requester = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Publish with an initial largest so the forwarder reports IN_PROGRESS.
+  PublishRequest pub;
+  pub.fullTrackName = kTestTrackName;
+  pub.largest = AbsoluteLocation{4, 2};
+  withSessionContext(publisherSession, [&]() {
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
+    ASSERT_TRUE(res.hasValue());
+    getOrCreateMockState(publisherSession)->publishConsumers.push_back(res->consumer);
+    co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(res->reply))
+        .start();
+  });
+  exec_->drive();
+
+  // A real forwarding subscriber keeps numForwardingSubscribers() > 0.
+  auto consumer = createMockConsumer();
+  auto handle = subscribeToTrack(subscriber, kTestTrackName, consumer, RequestID(1));
+  ASSERT_NE(handle, nullptr);
+  driveIfMultiThread();
+
+  // The requester never subscribed; trackStatus must never go upstream.
+  EXPECT_CALL(*publisherSession, trackStatus(_)).Times(0);
+
+  TrackStatus trackStatus;
+  trackStatus.fullTrackName = kTestTrackName;
+  trackStatus.requestID = RequestID(2);
+  withSessionContext(requester, [&]() {
+    auto task = publisherInterface()->trackStatus(trackStatus);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    ASSERT_TRUE(res.hasValue());
+    EXPECT_EQ(res.value().statusCode, TrackStatusCode::IN_PROGRESS);
+    EXPECT_EQ(res.value().fullTrackName, kTestTrackName);
+    ASSERT_TRUE(res.value().largest.has_value());
+    EXPECT_EQ(res.value().largest->group, 4);
+    EXPECT_EQ(res.value().largest->object, 2);
+  });
+
+  removeSession(subscriber);
+  exec_->drive();
+  removeSession(requester);
+  removeSession(publisherSession);
+  driveIfMultiThread();
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
In LF mode the registry's forwarder lives on the publisher exec, so reading its largest/groupOrder/numForwardingSubscribers from relayExec_ (or the requesting session exec) in trackStatusImpl was an unsynchronized cross-thread read of non-atomic fields.

Resolve trackStatus against thread-local forwarders instead. LocalSubscribeFilter gains a trackStatus override that answers from the requester's local forwarder on the subscriber exec (zero hops). When the requester isn't subscribed, trackStatusImpl hops to the publisher exec and reads the publisher forwarder via tlForwarders_ by FTN, only falling through to upstream when the relay has no forwarding subscription. Non-LF modes still read the registry forwarder inline; relayExec_ owns the sole forwarder there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/451)
<!-- Reviewable:end -->
