### PR TITLE
scripts & onboarding cleanup: README + no-sudo, bind-address knob, #441/#391

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,9 @@ DartConfiguration.tcl
 # CPack
 _CPack_Packages/
 
-# Dependency scratch dir
+# Dependency scratch dirs
 /.scratch/
+/.docker-deps/
 
 # OS
 .DS_Store
@@ -29,6 +30,7 @@ _CPack_Packages/
 .vscode/
 .claude/
 .cache/
+AGENTS.md
 
 # Docker secrets (never commit)
 docker/.env

--- a/BUILD.md
+++ b/BUILD.md
@@ -19,7 +19,7 @@ formatting, and CI.
 Six steps. Each links to its detail section.
 
 1. **Clone and init the moxygen submodule.**
-   `git clone … && cd moqx && git submodule update --init` —
+   `git clone … && cd moqx && git submodule update --init --recursive` —
    the submodule pins the exact moxygen commit the build will use
    (see [Dependency Modes](#dependency-modes)).
 2. **Ensure CMake 3.22+** is on `PATH`. All current targets ship a
@@ -100,7 +100,7 @@ docker run --rm -it -v "$PWD":/src -w /src ubuntu:22.04 bash
 
 # Inside the container:
 apt-get update && apt-get install -y cmake ninja-build sudo git curl ca-certificates
-git submodule update --init
+git submodule update --init --recursive
 sudo deps/moxygen/standalone/install-system-deps.sh
 ./scripts/build.sh setup --from-source   # build from source (no release artifacts available offline)
 ./scripts/build.sh

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ handler and create `MoQRelaySession` instances for incoming connections.
 
 ```bash
 git clone https://github.com/openmoq/moqx.git && cd moqx
-git submodule update --init
+git submodule update --init --recursive
 sudo deps/moxygen/standalone/install-system-deps.sh   # system libs (both modes)
 
 ./scripts/build.sh setup     # download prebuilt deps (~1 min)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,80 @@
+# moqx scripts
+
+Helper scripts for running and benchmarking a moqx relay. Run them from the
+repository root.
+
+## Relay quickstart
+
+Run a relay with [`moqx-run.sh`](moqx-run.sh). It fills
+[`config.bench.yaml`](config.bench.yaml) (a template with sensible defaults)
+and serves it. Override anything with a flag or env var — you rarely need to.
+
+### Simplest possible
+
+```bash
+# local dev relay — built-in self-signed cert, no root needed
+./scripts/moqx-run.sh --insecure --no-sudo
+```
+
+Listens on **udp/4433** (MoQT), admin HTTP on **8000**, WebTransport endpoint
+**`/moq-relay`**. Offers MoQT drafts **16, 14, 18** (negotiates 16 with most
+clients; draft-18-only clients get 18).
+
+### The handful of commands you'll actually use
+
+```bash
+# 1. Local dev (insecure, no sudo)
+./scripts/moqx-run.sh --insecure --no-sudo
+
+# 2. Real TLS — Let's Encrypt cert under DOMAIN (sudo, to read the 0600 key)
+DOMAIN=relay.example.com ./scripts/moqx-run.sh
+
+# 3. Pin a single draft (e.g. force draft-18)
+./scripts/moqx-run.sh --insecure --no-sudo --moqt-versions 18
+
+# 4. Different port / endpoint
+./scripts/moqx-run.sh --insecure --no-sudo --port 5433 --endpoint /relay
+
+# 5. Validate the config without serving
+./scripts/moqx-run.sh --subcmd validate-config --no-sudo
+
+# 6. Show the resolved config + exact command, run nothing
+./scripts/moqx-run.sh -n
+```
+
+### Defaults (all overridable)
+
+| knob | default | flag / env |
+|---|---|---|
+| QUIC stack | mvfst | `--quic-stack mvfst\|picoquic` |
+| listen port | 4433 | `--port` |
+| admin port | 8000 | `--admin-port` |
+| endpoint | `/moq-relay` | `--endpoint` |
+| MoQT drafts | 16,14,18 (server-pref order) | `--moqt-versions` |
+| IO threads | 4 | `--threads` |
+| congestion control | bbr | `--cc` |
+| object cache | on | `--cache` / `--no-cache` |
+| TLS | real cert under `DOMAIN`, else dev cert | `--insecure` / `--cert` / `--key` |
+
+Full option list: `./scripts/moqx-run.sh --help`.
+
+### Gotchas
+
+- **picoquic needs a *real* cert** (no insecure dev cert): `--quic-stack picoquic`
+  with `DOMAIN=...` (or `--cert/--key`).
+- `--no-sudo` is fine for insecure local runs; real TLS under `/etc/letsencrypt`
+  needs sudo to read the private key.
+- Check the relay is up: `curl http://localhost:8000/info`.
+
+### Logging (if you need it)
+
+- `-x ".=DBG4"` — verbose for **moqx's own** components (folly XLOG).
+- `-v 2` — verbose for the **QUIC/HTTP stack** underneath (mvfst/proxygen, glog).
+
+## Other scripts
+
+- [`perf-test.sh`](perf-test.sh) — relay throughput / subscriber-ramp perf test
+  (drives the relay via `moqx-run.sh`). See `./scripts/perf-test.sh` header for
+  options; short flags `-s`/`-d`/`-t`/`-l`/`-j` mirror the common ones.
+- [`config.bench.yaml`](config.bench.yaml) — the relay config template
+  `moqx-run.sh` renders.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ and serves it. Override anything with a flag or env var — you rarely need to.
 
 ```bash
 # local dev relay — built-in self-signed cert, no root needed
-./scripts/moqx-run.sh --insecure --no-sudo
+./scripts/moqx-run.sh --insecure
 ```
 
 Listens on **udp/4433** (MoQT), admin HTTP on **8000**, WebTransport endpoint
@@ -23,20 +23,20 @@ clients; draft-18-only clients get 18).
 ### The handful of commands you'll actually use
 
 ```bash
-# 1. Local dev (insecure, no sudo)
-./scripts/moqx-run.sh --insecure --no-sudo
+# 1. Local dev (insecure dev cert, no root needed)
+./scripts/moqx-run.sh --insecure
 
-# 2. Real TLS — Let's Encrypt cert under DOMAIN (sudo, to read the 0600 key)
-DOMAIN=relay.example.com ./scripts/moqx-run.sh
+# 2. Real TLS — Let's Encrypt cert under DOMAIN (add --sudo if the key is root-owned 0600)
+DOMAIN=relay.example.com ./scripts/moqx-run.sh --sudo
 
 # 3. Pin a single draft (e.g. force draft-18)
-./scripts/moqx-run.sh --insecure --no-sudo --moqt-versions 18
+./scripts/moqx-run.sh --insecure --moqt-versions 18
 
 # 4. Different port / endpoint
-./scripts/moqx-run.sh --insecure --no-sudo --port 5433 --endpoint /relay
+./scripts/moqx-run.sh --insecure --port 5433 --endpoint /relay
 
 # 5. Validate the config without serving
-./scripts/moqx-run.sh --subcmd validate-config --no-sudo
+./scripts/moqx-run.sh --subcmd validate-config
 
 # 6. Show the resolved config + exact command, run nothing
 ./scripts/moqx-run.sh -n
@@ -55,6 +55,7 @@ DOMAIN=relay.example.com ./scripts/moqx-run.sh
 | congestion control | bbr | `--cc` |
 | object cache | on | `--cache` / `--no-cache` |
 | TLS | real cert under `DOMAIN`, else dev cert | `--insecure` / `--cert` / `--key` |
+| sudo | off (runs as you) | `--sudo` (only for a root-owned key) |
 
 Full option list: `./scripts/moqx-run.sh --help`.
 
@@ -62,8 +63,8 @@ Full option list: `./scripts/moqx-run.sh --help`.
 
 - **picoquic needs a *real* cert** (no insecure dev cert): `--quic-stack picoquic`
   with `DOMAIN=...` (or `--cert/--key`).
-- `--no-sudo` is fine for insecure local runs; real TLS under `/etc/letsencrypt`
-  needs sudo to read the private key.
+- Runs without sudo by default. If your TLS key is root-owned (e.g. a
+  letsencrypt `0600 privkey.pem`), add `--sudo` so the relay can read it.
 - Check the relay is up: `curl http://localhost:8000/info`.
 
 ### Logging (if you need it)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -180,7 +180,7 @@ check_system_deps() {
           echo "  sudo apt-get install -y build-essential cmake ninja-build \\"
           echo "    libssl-dev libunwind-dev libgoogle-glog-dev libgflags-dev \\"
           echo "    libdouble-conversion-dev libevent-dev libsodium-dev libzstd-dev \\"
-          echo "    libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev gperf"
+          echo "    libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev gperf libbrotli-dev"
           ;;
         fedora|centos|rhel)
           echo "Install with:"

