### PR TITLE
build.sh: drop libbrotli-dev from apt hint (optional, not required)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -180,7 +180,7 @@ check_system_deps() {
           echo "  sudo apt-get install -y build-essential cmake ninja-build \\"
           echo "    libssl-dev libunwind-dev libgoogle-glog-dev libgflags-dev \\"
           echo "    libdouble-conversion-dev libevent-dev libsodium-dev libzstd-dev \\"
-          echo "    libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev gperf libbrotli-dev"
+          echo "    libboost-all-dev libfmt-dev zlib1g-dev libc-ares-dev gperf"
           ;;
         fedora|centos|rhel)
           echo "Install with:"


### PR DESCRIPTION
Follow-up to #456. Removes `libbrotli-dev` from the Ubuntu/Debian apt hint in `scripts/build.sh`.

It was added implying it's a required system dep, but it isn't:
- **Optional, auto-detected.** picotls (pulled in by the pico transport) probes it via `PKG_CHECK_MODULES(BROTLI_DEC libbrotlidec)` and only enables brotli cert compression (`-DPICOTLS_USE_BROTLI=1`) when found. Without it, the build succeeds — just without brotli cert compression.
- **Not a moxygen/upstream concern.** folly here is built with brotli disabled (no `FOLLY_HAVE_BROTLI`); fizz/proxygen/mvfst don't reference it. The dependency is picotls-specific (openmoq's pico transport), so it's not relevant to upstream facebookexperimental/moxygen's `install-system-deps.sh`.

Refs #441 (the original request — its `libbrotli-dev` ask is addressed here as "optional, not added"; the recursive-submodule part already landed in #456).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/466)
<!-- Reviewable:end -->
