### PR TITLE
relay: fix LF onTrackEvicted no-op and local-forwarder seed-read race

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1110,9 +1110,22 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
     }
   }
 
+  // Capture largest/extensions on publisherExec; reading them on subscriberExec would
+  // race the publisher advancing largest_.
+  std::optional<AbsoluteLocation> seedLargest;
+  Extensions seedExtensions;
+  co_await folly::coro::co_withExecutor(
+      folly::getKeepAliveToken(publisherExec),
+      [&]() -> folly::coro::Task<void> {
+        seedLargest = publisherFwd->largest();
+        seedExtensions = publisherFwd->extensions();
+        co_return;
+      }()
+  );
+
   auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, [&] {
-    auto fwd = std::make_shared<MoQForwarder>(ftn, publisherFwd->largest());
-    fwd->setExtensions(publisherFwd->extensions());
+    auto fwd = std::make_shared<MoQForwarder>(ftn, seedLargest);
+    fwd->setExtensions(seedExtensions);
     return fwd;
   });
 
@@ -2466,23 +2479,34 @@ void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSess
     return;
   }
 
-  auto forwarder = registry_.getForwarder(ftn);
-  if (!forwarder) {
+  // PublishDone makes removeSubscriber notify the downstream via publishDone() rather
+  // than silently dropping it.
+  auto evict = [session](const std::shared_ptr<MoQForwarder>& fwd) {
+    if (!fwd) {
+      return;
+    }
+    auto sub = fwd->getSubscriber(session.get());
+    if (!sub || sub->isPinned()) {
+      XLOG(DBG4) << "onTrackEvicted: pinned/missing subscriber, skipping";
+      return;
+    }
+    fwd->removeSubscriber(
+        session,
+        PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "evicted"},
+        "onTrackEvicted"
+    );
+  };
+
+  if (mode() == Mode::LocalForwarder) {
+    // The subscriber lives on the per-thread local forwarder, not the registry's
+    // publisher forwarder; evict it on its owning exec.
+    folly::via(session->getExecutor(), [this, ftn, evict = std::move(evict)]() {
+      auto* localReg = tlForwarders_.get();
+      evict(localReg ? localReg->get(ftn) : nullptr);
+    });
     return;
   }
-  auto sub = forwarder->getSubscriber(session.get());
-  if (!sub || sub->isPinned()) {
-    XLOG(DBG4) << "onTrackEvicted: pinned subscriber, skipping";
-    return;
-  }
-  // Pass PublishDone so removeSubscriber calls trackConsumer->publishDone() before
-  // removing the subscriber. Passing nullopt would silently drop the subscriber
-  // without notifying the downstream session that its subscription ended.
-  forwarder->removeSubscriber(
-      session,
-      PublishDone{RequestID(0), PublishDoneStatusCode::SUBSCRIPTION_ENDED, 0, "evicted"},
-      "onTrackEvicted"
-  );
+  evict(registry_.getForwarder(ftn));
 }
 
 void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {


### PR DESCRIPTION
In LocalForwarder mode onTrackEvicted looked up a session-keyed subscriber on the registry's publisher forwarder, but the subscriber lives on the per-thread local forwarder (exec-keyed channel subscribers on the publisher fwd) — so it silently evicted nothing and never sent publishDone. Branch on mode(): hop to session's exec, resolve the local forwarder, and evict there.

Also seed a new local forwarder's largest/extensions from a publisherExec hop instead of reading them on subscriberExec while the publisher advances largest_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/452)
<!-- Reviewable:end -->
