### PR TITLE
qlog: enabled qlog for moqx(mvfst)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ add_library(moqx_core STATIC
   src/relay/WeakRelayForwarderCallback.cpp
   src/relay/PublisherCrossExecFilter.cpp
   src/relay/SubscriberCrossExecFilter.cpp
-  src/logging/MLogSetup.cpp
+  src/logging/LogSetup.cpp
 )
 
 target_include_directories(moqx_core
@@ -181,6 +181,7 @@ target_link_libraries(moqx_core PUBLIC
   moxygen::moxygen_mlog_file_mlogger
   moxygen::moxygen_mlog_mlogger_factory
   moxygen::moxygen_mlog_sampling_mlogger_factory
+  mvfst::mvfst_logging_file_qlogger
 )
 
 target_compile_options(moqx_core PRIVATE -Wall -Wextra -Wpedantic)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,8 +86,11 @@ admin:
 logging:                    # Logging configuration (optional)
   mlog:                     # MoQ-level structured logging
     dir: "/tmp/moqx-mlog"          # Output directory for per-session mlog files
-    sample_rate: 1              # Fraction of sessions to log (0.0–1.0, default: 1.0)
+    sample_rate: 1              # Fraction of sessions to log (0.0–1.0, default: 0.0)
 
+  qlog:                     # QUIC-level per-connection packet tracing (optional)
+    dir: "/tmp/moqx-qlog"          # Output directory; files named <cid_hex>.qlog (mvfst)
+    sample_rate: 1.0       # Fraction of connections to log (0.0–1.0, default: 0.0; mvfst only)
 
 # relay_id: "my-relay-1"     # Relay identity (optional; random hex string generated if absent)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -257,13 +257,13 @@ events, one file per session.
 logging:
   mlog:
     dir: "/var/log/moqx/mlog"   # required to enable; empty string disables
-    sample_rate: 0.01            # log 1% of sessions (default: 1.0 = all)
+    sample_rate: 0.01            # log 1% of sessions (default: 0.0 = none)
 ```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `dir` | `string` | — (disabled) | Output directory. Each session writes to `<dir>/<dcid>.mlog`. If empty, mlog is disabled. |
-| `sample_rate` | `float` | `1.0` | Fraction of sessions to log, in `[0.0, 1.0]`. `1.0` logs all sessions; `0.01` logs ~1%. |
+| `sample_rate` | `float` | `0.0` | Fraction of sessions to log, in `[0.0, 1.0]`. `0.0` logs none; `1.0` logs all sessions; `0.01` logs ~1%. |
 
 
 #### Lifecycle

--- a/scripts/log-cleanup.sh
+++ b/scripts/log-cleanup.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# mlog-cleanup.sh — Manual retention cleanup for moqx .mlog files.
+# log-cleanup.sh — Manual retention cleanup for moqx log files (.mlog, .qlog, etc.).
 #
 # Usage:
-#   mlog-cleanup.sh --dir <path> [--max-age-days <N>] [--max-dir-mb <N>] [--dry-run]
+#   log-cleanup.sh --dir <path> [--ext <.EXT>] [--max-age-days <N>] [--max-dir-mb <N>] [--dry-run]
 #
 # Options:
-#   --dir <path>          Directory containing .mlog files (required).
-#   --max-age-days <N>    Delete .mlog files last modified more than N days ago.
+#   --dir <path>          Directory containing log files (required).
+#   --ext <.EXT>          File extension to match (default: .mlog). Use .qlog for qlog cleanup.
+#   --max-age-days <N>    Delete files last modified more than N days ago.
 #                         N must be >= 1.
 #   --max-dir-mb <N>      After age-based deletion, trim the directory to N MB
 #                         by deleting the oldest files first.
@@ -16,8 +17,9 @@
 #
 # At least one of --max-age-days or --max-dir-mb must be provided.
 #
-# Example — delete files older than 7 days and cap the directory at 1 GB:
-#   mlog-cleanup.sh --dir /var/log/moqx/mlog --max-age-days 7 --max-dir-mb 1024
+# Examples:
+#   log-cleanup.sh --dir /var/log/moqx/mlog --max-age-days 7 --max-dir-mb 1024
+#   log-cleanup.sh --dir /var/log/moqx/qlog --ext .qlog --max-age-days 3 --max-dir-mb 2048
 
 set -euo pipefail
 
@@ -26,6 +28,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 
 DIR=""
+EXT=".mlog"
 MAX_AGE_DAYS=""
 MAX_DIR_MB=""
 DRY_RUN=0
@@ -39,6 +42,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dir)
       DIR="${2:?'--dir requires a path argument'}"
+      shift 2
+      ;;
+    --ext)
+      EXT="${2:?'--ext requires an extension argument (e.g. .mlog or .qlog)'}"
       shift 2
       ;;
     --max-age-days)
@@ -100,8 +107,8 @@ fi
 # Helpers
 # ---------------------------------------------------------------------------
 
-log() { echo "[mlog-cleanup] $*"; }
-warn() { echo "[mlog-cleanup] WARNING: $*" >&2; }
+log() { echo "[log-cleanup] $*"; }
+warn() { echo "[log-cleanup] WARNING: $*" >&2; }
 
 remove_file() {
   local path="$1"
@@ -118,10 +125,10 @@ remove_file() {
 # ---------------------------------------------------------------------------
 
 if [[ -n "$MAX_AGE_DAYS" ]]; then
-  log "Phase 1: removing .mlog files older than ${MAX_AGE_DAYS} day(s) in '$DIR'..."
+  log "Phase 1: removing *${EXT} files older than ${MAX_AGE_DAYS} day(s) in '$DIR'..."
   while IFS= read -r -d '' file; do
     remove_file "$file"
-  done < <(find "$DIR" -maxdepth 1 -name '*.mlog' -type f \
+  done < <(find "$DIR" -maxdepth 1 -name "*${EXT}" -type f \
     -mtime +"$((MAX_AGE_DAYS - 1))" -print0)
 fi
 
@@ -143,10 +150,10 @@ if [[ -n "$MAX_DIR_MB" ]]; then
   fi
 
   # Collect current .mlog files with mtime and size.
-  mapfile -d '' files < <(find "$DIR" -maxdepth 1 -name '*.mlog' -type f -print0)
+  mapfile -d '' files < <(find "$DIR" -maxdepth 1 -name "*${EXT}" -type f -print0)
 
   if [[ ${#files[@]} -eq 0 ]]; then
-    log "Phase 2: no .mlog files found, skipping size check."
+    log "Phase 2: no *${EXT} files found, skipping size check."
   else
     # Build sortable lines: "<epoch> <size> <path>"
     tmp_list=()

--- a/src/MoqxRelayServer.cpp
+++ b/src/MoqxRelayServer.cpp
@@ -12,8 +12,10 @@
 #include <moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h>
 #include <proxygen/httpserver/samples/hq/FizzContext.h>
 
+#include <folly/Random.h>
 #include <folly/logging/xlog.h>
 #include <quic/QuicConstants.h>
+#include <quic/logging/FileQLogger.h>
 
 using namespace moxygen;
 
@@ -226,6 +228,33 @@ std::shared_ptr<MoQSession> MoqxRelayServer::createSession(
       folly::MaybeManagedPtr<proxygen::WebTransport>(std::move(wt)),
       *this,
       std::move(executor)
+  );
+}
+
+std::shared_ptr<quic::QLogger> MoqxRelayServer::makeQLogger(quic::VantagePoint vantagePoint) {
+  if (qlogDir_.empty()) {
+    return nullptr;
+  }
+  if (qlogSampleRate_ <= 0.0f) {
+    return nullptr;
+  }
+  // Per-connection sampling: skip with probability (1 - sampleRate).
+  // folly::Random::oneIn is thread-safe (ThreadLocalPRNG).
+  if (qlogSampleRate_ < 1.0f) {
+    const auto bucket = static_cast<uint32_t>(1.0f / qlogSampleRate_);
+    if (!folly::Random::oneIn(bucket)) {
+      return nullptr;
+    }
+  }
+  // streaming=true → AsyncFileWriter runs in its own background thread;
+  // the event-loop thread only pays for JSON serialisation + queue push.
+  return std::make_shared<quic::FileQLogger>(
+      vantagePoint,
+      "MOQT",
+      qlogDir_,
+      /*prettyJson=*/false,
+      /*streaming=*/true,
+      /*compress=*/false
   );
 }
 

--- a/src/MoqxRelayServer.h
+++ b/src/MoqxRelayServer.h
@@ -36,6 +36,11 @@ public:
     moxygen::MoQServerBase::setMLoggerFactory(std::move(factory));
   }
 
+  void setQLogConfig(const config::QLogConfig& cfg) {
+    qlogDir_ = cfg.dir;
+    qlogSampleRate_ = cfg.sampleRate;
+  }
+
   // Preferred entry point: binds the address from the stored ListenerConfig.
   void start();
 
@@ -58,11 +63,15 @@ protected:
       std::shared_ptr<moxygen::MoQExecutor> executor
   ) override;
 
+  std::shared_ptr<quic::QLogger> makeQLogger(quic::VantagePoint vantagePoint) override;
+
 private:
   config::ListenerConfig listenerCfg_;
   std::shared_ptr<MoqxRelayContext> context_;
   folly::IOThreadPoolExecutor* ioExecutor_;
   bool stopped_{false};
+  std::string qlogDir_;
+  float qlogSampleRate_{0.0f};
 };
 
 } // namespace openmoq::moqx

--- a/src/MoqxServerFactory.h
+++ b/src/MoqxServerFactory.h
@@ -29,7 +29,8 @@ inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
     std::shared_ptr<MoqxRelayContext> context,
     folly::IOThreadPoolExecutor* ioExecutor,
     std::shared_ptr<stats::StatsRegistry> statsRegistry,
-    std::shared_ptr<moxygen::MLoggerFactory> mlogFactory = nullptr
+    std::shared_ptr<moxygen::MLoggerFactory> mlogFactory = nullptr,
+    const config::QLogConfig* qlogConfig = nullptr
 ) {
   if (listenerCfg.quicStack == config::QuicStack::Picoquic) {
     auto server =
@@ -50,6 +51,9 @@ inline std::shared_ptr<moxygen::MoQServerBase> makeRelayServer(
   server->setStatsRegistry(std::move(statsRegistry));
   if (mlogFactory) {
     server->setMLoggerFactory(std::move(mlogFactory));
+  }
+  if (qlogConfig && !qlogConfig->dir.empty()) {
+    server->setQLogConfig(*qlogConfig);
   }
   return server;
 }

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -218,8 +218,14 @@ struct MLogConfig {
   float sampleRate{1.0f}; // 1.0 = log all sessions, 0.0 = none
 };
 
+struct QLogConfig {
+  std::string dir;        // output directory; empty = disabled
+  float sampleRate{1.0f}; // fraction of connections to log (0.0–1.0); mvfst only
+};
+
 struct LoggingConfig {
   std::optional<MLogConfig> mlog;
+  std::optional<QLogConfig> qlog;
 };
 
 struct Config {

--- a/src/config/ConfigResolver.cpp
+++ b/src/config/ConfigResolver.cpp
@@ -1028,7 +1028,7 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
       const auto& parsedMlog = *parsedLogging.mlog.value();
       MLogConfig mlogConfig;
       mlogConfig.dir = parsedMlog.dir.value();
-      mlogConfig.sampleRate = parsedMlog.sample_rate.value().value_or(1.0f);
+      mlogConfig.sampleRate = parsedMlog.sample_rate.value().value_or(0.0f);
       if (!mlogConfig.dir.empty()) {
         std::error_code ec;
         const auto st = std::filesystem::status(mlogConfig.dir, ec);
@@ -1044,6 +1044,21 @@ folly::Expected<ResolvedConfig, std::string> resolveConfig(const ParsedConfig& c
         }
       }
       resolved.mlog = std::move(mlogConfig);
+    }
+    if (parsedLogging.qlog.value().has_value()) {
+      const auto& parsedQlog = *parsedLogging.qlog.value();
+      QLogConfig qlogConfig;
+      qlogConfig.dir = parsedQlog.dir.value();
+      qlogConfig.sampleRate = parsedQlog.sample_rate.value().value_or(0.0f);
+
+      if (qlogConfig.sampleRate < 0.0f || qlogConfig.sampleRate > 1.0f) {
+        return folly::makeUnexpected(
+            "qlog.sample_rate must be in range [0.0, 1.0], got " +
+            std::to_string(qlogConfig.sampleRate)
+        );
+      }
+
+      resolved.qlog = std::move(qlogConfig);
     }
     loggingConfig = std::move(resolved);
   }

--- a/src/config/loader/ParsedConfig.h
+++ b/src/config/loader/ParsedConfig.h
@@ -408,12 +408,23 @@ struct ParsedServiceDefaultsConfig {
 
 struct ParsedMLogConfig {
   rfl::Description<"Directory for per-session MoQ log files (empty = disabled)", std::string> dir;
-  rfl::Description<"Fraction of sessions to log (0.0-1.0, default 1.0)", std::optional<float>>
+  rfl::Description<"Fraction of sessions to log (0.0-1.0, default 0.0)", std::optional<float>>
+      sample_rate;
+};
+
+struct ParsedQLogConfig {
+  rfl::Description<"Directory for per-connection QUIC qlog files (empty = disabled)", std::string>
+      dir;
+  rfl::Description<
+      "Fraction of connections to log (0.0-1.0, default 0.0; mvfst only)",
+      std::optional<float>>
       sample_rate;
 };
 
 struct ParsedLoggingConfig {
   rfl::Description<"MoQ-level (mlog) per-session logging", std::optional<ParsedMLogConfig>> mlog;
+  rfl::Description<"QUIC-level (qlog) per-connection logging", std::optional<ParsedQLogConfig>>
+      qlog;
 };
 
 struct ParsedConfig {

--- a/src/logging/LogSetup.cpp
+++ b/src/logging/LogSetup.cpp
@@ -4,7 +4,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "logging/MLogSetup.h"
+#include "logging/LogSetup.h"
 
 #include <filesystem>
 
@@ -20,6 +20,7 @@ folly::Expected<MLogSetup, int> setupMLog(const config::Config& config) {
   if (!config.logging || !config.logging->mlog) {
     return result;
   }
+
   const auto& mcfg = *config.logging->mlog;
   if (mcfg.dir.empty()) {
     return result;
@@ -47,6 +48,26 @@ folly::Expected<MLogSetup, int> setupMLog(const config::Config& config) {
   }
 
   return result;
+}
+
+folly::Expected<const config::QLogConfig*, int> setupQLog(const config::Config& config) {
+  if (!config.logging || !config.logging->qlog) {
+    return nullptr;
+  }
+
+  const auto& qcfg = *config.logging->qlog;
+  if (qcfg.dir.empty()) {
+    return nullptr;
+  }
+
+  std::error_code ec;
+  std::filesystem::create_directories(qcfg.dir, ec);
+  if (ec) {
+    XLOG(ERR) << "Failed to create qlog directory '" << qcfg.dir << "': " << ec.message();
+    return folly::makeUnexpected(1);
+  }
+
+  return &qcfg;
 }
 
 } // namespace openmoq::moqx::logging

--- a/src/logging/LogSetup.h
+++ b/src/logging/LogSetup.h
@@ -26,10 +26,17 @@ struct MLogSetup {
 };
 
 /**
- * Constructs an MLogSetup from the resolved config.
+ * Constructs an MLogSetup (factory + executor) from the resolved config.
  * Creates the mlog directory if it does not already exist.
  * Returns makeUnexpected(1) (exit code) on failure.
  */
 folly::Expected<MLogSetup, int> setupMLog(const config::Config& config);
+
+/**
+ * Ensures the configured qlog directory exists and returns a pointer to the
+ * resolved qlog config (or nullptr when qlog is disabled).
+ * Returns makeUnexpected(1) (exit code) on failure.
+ */
+folly::Expected<const config::QLogConfig*, int> setupQLog(const config::Config& config);
 
 } // namespace openmoq::moqx::logging

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@
 #include "admin/StateHandler.h"
 #include "bpf/QuicReuseportSteering.h"
 #include "config/loader/ConfigInit.h"
-#include "logging/MLogSetup.h"
+#include "logging/LogSetup.h"
 #include "stats/StatsRegistry.h"
 
 #include <csignal>
@@ -110,6 +110,12 @@ int main(int argc, char* argv[]) {
   }
   auto mlog = std::move(*mlogResult);
 
+  auto qlogResult = logging::setupQLog(config);
+  if (!qlogResult) {
+    return qlogResult.error();
+  }
+  const cfg::QLogConfig* qlogConfig = *qlogResult;
+
   // === 3. Set up signal handling ===
   folly::EventBase evb;
   ShutdownSignalHandler signalHandler(&evb);
@@ -141,9 +147,14 @@ int main(int argc, char* argv[]) {
   std::vector<std::shared_ptr<moxygen::MoQServerBase>> servers;
   try {
     for (const auto& listenerCfg : config.listeners) {
-      servers.emplace_back(
-          makeRelayServer(listenerCfg, context, ioExecutor.get(), statsRegistry, mlog.factory)
-      );
+      servers.emplace_back(makeRelayServer(
+          listenerCfg,
+          context,
+          ioExecutor.get(),
+          statsRegistry,
+          mlog.factory,
+          qlogConfig
+      ));
     }
   } catch (const std::exception& e) {
     // Listener setup (e.g. TLS cert loading) can throw. Report cleanly and exit


### PR DESCRIPTION
- Enabled qLog logging for mvfst in moqx
- Renamed MLogSetup to LogSetup to use it for qlog setup as well

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/464)
<!-- Reviewable:end -->
