### PR TITLE
tls: PKCS#12 bundle support (in-memory, cloud-vault-friendly)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,7 @@ add_library(moqx_config_loader STATIC
   src/config/Loader.cpp
   src/config/ConfigResolver.cpp
   src/config/ConfigInit.cpp
+  src/config/Pkcs12.cpp
 )
 
 target_include_directories(moqx_config_loader
@@ -241,6 +242,9 @@ target_link_libraries(moqx_config_loader PUBLIC
   yaml-cpp
   Folly::folly_file_util
 )
+
+# PKCS#12 transcode (Pkcs12.cpp) + OPENSSL_cleanse in ConfigResolver.cpp.
+target_link_libraries(moqx_config_loader PRIVATE OpenSSL::Crypto)
 
 target_compile_options(moqx_config_loader PRIVATE -Wall -Wextra -Wpedantic)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,8 +243,12 @@ target_link_libraries(moqx_config_loader PUBLIC
   Folly::folly_file_util
 )
 
-# PKCS#12 transcode (Pkcs12.cpp) + OPENSSL_cleanse in ConfigResolver.cpp.
-target_link_libraries(moqx_config_loader PRIVATE OpenSSL::Crypto)
+# PKCS#12 transcode (Pkcs12.cpp) + OPENSSL_cleanse in ConfigResolver.cpp;
+# folly cert utils supplies OpenSSLCertUtils::pemEncode.
+target_link_libraries(moqx_config_loader PRIVATE
+  OpenSSL::Crypto
+  Folly::folly_ssl_openssl_cert_utils
+)
 
 target_compile_options(moqx_config_loader PRIVATE -Wall -Wextra -Wpedantic)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,6 +10,13 @@ listeners:
     tls:
       # cert_file: /path/to/cert.pem   # Required when insecure: false
       # key_file: /path/to/key.pem     # Required when insecure: false
+      # --- PKCS#12 bundle (alternative to cert_file/key_file) ---
+      # A single .p12/.pfx carrying the cert chain + private key. Decrypted in
+      # memory; the key is never written to disk. Mutually exclusive with
+      # cert_file/key_file. Not yet supported on quic_stack: picoquic.
+      # pkcs12_file: /path/to/bundle.p12
+      # pkcs12_password_file: /path/to/password.txt  # Preferred: keep the secret off the YAML
+      # pkcs12_password: "inline-secret"             # Discouraged: persists in the config at rest
       insecure: true          # Skip TLS for local development
     endpoint: "/moq-relay"    # WebTransport endpoint path
     # moqt_versions: [14, 16] # MOQT draft versions (empty = default 14,16)
@@ -82,6 +89,9 @@ admin:
   # tls:
   #   cert_file: /path/to/cert.pem
   #   key_file: /path/to/key.pem
+  #   # Or a PKCS#12 bundle (mutually exclusive with cert_file/key_file; decrypted in memory):
+  #   # pkcs12_file: /path/to/bundle.p12
+  #   # pkcs12_password_file: /path/to/password.txt
 
 logging:                    # Logging configuration (optional)
   mlog:                     # MoQ-level structured logging

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,7 @@ listeners:
       # cert_file/key_file. Not yet supported on quic_stack: picoquic.
       # pkcs12_file: /path/to/bundle.p12
       # pkcs12_password_file: /path/to/password.txt  # Preferred: keep the secret off the YAML
+      # pkcs12_password_env: MOQX_PKCS12_PASSWORD    # Cloud-vault friendly: read the password from this env var
       # pkcs12_password: "inline-secret"             # Discouraged: persists in the config at rest
       insecure: true          # Skip TLS for local development
     endpoint: "/moq-relay"    # WebTransport endpoint path

--- a/scripts/moqx-run.sh
+++ b/scripts/moqx-run.sh
@@ -77,6 +77,10 @@ Environment overrides (via .env or shell):
   MOQX_RELAY_THREAD, MOQX_STACK, MOQX_MOQT_VERSIONS, MOQX_BIND_ADDR, MOQX_PORT, MOQX_ADMIN_PORT, MOQX_ENDPOINT,
   MOQX_INSECURE, MOQX_CERT, MOQX_KEY, MOQX_MAX_TRACKS, MOQX_MAX_GROUPS,
   MOQX_RELAY_ID, MOQX_RESOLVED_CONFIG  (env-only; no CLI flag)
+  MOQX_PKCS12_PASSWORD  (env-only; PKCS#12 bundle password. Forwarded to the relay
+                         process and across sudo, but NEVER written into the resolved
+                         config. Reference it in your config as:
+                         pkcs12_password_env: MOQX_PKCS12_PASSWORD)
 
 Examples:
   $0                                       # serve with .env + defaults
@@ -334,6 +338,11 @@ if (( DRY_RUN )); then
   echo "GLOG_minloglevel=$GLOG_minloglevel GLOG_v=$GLOG_v"
   echo "GLOG_vmodule=$GLOG_vmodule"
   echo "LD_PRELOAD=${JEMALLOC:-<none>}"
+  if [[ -n "${MOQX_PKCS12_PASSWORD:-}" ]]; then
+    echo "MOQX_PKCS12_PASSWORD=<set> (forwarded to relay; value hidden)"
+  else
+    echo "MOQX_PKCS12_PASSWORD=<unset>"
+  fi
   echo "# resolved config: $RESOLVED_CONFIG (from $CONFIG_TEMPLATE)"
   echo "# command"
   if (( USE_SUDO )); then
@@ -384,8 +393,13 @@ if (( USE_SUDO )); then
     GLOG_colorlogtostderr="$GLOG_colorlogtostderr"
   )
   [[ -n "$JEMALLOC" ]] && SUDO_ENV+=("LD_PRELOAD=$JEMALLOC")
+  # Forward the PKCS#12 password across the sudo boundary (env_reset strips any
+  # var not listed here). It is never written into the resolved config.
+  [[ -n "${MOQX_PKCS12_PASSWORD:-}" ]] && SUDO_ENV+=("MOQX_PKCS12_PASSWORD=$MOQX_PKCS12_PASSWORD")
   exec sudo "${SUDO_ENV[@]}" "${CMD[@]}"
 else
   [[ -n "$JEMALLOC" ]] && export LD_PRELOAD="$JEMALLOC"
+  # Ensure the relay child inherits the PKCS#12 password if one is set.
+  [[ -n "${MOQX_PKCS12_PASSWORD:-}" ]] && export MOQX_PKCS12_PASSWORD
   exec "${CMD[@]}"
 fi

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -38,13 +38,10 @@ std::vector<std::string> buildAlpns(const std::string& versions) {
   return alpns;
 }
 
