### PR TITLE
stats: add subgroup-reset and object-ack-latency MoQ metrics

### DIFF
--- a/src/stats/MoQStatsCollector.cpp
+++ b/src/stats/MoQStatsCollector.cpp
@@ -48,6 +48,13 @@ StatsSnapshot MoQStatsCollector::snapshot() const {
   STATS_ERROR_COUNTER_FIELDS(COPY_ERROR_ARRAY)
 #undef COPY_ERROR_ARRAY
 
+#define COPY_RESET_ARRAY(name)                                                                     \
+  for (size_t i = 0; i < kResetStreamErrorCodeCount; ++i) {                                        \
+    snap.name##ByResetCodes[i] = name##ByResetCodes_[i];                                           \
+  }
+  STATS_RESET_COUNTER_FIELDS(COPY_RESET_ARRAY)
+#undef COPY_RESET_ARRAY
+
   return snap;
 }
 
@@ -203,6 +210,17 @@ void MoQStatsCollector::PublisherCallback::onPublishSuccess() {
   ++parent_.moqPublishSuccess_;
 }
 
+void MoQStatsCollector::PublisherCallback::onSubgroupReset(moxygen::ResetStreamErrorCode errorCode
+) {
+  // Relay reset an outbound subgroup; errorCode carries the cause (e.g.
+  // DELIVERY_TIMEOUT).
+  ++parent_.pubSubgroupResetByResetCodes_[resetStreamErrorCodeIndex(errorCode)];
+}
+
+void MoQStatsCollector::PublisherCallback::recordObjectAckLatency(uint64_t latencyUsec) {
+  parent_.moqObjectAckLatency_.addValue(latencyUsec);
+}
+
 // --- SubscriberCallback implementations ---
 // Each method corresponds to an event from the relay's subscriber role
 
@@ -330,6 +348,12 @@ void MoQStatsCollector::SubscriberCallback::onPublishError(moxygen::PublishError
   // Relay rejected an upstream publisher with PUBLISH_ERROR.
   ++parent_.subPublishError_;
   ++parent_.subPublishErrorByCodes_[requestErrorCodeIndex(errorCode)];
+}
+
+void MoQStatsCollector::SubscriberCallback::onSubgroupReset(moxygen::ResetStreamErrorCode errorCode
+) {
+  // A peer reset an inbound stream to us; errorCode carries the peer's cause.
+  ++parent_.subSubgroupResetByResetCodes_[resetStreamErrorCodeIndex(errorCode)];
 }
 
 } // namespace openmoq::moqx::stats

--- a/src/stats/MoQStatsCollector.h
+++ b/src/stats/MoQStatsCollector.h
@@ -59,12 +59,14 @@ public:
     void onSubscriptionStreamClosed() override;
     void onSubscriptionBegin() override;
     void onSubscriptionEnd() override;
+    void onSubgroupReset(moxygen::ResetStreamErrorCode errorCode) override;
 
     // Publisher-only methods
     void recordPublishNamespaceLatency(uint64_t latencyMsec) override;
     void recordPublishLatency(uint64_t latencyMsec) override;
     void onPublishError(moxygen::PublishErrorCode errorCode) override;
     void onPublishSuccess() override;
+    void recordObjectAckLatency(uint64_t latencyUsec) override;
 
   private:
     MoQStatsCollector& parent_;
@@ -97,6 +99,7 @@ public:
     void onSubscriptionStreamClosed() override;
     void onSubscriptionBegin() override;
     void onSubscriptionEnd() override;
+    void onSubgroupReset(moxygen::ResetStreamErrorCode errorCode) override;
 
     // Subscriber-only methods
     void recordSubscribeLatency(uint64_t latencyMsec) override;
@@ -154,6 +157,12 @@ private:
 #define DEFINE_ERROR_ARRAY(name) std::array<uint64_t, kRequestErrorCodeCount> name##ByCodes_{};
   STATS_ERROR_COUNTER_FIELDS(DEFINE_ERROR_ARRAY)
 #undef DEFINE_ERROR_ARRAY
+
+  // Per-ResetStreamErrorCode breakdown arrays; the total is sum() over labels.
+#define DEFINE_RESET_ARRAY(name)                                                                   \
+  std::array<uint64_t, kResetStreamErrorCodeCount> name##ByResetCodes_{};
+  STATS_RESET_COUNTER_FIELDS(DEFINE_RESET_ARRAY)
+#undef DEFINE_RESET_ARRAY
 };
 
 } // namespace openmoq::moqx::stats