--- a/scripts/config.bench.yaml
+++ b/scripts/config.bench.yaml
@@ -67,7 +67,7 @@ listeners:
     moqt_versions: ${MOQX_MOQT_VERSIONS}
     udp:
       socket:
-        address: "::"
+        address: "${MOQX_BIND_ADDR}"
         port: ${MOQX_PORT}
     tls:
       cert_file: "${MOQX_CERT}"
@@ -106,5 +106,5 @@ service_defaults:
 
 admin:
   port: ${MOQX_ADMIN_PORT}
-  address: "::"
+  address: "${MOQX_BIND_ADDR}"
   plaintext: true

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -15,10 +15,13 @@ usage() {
 Usage: $(basename "$0") [options] [-- <extra args to moqx>]
 
 Logging (override .env/defaults):
+  -x, --xlog SPEC           folly XLOG config for moqx's own components, passed as
+                            --logging=SPEC. Primary logging (moqx standardizes on XLOG).
+  The -v/-L/-m flags below tune the underlying QUIC/HTTP stack (mvfst/proxygen/
+  fizz), which still logs via glog — kept until that stack moves to folly XLOG:
   -v, --verbose N           GLOG_v (0=off, 1-4 increasing detail)
   -L, --log-level N         GLOG_minloglevel (0=INFO 1=WARN 2=ERR 3=FATAL)
   -m, --vmodule SPEC        GLOG_vmodule (e.g. MoQSession=4,MoQForwarder=3)
-  -x, --xlog SPEC           folly XLOG config (passed as --logging=SPEC)
 
 Relay tuning (templated into the config; CLI > .env > default):
       --threads N           IO worker threads, must be >= 1 (default 4)
@@ -38,6 +41,8 @@ Listener (templated into the config; CLI > .env > default):
       --moqt-versions LIST  advertised MoQT drafts in server-preference order,
                             e.g. 16,14,18 (default 16,14,18; first listed wins).
                             Pass a single value (e.g. 18) to pin one draft.
+      --bind ADDR           bind address for the listener + admin (default 127.0.0.1;
+                            use :: or 0.0.0.0 to accept remote clients, e.g. cross-box bench)
       --port N              UDP listen port (default 4433)
       --admin-port N        admin HTTP port (default 8000)
       --endpoint PATH       WebTransport endpoint path (default /moq-relay)
@@ -67,7 +72,7 @@ Environment overrides (via .env or shell):
   MOQX_VERBOSE, MOQX_LOG_LEVEL, GLOG_vmodule, MOQX_JEMALLOC
   MOQX_THREADS, MOQX_UDP_BUFFER, MOQX_RECV_PKTS, MOQX_SEND_PKTS, MOQX_CC,
   MOQX_LOCAL_FWD, MOQX_CACHE, MOQX_BPF_STEERING, MOQX_IGNORE_PATH_MTU,
-  MOQX_RELAY_THREAD, MOQX_STACK, MOQX_MOQT_VERSIONS, MOQX_PORT, MOQX_ADMIN_PORT, MOQX_ENDPOINT,
+  MOQX_RELAY_THREAD, MOQX_STACK, MOQX_MOQT_VERSIONS, MOQX_BIND_ADDR, MOQX_PORT, MOQX_ADMIN_PORT, MOQX_ENDPOINT,
   MOQX_INSECURE, MOQX_CERT, MOQX_KEY, MOQX_MAX_TRACKS, MOQX_MAX_GROUPS,
   MOQX_RELAY_ID, MOQX_RESOLVED_CONFIG  (env-only; no CLI flag)
 
@@ -131,7 +136,7 @@ CLI_JEMALLOC=""   # "" = unset; "auto" or explicit path
 CLI_THREADS="" CLI_UDP_BUFFER="" CLI_RECV_PKTS="" CLI_SEND_PKTS="" CLI_CC=""
 CLI_LOCAL_FWD="" CLI_CACHE="" CLI_RELAY_THREAD="" CLI_INSECURE=""   # tri-state booleans
 CLI_IGNORE_PMTU="" CLI_BPF=""   # tri-state booleans
-CLI_STACK="" CLI_MOQT_VERSIONS="" CLI_PORT="" CLI_ADMIN_PORT="" CLI_ENDPOINT="" CLI_CERT="" CLI_KEY=""
+CLI_STACK="" CLI_MOQT_VERSIONS="" CLI_BIND="" CLI_PORT="" CLI_ADMIN_PORT="" CLI_ENDPOINT="" CLI_CERT="" CLI_KEY=""
 CHECK_SYSCTL=0 DRY_RUN=0
 PASSTHRU=()
 
@@ -156,6 +161,7 @@ while (($#)); do
     --bpf-steering)    CLI_BPF=true;         shift ;;
     --quic-stack)    CLI_STACK="$2"; shift 2 ;;
     --moqt-versions) CLI_MOQT_VERSIONS="$2"; shift 2 ;;
