### PR TITLE
config: clean error for empty/unresolvable bind address (#459)

### DIFF
--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <folly/SocketAddress.h>
 #include <folly/String.h>
 
 namespace openmoq::moqx::config {
@@ -169,6 +170,28 @@ std::string makeCompositeKey(
 
 // --- Listener validation ---
 
+// Validate a bind address so an empty or unresolvable value fails as a clean
+// config error rather than letting folly::SocketAddress throw uncaught at
+// resolution time, which aborts the process (#459). Literal IPs cost nothing;
+// a hostname is resolved once here.
+void validateBindAddress(
+    const std::string& address,
+    uint16_t port,
+    const std::string& context,
+    std::vector<std::string>& errors
+) {
+  if (address.empty()) {
+    errors.push_back(context + ": address must be non-empty");
+    return;
+  }
+  try {
+    folly::SocketAddress probe(address, port);
+    (void)probe;
+  } catch (const std::exception& e) {
+    errors.push_back(context + ": invalid bind address '" + address + "': " + e.what());
+  }
+}
+
 void validateListener(
     const ParsedListenerConfig& listener,
     std::vector<std::string>& errors,
@@ -178,6 +201,12 @@ void validateListener(
   if (sock.port.value() == 0) {
     errors.push_back("Listener '" + listener.name.value() + "' port must be 1-65535, got 0");
   }
+  validateBindAddress(
+      sock.address.value(),
+      sock.port.value(),
+      "Listener '" + listener.name.value() + "'",
+      errors
+  );
 
   // TLS validation
   validateListenerTlsConfig(
@@ -212,6 +241,12 @@ void validateAdmin(const ParsedConfig& config, std::vector<std::string>& errors)
     if (adminOptional->port.value() == 0) {
       errors.push_back("admin.port must be 1-65535, got 0");
     }
+    validateBindAddress(
+        adminOptional->address.value(),
+        adminOptional->port.value(),
+        "admin",
+        errors
+    );
     bool hasTls = adminOptional->tls.value().has_value();
     bool hasPlaintext = adminOptional->plaintext.value();
     if (hasTls && hasPlaintext) {

--- a/test/config/ConfigResolverTest.cpp
+++ b/test/config/ConfigResolverTest.cpp
@@ -187,6 +187,38 @@ TEST(ResolveConfig, InsecureWithCertsWarning) {
   EXPECT_THAT(result.value().warnings[0], HasSubstr("ignored"));
 }
 
+// #459: an empty/unresolvable bind address must fail as a clean config error,
+// not let folly::SocketAddress throw uncaught and abort the process.
+TEST(ResolveConfig, ListenerEmptyAddressRejected) {
+  auto cfg = makeMinimalInsecureConfig();
+  cfg.listeners.value()[0].udp.value().socket.value().address = std::string("");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("address must be non-empty"));
+}
+
+TEST(ResolveConfig, ListenerUnresolvableAddressRejected) {
+  auto cfg = makeMinimalInsecureConfig();
+  // .invalid is a reserved TLD (RFC 2606): guaranteed to fail resolution fast.
+  cfg.listeners.value()[0].udp.value().socket.value().address = std::string("no.such.host.invalid");
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("invalid bind address"));
+}
+
+TEST(ResolveConfig, AdminEmptyAddressRejected) {
+  auto cfg = makeMinimalInsecureConfig();
+  auto admin = makeDefaultAdmin();
+  admin.address = std::string("");
+  cfg.admin = std::optional<ParsedAdminConfig>{std::move(admin)};
+
+  auto result = resolveConfig(cfg);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_THAT(result.error(), HasSubstr("address must be non-empty"));
+}
+
 // --- Service validation error tests ---
 
 TEST(ResolveConfig, NoServices) {


### PR DESCRIPTION
Fixes #459.

`resolveConfig` passed the listener/admin `address` straight to
`folly::SocketAddress(host, port)`, which throws an uncaught
`std::system_error` when the host is empty or unresolvable — aborting the
process with **SIGABRT** instead of returning a clean config error.

Add a `validateBindAddress()` helper (non-empty check + try-construct the
`SocketAddress`, converting any failure to a collected validation error) and
call it for each listener and the admin server during config validation.
Empty → "address must be non-empty"; unresolvable → "invalid bind address
'<host>': <reason>". Sibling of the #173 unreadable-cert fix.

Repro (was SIGABRT, now exit 1 with a clean message):
```
listeners:
  - name: main
    udp: {socket: {address: "", port: 9668}}
    tls: {insecure: true}
    endpoint: "/moq-relay"
services:
  s1:
    match: [{authority: {any: true}, path: {exact: "/moq-relay"}}]
    cache: {enabled: true, max_tracks: 100, max_groups_per_track: 3}
```

Adds listener (empty + unresolvable) and admin (empty) regression tests.

Note: surfaced while testing PR #456; pulled into its own PR so it doesn't
ride on that scripts/docs branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/461)
<!-- Reviewable:end -->