--- a/src/stats/StatsRegistry.cpp
+++ b/src/stats/StatsRegistry.cpp
@@ -42,6 +42,13 @@ StatsSnapshot& StatsSnapshot::operator+=(const StatsSnapshot& o) {
   STATS_ERROR_COUNTER_FIELDS(ADD_ERROR_ARRAY)
 #undef ADD_ERROR_ARRAY
 
+#define ADD_RESET_ARRAY(name)                                                                      \
+  for (size_t i = 0; i < kResetStreamErrorCodeCount; ++i) {                                        \
+    name##ByResetCodes[i] += o.name##ByResetCodes[i];                                              \
+  }
+  STATS_RESET_COUNTER_FIELDS(ADD_RESET_ARRAY)
+#undef ADD_RESET_ARRAY
+
   return *this;
 }
 
@@ -128,6 +135,24 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
   app("\n");
   STATS_ERROR_COUNTER_FIELDS(EMIT_ERROR_COUNTER)
 #undef EMIT_ERROR_COUNTER
+
+  // --- Per-ResetStreamErrorCode breakdowns ---
+  // Each field emits one labelled counter series:
+  //   moqx_<name>_total{code="<label>"}
+#define EMIT_RESET_COUNTER(name)                                                                   \
+  app("# HELP moqx_" #name "_total"                                                                \
+      " Subgroup resets broken down by ResetStreamErrorCode\n"                                     \
+      "# TYPE moqx_" #name "_total counter\n");                                                    \
+  for (size_t i = 0; i < kResetStreamErrorCodeCount; ++i) {                                        \
+    app("moqx_" #name "_total{code=\"");                                                           \
+    app(kResetStreamErrorCodeLabels[i]);                                                           \
+    app("\"} ");                                                                                   \
+    appNum(snap.name##ByResetCodes[i]);                                                            \
+    app("\n");                                                                                     \
+  }                                                                                                \
+  app("\n");
+  STATS_RESET_COUNTER_FIELDS(EMIT_RESET_COUNTER)
+#undef EMIT_RESET_COUNTER
 
   return queue.move();
 }

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -96,6 +96,53 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
     "cancelled",
 }};
 
+// ResetStreamErrorCode compact-index table, for per-reason breakdown of
+// subgroup/stream resets.  Mirrors the RequestErrorCode table above, but adds a
+// trailing "unknown" slot so unrecognized/future codes don't collide with a
+// real reason.
+inline constexpr std::array<moxygen::ResetStreamErrorCode, 10> kResetStreamErrorCodeValues = {{
+    moxygen::ResetStreamErrorCode::INTERNAL_ERROR,
+    moxygen::ResetStreamErrorCode::CANCELLED,
+    moxygen::ResetStreamErrorCode::DELIVERY_TIMEOUT,
+    moxygen::ResetStreamErrorCode::SESSION_CLOSED,
+    moxygen::ResetStreamErrorCode::GOING_AWAY,
+    moxygen::ResetStreamErrorCode::TOO_FAR_BEHIND,
+    moxygen::ResetStreamErrorCode::UNKNOWN_OBJECT_STATUS,
+    moxygen::ResetStreamErrorCode::EXPIRED_AUTH_TOKEN,
+    moxygen::ResetStreamErrorCode::EXCESSIVE_LOAD,
+    moxygen::ResetStreamErrorCode::MALFORMED_TRACK,
+}};
+
+inline constexpr size_t kResetStreamErrorCodeCount = kResetStreamErrorCodeValues.size() + 1;
+
+// Maps any ResetStreamErrorCode to a compact index in
+// [0, kResetStreamErrorCodeCount).  Unknown / future codes fall into the last
+// ("unknown") slot.
+constexpr size_t resetStreamErrorCodeIndex(moxygen::ResetStreamErrorCode code) {
+  for (size_t i = 0; i < kResetStreamErrorCodeValues.size(); ++i) {
+    if (kResetStreamErrorCodeValues[i] == code) {
+      return i;
+    }
+  }
+  return kResetStreamErrorCodeCount - 1;
+}
+
+// Prometheus label values for each ResetStreamErrorCode slot.
+inline constexpr std::array<std::string_view, kResetStreamErrorCodeCount>
+    kResetStreamErrorCodeLabels = {{
+        "internal_error",
+        "cancelled",
+        "delivery_timeout",
+        "session_closed",
+        "going_away",
+        "too_far_behind",
+        "unknown_object_status",
+        "expired_auth_token",
+        "excessive_load",
+        "malformed_track",
+        "unknown",
+    }};
+
 // uint64_t monotonically-increasing counters — MoQ application layer.
 // pub* = relay acting as publisher (serving downstream subscribers).
 // sub* = relay acting as subscriber (consuming from upstream publishers).