+    --bind)          CLI_BIND="$2"; shift 2 ;;
     --port)          CLI_PORT="$2"; shift 2 ;;
     --admin-port)    CLI_ADMIN_PORT="$2"; shift 2 ;;
     --endpoint)      CLI_ENDPOINT="$2"; shift 2 ;;
@@ -229,6 +235,9 @@ case "$MOQX_STACK" in mvfst|picoquic) ;; *) echo "invalid --quic-stack: $MOQX_ST
 # server-preference order — the relay picks the first listed version the client
 # also supports. Default offers d16, d14, then d18 as a fallback.
 export MOQX_MOQT_VERSIONS="$(norm_versions "${CLI_MOQT_VERSIONS:-${MOQX_MOQT_VERSIONS:-16,14,18}}")"
+# Bind address for the listener + admin. Local-safe default (127.0.0.1); set
+# :: / 0.0.0.0 (e.g. via perf-test.sh or --bind) to accept remote clients.
+export MOQX_BIND_ADDR="${CLI_BIND:-${MOQX_BIND_ADDR:-127.0.0.1}}"
 export MOQX_PORT="${CLI_PORT:-${MOQX_PORT:-4433}}"
 export MOQX_ADMIN_PORT="${CLI_ADMIN_PORT:-${MOQX_ADMIN_PORT:-8000}}"
 export MOQX_ENDPOINT="${CLI_ENDPOINT:-${MOQX_ENDPOINT:-/moq-relay}}"