-// Build a FizzServerContext from in-memory PEM buffers (cert chain + key)
-// instead of file paths, so a PKCS#12-derived private key never touches disk.
-// This mirrors quic::samples::createFizzServerContextImpl (proxygen hq sample,
-// minus the insecure-default branch) so a pkcs12-sourced context behaves
-// identically to the PEM-file one (session tickets, resumption, ALPN mode).
-// Keep in sync with that helper if it changes upstream. TODO: replace with a
-// buffer-based helper in the moxygen fork to avoid duplicating this logic.
+// Build a FizzServerContext from in-memory PEM buffers so a PKCS#12-derived key
+// never touches disk. Mirrors quic::samples::createFizzServerContextImpl (the
+// path-based sample helper) to match the PEM-file path's TLS behavior.
+// TODO(#482): replace with a buffer-based helper in the moxygen fork.
 std::shared_ptr<const fizz::server::FizzServerContext> buildFizzContextFromMaterial(
     const std::vector<std::string>& alpns,
     fizz::server::ClientAuthMode clientAuth,

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -12,10 +12,18 @@
 #include <moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h>
 #include <proxygen/httpserver/samples/hq/FizzContext.h>
 
+#include <fizz/backend/openssl/certificate/CertUtils.h>
+#include <fizz/server/AeadTicketCipher.h>
+#include <fizz/server/DefaultCertManager.h>
+#include <fizz/server/ReplayCache.h>
+#include <fizz/server/TicketCodec.h>
+#include <fizz/util/Status.h>
 #include <folly/Random.h>
 #include <folly/logging/xlog.h>
 #include <quic/QuicConstants.h>
 #include <quic/logging/FileQLogger.h>
+
+#include <array>
 
 using namespace moxygen;
 
@@ -28,6 +36,52 @@ std::vector<std::string> buildAlpns(const std::string& versions) {
   auto moqt = getMoqtProtocols(versions, true);
   alpns.insert(alpns.end(), moqt.begin(), moqt.end());
   return alpns;
+}
+
+// Build a FizzServerContext from in-memory PEM buffers (cert chain + key)
+// instead of file paths, so a PKCS#12-derived private key never touches disk.
+// This mirrors quic::samples::createFizzServerContextImpl (proxygen hq sample,
+// minus the insecure-default branch) so a pkcs12-sourced context behaves
+// identically to the PEM-file one (session tickets, resumption, ALPN mode).
+// Keep in sync with that helper if it changes upstream. TODO: replace with a
+// buffer-based helper in the moxygen fork to avoid duplicating this logic.
+std::shared_ptr<const fizz::server::FizzServerContext> buildFizzContextFromMaterial(
+    const std::vector<std::string>& alpns,
+    fizz::server::ClientAuthMode clientAuth,
+    const std::string& certChainPem,
+    const std::string& keyPem
+) {
+  std::unique_ptr<fizz::SelfCert> cert;
+  fizz::Error err;
+  FIZZ_THROW_ON_ERROR(fizz::openssl::CertUtils::makeSelfCert(cert, err, certChainPem, keyPem), err);
+  auto certManager = std::make_shared<fizz::server::DefaultCertManager>();
+  certManager->addCertAndSetDefault(std::move(cert));
+
+  auto ctx = std::make_shared<fizz::server::FizzServerContext>();
+  ctx->setCertManager(certManager);
+  auto ticketCipher = std::make_shared<fizz::server::Aead128GCMTicketCipher<
+      fizz::server::TicketCodec<fizz::server::CertificateStorage::X509>>>(
+      ctx->getFactoryPtr(),
+      std::move(certManager)
+  );
+  std::array<uint8_t, 32> ticketSeed;
+  folly::Random::secureRandom(ticketSeed.data(), ticketSeed.size());
+  ticketCipher->setTicketSecrets({{folly::range(ticketSeed)}});
+  ctx->setTicketCipher(ticketCipher);
+  ctx->setClientAuthMode(clientAuth);
+  ctx->setSupportedAlpns(alpns);
+  ctx->setAlpnMode(fizz::server::AlpnMode::Required);
+  ctx->setSendNewSessionTicket(true);
+  ctx->setEarlyDataFbOnly(false);
+  ctx->setVersionFallbackEnabled(false);
+
+  fizz::server::ClockSkewTolerance tolerance;
+  tolerance.before = std::chrono::minutes(-5);
+  tolerance.after = std::chrono::minutes(5);
+  std::shared_ptr<fizz::server::ReplayCache> replayCache =
+      std::make_shared<fizz::server::AllowAllReplayReplayCache>();
+  ctx->setEarlyDataSettings(true, tolerance, std::move(replayCache));
+  return ctx;
 }
 
 std::shared_ptr<const fizz::server::FizzServerContext>
@@ -44,6 +98,16 @@ buildFizzContext(const config::ListenerConfig& cfg) {
               ""
           );
         } else {
+          // PKCS#12 source: build the context from the in-memory PEM material
+          // (cert/key never written to disk).
+          if (tls.material.has_value()) {
+            return buildFizzContextFromMaterial(
+                alpns,
+                fizz::server::ClientAuthMode::Optional,
+                tls.material->certChainPem,
+                tls.material->keyPem
+            );
+          }
           // createFizzServerContext throws (deep in fizz) when the cert/key
           // can't be read or contain no certificate. Enrich the message with
           // the offending paths so the caller can report it cleanly instead of

--- a/src/admin/AdminServer.cpp
+++ b/src/admin/AdminServer.cpp
@@ -122,7 +122,13 @@ bool AdminServer::start(const config::AdminConfig& adminConfig) {
     const auto& tls = *adminConfig.tls;
     wangle::SSLContextConfig sslCtx;
     sslCtx.isDefault = true;
-    sslCtx.setCertificate(tls.certFile, tls.keyFile, "");
+    // PKCS#12 source: load cert chain + key from in-memory PEM buffers so the
+    // decrypted key never touches disk; otherwise load from the configured paths.
+    if (tls.material.has_value()) {
+      sslCtx.setCertificateBuf(tls.material->certChainPem, tls.material->keyPem);
+    } else {
+      sslCtx.setCertificate(tls.certFile, tls.keyFile, "");
+    }
     sslCtx.clientVerification = folly::SSLContext::VerifyClientCertificate::DO_NOT_REQUEST;
     sslCtx.setNextProtocols(std::list<std::string>(tls.alpn.begin(), tls.alpn.end()));
     cfg.sslConfigs.push_back(std::move(sslCtx));

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -23,10 +23,22 @@
 // build until you do. See docs/dev/config.md ("How to add a new config field").
 namespace openmoq::moqx::config {
 
+// Resolved, in-memory TLS material produced by transcoding a PKCS#12 bundle
+// (cert chain + private key) without touching disk. The keyPem is unencrypted
+// and lives only in process memory; never log it or write it out.
+struct TlsMaterial {
+  std::string certChainPem; // leaf + intermediates, concatenated PEM
+  std::string keyPem;       // unencrypted private key PEM
+};
+
 struct TlsConfig {
   std::string certFile;
   std::string keyFile;
   std::vector<std::string> alpn; // must be empty for QUIC listener: ALPN derived from moqt_versions
+  // When set (PKCS#12 source), consumers build their TLS context from these
+  // in-memory PEM buffers instead of reading certFile/keyFile from disk.
+  // certFile/keyFile are empty in that case.
+  std::optional<TlsMaterial> material;
 };
 
 struct Insecure {};

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -6,6 +6,7 @@
 
 #include "config/loader/ConfigResolver.h"
 
+#include <cstdlib>
 #include <filesystem>
 #include <iomanip>
 #include <random>
@@ -89,12 +90,20 @@ void validatePkcs12PasswordExclusivity(
     std::string_view context,
     std::vector<std::string>& errors
 ) {
-  bool hasPwInline = tls.pkcs12_password.value().has_value();
-  bool hasPwFile =
-      tls.pkcs12_password_file.value().has_value() && !tls.pkcs12_password_file.value()->empty();
-  if (hasPwInline && hasPwFile) {
+  int sources = 0;
+  if (tls.pkcs12_password.value().has_value()) {
+    ++sources;
+  }
+  if (tls.pkcs12_password_file.value().has_value() && !tls.pkcs12_password_file.value()->empty()) {
+    ++sources;
+  }
+  if (tls.pkcs12_password_env.value().has_value() && !tls.pkcs12_password_env.value()->empty()) {
+    ++sources;
+  }
+  if (sources > 1) {
     errors.push_back(
-        std::string(context) + ": set only one of pkcs12_password or pkcs12_password_file"
+        std::string(context) +
+        ": set only one of pkcs12_password, pkcs12_password_file, or pkcs12_password_env"
     );
   }
 }
@@ -172,12 +181,14 @@ TlsConfig resolveAdminTlsConfig(
   };
 }
 
-// Resolve the PKCS#12 password from a file or inline value. Exactly one (or
-// neither, for a password-less bundle) is expected; structural validation
-// enforces not-both. Returns the password, possibly empty.
+// Resolve the PKCS#12 password from a file, environment variable, or inline
+// value. Exactly one (or none, for a password-less bundle) is expected;
+// structural validation enforces not-more-than-one. Returns the password,
+// possibly empty.
 folly::Expected<std::string, std::string> resolvePkcs12Password(
     const std::optional<std::string>& inlinePw,
-    const std::optional<std::string>& pwFile
+    const std::optional<std::string>& pwFile,
+    const std::optional<std::string>& pwEnv
 ) {
   if (pwFile.has_value() && !pwFile->empty()) {
     std::string pw;
@@ -194,6 +205,15 @@ folly::Expected<std::string, std::string> resolvePkcs12Password(
     // Value and error types are both std::string, so construct explicitly to
     // disambiguate the success path from makeUnexpected.
     return folly::makeExpected<std::string>(std::move(pw));
+  }
+  if (pwEnv.has_value() && !pwEnv->empty()) {
+    const char* val = std::getenv(pwEnv->c_str());
+    if (val == nullptr) {
+      return folly::makeUnexpected(
+          "environment variable '" + *pwEnv + "' (pkcs12_password_env) is not set"
+      );
+    }
+    return folly::makeExpected<std::string>(std::string(val));
   }
   if (inlinePw.has_value()) {
     return folly::makeExpected<std::string>(*inlinePw);
@@ -231,7 +251,11 @@ std::optional<TlsMaterial> resolvePkcs12Material(
         "prefer pkcs12_password_file"
     );
   }
-  auto pw = resolvePkcs12Password(tls.pkcs12_password.value(), tls.pkcs12_password_file.value());
+  auto pw = resolvePkcs12Password(
+      tls.pkcs12_password.value(),
+      tls.pkcs12_password_file.value(),
+      tls.pkcs12_password_env.value()
+  );
   if (pw.hasError()) {
     errors.push_back(context + ": " + pw.error());
     return std::nullopt;

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -13,8 +13,13 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <folly/FileUtil.h>
 #include <folly/SocketAddress.h>
 #include <folly/String.h>
+
+#include <openssl/crypto.h>
+
+#include "config/Pkcs12.h"
 
 namespace openmoq::moqx::config {
 
@@ -76,6 +81,24 @@ mergeCacheConfigs(const ParsedCacheConfig& base, const ParsedCacheConfig& overla
   return merged;
 }
 
+// Both ParsedListenerTlsConfig and ParsedAdminTlsConfig expose identically-named
+// pkcs12_* fields; this template validates the password-source fields for either.
+template <typename T>
+void validatePkcs12PasswordExclusivity(
+    const T& tls,
+    std::string_view context,
+    std::vector<std::string>& errors
+) {
+  bool hasPwInline = tls.pkcs12_password.value().has_value();
+  bool hasPwFile =
+      tls.pkcs12_password_file.value().has_value() && !tls.pkcs12_password_file.value()->empty();
+  if (hasPwInline && hasPwFile) {
+    errors.push_back(
+        std::string(context) + ": set only one of pkcs12_password or pkcs12_password_file"
+    );
+  }
+}
+
 void validateListenerTlsConfig(
     const ParsedListenerTlsConfig& tls,
     std::string_view context,
@@ -84,15 +107,28 @@ void validateListenerTlsConfig(
 ) {
   bool hasCert = tls.cert_file.value().has_value() && !tls.cert_file.value()->empty();
   bool hasKey = tls.key_file.value().has_value() && !tls.key_file.value()->empty();
-  if (!tls.insecure.value()) {
-    if (!hasCert || !hasKey) {
-      errors.push_back(
-          std::string(context) + ": cert_file and key_file are required when insecure=false"
+  bool hasPkcs12 = tls.pkcs12_file.value().has_value() && !tls.pkcs12_file.value()->empty();
+
+  if (tls.insecure.value()) {
+    if (hasCert || hasKey || hasPkcs12) {
+      warnings.push_back(
+          std::string(context) + ": cert_file/key_file/pkcs12_file are ignored when insecure=true"
       );
     }
-  } else if (hasCert || hasKey) {
-    warnings.push_back(
-        std::string(context) + ": cert_file/key_file are ignored when insecure=true"
+    return;
+  }
+
+  if (hasPkcs12) {
+    if (hasCert || hasKey) {
+      errors.push_back(
+          std::string(context) + ": pkcs12_file is mutually exclusive with cert_file/key_file"
+      );
+    }
+    validatePkcs12PasswordExclusivity(tls, context, errors);
+  } else if (!hasCert || !hasKey) {
+    errors.push_back(
+        std::string(context) +
+        ": cert_file and key_file (or pkcs12_file) are required when insecure=false"
     );
   }
 }
@@ -100,28 +136,115 @@ void validateListenerTlsConfig(
 void validateAdminTlsConfig(const ParsedAdminTlsConfig& tls, std::vector<std::string>& errors) {
   bool hasCert = tls.cert_file.value().has_value() && !tls.cert_file.value()->empty();
   bool hasKey = tls.key_file.value().has_value() && !tls.key_file.value()->empty();
-  if (!hasCert || !hasKey) {
-    errors.push_back("admin.tls: cert_file and key_file are required");
+  bool hasPkcs12 = tls.pkcs12_file.value().has_value() && !tls.pkcs12_file.value()->empty();
+  if (hasPkcs12) {
+    if (hasCert || hasKey) {
+      errors.push_back("admin.tls: pkcs12_file is mutually exclusive with cert_file/key_file");
+    }
+    validatePkcs12PasswordExclusivity(tls, "admin.tls", errors);
+  } else if (!hasCert || !hasKey) {
+    errors.push_back("admin.tls: cert_file and key_file (or pkcs12_file) are required");
   }
 }
 
-TlsConfig resolveTlsConfig(const ParsedListenerTlsConfig& tls) {
+TlsConfig
+resolveTlsConfig(const ParsedListenerTlsConfig& tls, std::optional<TlsMaterial> material) {
+  const bool hasMaterial = material.has_value();
   return TlsConfig{
-      .certFile = tls.cert_file.value().value_or(""),
-      .keyFile = tls.key_file.value().value_or(""),
+      .certFile = hasMaterial ? std::string{} : tls.cert_file.value().value_or(""),
+      .keyFile = hasMaterial ? std::string{} : tls.key_file.value().value_or(""),
       .alpn = {},
+      .material = std::move(material),
   };
 }
 
 TlsConfig resolveAdminTlsConfig(
     const ParsedAdminTlsConfig& tls,
-    const std::vector<std::string>& defaultAlpn
+    const std::vector<std::string>& defaultAlpn,
+    std::optional<TlsMaterial> material
 ) {
+  const bool hasMaterial = material.has_value();
   return TlsConfig{
-      .certFile = tls.cert_file.value().value_or(""),
-      .keyFile = tls.key_file.value().value_or(""),
+      .certFile = hasMaterial ? std::string{} : tls.cert_file.value().value_or(""),
+      .keyFile = hasMaterial ? std::string{} : tls.key_file.value().value_or(""),
       .alpn = tls.alpn.value().value_or(defaultAlpn),
+      .material = std::move(material),
   };
+}
+
+// Resolve the PKCS#12 password from a file or inline value. Exactly one (or
+// neither, for a password-less bundle) is expected; structural validation
+// enforces not-both. Returns the password, possibly empty.
+folly::Expected<std::string, std::string> resolvePkcs12Password(
+    const std::optional<std::string>& inlinePw,
+    const std::optional<std::string>& pwFile
+) {
+  if (pwFile.has_value() && !pwFile->empty()) {
+    std::string pw;
+    if (!folly::readFile(pwFile->c_str(), pw)) {
+      return folly::makeUnexpected("failed to read pkcs12_password_file '" + *pwFile + "'");
+    }
+    // Strip a single trailing CR/LF (common when the file ends with a newline).
+    if (!pw.empty() && pw.back() == '\n') {
+      pw.pop_back();
+    }
+    if (!pw.empty() && pw.back() == '\r') {
+      pw.pop_back();
+    }
+    // Value and error types are both std::string, so construct explicitly to
+    // disambiguate the success path from makeUnexpected.
+    return folly::makeExpected<std::string>(std::move(pw));
+  }
+  if (inlinePw.has_value()) {
+    return folly::makeExpected<std::string>(*inlinePw);
+  }
+  return folly::makeExpected<std::string>(std::string{});
+}
+
+// Transcode the configured PKCS#12 bundle into in-memory PEM material. Returns
+// nullopt when no pkcs12_file is set. On any failure, pushes a descriptive error
+// (prefixed with context) and returns nullopt. The resolved password copy is
+// wiped before returning. T is ParsedListenerTlsConfig or ParsedAdminTlsConfig.
+template <typename T>
+std::optional<TlsMaterial> resolvePkcs12Material(
+    const T& tls,
+    const std::string& context,
+    std::vector<std::string>& errors,
+    std::vector<std::string>& warnings
+) {
+  const auto& pkcs12File = tls.pkcs12_file.value();
+  if (!pkcs12File.has_value() || pkcs12File->empty()) {
+    return std::nullopt;
+  }
+  // If cert_file/key_file are also set, validation already reports the
+  // mutual-exclusion error; skip transcoding to avoid a confusing secondary
+  // decrypt failure.
+  bool hasCert = tls.cert_file.value().has_value() && !tls.cert_file.value()->empty();
+  bool hasKey = tls.key_file.value().has_value() && !tls.key_file.value()->empty();
+  if (hasCert || hasKey) {
+    return std::nullopt;
+  }
+  if (tls.pkcs12_password.value().has_value()) {
+    warnings.push_back(
+        context +
+        ": inline pkcs12_password is discouraged (it persists in the plaintext config at rest); "
+        "prefer pkcs12_password_file"
+    );
+  }
+  auto pw = resolvePkcs12Password(tls.pkcs12_password.value(), tls.pkcs12_password_file.value());
+  if (pw.hasError()) {
+    errors.push_back(context + ": " + pw.error());
+    return std::nullopt;
+  }
+  auto material = loadPkcs12File(*pkcs12File, *pw);
+  if (!pw->empty()) {
+    OPENSSL_cleanse(pw->data(), pw->size());
+  }
+  if (material.hasError()) {
+    errors.push_back(context + ": " + material.error());
+    return std::nullopt;
+  }
+  return std::move(*material);
 }
 
 CacheConfig resolveCacheConfig(const ParsedCacheConfig& cache) {
@@ -229,6 +352,14 @@ void validateListener(
     errors.push_back(
         "Listener '" + listener.name.value() +
         "': quic_stack \"picoquic\" requires real TLS credentials (insecure: true is not supported)"
+    );
+  }
+  const auto& pkcs12File = listener.tls.value().pkcs12_file.value();
+  if (stackOpt.value_or(kStackMvfst) == kStackPicoquic && pkcs12File.has_value() &&
+      !pkcs12File->empty()) {
+    errors.push_back(
+        "Listener '" + listener.name.value() +
+        "': quic_stack \"picoquic\" does not support pkcs12_file yet; use cert_file/key_file"
     );
   }
 }
@@ -789,7 +920,8 @@ void validatePicoServicePaths(
 ListenerConfig resolveListener(
     const ParsedListenerConfig& listener,
     const QuicConfig& quic,
-    const MvfstConfig& mvfst
+    const MvfstConfig& mvfst,
+    std::optional<TlsMaterial> material
 ) {
   const auto& sock = listener.udp.value().socket.value();
   const auto& tls = listener.tls.value();
@@ -798,7 +930,7 @@ ListenerConfig resolveListener(
   if (tls.insecure.value()) {
     tlsMode = Insecure{};
   } else {
-    tlsMode = resolveTlsConfig(tls);
+    tlsMode = resolveTlsConfig(tls, std::move(material));
   }
 
   const auto& stackStr = listener.quic_stack.value().value_or(kStackMvfst);
@@ -885,10 +1017,23 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
 
   std::vector<QuicConfig> mergedQuicConfigs;
   std::vector<MvfstConfig> mergedMvfstConfigs;
+  std::vector<std::optional<TlsMaterial>> listenerTlsMaterials;
   {
     std::unordered_set<std::string> listenerAddrs;
     for (const auto& listener : config.listeners.value()) {
       validateListener(listener, errors, warnings);
+      // Transcode any PKCS#12 bundle now (skipped for insecure listeners) so a
+      // bad password/file surfaces as a load-time config error.
+      std::optional<TlsMaterial> material;
+      if (!listener.tls.value().insecure.value()) {
+        material = resolvePkcs12Material(
+            listener.tls.value(),
+            "Listener '" + listener.name.value() + "'",
+            errors,
+            warnings
+        );
+      }
+      listenerTlsMaterials.push_back(std::move(material));
       auto addr = listener.udp.value().socket.value().address.value() + ":" +
                   std::to_string(listener.udp.value().socket.value().port.value());
       if (!listenerAddrs.insert(addr).second) {
@@ -939,6 +1084,16 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
 
   // === Validate admin ===
   validateAdmin(config, errors);
+
+  // Transcode the admin PKCS#12 bundle (if any) during validation so failures
+  // are reported as config errors alongside everything else.
+  std::optional<TlsMaterial> adminMaterial;
+  {
+    const auto& adminOpt = config.admin.value();
+    if (adminOpt.has_value() && adminOpt->tls.value().has_value()) {
+      adminMaterial = resolvePkcs12Material(*adminOpt->tls.value(), "admin.tls", errors, warnings);
+    }
+  }
 
   // === Validate services ===
   // Per-service upstream config is validated inside validateService().
@@ -1007,7 +1162,11 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
     static const std::vector<std::string> kDefaultAdminAlpn = {"h2", "http/1.1"};
     std::optional<TlsConfig> adminTls;
     if (adminOptional->tls.value().has_value()) {
-      adminTls = resolveAdminTlsConfig(*adminOptional->tls.value(), kDefaultAdminAlpn);
+      adminTls = resolveAdminTlsConfig(
+          *adminOptional->tls.value(),
+          kDefaultAdminAlpn,
+          std::move(adminMaterial)
+      );
     }
     adminConfig = AdminConfig{
         .address =
@@ -1072,9 +1231,12 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
                     v.reserve(config.listeners.value().size());
                     const auto& listeners = config.listeners.value();
                     for (size_t i = 0; i < listeners.size(); ++i) {
-                      v.push_back(
-                          resolveListener(listeners[i], mergedQuicConfigs[i], mergedMvfstConfigs[i])
-                      );
+                      v.push_back(resolveListener(
+                          listeners[i],
+                          mergedQuicConfigs[i],
+                          mergedMvfstConfigs[i],
+                          std::move(listenerTlsMaterials[i])
+                      ));
                     }
                     return v;
                   }(),

--- a/src/config/ConfigSerializer.h
+++ b/src/config/ConfigSerializer.h
@@ -59,6 +59,9 @@ inline void serializeTls(ConfigSink& s, const TlsConfig& tls) {
   s.boolField("insecure", false);
   s.stringField("cert_file", tls.certFile);
   s.stringField("key_file", tls.keyFile);
+  // PKCS#12-sourced material holds the decrypted private key in memory. Never
+  // serialize it into the /config dump — expose only whether it is present.
+  s.boolField("pkcs12_in_memory", tls.material.has_value());
   s.beginArray("alpn");
   for (const auto& a : tls.alpn) {
     s.stringField("", a);

--- a/src/config/Pkcs12.cpp
+++ b/src/config/Pkcs12.cpp
@@ -7,12 +7,12 @@
 #include "config/Pkcs12.h"
 
 #include <memory>
-#include <optional>
 
 #include <folly/FileUtil.h>
+#include <folly/ssl/OpenSSLCertUtils.h>
+#include <folly/ssl/OpenSSLPtrTypes.h>
 
 #include <openssl/bio.h>
-#include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
 #include <openssl/x509.h>
@@ -21,14 +21,8 @@ namespace openmoq::moqx::config {
 
 namespace {
 
-// OpenSSL RAII deleters.
-struct BioDeleter {
-  void operator()(BIO* b) const noexcept {
-    if (b) {
-      BIO_free(b);
-    }
-  }
-};
+// folly/ssl provides RAII wrappers for BIO, EVP_PKEY, X509, and STACK_OF(X509);
+// only PKCS12 lacks one, so define that single deleter here.
 struct Pkcs12Deleter {
   void operator()(PKCS12* p) const noexcept {
     if (p) {
@@ -36,60 +30,10 @@ struct Pkcs12Deleter {
     }
   }
 };
-struct EvpPkeyDeleter {
-  void operator()(EVP_PKEY* k) const noexcept {
-    if (k) {
-      EVP_PKEY_free(k);
-    }
-  }
-};
-struct X509Deleter {
-  void operator()(X509* c) const noexcept {
-    if (c) {
-      X509_free(c);
-    }
-  }
-};
-struct X509StackDeleter {
-  void operator()(STACK_OF(X509) * s) const noexcept {
-    if (s) {
-      sk_X509_pop_free(s, X509_free);
-    }
-  }
-};
-
-using BioPtr = std::unique_ptr<BIO, BioDeleter>;
 using Pkcs12Ptr = std::unique_ptr<PKCS12, Pkcs12Deleter>;
-using EvpPkeyPtr = std::unique_ptr<EVP_PKEY, EvpPkeyDeleter>;
-using X509Ptr = std::unique_ptr<X509, X509Deleter>;
-using X509StackPtr = std::unique_ptr<STACK_OF(X509), X509StackDeleter>;
 
 folly::Unexpected<std::string> err(const std::string& msg) {
   return folly::makeUnexpected(msg);
-}
-
-// Copy the contents of a memory BIO into a std::string.
-std::string bioToString(BIO* bio) {
-  char* data = nullptr;
-  long len = BIO_get_mem_data(bio, &data);
-  if (len <= 0 || data == nullptr) {
-    return {};
-  }
-  return std::string(data, static_cast<size_t>(len));
-}
-
-// Append a single certificate as PEM to `out`. Returns an error string on
-// serialization failure, std::nullopt on success.
-std::optional<std::string> appendCertPem(std::string& out, X509* cert) {
-  BioPtr bio(BIO_new(BIO_s_mem()));
-  if (!bio) {
-    return std::string("failed to allocate BIO for certificate PEM");
-  }
-  if (PEM_write_bio_X509(bio.get(), cert) != 1) {
-    return std::string("failed to serialize certificate to PEM");
-  }
-  out += bioToString(bio.get());
-  return std::nullopt;
 }
 
 } // namespace
@@ -100,7 +44,7 @@ transcodePkcs12(folly::StringPiece der, folly::StringPiece password) {
     return err("PKCS#12 data is empty");
   }
 
-  BioPtr bio(BIO_new_mem_buf(der.data(), static_cast<int>(der.size())));
+  folly::ssl::BioUniquePtr bio(BIO_new_mem_buf(der.data(), static_cast<int>(der.size())));
   if (!bio) {
     return err("failed to allocate BIO for PKCS#12 data");
   }
@@ -121,9 +65,9 @@ transcodePkcs12(folly::StringPiece der, folly::StringPiece password) {
     OPENSSL_cleanse(pass.data(), pass.size());
   }
 
-  EvpPkeyPtr pkey(pkeyRaw);
-  X509Ptr leaf(leafRaw);
-  X509StackPtr chain(chainRaw);
+  folly::ssl::EvpPkeyUniquePtr pkey(pkeyRaw);
+  folly::ssl::X509UniquePtr leaf(leafRaw);
+  folly::ssl::OwningStackOfX509UniquePtr chain(chainRaw);
 
   if (rc != 1) {
     return err("failed to decrypt/parse PKCS#12 bundle (wrong password or corrupt data)");
@@ -135,31 +79,35 @@ transcodePkcs12(folly::StringPiece der, folly::StringPiece password) {
     return err("PKCS#12 bundle contains no certificate");
   }
 
-  // Certificate chain PEM: leaf first, then any intermediates.
+  // Certificate chain PEM: leaf first, then any intermediates. pemEncode throws
+  // on failure; convert to our error-string contract so config load stays clean.
   std::string certChainPem;
-  if (auto e = appendCertPem(certChainPem, leaf.get())) {
-    return folly::makeUnexpected(*e);
-  }
-  const int n = chain ? sk_X509_num(chain.get()) : 0;
-  for (int i = 0; i < n; ++i) {
-    if (auto e = appendCertPem(certChainPem, sk_X509_value(chain.get(), i))) {
-      return folly::makeUnexpected(*e);
+  try {
+    certChainPem = folly::ssl::OpenSSLCertUtils::pemEncode(*leaf);
+    const int n = chain ? sk_X509_num(chain.get()) : 0;
+    for (int i = 0; i < n; ++i) {
+      certChainPem += folly::ssl::OpenSSLCertUtils::pemEncode(*sk_X509_value(chain.get(), i));
     }
+  } catch (const std::exception& e) {
+    return err(std::string("failed to serialize certificate to PEM: ") + e.what());
   }
 
-  // Private key PEM, unencrypted (no cipher).
-  std::string keyPem;
-  {
-    BioPtr kbio(BIO_new(BIO_s_mem()));
-    if (!kbio) {
-      return err("failed to allocate BIO for private key PEM");
-    }
-    if (PEM_write_bio_PrivateKey(kbio.get(), pkey.get(), nullptr, nullptr, 0, nullptr, nullptr) !=
-        1) {
-      return err("failed to serialize private key to PEM");
-    }
-    keyPem = bioToString(kbio.get());
+  // Private key PEM, unencrypted (no cipher). folly's cert utils are
+  // certificate-only, so serialize the key directly.
+  folly::ssl::BioUniquePtr kbio(BIO_new(BIO_s_mem()));
+  if (!kbio) {
+    return err("failed to allocate BIO for private key PEM");
   }
+  if (PEM_write_bio_PrivateKey(kbio.get(), pkey.get(), nullptr, nullptr, 0, nullptr, nullptr) !=
+      1) {
+    return err("failed to serialize private key to PEM");
+  }
+  char* keyData = nullptr;
+  long keyLen = BIO_get_mem_data(kbio.get(), &keyData);
+  if (keyLen <= 0 || keyData == nullptr) {
+    return err("failed to serialize private key to PEM");
+  }
+  std::string keyPem(keyData, static_cast<size_t>(keyLen));
 
   return TlsMaterial{.certChainPem = std::move(certChainPem), .keyPem = std::move(keyPem)};
 }

--- a/src/config/Pkcs12.cpp
+++ b/src/config/Pkcs12.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "config/Pkcs12.h"
+
+#include <memory>
+#include <optional>
+
+#include <folly/FileUtil.h>
+
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/pkcs12.h>
+#include <openssl/x509.h>
+
+namespace openmoq::moqx::config {
+
+namespace {
+
+// OpenSSL RAII deleters.
+struct BioDeleter {
+  void operator()(BIO* b) const noexcept {
+    if (b) {
+      BIO_free(b);
+    }
+  }
+};
+struct Pkcs12Deleter {
+  void operator()(PKCS12* p) const noexcept {
+    if (p) {
+      PKCS12_free(p);
+    }
+  }
+};
+struct EvpPkeyDeleter {
+  void operator()(EVP_PKEY* k) const noexcept {
+    if (k) {
+      EVP_PKEY_free(k);
+    }
+  }
+};
+struct X509Deleter {
+  void operator()(X509* c) const noexcept {
+    if (c) {
+      X509_free(c);
+    }
+  }
+};
+struct X509StackDeleter {
+  void operator()(STACK_OF(X509) * s) const noexcept {
+    if (s) {
+      sk_X509_pop_free(s, X509_free);
+    }
+  }
+};
+
+using BioPtr = std::unique_ptr<BIO, BioDeleter>;
+using Pkcs12Ptr = std::unique_ptr<PKCS12, Pkcs12Deleter>;
+using EvpPkeyPtr = std::unique_ptr<EVP_PKEY, EvpPkeyDeleter>;
+using X509Ptr = std::unique_ptr<X509, X509Deleter>;
+using X509StackPtr = std::unique_ptr<STACK_OF(X509), X509StackDeleter>;
+
+folly::Unexpected<std::string> err(const std::string& msg) {
+  return folly::makeUnexpected(msg);
+}
+
+// Copy the contents of a memory BIO into a std::string.
+std::string bioToString(BIO* bio) {
+  char* data = nullptr;
+  long len = BIO_get_mem_data(bio, &data);
+  if (len <= 0 || data == nullptr) {
+    return {};
+  }
+  return std::string(data, static_cast<size_t>(len));
+}
+
+// Append a single certificate as PEM to `out`. Returns an error string on
+// serialization failure, std::nullopt on success.
+std::optional<std::string> appendCertPem(std::string& out, X509* cert) {
+  BioPtr bio(BIO_new(BIO_s_mem()));
+  if (!bio) {
+    return std::string("failed to allocate BIO for certificate PEM");
+  }
+  if (PEM_write_bio_X509(bio.get(), cert) != 1) {
+    return std::string("failed to serialize certificate to PEM");
+  }
+  out += bioToString(bio.get());
+  return std::nullopt;
+}
+
+} // namespace
+
+folly::Expected<TlsMaterial, std::string>
+transcodePkcs12(folly::StringPiece der, folly::StringPiece password) {
+  if (der.empty()) {
+    return err("PKCS#12 data is empty");
+  }
+
+  BioPtr bio(BIO_new_mem_buf(der.data(), static_cast<int>(der.size())));
+  if (!bio) {
+    return err("failed to allocate BIO for PKCS#12 data");
+  }
+
+  Pkcs12Ptr p12(d2i_PKCS12_bio(bio.get(), nullptr));
+  if (!p12) {
+    return err("failed to parse PKCS#12 structure (not a valid .p12/.pfx file)");
+  }
+
+  // PKCS12_parse needs a NUL-terminated password; StringPiece is not guaranteed
+  // NUL-terminated, so copy into a local string and wipe it after parsing.
+  std::string pass(password.data(), password.size());
+  EVP_PKEY* pkeyRaw = nullptr;
+  X509* leafRaw = nullptr;
+  STACK_OF(X509)* chainRaw = nullptr;
+  int rc = PKCS12_parse(p12.get(), pass.c_str(), &pkeyRaw, &leafRaw, &chainRaw);
+  if (!pass.empty()) {
+    OPENSSL_cleanse(pass.data(), pass.size());
+  }
+
+  EvpPkeyPtr pkey(pkeyRaw);
+  X509Ptr leaf(leafRaw);
+  X509StackPtr chain(chainRaw);
+
+  if (rc != 1) {
+    return err("failed to decrypt/parse PKCS#12 bundle (wrong password or corrupt data)");
+  }
+  if (!pkey) {
+    return err("PKCS#12 bundle contains no private key");
+  }
+  if (!leaf) {
+    return err("PKCS#12 bundle contains no certificate");
+  }
+
+  // Certificate chain PEM: leaf first, then any intermediates.
+  std::string certChainPem;
+  if (auto e = appendCertPem(certChainPem, leaf.get())) {
+    return folly::makeUnexpected(*e);
+  }
+  const int n = chain ? sk_X509_num(chain.get()) : 0;
+  for (int i = 0; i < n; ++i) {
+    if (auto e = appendCertPem(certChainPem, sk_X509_value(chain.get(), i))) {
+      return folly::makeUnexpected(*e);
+    }
+  }
+
+  // Private key PEM, unencrypted (no cipher).
+  std::string keyPem;
+  {
+    BioPtr kbio(BIO_new(BIO_s_mem()));
+    if (!kbio) {
+      return err("failed to allocate BIO for private key PEM");
+    }
+    if (PEM_write_bio_PrivateKey(kbio.get(), pkey.get(), nullptr, nullptr, 0, nullptr, nullptr) !=
+        1) {
+      return err("failed to serialize private key to PEM");
+    }
+    keyPem = bioToString(kbio.get());
+  }
+
+  return TlsMaterial{.certChainPem = std::move(certChainPem), .keyPem = std::move(keyPem)};
+}
+
+folly::Expected<TlsMaterial, std::string>
+loadPkcs12File(const std::string& path, folly::StringPiece password) {
+  std::string der;
+  if (!folly::readFile(path.c_str(), der)) {
+    return err("failed to read PKCS#12 file '" + path + "'");
+  }
+  return transcodePkcs12(der, password);
+}
+
+} // namespace openmoq::moqx::config

--- a/src/config/Pkcs12.h
+++ b/src/config/Pkcs12.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <folly/Expected.h>
+#include <folly/Range.h>
+
+#include "config/Config.h"
+
+namespace openmoq::moqx::config {
+
+// Transcode a PKCS#12 bundle (DER bytes) into in-memory PEM material: the
+// certificate chain (leaf + intermediates) and the unencrypted private key.
+// Performed entirely in memory; nothing is written to disk.
+//
+// `password` may be empty for password-less bundles. A NUL-terminated copy is
+// made internally (StringPiece is not guaranteed NUL-terminated) and wiped
+// before returning. The caller still owns and should wipe its own copy of the
+// password, and must never log the returned key material.
+//
+// Returns a descriptive error string on failure (empty input, invalid
+// structure, wrong password / corrupt bundle, or a bundle missing the key or
+// certificate).
+folly::Expected<TlsMaterial, std::string>
+transcodePkcs12(folly::StringPiece der, folly::StringPiece password);
+
+// Read a PKCS#12 file into memory, then transcode it (see transcodePkcs12).
+// Returns an error string if the file cannot be read or fails to transcode.
+folly::Expected<TlsMaterial, std::string>
+loadPkcs12File(const std::string& path, folly::StringPiece password);
+
+} // namespace openmoq::moqx::config

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -35,12 +35,40 @@ struct ParsedUdpConfig {
 struct ParsedListenerTlsConfig {
   rfl::Description<"Path to TLS certificate file", std::optional<std::string>> cert_file;
   rfl::Description<"Path to TLS private key file", std::optional<std::string>> key_file;
+  rfl::Description<
+      "Path to a PKCS#12 bundle (.p12/.pfx) carrying the cert chain + private key; "
+      "mutually exclusive with cert_file/key_file. Decrypted in memory (key never hits disk).",
+      std::optional<std::string>>
+      pkcs12_file;
+  rfl::Description<
+      "Inline PKCS#12 password (discouraged; prefer pkcs12_password_file). Empty for "
+      "password-less bundles.",
+      std::optional<std::string>>
+      pkcs12_password;
+  rfl::Description<
+      "Path to a file containing the PKCS#12 password (preferred over inline).",
+      std::optional<std::string>>
+      pkcs12_password_file;
   rfl::Description<"Insecure mode, use default compiled-in cert", bool> insecure;
 };
 
 struct ParsedAdminTlsConfig {
   rfl::Description<"Path to TLS certificate file", std::optional<std::string>> cert_file;
   rfl::Description<"Path to TLS private key file", std::optional<std::string>> key_file;
+  rfl::Description<
+      "Path to a PKCS#12 bundle (.p12/.pfx) carrying the cert chain + private key; "
+      "mutually exclusive with cert_file/key_file. Decrypted in memory (key never hits disk).",
+      std::optional<std::string>>
+      pkcs12_file;
+  rfl::Description<
+      "Inline PKCS#12 password (discouraged; prefer pkcs12_password_file). Empty for "
+      "password-less bundles.",
+      std::optional<std::string>>
+      pkcs12_password;
+  rfl::Description<
+      "Path to a file containing the PKCS#12 password (preferred over inline).",
+      std::optional<std::string>>
+      pkcs12_password_file;
   rfl::Description<"ALPN protocol list", std::optional<std::vector<std::string>>> alpn;
 };
 

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -49,6 +49,11 @@ struct ParsedListenerTlsConfig {
       "Path to a file containing the PKCS#12 password (preferred over inline).",
       std::optional<std::string>>
       pkcs12_password_file;
+  rfl::Description<
+      "Name of an environment variable holding the PKCS#12 password (cloud-vault "
+      "friendly: the secret stays out of the config file). Errors if the variable is unset.",
+      std::optional<std::string>>
+      pkcs12_password_env;
   rfl::Description<"Insecure mode, use default compiled-in cert", bool> insecure;
 };
 
@@ -69,6 +74,11 @@ struct ParsedAdminTlsConfig {
       "Path to a file containing the PKCS#12 password (preferred over inline).",
       std::optional<std::string>>
       pkcs12_password_file;
+  rfl::Description<
+      "Name of an environment variable holding the PKCS#12 password (cloud-vault "
+      "friendly: the secret stays out of the config file). Errors if the variable is unset.",
+      std::optional<std::string>>
+      pkcs12_password_env;
   rfl::Description<"ALPN protocol list", std::optional<std::vector<std::string>>> alpn;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(moqx_config_resolver_test
 )
 target_link_libraries(moqx_config_resolver_test PRIVATE
   moqx_config_loader
+  OpenSSL::Crypto
   GTest::gtest_main
   GTest::gmock
 )
@@ -120,6 +121,30 @@ target_link_libraries(moqx_config_serializer_test PRIVATE
   GTest::gmock
 )
 gtest_discover_tests(moqx_config_serializer_test)
+
+add_executable(moqx_pkcs12_test
+  config/Pkcs12Test.cpp
+)
+target_link_libraries(moqx_pkcs12_test PRIVATE
+  moqx_config_loader
+  OpenSSL::Crypto
+  GTest::gtest_main
+  GTest::gmock
+)
+if(NOT GFLAGS_SHARED)
+  if(APPLE)
+    target_link_libraries(moqx_pkcs12_test PRIVATE
+      "-Wl,-force_load,$<TARGET_FILE:gflags_nothreads_static>"
+    )
+  else()
+    target_link_libraries(moqx_pkcs12_test PRIVATE
+      "-Wl,--whole-archive"
+      gflags_nothreads_static
+      "-Wl,--no-whole-archive"
+    )
+  endif()
+endif()
+gtest_discover_tests(moqx_pkcs12_test)
 
 add_executable(moqx_bounded_histogram_test
   stats/BoundedHistogramTest.cpp

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -6,8 +6,12 @@
 
 #include "config/loader/ConfigResolver.h"
 
+#include "Pkcs12TestUtils.h"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <variant>
 
 namespace openmoq::moqx::config {
 namespace {
@@ -217,6 +221,158 @@ TEST(ResolveConfig, AdminEmptyAddressRejected) {
   auto result = resolveConfig(cfg);
   ASSERT_TRUE(result.hasError());
   EXPECT_THAT(result.error(), HasSubstr("address must be non-empty"));
+}
+
+// --- PKCS#12 TLS tests ---
+
+TEST(ResolveConfig, Pkcs12HappyPathPopulatesMaterial) {
+  auto der = test::makeSelfSignedPkcs12Der("s3cret");
+  test::TempFile p12(der, ".p12");
+  test::TempFile pwFile("s3cret", ".txt");
+
+  auto cfg = makeMinimalInsecureConfig();
+  auto& tls = cfg.listeners.value()[0].tls.value();
+  tls.insecure = false;
+  tls.pkcs12_file = p12.path();
+  tls.pkcs12_password_file = pwFile.path();
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue()) << result.error();
+  const auto& mode = result.value().config.listeners[0].tlsMode;
+  ASSERT_TRUE(std::holds_alternative<TlsConfig>(mode));
+  const auto& resolved = std::get<TlsConfig>(mode);
+  ASSERT_TRUE(resolved.material.has_value());
+  EXPECT_THAT(resolved.material->certChainPem, HasSubstr("BEGIN CERTIFICATE"));
+  EXPECT_THAT(resolved.material->keyPem, HasSubstr("PRIVATE KEY"));
+  // Paths are left empty when material is sourced from a bundle.
+  EXPECT_THAT(resolved.certFile, IsEmpty());
+  EXPECT_THAT(resolved.keyFile, IsEmpty());
+}
+
+TEST(ResolveConfig, Pkcs12InlinePasswordWarns) {
+  auto der = test::makeSelfSignedPkcs12Der("s3cret");
+  test::TempFile p12(der, ".p12");
+
+  auto cfg = makeMinimalInsecureConfig();
+  auto& tls = cfg.listeners.value()[0].tls.value();
+  tls.insecure = false;
+  tls.pkcs12_file = p12.path();
+  tls.pkcs12_password = std::string("s3cret");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue()) << result.error();
+  ASSERT_FALSE(result.value().warnings.empty());
+  EXPECT_THAT(result.value().warnings[0], HasSubstr("discouraged"));
+}
+
+TEST(ResolveConfig, Pkcs12WrongPasswordError) {
+  auto der = test::makeSelfSignedPkcs12Der("s3cret");
+  test::TempFile p12(der, ".p12");
+
+  auto cfg = makeMinimalInsecureConfig();
+  auto& tls = cfg.listeners.value()[0].tls.value();
+  tls.insecure = false;
+  tls.pkcs12_file = p12.path();
+  tls.pkcs12_password = std::string("wrong");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("wrong password"));
+}
+
+TEST(ResolveConfig, Pkcs12MutualExclusionWithCertKey) {
+  auto cfg = makeMinimalInsecureConfig();
+  auto& tls = cfg.listeners.value()[0].tls.value();
+  tls.insecure = false;
+  tls.pkcs12_file = std::string("/some/bundle.p12");
+  tls.cert_file = std::string("/some/cert.pem");
+  tls.key_file = std::string("/some/key.pem");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("mutually exclusive"));
+}
+
+TEST(ResolveConfig, Pkcs12PasswordSourcesExclusive) {
+  auto der = test::makeSelfSignedPkcs12Der("s3cret");
+  test::TempFile p12(der, ".p12");
+  test::TempFile pwFile("s3cret", ".txt");
+
+  auto cfg = makeMinimalInsecureConfig();
+  auto& tls = cfg.listeners.value()[0].tls.value();
+  tls.insecure = false;
+  tls.pkcs12_file = p12.path();
+  tls.pkcs12_password = std::string("s3cret");
+  tls.pkcs12_password_file = pwFile.path();
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("set only one"));
+}
+
+TEST(ResolveConfig, Pkcs12PicoquicRejected) {
+  auto der = test::makeSelfSignedPkcs12Der("s3cret");
+  test::TempFile p12(der, ".p12");
+  test::TempFile pwFile("s3cret", ".txt");
+
+  auto cfg = makeMinimalInsecureConfig();
+  auto& tls = cfg.listeners.value()[0].tls.value();
+  tls.insecure = false;
+  tls.pkcs12_file = p12.path();
+  tls.pkcs12_password_file = pwFile.path();
+  cfg.listeners.value()[0].quic_stack = std::string("picoquic");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("does not support pkcs12_file"));
+}
+
+TEST(ResolveConfig, InsecureIgnoresPkcs12Warning) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.listeners.value()[0].tls.value().pkcs12_file = std::string("/some/bundle.p12");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_FALSE(result.value().warnings.empty());
+  EXPECT_THAT(result.value().warnings[0], HasSubstr("ignored"));
+}
+
+TEST(ResolveConfig, AdminTlsRequiresCertOrPkcs12) {
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedAdminConfig admin;
+  admin.port = uint16_t{9669};
+  admin.address = std::string{"::"};
+  admin.plaintext = false;
+  admin.tls = std::optional<ParsedAdminTlsConfig>{ParsedAdminTlsConfig{}};
+  cfg.admin = std::optional<ParsedAdminConfig>{std::move(admin)};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("or pkcs12_file"));
+}
+
+TEST(ResolveConfig, AdminPkcs12HappyPath) {
+  auto der = test::makeSelfSignedPkcs12Der("s3cret");
+  test::TempFile p12(der, ".p12");
+  test::TempFile pwFile("s3cret", ".txt");
+
+  auto cfg = makeMinimalInsecureConfig();
+  ParsedAdminConfig admin;
+  admin.port = uint16_t{9669};
+  admin.address = std::string{"::"};
+  admin.plaintext = false;
+  ParsedAdminTlsConfig tls;
+  tls.pkcs12_file = p12.path();
+  tls.pkcs12_password_file = pwFile.path();
+  admin.tls = std::optional<ParsedAdminTlsConfig>{std::move(tls)};
+  cfg.admin = std::optional<ParsedAdminConfig>{std::move(admin)};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasValue()) << result.error();
+  ASSERT_TRUE(result.value().config.admin.has_value());
+  ASSERT_TRUE(result.value().config.admin->tls.has_value());
+  ASSERT_TRUE(result.value().config.admin->tls->material.has_value());
+  EXPECT_THAT(result.value().config.admin->tls->material->keyPem, HasSubstr("PRIVATE KEY"));
 }
 
 // --- Service validation error tests ---
@@ -905,7 +1061,7 @@ TEST(ResolveConfig, AdminTlsPartialCreds) {
     cfg.admin = std::optional<ParsedAdminConfig>{makeAdminWithTls(cert, key)};
     auto result = resolveConfig(cfg);
     ASSERT_TRUE(result.hasError());
-    EXPECT_THAT(result.error(), HasSubstr("cert_file and key_file are required"));
+    EXPECT_THAT(result.error(), HasSubstr("cert_file and key_file"));
   }
 }
 

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -375,6 +375,41 @@ TEST(ResolveConfig, AdminPkcs12HappyPath) {
   EXPECT_THAT(result.value().config.admin->tls->material->keyPem, HasSubstr("PRIVATE KEY"));
 }
 
+TEST(ResolveConfig, Pkcs12PasswordFromEnv) {
+  auto der = test::makeSelfSignedPkcs12Der("env-secret");
+  test::TempFile p12(der, ".p12");
+  ::setenv("MOQX_TEST_P12_PW", "env-secret", 1);
+
+  auto cfg = makeMinimalInsecureConfig();
+  auto& tls = cfg.listeners.value()[0].tls.value();
+  tls.insecure = false;
+  tls.pkcs12_file = p12.path();
+  tls.pkcs12_password_env = std::string("MOQX_TEST_P12_PW");
+
+  auto result = resolveConfig(cfg);
+  ::unsetenv("MOQX_TEST_P12_PW");
+  ASSERT_TRUE(result.hasValue()) << result.error();
+  const auto& resolved = std::get<TlsConfig>(result.value().config.listeners[0].tlsMode);
+  ASSERT_TRUE(resolved.material.has_value());
+  EXPECT_THAT(resolved.material->keyPem, HasSubstr("PRIVATE KEY"));
+}
+
+TEST(ResolveConfig, Pkcs12PasswordEnvUnset) {
+  auto der = test::makeSelfSignedPkcs12Der("whatever");
+  test::TempFile p12(der, ".p12");
+  ::unsetenv("MOQX_TEST_P12_MISSING");
+
+  auto cfg = makeMinimalInsecureConfig();
+  auto& tls = cfg.listeners.value()[0].tls.value();
+  tls.insecure = false;
+  tls.pkcs12_file = p12.path();
+  tls.pkcs12_password_env = std::string("MOQX_TEST_P12_MISSING");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("is not set"));
+}
+
 // --- Service validation error tests ---
 
 TEST(ResolveConfig, NoServices) {

--- a/test/config/ConfigSerializerTest.cpp
+++ b/test/config/ConfigSerializerTest.cpp
@@ -29,7 +29,7 @@ static_assert(
     "ListenerConfig changed — update serializeConfig()"
 );
 static_assert(
-    rfl::internal::num_fields<TlsConfig> == 3,
+    rfl::internal::num_fields<TlsConfig> == 4,
     "TlsConfig changed — update serializeTls()"
 );
 static_assert(

--- a/test/config/Pkcs12Test.cpp
+++ b/test/config/Pkcs12Test.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "config/Pkcs12.h"
+#include "Pkcs12TestUtils.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace openmoq::moqx::config;
+using namespace openmoq::moqx::config::test;
+using ::testing::HasSubstr;
+
+TEST(Pkcs12, TranscodeHappyPath) {
+  auto der = makeSelfSignedPkcs12Der("s3cret");
+  auto result = transcodePkcs12(der, "s3cret");
+  ASSERT_FALSE(result.hasError()) << result.error();
+  EXPECT_THAT(result->certChainPem, HasSubstr("BEGIN CERTIFICATE"));
+  EXPECT_THAT(result->keyPem, HasSubstr("PRIVATE KEY"));
+  // Decrypted key must not be password-encrypted.
+  EXPECT_THAT(result->keyPem, ::testing::Not(HasSubstr("ENCRYPTED")));
+}
+
+TEST(Pkcs12, TranscodePasswordLess) {
+  auto der = makeSelfSignedPkcs12Der("");
+  auto result = transcodePkcs12(der, "");
+  ASSERT_FALSE(result.hasError()) << result.error();
+  EXPECT_THAT(result->certChainPem, HasSubstr("BEGIN CERTIFICATE"));
+  EXPECT_THAT(result->keyPem, HasSubstr("PRIVATE KEY"));
+}
+
+TEST(Pkcs12, TranscodeWrongPassword) {
+  auto der = makeSelfSignedPkcs12Der("s3cret");
+  auto result = transcodePkcs12(der, "wrong");
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("wrong password"));
+}
+
+TEST(Pkcs12, TranscodeEmptyInput) {
+  auto result = transcodePkcs12("", "x");
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("empty"));
+}
+
+TEST(Pkcs12, TranscodeGarbageBytes) {
+  auto result = transcodePkcs12("this is not a pkcs12 bundle", "x");
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("not a valid"));
+}
+
+TEST(Pkcs12, LoadFromFileHappyPath) {
+  auto der = makeSelfSignedPkcs12Der("pw123");
+  TempFile p12(der, ".p12");
+  auto result = loadPkcs12File(p12.path(), "pw123");
+  ASSERT_FALSE(result.hasError()) << result.error();
+  EXPECT_THAT(result->certChainPem, HasSubstr("BEGIN CERTIFICATE"));
+}
+
+TEST(Pkcs12, LoadFromFileMissing) {
+  auto result = loadPkcs12File("/no/such/bundle.p12", "");
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("failed to read"));
+}

--- a/test/config/Pkcs12TestUtils.h
+++ b/test/config/Pkcs12TestUtils.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pkcs12.h>
+#include <openssl/x509.h>
+
+namespace openmoq::moqx::config::test {
+
+// Build a self-signed RSA cert + key and pack them into a PKCS#12 bundle,
+// returning the DER bytes. `password` may be empty (password-less bundle).
+// Throws std::runtime_error on any OpenSSL failure. Test-only.
+inline std::string makeSelfSignedPkcs12Der(const std::string& password) {
+  EVP_PKEY* pkey = EVP_RSA_gen(2048);
+  if (!pkey) {
+    throw std::runtime_error("EVP_RSA_gen failed");
+  }
+  X509* x509 = X509_new();
+  if (!x509) {
+    EVP_PKEY_free(pkey);
+    throw std::runtime_error("X509_new failed");
+  }
+  ASN1_INTEGER_set(X509_get_serialNumber(x509), 1);
+  X509_gmtime_adj(X509_getm_notBefore(x509), 0);
+  X509_gmtime_adj(X509_getm_notAfter(x509), 3600);
+  X509_set_pubkey(x509, pkey);
+  X509_NAME* name = X509_get_subject_name(x509);
+  X509_NAME_add_entry_by_txt(
+      name,
+      "CN",
+      MBSTRING_ASC,
+      reinterpret_cast<const unsigned char*>("moqx-test"),
+      -1,
+      -1,
+      0
+  );
+  X509_set_issuer_name(x509, name); // self-signed
+  bool ok = X509_sign(x509, pkey, EVP_sha256()) > 0;
+
+  PKCS12* p12 = nullptr;
+  if (ok) {
+    // nid_key/nid_cert 0 => OpenSSL defaults; iter/mac_iter 0 => defaults.
+    p12 = PKCS12_create(password.c_str(), "moqx-test", pkey, x509, /*ca=*/nullptr, 0, 0, 0, 0, 0);
+  }
+
+  std::string der;
+  if (p12) {
+    BIO* bio = BIO_new(BIO_s_mem());
+    if (bio && i2d_PKCS12_bio(bio, p12) == 1) {
+      char* data = nullptr;
+      long len = BIO_get_mem_data(bio, &data);
+      if (len > 0 && data) {
+        der.assign(data, static_cast<size_t>(len));
+      }
+    }
+    if (bio) {
+      BIO_free(bio);
+    }
+    PKCS12_free(p12);
+  }
+
+  X509_free(x509);
+  EVP_PKEY_free(pkey);
+  if (der.empty()) {
+    throw std::runtime_error("failed to build PKCS#12 DER");
+  }
+  return der;
+}
+
+// RAII temp file: writes the given bytes (binary) to a unique path, removes it
+// on destruction. Test-only.
+class TempFile {
+public:
+  TempFile(std::string_view bytes, std::string_view suffix) {
+    static std::atomic<int> counter{0};
+    path_ =
+        std::filesystem::temp_directory_path() / ("moqx_test_" + std::to_string(::getpid()) + "_" +
+                                                  std::to_string(counter++) + std::string(suffix));
+    std::ofstream ofs(path_, std::ios::binary);
+    ofs.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+  }
+  ~TempFile() {
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+  }
+  TempFile(const TempFile&) = delete;
+  TempFile& operator=(const TempFile&) = delete;
+
+  std::string path() const { return path_.string(); }
+
+private:
+  std::filesystem::path path_;
+};
+
+} // namespace openmoq::moqx::config::test


### PR DESCRIPTION
Adds support for a single password-protected **PKCS#12 bundle** (`.p12`/`.pfx`) as an alternative to the `cert_file` + `key_file` PEM pair, for both QUIC listeners (mvfst) and the admin HTTPS server. The bundle is decrypted and transcoded to PEM **entirely in memory** — the private key is never written to disk.

### Commits
1. **PKCS#12 in-memory cert/key source** — new `Pkcs12.{h,cpp}` transcode helper (OpenSSL, RAII, password wiped); `pkcs12_file` + `pkcs12_password` / `pkcs12_password_file` on `listener.tls` and `admin.tls`, mutually exclusive with `cert_file`/`key_file`. Resolver transcodes during validation (bad password/file → clean load-time error), stores in-memory `TlsMaterial` on `TlsConfig`. fizz path builds the context from buffers (mirrors the proxygen sample helper so behavior matches the PEM path); admin uses `setCertificateBuf`. picoquic is rejected for now (no in-memory key path wired).
2. **`pkcs12_password_env`** — source the password from a named env var, so a vault/orchestrator can inject it and keep the secret out of the config entirely. `scripts/moqx-run.sh` forwards `MOQX_PKCS12_PASSWORD` to the relay process and across the sudo boundary, never templating it to disk (dry-run shows set/unset, never the value).

### Testing
- `Pkcs12Test` (7): transcode happy path + password-less + wrong-password + empty/garbage + file load/missing.
- `ConfigResolverTest` (+11): mutual exclusion, pico rejection, admin requires cert-or-pkcs12, password-source exclusivity, insecure-ignored + inline-password warnings, env resolution (set/unset), and end-to-end material population for listener + admin.
- All 126 tests green; example config validates; clang-format v19 clean.

### Notes
- **Stacked on #456** (`docs/scripts-readme`) — it shares edits to `MoqxRelayServer.cpp` and `moqx-run.sh`; base will retarget to `main` once #456 merges.
- Security posture and the inline-password caveat are documented in `openmoq/notes/moqx-pkcs12-tls-design.md` (Future direction covers pluggable secret sources and a keyless/async-signer track).
- Unrelated crash surfaced while testing, filed separately as #459 (empty/bad `address` → SIGABRT instead of clean error).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/460)
<!-- Reviewable:end -->