@@ -205,7 +252,8 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
   X(moqSubscribeLatency, kLatencyBucketsUs, "microseconds")                                        \
   X(moqFetchLatency, kLatencyBucketsUs, "microseconds")                                            \
   X(moqPublishNamespaceLatency, kLatencyBucketsUs, "microseconds")                                 \
-  X(moqPublishLatency, kLatencyBucketsUs, "microseconds")
+  X(moqPublishLatency, kLatencyBucketsUs, "microseconds")                                          \
+  X(moqObjectAckLatency, kLatencyBucketsUs, "microseconds")
 
 // QUIC transport histograms — populated by QuicStatsCollector and PicoQuicStatsCollector.
 // Per-loop packet fields require an EventBaseStatsCollector loop observer to be wired up.
@@ -240,6 +288,13 @@ inline constexpr std::array<std::string_view, 8> kRequestErrorCodeLabels = {{
   X(subSubscribeNamespaceError)                                                                    \
   X(subPublishError)
 
+// Reset-reason breakdowns: counters whose callback receives a
+// ResetStreamErrorCode.  Each expands to a
+// std::array<uint64_t, kResetStreamErrorCodeCount> named name##ByResetCodes.
+#define STATS_RESET_COUNTER_FIELDS(X)                                                              \
+  X(pubSubgroupReset)                                                                              \
+  X(subSubgroupReset)
+
 struct StatsSnapshot {
   // --- Scalar fields ---
 #define DEFINE_FIELD(type, name) type name{0};
@@ -259,6 +314,12 @@ struct StatsSnapshot {
 #define DEFINE_ERROR_ARRAY(name) std::array<uint64_t, kRequestErrorCodeCount> name##ByCodes{};
   STATS_ERROR_COUNTER_FIELDS(DEFINE_ERROR_ARRAY)
 #undef DEFINE_ERROR_ARRAY
+
+  // --- Per-ResetStreamErrorCode breakdown arrays ---
+#define DEFINE_RESET_ARRAY(name)                                                                   \
+  std::array<uint64_t, kResetStreamErrorCodeCount> name##ByResetCodes{};
+  STATS_RESET_COUNTER_FIELDS(DEFINE_RESET_ARRAY)
+#undef DEFINE_RESET_ARRAY
 
   StatsSnapshot& operator+=(const StatsSnapshot& o);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -159,6 +159,19 @@ target_link_libraries(moqx_pico_quic_stats_test PRIVATE
 )
 gtest_discover_tests(moqx_pico_quic_stats_test)
 
+add_executable(moqx_moq_stats_collector_test
+  stats/MoQStatsCollectorTest.cpp
+)
+target_include_directories(moqx_moq_stats_collector_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(moqx_moq_stats_collector_test PRIVATE
+  moqx_core
+  GTest::gtest_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_moq_stats_collector_test)
+
 add_executable(moqx_service_matcher_test
   ServiceMatcherTest.cpp
 )

--- a/test/stats/MoQStatsCollectorTest.cpp
+++ b/test/stats/MoQStatsCollectorTest.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "stats/MoQStatsCollector.h"
+#include "stats/StatsRegistry.h"
+
+namespace openmoq::moqx::stats {
+
+namespace {
+std::string prometheusText(const StatsSnapshot& snap) {
+  auto out = StatsSnapshot::formatPrometheus(snap);
+  out->coalesce();
+  return std::string(reinterpret_cast<const char*>(out->data()), out->length());
+}
+} // namespace
+
+class MoQStatsCollectorTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    registry_ = std::make_shared<StatsRegistry>();
+    collector_ = MoQStatsCollector::create_moq_stats_collector(registry_);
+  }
+
+  std::shared_ptr<StatsRegistry> registry_;
+  std::shared_ptr<MoQStatsCollector> collector_;
+};
+
+TEST_F(MoQStatsCollectorTest, SubgroupResetBrokenDownByReason) {
+  auto pub = collector_->publisherCallback();
+  // Two delivery-timeout resets, one cancelled; metric #2 is just one label.
+  pub->onSubgroupReset(moxygen::ResetStreamErrorCode::DELIVERY_TIMEOUT);
+  pub->onSubgroupReset(moxygen::ResetStreamErrorCode::DELIVERY_TIMEOUT);
+  pub->onSubgroupReset(moxygen::ResetStreamErrorCode::CANCELLED);
+
+  auto sub = collector_->subscriberCallback();
+  sub->onSubgroupReset(moxygen::ResetStreamErrorCode::INTERNAL_ERROR);
+
+  auto snap = collector_->snapshot();
+  const auto timeoutIdx =
+      resetStreamErrorCodeIndex(moxygen::ResetStreamErrorCode::DELIVERY_TIMEOUT);
+  const auto cancelledIdx = resetStreamErrorCodeIndex(moxygen::ResetStreamErrorCode::CANCELLED);
+  const auto internalIdx = resetStreamErrorCodeIndex(moxygen::ResetStreamErrorCode::INTERNAL_ERROR);
+
+  EXPECT_EQ(snap.pubSubgroupResetByResetCodes[timeoutIdx], 2);
+  EXPECT_EQ(snap.pubSubgroupResetByResetCodes[cancelledIdx], 1);
+  EXPECT_EQ(snap.pubSubgroupResetByResetCodes[internalIdx], 0);
+  EXPECT_EQ(snap.subSubgroupResetByResetCodes[internalIdx], 1);
+  EXPECT_EQ(snap.subSubgroupResetByResetCodes[timeoutIdx], 0);
+}
+
+TEST_F(MoQStatsCollectorTest, UnknownResetCodeFallsIntoUnknownSlot) {
+  auto pub = collector_->publisherCallback();
+  // 0x99 is not a defined ResetStreamErrorCode; it must map to the last slot.
+  pub->onSubgroupReset(static_cast<moxygen::ResetStreamErrorCode>(0x99));
+
+  auto snap = collector_->snapshot();
+  EXPECT_EQ(snap.pubSubgroupResetByResetCodes[kResetStreamErrorCodeCount - 1], 1);
+  EXPECT_EQ(kResetStreamErrorCodeLabels[kResetStreamErrorCodeCount - 1], "unknown");
+}
+
+TEST_F(MoQStatsCollectorTest, ObjectAckLatencyHistogram) {
+  auto pub = collector_->publisherCallback();
+  pub->recordObjectAckLatency(120);
+  pub->recordObjectAckLatency(880);
+
+  auto snap = collector_->snapshot();
+  EXPECT_EQ(snap.moqObjectAckLatencyCount, 2);
+  EXPECT_EQ(snap.moqObjectAckLatencySum, 1000);
+}
+
+TEST_F(MoQStatsCollectorTest, PrometheusExportsResetAndAckLatency) {
+  auto pub = collector_->publisherCallback();
+  pub->onSubgroupReset(moxygen::ResetStreamErrorCode::DELIVERY_TIMEOUT);
+  pub->recordObjectAckLatency(300);
+
+  auto text = prometheusText(collector_->snapshot());
+
+  EXPECT_NE(
+      text.find("moqx_pubSubgroupReset_total{code=\"delivery_timeout\"} 1"),
+      std::string::npos
+  );
+  // Total is sum() over labels: an unhit reason still emits a zero series.
+  EXPECT_NE(text.find("moqx_pubSubgroupReset_total{code=\"cancelled\"} 0"), std::string::npos);
+  EXPECT_NE(text.find("moqx_moqObjectAckLatency_microseconds_count 1"), std::string::npos);
+}
+
+} // namespace openmoq::moqx::stats


### PR DESCRIPTION
Wire the onSubgroupReset and recordObjectAckLatency stats callbacks through MoQStatsCollector:

- Per-ResetStreamErrorCode breakdown counters (pubSubgroupReset, subSubgroupReset) emitted as labelled Prometheus series, mirroring the existing request-error tables with a trailing "unknown" slot.
- moqObjectAckLatency histogram fed by recordObjectAckLatency.
- Add MoQStatsCollectorTest covering the new metrics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/462)
<!-- Reviewable:end -->