@@ -271,6 +280,9 @@ RESOLVED_CONFIG="${MOQX_RESOLVED_CONFIG:-/tmp/moqx-resolved.yaml}"
 envsubst < "$CONFIG_TEMPLATE" > "$RESOLVED_CONFIG"
 
 # ── GLOG — map MOQX_* → GLOG_* (matches docker/entrypoint.sh convention) ─
+# TODO(folly-xlog): drop this block once the QUIC/HTTP stack (mvfst/proxygen/
+# fizz) logging moves to folly XLOG and glog leaves the link. Load-bearing
+# until then — it's the only knob for stack-level diagnostics.
 export GLOG_logtostderr=1
 export GLOG_colorlogtostderr=1
 export GLOG_minloglevel="${CLI_LOG_LEVEL:-${MOQX_LOG_LEVEL:-0}}"
@@ -309,7 +321,7 @@ CMD=("$MOQX_BIN" "$SUBCMD" --config "$RESOLVED_CONFIG" "${PASSTHRU[@]}")
 
 if (( DRY_RUN )); then
   echo "# relay knobs (templated into config)"
-  echo "relay_id=$MOQX_RELAY_ID stack=$MOQX_STACK moqt_versions=$MOQX_MOQT_VERSIONS port=$MOQX_PORT admin_port=$MOQX_ADMIN_PORT endpoint=$MOQX_ENDPOINT insecure=$MOQX_INSECURE"
+  echo "relay_id=$MOQX_RELAY_ID stack=$MOQX_STACK moqt_versions=$MOQX_MOQT_VERSIONS bind=$MOQX_BIND_ADDR port=$MOQX_PORT admin_port=$MOQX_ADMIN_PORT endpoint=$MOQX_ENDPOINT insecure=$MOQX_INSECURE"
   echo "resolved_config=$RESOLVED_CONFIG"
   echo "threads=$MOQX_THREADS relay_thread=$MOQX_RELAY_THREAD local_fwd=$MOQX_LOCAL_FWD bpf_steering=$MOQX_BPF_STEERING cache=$MOQX_CACHE"
   echo "cc=$MOQX_CC send_pkts=$MOQX_SEND_PKTS recv_pkts=$MOQX_RECV_PKTS udp_buffer=$MOQX_UDP_BUFFER ignore_path_mtu=$MOQX_IGNORE_PATH_MTU"

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -21,7 +21,9 @@ Logging (override .env/defaults):
   fizz), which still logs via glog — kept until that stack moves to folly XLOG:
   -v, --verbose N           GLOG_v (0=off, 1-4 increasing detail)
   -L, --log-level N         GLOG_minloglevel (0=INFO 1=WARN 2=ERR 3=FATAL)
-  -m, --vmodule SPEC        GLOG_vmodule (e.g. MoQSession=4,MoQForwarder=3)
+  -m, --vmodule SPEC        GLOG_vmodule — per-source-file glog VLOG for the stack
+                            (e.g. Acceptor=4,SSLContextManager=2). moqx/moxygen
+                            components log via XLOG: use -x for those, not -m.
 
 Relay tuning (templated into the config; CLI > .env > default):
       --threads N           IO worker threads, must be >= 1 (default 4)
@@ -287,7 +289,10 @@ export GLOG_logtostderr=1
 export GLOG_colorlogtostderr=1
 export GLOG_minloglevel="${CLI_LOG_LEVEL:-${MOQX_LOG_LEVEL:-0}}"
 export GLOG_v="${CLI_VERBOSE:-${MOQX_VERBOSE:-0}}"
-export GLOG_vmodule="${CLI_VMODULE:-${GLOG_vmodule:-MoqxRelay=3,MoQSession=3,MoQForwarder=3,MoqxCache=2}}"
+# Default empty: GLOG_v already sets global stack VLOG; vmodule only targets
+# specific stack source files (glog VLOG). The old default named moqx/moxygen
+# components, which log via folly XLOG (-x), so it filtered nothing.
+export GLOG_vmodule="${CLI_VMODULE:-${GLOG_vmodule:-}}"
 
 # ── jemalloc resolution (CLI > env) ──────────────────────────────────────
 JEMALLOC_REQ="${CLI_JEMALLOC:-${MOQX_JEMALLOC:-}}"

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -56,7 +56,9 @@ Execution:
                             Bare flag auto-detects libjemalloc.so.2.
       --check-sysctl        report current vs recommended UDP/network sysctls
                             (with the commands to raise them) and exit
-      --no-sudo             run without sudo (cert files must be user-readable)
+      --sudo                run the relay under sudo (only needed to read a
+                            root-owned key, e.g. letsencrypt's 0600 privkey;
+                            default is no sudo)
   -n, --dry-run             print resolved env + command, don't exec
   -h, --help                this help
 
@@ -74,7 +76,8 @@ Examples:
   $0 --threads 8 --udp-buffer 16777216     # 8 IO threads, 16 MB socket buffer
   $0 --recv-pkts 256 -j                    # Alan's recv loop + jemalloc
   $0 --check-sysctl                        # audit kernel UDP buffers, then exit
-  $0 --subcmd validate-config --no-sudo    # just validate the config
+  $0 --subcmd validate-config              # just validate the config
+  DOMAIN=relay.example.com $0 --sudo       # real TLS, root-owned letsencrypt key
   $0 -n                                    # show what would run
 EOF
 }
@@ -168,7 +171,7 @@ while (($#)); do
       if [[ -n "${2:-}" && "$2" != -* ]]; then CLI_JEMALLOC="$2"; shift 2
       else CLI_JEMALLOC="auto"; shift; fi ;;
     --check-sysctl)  CHECK_SYSCTL=1; shift ;;
-    --no-sudo)       CLI_USE_SUDO=0; shift ;;
+    --sudo)          CLI_USE_SUDO=1; shift ;;
     -n|--dry-run)    DRY_RUN=1; shift ;;
     -h|--help)       usage; exit 0 ;;
     --)              shift; PASSTHRU+=("$@"); break ;;
@@ -301,7 +304,7 @@ fi
 
 # ── Run ──────────────────────────────────────────────────────────────────
 SUBCMD="${CLI_SUBCMD:-${MOQX_SUBCMD:-serve}}"
-USE_SUDO="${CLI_USE_SUDO:-${MOQX_USE_SUDO:-1}}"
+USE_SUDO="${CLI_USE_SUDO:-${MOQX_USE_SUDO:-0}}"
 CMD=("$MOQX_BIN" "$SUBCMD" --config "$RESOLVED_CONFIG" "${PASSTHRU[@]}")
 
 if (( DRY_RUN )); then
@@ -341,6 +344,10 @@ if [[ "$SUBCMD" == serve && "$MOQX_INSECURE" == false ]]; then
   for f in "$MOQX_CERT" "$MOQX_KEY"; do
     "${probe[@]}" "$f" 2>/dev/null || {
       echo "error: TLS cert/key not readable: $f" >&2
+      if [[ -e "$f" ]]; then
+        echo "  - file exists but isn't readable as $(id -un); if it's root-owned (e.g." >&2
+        echo "    letsencrypt's 0600 privkey), re-run with --sudo" >&2
+      fi
       echo "  - check DOMAIN spelling — it names the /etc/letsencrypt/live/<dir>, not the served host" >&2
       echo "    (a wildcard *.example.com cert lives under the 'example.com' dir)" >&2
       echo "  - or pass --cert/--key explicitly, or --insecure for the built-in dev cert" >&2

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -244,10 +244,11 @@ echo ""
 ulimit -n 65536 2>/dev/null || true
 echo "Starting relay (use_relay_thread=$USE_RELAY_THREAD, local_forwarders=$USE_LOCAL_FORWARDERS, io_threads=$IO_THREADS, transport=$TRANSPORT, mvfst_bpf_steering=$BPF_STEERING)..."
 
-# Map perf knobs -> moqx-run.sh. --no-sudo is REQUIRED: moqx-run execs the relay,
-# so under sudo $! would be the sudo PID and perf -p would profile sudo, not moqx.
+# Map perf knobs -> moqx-run.sh. moqx-run runs without sudo by default (do NOT
+# set MOQX_USE_SUDO=1 / pass --sudo here): it execs the relay, so under sudo $!
+# would be the sudo PID and perf -p would profile sudo, not moqx.
 RELAY_RUN_ARGS=(
-  --no-sudo --insecure --no-cache --ignore-path-mtu
+  --insecure --no-cache --ignore-path-mtu
   --bin        "$BINARY"
   --port       "$RELAY_PORT"
   --admin-port "$RELAY_ADMIN_PORT"

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -250,6 +250,7 @@ echo "Starting relay (use_relay_thread=$USE_RELAY_THREAD, local_forwarders=$USE_
 RELAY_RUN_ARGS=(
   --insecure --no-cache --ignore-path-mtu
   --bin        "$BINARY"
+  --bind       "::"        # all interfaces: the perf client may run on another box
   --port       "$RELAY_PORT"
   --admin-port "$RELAY_ADMIN_PORT"
   --endpoint   "$ENDPOINT"


### PR DESCRIPTION
Scripts, launcher, and onboarding cleanup. (The empty-address config crash fix moved to its own PR, #461, so this branch stays scripts/docs-only and doesn't overlap the resolver.)

### 1. `scripts/README.md` (new)
Short quickstart for running/benchmarking a moqx relay via `moqx-run.sh` + `config.bench.yaml`: the one-liner, the commands you'll actually use, defaults table, gotchas, and the two-layer logging note (`-x` for moqx's own components, `-v` for the QUIC/HTTP stack).

### 2. Default the relay to no-sudo (`--sudo` to opt in)
Running as yourself is the common case (insecure dev, perf bench, `validate-config`, containers, non-root keys). Sudo is now opt-in via `--sudo`. `perf-test.sh` drops the now-redundant `--no-sudo`.

### 3. Bind-address knob + logging help cleanup
`moqx-run.sh` gains `--bind ADDR` / `MOQX_BIND_ADDR` (default `127.0.0.1`, local-safe). `config.bench.yaml` templates the listener + admin address from it instead of hardcoding `"::"`; `perf-test.sh` passes `--bind ::` so benches keep binding all interfaces (cross-box). The `--help` Logging section now leads with `-x/--xlog` (folly XLOG, primary) and scopes `GLOG_*` as the underlying stack (mvfst/proxygen/fizz); the inert `GLOG_vmodule` default (it named XLOG components, which emit no glog VLOG) is dropped, and a `TODO(folly-xlog)` signpost added.

### 4. Onboarding fixes (#441, #391)
- README/BUILD: `git submodule update --init --recursive` (nested submodules like catapult are required).
- `.gitignore`: ignore `/.docker-deps/` and `AGENTS.md`.

(Note: #441 also mentioned `libbrotli-dev` — intentionally not added. It's optional, not required: picotls auto-detects it via pkg-config and only enables brotli cert compression when present; the build succeeds without it. See the #441 comment.)

---
Related: #461 (empty/unresolvable bind-address crash fix, #459). PKCS#12 PR #460 is stacked on this branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/456)
<!-- Reviewable:end -->
