### PR TITLE
auth: add CAT4MOQ issuer utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ target_compile_options(moqx_cache PRIVATE -Wall -Wextra -Wpedantic)
 
 add_library(moqx_core STATIC
   src/auth/Auth.cpp
+  src/auth/AuthTokenIssuer.cpp
   src/LoggingMultiFlag.cpp
   src/NamespaceTree.cpp
   src/SubscriptionRegistry.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,11 +123,25 @@ target_link_libraries(moqx_cache PUBLIC
 
 target_compile_options(moqx_cache PRIVATE -Wall -Wextra -Wpedantic)
 
+# --- HMAC key derivation (shared by the relay's verifier and the issuer) ---
+
+add_library(moqx_hmac_key STATIC
+  src/auth/HmacKey.cpp
+)
+
+target_include_directories(moqx_hmac_key
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(moqx_hmac_key PUBLIC OpenSSL::Crypto)
+
+target_compile_options(moqx_hmac_key PRIVATE -Wall -Wextra -Wpedantic)
+
 # --- Core library ---
 
 add_library(moqx_core STATIC
   src/auth/Auth.cpp
-  src/auth/AuthTokenIssuer.cpp
   src/LoggingMultiFlag.cpp
   src/NamespaceTree.cpp
   src/SubscriptionRegistry.cpp
@@ -166,6 +180,7 @@ target_include_directories(moqx_core
 
 target_link_libraries(moqx_core PUBLIC
   moqx_cache
+  moqx_hmac_key
   moxygen::moxygen_relay_moq_forwarder
   moxygen::moxygen_moq_relay_session
   moxygen::moxygen_moq_server
@@ -243,6 +258,43 @@ endif()
 
 target_link_libraries(moqx PRIVATE moqx_core moqx_config_loader)
 
+# --- CAT4MOQ token issuer (signing) library, shared by the CLI and tests ---
+
+add_library(moqx_issuer_lib STATIC
+  src/auth/AuthTokenIssuer.cpp
+)
+
+target_include_directories(moqx_issuer_lib
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(moqx_issuer_lib PUBLIC
+  moqx_hmac_key
+  moqx_config
+  catapult
+  moxygen::moxygen_moq_types
+)
+
+target_compile_options(moqx_issuer_lib PRIVATE -Wall -Wextra -Wpedantic)
+
+# --- Standalone moqx-issuer CLI ---
+
+add_executable(moqx-issuer
+  src/auth/IssuerMain.cpp
+)
+
+target_link_libraries(moqx-issuer PRIVATE
+  moqx_issuer_lib
+  moqx_config_loader
+  Folly::folly_init_init
+  Folly::folly_base64
+  Folly::folly_string
+  gflags
+)
+
+target_compile_options(moqx-issuer PRIVATE -Wall -Wextra -Wpedantic)
+
 # --- Tests ---
 
 if(MOQX_BUILD_TESTS)
@@ -256,4 +308,4 @@ endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/Lint.cmake)
 
-install(TARGETS moqx moqx_core moqx_config_loader)
+install(TARGETS moqx moqx-issuer moqx_core moqx_config_loader)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -60,7 +60,7 @@ services:
     #   token_type: 16            # MOQT AUTHORIZATION_TOKEN type for CAT4MOQ/moqxr; 0 is valid for private deployments
     #   hmac_keys:                # Keys that sign/verify CAT tokens (HMAC-SHA256)
     #     - id: "cat-dev"         # Key ID carried in the token envelope; selects which secret verifies it
-    #       secret: "replace-with-long-random-secret"   # Shared secret used by moqx issue-cat-token
+    #       secret: "replace-with-long-random-secret"   # Shared secret used by moqx-issuer
     #   require_setup_token: true            # Require a client_setup token during CLIENT_SETUP
     #   allow_request_token_override: true   # Allow a per-request token to override the session's setup grants
     #   strict_claims: false       # Keep false for current CAT4MOQ interop unless all issuers send only supported claims

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -57,13 +57,13 @@ services:
     #     # ca_cert: /path/to/ca.pem  # Custom CA cert (mutually exclusive with insecure: true)
     # auth:                       # Optional: enable CAT-style authorization for this service
     #   enabled: true             # Turn auth on for this service (default: false)
-    #   token_type: 0             # MOQT AUTHORIZATION_TOKEN type; 0 = out-of-band/private type (draft-ietf-moq-transport, "Token Type")
+    #   token_type: 16            # MOQT AUTHORIZATION_TOKEN type for CAT4MOQ/moqxr; 0 is valid for private deployments
     #   hmac_keys:                # Keys that sign/verify CAT tokens (HMAC-SHA256)
-    #     - id: "key-1"           # Key ID carried in the token envelope; selects which secret verifies it
-    #       secret: "replace-with-secret"   # Shared secret (use a long, random value)
-    #   require_setup_token: true            # Require a token at CLIENT_SETUP, not just on individual requests
+    #     - id: "cat-dev"         # Key ID carried in the token envelope; selects which secret verifies it
+    #       secret: "replace-with-long-random-secret"   # Shared secret used by moqx issue-cat-token
+    #   require_setup_token: true            # Require a client_setup token during CLIENT_SETUP
     #   allow_request_token_override: true   # Allow a per-request token to override the session's setup grants
-    #   strict_claims: false       # Reject unsupported token claims instead of ignoring them
+    #   strict_claims: false       # Keep false for current CAT4MOQ interop unless all issuers send only supported claims
 
   testing:
     match:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install/bin/moqx /usr/local/bin/moqx
+COPY --from=builder /install/bin/moqx-issuer /usr/local/bin/moqx-issuer
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY docker/config.docker.yaml /usr/local/share/moqx/config.docker.yaml
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -44,6 +44,10 @@ export GLOG_logtostderr=1
 export GLOG_minloglevel="${MOQX_LOG_LEVEL:-0}"
 export GLOG_v="${MOQX_VERBOSE:-0}"
 
+if [ "${1:-}" = "issue-cat-token" ]; then
+  exec /usr/local/bin/moqx "$@"
+fi
+
 # Enable core dumps (requires ulimits.core=-1 and --privileged in compose)
 if [ -d /var/coredumps ] && [ -w /proc/sys/kernel/core_pattern ]; then
   echo "/var/coredumps/core.%e.%p.%t" > /proc/sys/kernel/core_pattern

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -45,7 +45,8 @@ export GLOG_minloglevel="${MOQX_LOG_LEVEL:-0}"
 export GLOG_v="${MOQX_VERBOSE:-0}"
 
 if [ "${1:-}" = "issue-cat-token" ]; then
-  exec /usr/local/bin/moqx "$@"
+  shift
+  exec /usr/local/bin/moqx-issuer "$@"
 fi
 
 # Enable core dumps (requires ulimits.core=-1 and --privileged in compose)

--- a/docs/config.md
+++ b/docs/config.md
@@ -181,12 +181,12 @@ Grant decisions are encoded by the token issuer as CAT4MOQ actions and scopes.
 
 ### Issuing Tokens
 
-Use `moqx issue-cat-token` as the deployment/operator tool. For production-like
-deployments, point it at the same config file used by the relay so the selected
-service key is read from one place:
+Use the standalone `moqx-issuer` binary as the deployment/operator tool. For
+production-like deployments, point it at the same config file used by the relay
+so the selected service key is read from one place:
 
 ```bash
-moqx issue-cat-token \
+moqx-issuer \
   --config /etc/moqx/config.yaml \
   --auth-service live \
   --auth-key-id cat-dev \
@@ -204,7 +204,7 @@ For local development, the command can issue from an explicit secret without
 reading relay config:
 
 ```bash
-moqx issue-cat-token \
+moqx-issuer \
   --auth-key-id cat-dev \
   --auth-secret replace-with-long-random-secret \
   --auth-actions client_setup,publish_namespace,publish \
@@ -238,10 +238,10 @@ segments are slash-separated on the CLI, for example `live/event/main`.
 A publisher app should obtain a token before connecting or before issuing a
 request that needs narrower grants, then pass that token as the MOQT
 `AUTHORIZATION_TOKEN` value with the relay's configured token type. For moqxr's
-auth example, the easiest local setup is to call the moqx issuer command:
+auth example, the easiest local setup is to call the moqx-issuer command:
 
 ```bash
-export CATAPULT_CAT4MOQ_COMMAND='moqx issue-cat-token \
+export CATAPULT_CAT4MOQ_COMMAND='moqx-issuer \
   --config /etc/moqx/config.yaml \
   --auth-service live \
   --auth-key-id cat-dev \
@@ -259,8 +259,9 @@ token and `publish` for the action token.
 
 ### Docker Usage
 
-The container entrypoint passes `issue-cat-token` through to the moqx binary, so
-operators can generate tokens from the same image used to run the relay:
+The container entrypoint routes an `issue-cat-token` argument to the bundled
+`moqx-issuer` binary, so operators can generate tokens from the same image used
+to run the relay:
 
 ```bash
 docker run --rm \

--- a/docs/config.md
+++ b/docs/config.md
@@ -143,6 +143,149 @@ route correctly.
 
 ---
 
+## Authentication and Authorization
+
+Authentication is configured per service under `services.<name>.auth`. When
+enabled, moqx expects MOQT `AUTHORIZATION_TOKEN` parameters whose token type
+matches the configured `token_type`. The token value is a CAT/CWT token signed
+with an HMAC key shared by the token issuer and the relay.
+
+```yaml
+services:
+  live:
+    match:
+      - authority: {exact: "live.example.com"}
+        path: {exact: "/moq-relay"}
+    auth:
+      enabled: true
+      token_type: 16
+      hmac_keys:
+        - id: "cat-dev"
+          secret: "replace-with-long-random-secret"
+      require_setup_token: true
+      allow_request_token_override: true
+      strict_claims: false
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Enables CAT-style authorization for this service. |
+| `token_type` | `0` | MOQT `AUTHORIZATION_TOKEN` type to accept. Use `16` with CAT4MOQ tokens produced for moqxr's CAT wrapper. Type `0` is valid for private or out-of-band deployments. The value must fit in a QUIC variable integer. |
+| `hmac_keys` | empty | Required when `enabled: true`. Each key needs a non-empty `id` and `secret`; duplicate key IDs are rejected. The token issuer must use the same key ID and secret. |
+| `require_setup_token` | `true` | Requires a valid setup token authorizing `client_setup` during CLIENT_SETUP. If `false`, clients can connect without setup grants, but publish/subscribe requests still need an authorized setup or request token. |
+| `allow_request_token_override` | `true` | Allows a token on a request to replace the session setup grants for that request. If `false`, request tokens are ignored and authorization uses only the setup token grants. |
+| `strict_claims` | `false` | Rejects unsupported claims when `true`. Keep this `false` for current CAT4MOQ interop unless every issuer is known to send only supported claims. |
+
+The relay only verifies tokens; it does not call an external grant handler.
+Grant decisions are encoded by the token issuer as CAT4MOQ actions and scopes.
+
+### Issuing Tokens
+
+Use `moqx issue-cat-token` as the deployment/operator tool. For production-like
+deployments, point it at the same config file used by the relay so the selected
+service key is read from one place:
+
+```bash
+moqx issue-cat-token \
+  --config /etc/moqx/config.yaml \
+  --auth-service live \
+  --auth-key-id cat-dev \
+  --auth-actions client_setup,publish_namespace,publish \
+  --auth-namespace live/event/main \
+  --auth-track video \
+  --auth-ttl-seconds 3600
+```
+
+The default output is `base64:<token>`, which is suitable for tools that accept
+a base64-prefixed CAT token string. Use `--auth-output base64`, `hex`, or `raw`
+when integrating with software that expects a different representation.
+
+For local development, the command can issue from an explicit secret without
+reading relay config:
+
+```bash
+moqx issue-cat-token \
+  --auth-key-id cat-dev \
+  --auth-secret replace-with-long-random-secret \
+  --auth-actions client_setup,publish_namespace,publish \
+  --auth-namespace live/event/main \
+  --auth-track video
+```
+
+Supported action names are:
+
+| Name | Draft action |
+|---|---|
+| `client_setup` or `setup` | `CLIENT_SETUP` |
+| `server_setup` | `SERVER_SETUP` |
+| `publish_namespace` or `announce` | `ANNOUNCE` |
+| `subscribe_namespace` | `SUBSCRIBE_NAMESPACE` |
+| `subscribe` | `SUBSCRIBE` |
+| `request_update` or `subscribe_update` | `SUBSCRIBE_UPDATE` |
+| `publish` | `PUBLISH` |
+| `fetch` | `FETCH` |
+| `track_status` | `TRACK_STATUS` |
+
+The CLI also accepts the numeric draft action values `0` through `8`.
+`--auth-actions` defaults to `client_setup,publish_namespace,publish`, which is
+the common publisher case. The `client_setup` grant is unconstrained. Namespace
+actions are scoped by `--auth-namespace`, and track actions are scoped by
+`--auth-namespace` plus `--auth-track` when a track is provided. Namespace
+segments are slash-separated on the CLI, for example `live/event/main`.
+
+### Using Auth From moqxr
+
+A publisher app should obtain a token before connecting or before issuing a
+request that needs narrower grants, then pass that token as the MOQT
+`AUTHORIZATION_TOKEN` value with the relay's configured token type. For moqxr's
+auth example, the easiest local setup is to call the moqx issuer command:
+
+```bash
+export CATAPULT_CAT4MOQ_COMMAND='moqx issue-cat-token \
+  --config /etc/moqx/config.yaml \
+  --auth-service live \
+  --auth-key-id cat-dev \
+  --auth-actions client_setup,publish_namespace,publish \
+  --auth-namespace {namespace} \
+  --auth-track {track}'
+```
+
+The placeholders are replaced by the publisher example. If a deployment issues
+one broad publisher token, keep the fixed action list shown above. If it issues
+request-specific tokens, include the `{action}` placeholder and map it to the
+grant set required by that request; for the current moqxr auth example, the
+publisher command is invoked with `{action}` set to `client_setup` for the setup
+token and `publish` for the action token.
+
+### Docker Usage
+
+The container entrypoint passes `issue-cat-token` through to the moqx binary, so
+operators can generate tokens from the same image used to run the relay:
+
+```bash
+docker run --rm \
+  -v "$PWD/moqx-auth.yaml:/etc/moqx/config.yaml:ro" \
+  moqx:tag issue-cat-token \
+  --config /etc/moqx/config.yaml \
+  --auth-service live \
+  --auth-key-id cat-dev \
+  --auth-actions client_setup,publish_namespace,publish \
+  --auth-namespace live/event/main \
+  --auth-track video
+```
+
+### Operational Notes
+
+- Keep HMAC secrets out of source control and local shell history.
+- Rotate keys by adding a new `hmac_keys` entry, issuing new tokens with that
+key ID, waiting for old tokens to expire, then removing the old key.
+- A token signed with an unknown key ID, wrong secret, expired grant, wrong
+namespace, or wrong track is rejected.
+- Auth is currently service-local. Upstream relay connections still have no
+application-level credential exchange beyond TLS.
+
+---
+
 ## Cache
 
 Cache settings can be specified as global defaults under

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -6,6 +6,7 @@
 
 #include "auth/Auth.h"
 #include "auth/CborReader.h"
+#include "auth/HmacKey.h"
 
 #include <catapult/crypto.hpp>
 #include <catapult/cwt.hpp>
@@ -15,8 +16,6 @@
 #include <folly/Expected.h>
 #include <folly/Range.h>
 #include <folly/logging/xlog.h>
-#include <openssl/evp.h>
-#include <openssl/kdf.h>
 
 #include <algorithm>
 #include <array>
@@ -43,48 +42,6 @@ std::string canonicalNamespace(const TrackNamespace& ns) {
   return out;
 }
 
-// Derive a 256-bit HMAC key from the configured secret using HKDF-SHA256
-// (RFC 5869) rather than a bare hash. The fixed, non-secret salt and info
-// strings provide domain separation so the same configured secret can't yield
-// identical key material if reused for another purpose. (HKDF does not add
-// entropy: a low-entropy secret is still weak -- operators should use a long,
-// random secret.)
-constexpr std::string_view kHkdfSalt = "moqx-catapult-v1";
-constexpr std::string_view kHkdfInfo = "moqx-catapult-hmac-token-verify";
-
-std::vector<uint8_t> deriveHmacKey(std::string_view secret) {
-  std::vector<uint8_t> key(32); // 256-bit output for HMAC-SHA256
-
-  auto* ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr);
-  if (!ctx) {
-    throw std::runtime_error("EVP_PKEY_CTX_new_id(HKDF) failed");
-  }
-  auto guard = std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>(ctx, EVP_PKEY_CTX_free);
-
-  size_t keyLen = key.size();
-  if (EVP_PKEY_derive_init(ctx) <= 0 || EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha256()) <= 0 ||
-      EVP_PKEY_CTX_set1_hkdf_salt(
-          ctx,
-          reinterpret_cast<const unsigned char*>(kHkdfSalt.data()),
-          static_cast<int>(kHkdfSalt.size())
-      ) <= 0 ||
-      EVP_PKEY_CTX_set1_hkdf_key(
-          ctx,
-          reinterpret_cast<const unsigned char*>(secret.data()),
-          static_cast<int>(secret.size())
-      ) <= 0 ||
-      EVP_PKEY_CTX_add1_hkdf_info(
-          ctx,
-          reinterpret_cast<const unsigned char*>(kHkdfInfo.data()),
-          static_cast<int>(kHkdfInfo.size())
-      ) <= 0 ||
-      EVP_PKEY_derive(ctx, key.data(), &keyLen) <= 0) {
-    throw std::runtime_error("HKDF key derivation failed");
-  }
-  key.resize(keyLen);
-  return key;
-}
-
 std::vector<uint8_t> toBytes(std::string_view value) {
   return std::vector<uint8_t>(
       reinterpret_cast<const uint8_t*>(value.data()),
@@ -94,31 +51,6 @@ std::vector<uint8_t> toBytes(std::string_view value) {
 
 std::string toString(const std::vector<uint8_t>& bytes) {
   return std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
-}
-
-catapult::MoqtCompoundMatch toCatapultMatch(const std::vector<MatchRule>& rules) {
-  if (rules.empty()) {
-    return catapult::MoqtCompoundMatch::any();
-  }
-  std::vector<catapult::MoqtBinaryMatch> conditions;
-  conditions.reserve(rules.size());
-  for (const auto& rule : rules) {
-    switch (rule.type) {
-    case MatchRule::Type::Exact:
-      conditions.push_back(catapult::MoqtBinaryMatch::exact(rule.value));
-      break;
-    case MatchRule::Type::Prefix:
-      conditions.push_back(catapult::MoqtBinaryMatch::prefix(rule.value));
-      break;
-    case MatchRule::Type::Suffix:
-      conditions.push_back(catapult::MoqtBinaryMatch::suffix(rule.value));
-      break;
-    case MatchRule::Type::Contains:
-      conditions.push_back(catapult::MoqtBinaryMatch::contains(rule.value));
-      break;
-    }
-  }
-  return catapult::MoqtCompoundMatch::all(std::move(conditions));
 }
 
 MatchRule::Type fromCatapultMatchType(catapult::BinaryMatchType type) {
@@ -148,32 +80,6 @@ std::vector<MatchRule> fromCatapultMatch(const catapult::MoqtCompoundMatch& matc
     });
   }
   return rules;
-}
-
-catapult::CatToken tokenFromGrants(const Grants& grants) {
-  catapult::CatToken token;
-  if (grants.expiresAt != std::chrono::system_clock::time_point::max()) {
-    token.core.exp =
-        std::chrono::duration_cast<std::chrono::seconds>(grants.expiresAt.time_since_epoch())
-            .count();
-  }
-
-  catapult::MoqtClaims moqt = catapult::MoqtClaims::create(grants.scopes.size());
-  for (const auto& scope : grants.scopes) {
-    std::vector<int> actions;
-    actions.reserve(scope.actions.size());
-    for (auto action : scope.actions) {
-      actions.push_back(static_cast<int>(action));
-    }
-    moqt.addScope(
-        actions,
-        toCatapultMatch(scope.namespaceMatches),
-        toCatapultMatch(scope.trackMatches)
-    );
-  }
-  token.extended.setMoqtClaims(std::move(moqt));
-  token.validateTokenStructure();
-  return token;
 }
 
 Grants grantsFromToken(const catapult::CatToken& token) {
@@ -342,22 +248,6 @@ folly::Expected<folly::Unit, AuthError> authorize(
     return folly::makeUnexpected(AuthError::Forbidden);
   }
   return folly::unit;
-}
-
-std::string
-AuthTokenVerifier::sign(std::string_view keyID, std::string_view secret, const Grants& grants) {
-  catapult::HmacSha256Algorithm hmac(deriveHmacKey(secret));
-  catapult::Cwt cwt(catapult::ALG_HMAC256_256, tokenFromGrants(grants));
-  cwt.withKeyId(std::string(keyID));
-  return toString(cwt.createCwt(catapult::CwtMode::MACed, hmac));
-}
-
-std::string AuthTokenVerifier::signForTest(
-    std::string_view keyID,
-    std::string_view secret,
-    const Grants& grants
-) {
-  return sign(keyID, secret, grants);
 }
 
 std::optional<AuthToken> findAuthToken(const Parameters& params, uint64_t tokenType) {

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -344,15 +344,20 @@ folly::Expected<folly::Unit, AuthError> authorize(
   return folly::unit;
 }
 
+std::string
+AuthTokenVerifier::sign(std::string_view keyID, std::string_view secret, const Grants& grants) {
+  catapult::HmacSha256Algorithm hmac(deriveHmacKey(secret));
+  catapult::Cwt cwt(catapult::ALG_HMAC256_256, tokenFromGrants(grants));
+  cwt.withKeyId(std::string(keyID));
+  return toString(cwt.createCwt(catapult::CwtMode::MACed, hmac));
+}
+
 std::string AuthTokenVerifier::signForTest(
     std::string_view keyID,
     std::string_view secret,
     const Grants& grants
 ) {
-  catapult::HmacSha256Algorithm hmac(deriveHmacKey(secret));
-  catapult::Cwt cwt(catapult::ALG_HMAC256_256, tokenFromGrants(grants));
-  cwt.withKeyId(std::string(keyID));
-  return toString(cwt.createCwt(catapult::CwtMode::MACed, hmac));
+  return sign(keyID, secret, grants);
 }
 
 std::optional<AuthToken> findAuthToken(const Parameters& params, uint64_t tokenType) {

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -72,12 +72,6 @@ public:
 
   folly::Expected<Grants, AuthError> verify(const moxygen::AuthToken& token) const;
 
-  static std::string sign(std::string_view keyID, std::string_view secret, const Grants& grants);
-
-  // Test/local issuer helper for Catapult CWT tokens signed with the configured HMAC key.
-  static std::string
-  signForTest(std::string_view keyID, std::string_view secret, const Grants& grants);
-
 private:
   // HMAC key material derived once at construction. keyIdIndex_ maps each
   // configured key's id to its index in derivedKeys_, enabling O(1) key

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -72,6 +72,8 @@ public:
 
   folly::Expected<Grants, AuthError> verify(const moxygen::AuthToken& token) const;
 
+  static std::string sign(std::string_view keyID, std::string_view secret, const Grants& grants);
+
   // Test/local issuer helper for Catapult CWT tokens signed with the configured HMAC key.
   static std::string
   signForTest(std::string_view keyID, std::string_view secret, const Grants& grants);

--- a/src/auth/AuthTokenIssuer.cpp
+++ b/src/auth/AuthTokenIssuer.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "auth/AuthTokenIssuer.h"
+
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace openmoq::moqx::auth {
+namespace {
+
+std::string canonicalNamespace(const moxygen::TrackNamespace& ns) {
+  std::string out;
+  for (const auto& field : ns.trackNamespace) {
+    out.push_back(static_cast<char>((field.size() >> 24) & 0xff));
+    out.push_back(static_cast<char>((field.size() >> 16) & 0xff));
+    out.push_back(static_cast<char>((field.size() >> 8) & 0xff));
+    out.push_back(static_cast<char>(field.size() & 0xff));
+    out.append(field);
+  }
+  return out;
+}
+
+std::string trim(std::string_view value) {
+  auto begin = value.begin();
+  auto end = value.end();
+  while (begin != end && std::isspace(static_cast<unsigned char>(*begin))) {
+    ++begin;
+  }
+  while (begin != end && std::isspace(static_cast<unsigned char>(*(end - 1)))) {
+    --end;
+  }
+  return std::string(begin, end);
+}
+
+std::string normalizeActionName(std::string_view value) {
+  auto out = trim(value);
+  std::replace(out.begin(), out.end(), '-', '_');
+  std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return out;
+}
+
+Action parseAction(std::string_view value) {
+  const auto name = normalizeActionName(value);
+  if (name == "client_setup" || name == "setup" || name == "0") {
+    return Action::ClientSetup;
+  }
+  if (name == "server_setup" || name == "1") {
+    return Action::ServerSetup;
+  }
+  if (name == "publish_namespace" || name == "announce" || name == "2") {
+    return Action::PublishNamespace;
+  }
+  if (name == "subscribe_namespace" || name == "3") {
+    return Action::SubscribeNamespace;
+  }
+  if (name == "subscribe" || name == "4") {
+    return Action::Subscribe;
+  }
+  if (name == "request_update" || name == "subscribe_update" || name == "5") {
+    return Action::RequestUpdate;
+  }
+  if (name == "publish" || name == "6") {
+    return Action::Publish;
+  }
+  if (name == "fetch" || name == "7") {
+    return Action::Fetch;
+  }
+  if (name == "track_status" || name == "8") {
+    return Action::TrackStatus;
+  }
+  throw std::invalid_argument("unknown CAT4MOQ action: " + std::string(value));
+}
+
+bool containsAction(const std::vector<Action>& actions, Action action) {
+  return std::find(actions.begin(), actions.end(), action) != actions.end();
+}
+
+bool isNamespaceAction(Action action) {
+  switch (action) {
+  case Action::ServerSetup:
+  case Action::PublishNamespace:
+  case Action::SubscribeNamespace:
+    return true;
+  case Action::ClientSetup:
+  case Action::Subscribe:
+  case Action::RequestUpdate:
+  case Action::Publish:
+  case Action::Fetch:
+  case Action::TrackStatus:
+    return false;
+  }
+  return false;
+}
+
+} // namespace
+
+std::vector<Action> parseActions(std::string_view value) {
+  std::vector<Action> actions;
+  std::size_t start = 0;
+  while (start <= value.size()) {
+    const auto comma = value.find(',', start);
+    const auto end = comma == std::string_view::npos ? value.size() : comma;
+    auto token = trim(value.substr(start, end - start));
+    if (!token.empty()) {
+      actions.push_back(parseAction(token));
+    }
+    if (comma == std::string_view::npos) {
+      break;
+    }
+    start = comma + 1;
+  }
+  if (actions.empty()) {
+    throw std::invalid_argument("at least one CAT4MOQ action is required");
+  }
+  return actions;
+}
+
+moxygen::TrackNamespace parseTrackNamespace(std::string_view value) {
+  moxygen::TrackNamespace ns;
+  std::size_t start = 0;
+  while (start <= value.size()) {
+    const auto slash = value.find('/', start);
+    const auto end = slash == std::string_view::npos ? value.size() : slash;
+    if (end > start) {
+      ns.trackNamespace.emplace_back(value.substr(start, end - start));
+    }
+    if (slash == std::string_view::npos) {
+      break;
+    }
+    start = slash + 1;
+  }
+  if (ns.trackNamespace.empty()) {
+    ns.trackNamespace.emplace_back(value);
+  }
+  return ns;
+}
+
+IssuedToken issueToken(const IssueTokenOptions& options) {
+  if (options.keyID.empty()) {
+    throw std::invalid_argument("CAT4MOQ key id must be non-empty");
+  }
+  if (options.secret.empty()) {
+    throw std::invalid_argument("CAT4MOQ secret must be non-empty");
+  }
+  if (options.actions.empty()) {
+    throw std::invalid_argument("at least one CAT4MOQ action is required");
+  }
+  if (options.ttl <= std::chrono::seconds::zero()) {
+    throw std::invalid_argument("CAT4MOQ ttl must be greater than zero");
+  }
+
+  Grants grants;
+  grants.expiresAt = options.now + options.ttl;
+
+  if (containsAction(options.actions, Action::ClientSetup)) {
+    grants.scopes.push_back(Scope{
+        .actions = {Action::ClientSetup},
+        .namespaceMatches = {},
+        .trackMatches = {},
+    });
+  }
+
+  std::vector<MatchRule> namespaceMatches;
+  if (!options.trackNamespace.trackNamespace.empty()) {
+    namespaceMatches.push_back(MatchRule{
+        .type = MatchRule::Type::Exact,
+        .value = canonicalNamespace(options.trackNamespace),
+    });
+  }
+
+  std::vector<Action> namespaceActions;
+  namespaceActions.reserve(options.actions.size());
+  std::vector<Action> trackActions;
+  trackActions.reserve(options.actions.size());
+  for (auto action : options.actions) {
+    if (action == Action::ClientSetup) {
+      continue;
+    }
+    if (isNamespaceAction(action)) {
+      namespaceActions.push_back(action);
+    } else {
+      trackActions.push_back(action);
+    }
+  }
+
+  if (!namespaceActions.empty()) {
+    grants.scopes.push_back(Scope{
+        .actions = std::move(namespaceActions),
+        .namespaceMatches = namespaceMatches,
+        .trackMatches = {},
+    });
+  }
+
+  if (!trackActions.empty()) {
+    std::vector<MatchRule> trackMatches;
+    if (options.trackName.has_value()) {
+      trackMatches.push_back(MatchRule{
+          .type = MatchRule::Type::Exact,
+          .value = *options.trackName,
+      });
+    }
+
+    grants.scopes.push_back(Scope{
+        .actions = std::move(trackActions),
+        .namespaceMatches = std::move(namespaceMatches),
+        .trackMatches = std::move(trackMatches),
+    });
+  }
+
+  return IssuedToken{.tokenValue = AuthTokenVerifier::sign(options.keyID, options.secret, grants)};
+}
+
+config::AuthConfig::HmacKey selectHmacKey(const config::AuthConfig& auth, std::string_view keyID) {
+  if (!auth.enabled) {
+    throw std::invalid_argument("service auth is not enabled");
+  }
+  if (auth.hmacKeys.empty()) {
+    throw std::invalid_argument("service auth has no HMAC keys");
+  }
+  if (keyID.empty()) {
+    return auth.hmacKeys.front();
+  }
+  for (const auto& key : auth.hmacKeys) {
+    if (key.id == keyID) {
+      return key;
+    }
+  }
+  throw std::invalid_argument("service auth has no HMAC key with id: " + std::string(keyID));
+}
+
+} // namespace openmoq::moqx::auth

--- a/src/auth/AuthTokenIssuer.cpp
+++ b/src/auth/AuthTokenIssuer.cpp
@@ -6,11 +6,19 @@
 
 #include "auth/AuthTokenIssuer.h"
 
+#include "auth/HmacKey.h"
+
+#include <catapult/crypto.hpp>
+#include <catapult/cwt.hpp>
+#include <catapult/moqt_claims.hpp>
+
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace openmoq::moqx::auth {
 namespace {
@@ -25,6 +33,57 @@ std::string canonicalNamespace(const moxygen::TrackNamespace& ns) {
     out.append(field);
   }
   return out;
+}
+
+catapult::MoqtCompoundMatch toCatapultMatch(const std::vector<MatchRule>& rules) {
+  if (rules.empty()) {
+    return catapult::MoqtCompoundMatch::any();
+  }
+  std::vector<catapult::MoqtBinaryMatch> conditions;
+  conditions.reserve(rules.size());
+  for (const auto& rule : rules) {
+    switch (rule.type) {
+    case MatchRule::Type::Exact:
+      conditions.push_back(catapult::MoqtBinaryMatch::exact(rule.value));
+      break;
+    case MatchRule::Type::Prefix:
+      conditions.push_back(catapult::MoqtBinaryMatch::prefix(rule.value));
+      break;
+    case MatchRule::Type::Suffix:
+      conditions.push_back(catapult::MoqtBinaryMatch::suffix(rule.value));
+      break;
+    case MatchRule::Type::Contains:
+      conditions.push_back(catapult::MoqtBinaryMatch::contains(rule.value));
+      break;
+    }
+  }
+  return catapult::MoqtCompoundMatch::all(std::move(conditions));
+}
+
+catapult::CatToken tokenFromGrants(const Grants& grants) {
+  catapult::CatToken token;
+  if (grants.expiresAt != std::chrono::system_clock::time_point::max()) {
+    token.core.exp =
+        std::chrono::duration_cast<std::chrono::seconds>(grants.expiresAt.time_since_epoch())
+            .count();
+  }
+
+  catapult::MoqtClaims moqt = catapult::MoqtClaims::create(grants.scopes.size());
+  for (const auto& scope : grants.scopes) {
+    std::vector<int> actions;
+    actions.reserve(scope.actions.size());
+    for (auto action : scope.actions) {
+      actions.push_back(static_cast<int>(action));
+    }
+    moqt.addScope(
+        actions,
+        toCatapultMatch(scope.namespaceMatches),
+        toCatapultMatch(scope.trackMatches)
+    );
+  }
+  token.extended.setMoqtClaims(std::move(moqt));
+  token.validateTokenStructure();
+  return token;
 }
 
 std::string trim(std::string_view value) {
@@ -216,7 +275,15 @@ IssuedToken issueToken(const IssueTokenOptions& options) {
     });
   }
 
-  return IssuedToken{.tokenValue = AuthTokenVerifier::sign(options.keyID, options.secret, grants)};
+  return IssuedToken{.tokenValue = signGrants(options.keyID, options.secret, grants)};
+}
+
+std::string signGrants(std::string_view keyID, std::string_view secret, const Grants& grants) {
+  catapult::HmacSha256Algorithm hmac(deriveHmacKey(secret));
+  catapult::Cwt cwt(catapult::ALG_HMAC256_256, tokenFromGrants(grants));
+  cwt.withKeyId(std::string(keyID));
+  auto bytes = cwt.createCwt(catapult::CwtMode::MACed, hmac);
+  return std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
 }
 
 config::AuthConfig::HmacKey selectHmacKey(const config::AuthConfig& auth, std::string_view keyID) {

--- a/src/auth/AuthTokenIssuer.h
+++ b/src/auth/AuthTokenIssuer.h
@@ -34,6 +34,9 @@ struct IssuedToken {
 
 IssuedToken issueToken(const IssueTokenOptions& options);
 
+// Signs arbitrary grants into a CWT; kept out of moqx_core so the relay only verifies.
+std::string signGrants(std::string_view keyID, std::string_view secret, const Grants& grants);
+
 config::AuthConfig::HmacKey selectHmacKey(const config::AuthConfig& auth, std::string_view keyID);
 std::vector<Action> parseActions(std::string_view value);
 moxygen::TrackNamespace parseTrackNamespace(std::string_view value);

--- a/src/auth/AuthTokenIssuer.h
+++ b/src/auth/AuthTokenIssuer.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "auth/Auth.h"
+
+#include <moxygen/MoQTypes.h>
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace openmoq::moqx::auth {
+
+struct IssueTokenOptions {
+  std::string keyID;
+  std::string secret;
+  std::vector<Action> actions;
+  moxygen::TrackNamespace trackNamespace;
+  std::optional<std::string> trackName;
+  std::chrono::seconds ttl{3600};
+  std::chrono::system_clock::time_point now{std::chrono::system_clock::now()};
+};
+
+struct IssuedToken {
+  std::string tokenValue;
+};
+
+IssuedToken issueToken(const IssueTokenOptions& options);
+
+config::AuthConfig::HmacKey selectHmacKey(const config::AuthConfig& auth, std::string_view keyID);
+std::vector<Action> parseActions(std::string_view value);
+moxygen::TrackNamespace parseTrackNamespace(std::string_view value);
+
+} // namespace openmoq::moqx::auth

--- a/src/auth/HmacKey.cpp
+++ b/src/auth/HmacKey.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "auth/HmacKey.h"
+
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+
+#include <memory>
+#include <stdexcept>
+
+namespace openmoq::moqx::auth {
+namespace {
+
+// Derive a 256-bit HMAC key from the configured secret using HKDF-SHA256
+// (RFC 5869) rather than a bare hash. The fixed, non-secret salt and info
+// strings provide domain separation so the same configured secret can't yield
+// identical key material if reused for another purpose. (HKDF does not add
+// entropy: a low-entropy secret is still weak -- operators should use a long,
+// random secret.)
+constexpr std::string_view kHkdfSalt = "moqx-catapult-v1";
+constexpr std::string_view kHkdfInfo = "moqx-catapult-hmac-token-verify";
+
+} // namespace
+
+std::vector<uint8_t> deriveHmacKey(std::string_view secret) {
+  std::vector<uint8_t> key(32); // 256-bit output for HMAC-SHA256
+
+  auto* ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr);
+  if (!ctx) {
+    throw std::runtime_error("EVP_PKEY_CTX_new_id(HKDF) failed");
+  }
+  auto guard = std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>(ctx, EVP_PKEY_CTX_free);
+
+  size_t keyLen = key.size();
+  if (EVP_PKEY_derive_init(ctx) <= 0 || EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha256()) <= 0 ||
+      EVP_PKEY_CTX_set1_hkdf_salt(
+          ctx,
+          reinterpret_cast<const unsigned char*>(kHkdfSalt.data()),
+          static_cast<int>(kHkdfSalt.size())
+      ) <= 0 ||
+      EVP_PKEY_CTX_set1_hkdf_key(
+          ctx,
+          reinterpret_cast<const unsigned char*>(secret.data()),
+          static_cast<int>(secret.size())
+      ) <= 0 ||
+      EVP_PKEY_CTX_add1_hkdf_info(
+          ctx,
+          reinterpret_cast<const unsigned char*>(kHkdfInfo.data()),
+          static_cast<int>(kHkdfInfo.size())
+      ) <= 0 ||
+      EVP_PKEY_derive(ctx, key.data(), &keyLen) <= 0) {
+    throw std::runtime_error("HKDF key derivation failed");
+  }
+  key.resize(keyLen);
+  return key;
+}
+
+} // namespace openmoq::moqx::auth

--- a/src/auth/HmacKey.h
+++ b/src/auth/HmacKey.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace openmoq::moqx::auth {
+
+// Shared by the relay's verifier and the issuer so the HKDF salt/info can't
+// drift out of sync (a mismatch yields tokens the relay silently rejects).
+std::vector<uint8_t> deriveHmacKey(std::string_view secret);
+
+} // namespace openmoq::moqx::auth

--- a/src/auth/IssuerMain.cpp
+++ b/src/auth/IssuerMain.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// moqx-issuer: standalone CLI that mints Catapult CAT4MOQ CWT tokens for a moqx
+// relay. The relay only verifies tokens; issuing/signing lives here.
+
+#include "auth/AuthTokenIssuer.h"
+#include "config/loader/ConfigInit.h"
+
+#include <folly/String.h>
+#include <folly/base64.h>
+#include <folly/init/Init.h>
+
+#include <gflags/gflags.h>
+
+#include <chrono>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+DEFINE_string(config, "", "Path to config file (for --auth_service key lookup)");
+DEFINE_bool(strict_config, false, "Reject unknown config fields");
+DEFINE_string(auth_service, "", "Service name to read the auth key from --config");
+DEFINE_string(auth_key_id, "", "HMAC key id; defaults to first configured key");
+DEFINE_string(auth_secret, "", "HMAC secret; bypasses --config key lookup");
+DEFINE_string(
+    auth_actions,
+    "client_setup,publish_namespace,publish",
+    "Comma-separated CAT4MOQ actions"
+);
+DEFINE_string(auth_namespace, "", "Slash-separated track namespace");
+DEFINE_string(auth_track, "", "Optional track name");
+DEFINE_int32(auth_ttl_seconds, 3600, "Token lifetime in seconds");
+DEFINE_string(auth_output, "base64-prefix", "Output encoding: base64-prefix, base64, hex, or raw");
+
+using namespace openmoq::moqx;
+
+namespace {
+
+namespace cfg = config;
+
+constexpr std::string_view kServeCommand = "serve";
+
+auth::IssueTokenOptions makeIssueTokenOptions(const cfg::ResolvedConfig* resolvedConfig) {
+  std::string keyID = FLAGS_auth_key_id;
+  std::string secret = FLAGS_auth_secret;
+  if (secret.empty()) {
+    if (resolvedConfig == nullptr) {
+      throw std::invalid_argument(
+          "--auth_secret is required unless --config and --auth_service select a configured key"
+      );
+    }
+    if (FLAGS_auth_service.empty()) {
+      throw std::invalid_argument("--auth_service is required when issuing from --config");
+    }
+    const auto& services = resolvedConfig->config.services;
+    auto it = services.find(FLAGS_auth_service);
+    if (it == services.end()) {
+      throw std::invalid_argument("unknown auth service: " + FLAGS_auth_service);
+    }
+    auto key = auth::selectHmacKey(it->second.auth, FLAGS_auth_key_id);
+    keyID = std::move(key.id);
+    secret = std::move(key.secret);
+  } else if (keyID.empty()) {
+    keyID = "operator";
+  }
+
+  auth::IssueTokenOptions options{
+      .keyID = std::move(keyID),
+      .secret = std::move(secret),
+      .actions = auth::parseActions(FLAGS_auth_actions),
+      .ttl = std::chrono::seconds(FLAGS_auth_ttl_seconds),
+  };
+  if (!FLAGS_auth_namespace.empty()) {
+    options.trackNamespace = auth::parseTrackNamespace(FLAGS_auth_namespace);
+  }
+  if (!FLAGS_auth_track.empty()) {
+    options.trackName = FLAGS_auth_track;
+  }
+  return options;
+}
+
+int runIssueCatTokenCommand(const char* programName) {
+  std::optional<cfg::ResolvedConfig> resolvedConfig;
+  if (!FLAGS_config.empty()) {
+    auto result =
+        cfg::handleConfigSubcommand(kServeCommand, FLAGS_config, FLAGS_strict_config, programName);
+    if (result.hasError()) {
+      return result.error();
+    }
+    resolvedConfig = std::move(result.value());
+  }
+
+  try {
+    const auto token = auth::issueToken(
+        makeIssueTokenOptions(resolvedConfig.has_value() ? &resolvedConfig.value() : nullptr)
+    );
+    if (FLAGS_auth_output == "base64-prefix") {
+      std::cout << "base64:" << folly::base64Encode(token.tokenValue) << '\n';
+    } else if (FLAGS_auth_output == "base64") {
+      std::cout << folly::base64Encode(token.tokenValue) << '\n';
+    } else if (FLAGS_auth_output == "hex") {
+      std::cout << folly::hexlify(folly::StringPiece(token.tokenValue)) << '\n';
+    } else if (FLAGS_auth_output == "raw") {
+      std::cout.write(
+          token.tokenValue.data(),
+          static_cast<std::streamsize>(token.tokenValue.size())
+      );
+    } else {
+      throw std::invalid_argument("--auth_output must be base64-prefix, base64, hex, or raw");
+    }
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << '\n';
+    google::ShowUsageWithFlags(programName);
+    return 1;
+  }
+  return 0;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  google::SetUsageMessage("moqx-issuer — mint a Catapult CAT4MOQ CWT for publishers/subscribers\n\n"
+                          "Provide a key via --auth_secret, or via --config with --auth_service.\n"
+                          "Usage: moqx-issuer --auth_secret <secret> --auth_actions <a,b,c> "
+                          "[--auth_namespace <ns>] [--auth_track <t>]");
+  folly::Init init(&argc, &argv, true);
+  return runIssueCatTokenCommand(argv[0]);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,23 +11,15 @@
 #include "admin/CachePurgeHandler.h"
 #include "admin/MetricsHandler.h"
 #include "admin/StateHandler.h"
-#include "auth/AuthTokenIssuer.h"
 #include "bpf/QuicReuseportSteering.h"
 #include "config/loader/ConfigInit.h"
 #include "logging/MLogSetup.h"
 #include "stats/StatsRegistry.h"
 
-#include <gflags/gflags.h>
-
 #include <csignal>
 
 #include <chrono>
-#include <cstdint>
-#include <iostream>
-#include <optional>
-#include <stdexcept>
 #include <thread>
-#include <vector>
 
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <folly/executors/thread_factory/NamedThreadFactory.h>
@@ -48,22 +40,6 @@ FOLLY_INIT_LOGGING_CONFIG(".=INFO;default:async=true,sync_level=WARN");
 
 DEFINE_string(config, "", "Path to config file (required)");
 DEFINE_bool(strict_config, false, "Reject unknown config fields");
-DEFINE_string(auth_service, "", "issue-cat-token: service name to read auth key from --config");
-DEFINE_string(auth_key_id, "", "issue-cat-token: HMAC key id; defaults to first configured key");
-DEFINE_string(auth_secret, "", "issue-cat-token: HMAC secret; bypasses --config key lookup");
-DEFINE_string(
-    auth_actions,
-    "client_setup,publish_namespace,publish",
-    "issue-cat-token: comma-separated CAT4MOQ actions"
-);
-DEFINE_string(auth_namespace, "", "issue-cat-token: slash-separated track namespace");
-DEFINE_string(auth_track, "", "issue-cat-token: optional track name");
-DEFINE_int32(auth_ttl_seconds, 3600, "issue-cat-token: token lifetime in seconds");
-DEFINE_string(
-    auth_output,
-    "base64-prefix",
-    "issue-cat-token: output encoding: base64-prefix, base64, hex, or raw"
-);
 
 using namespace openmoq::moqx;
 
@@ -72,112 +48,6 @@ namespace {
 namespace cfg = config;
 
 constexpr std::string_view kServeCommand = "serve";
-constexpr std::string_view kIssueCatTokenCommand = "issue-cat-token";
-
-std::string base64Encode(std::string_view bytes) {
-  static constexpr char kAlphabet[] =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-  std::string out;
-  out.reserve(((bytes.size() + 2) / 3) * 4);
-  for (std::size_t i = 0; i < bytes.size(); i += 3) {
-    const auto b0 = static_cast<uint8_t>(bytes[i]);
-    const auto b1 = i + 1 < bytes.size() ? static_cast<uint8_t>(bytes[i + 1]) : uint8_t{0};
-    const auto b2 = i + 2 < bytes.size() ? static_cast<uint8_t>(bytes[i + 2]) : uint8_t{0};
-    out.push_back(kAlphabet[b0 >> 2]);
-    out.push_back(kAlphabet[((b0 & 0x03) << 4) | (b1 >> 4)]);
-    out.push_back(i + 1 < bytes.size() ? kAlphabet[((b1 & 0x0f) << 2) | (b2 >> 6)] : '=');
-    out.push_back(i + 2 < bytes.size() ? kAlphabet[b2 & 0x3f] : '=');
-  }
-  return out;
-}
-
-std::string hexEncode(std::string_view bytes) {
-  static constexpr char kHex[] = "0123456789abcdef";
-  std::string out;
-  out.reserve(bytes.size() * 2);
-  for (auto c : bytes) {
-    const auto b = static_cast<uint8_t>(c);
-    out.push_back(kHex[b >> 4]);
-    out.push_back(kHex[b & 0x0f]);
-  }
-  return out;
-}
-
-auth::IssueTokenOptions makeIssueTokenOptions(const cfg::ResolvedConfig* resolvedConfig) {
-  std::string keyID = FLAGS_auth_key_id;
-  std::string secret = FLAGS_auth_secret;
-  if (secret.empty()) {
-    if (resolvedConfig == nullptr) {
-      throw std::invalid_argument(
-          "--auth-secret is required unless --config and --auth-service select a configured key"
-      );
-    }
-    if (FLAGS_auth_service.empty()) {
-      throw std::invalid_argument("--auth-service is required when issuing from --config");
-    }
-    const auto& services = resolvedConfig->config.services;
-    auto it = services.find(FLAGS_auth_service);
-    if (it == services.end()) {
-      throw std::invalid_argument("unknown auth service: " + FLAGS_auth_service);
-    }
-    auto key = auth::selectHmacKey(it->second.auth, FLAGS_auth_key_id);
-    keyID = std::move(key.id);
-    secret = std::move(key.secret);
-  } else if (keyID.empty()) {
-    keyID = "operator";
-  }
-
-  auth::IssueTokenOptions options{
-      .keyID = std::move(keyID),
-      .secret = std::move(secret),
-      .actions = auth::parseActions(FLAGS_auth_actions),
-      .ttl = std::chrono::seconds(FLAGS_auth_ttl_seconds),
-  };
-  if (!FLAGS_auth_namespace.empty()) {
-    options.trackNamespace = auth::parseTrackNamespace(FLAGS_auth_namespace);
-  }
-  if (!FLAGS_auth_track.empty()) {
-    options.trackName = FLAGS_auth_track;
-  }
-  return options;
-}
-
-int runIssueCatTokenCommand(const char* programName) {
-  std::optional<cfg::ResolvedConfig> resolvedConfig;
-  if (!FLAGS_config.empty()) {
-    auto result =
-        cfg::handleConfigSubcommand(kServeCommand, FLAGS_config, FLAGS_strict_config, programName);
-    if (result.hasError()) {
-      return result.error();
-    }
-    resolvedConfig = std::move(result.value());
-  }
-
-  try {
-    const auto token = auth::issueToken(
-        makeIssueTokenOptions(resolvedConfig.has_value() ? &resolvedConfig.value() : nullptr)
-    );
-    if (FLAGS_auth_output == "base64-prefix") {
-      std::cout << "base64:" << base64Encode(token.tokenValue) << '\n';
-    } else if (FLAGS_auth_output == "base64") {
-      std::cout << base64Encode(token.tokenValue) << '\n';
-    } else if (FLAGS_auth_output == "hex") {
-      std::cout << hexEncode(token.tokenValue) << '\n';
-    } else if (FLAGS_auth_output == "raw") {
-      std::cout.write(
-          token.tokenValue.data(),
-          static_cast<std::streamsize>(token.tokenValue.size())
-      );
-    } else {
-      throw std::invalid_argument("--auth-output must be base64-prefix, base64, hex, or raw");
-    }
-  } catch (const std::exception& e) {
-    std::cerr << "Error: " << e.what() << '\n';
-    google::ShowUsageWithFlags(programName);
-    return 1;
-  }
-  return 0;
-}
 
 class ShutdownSignalHandler : public folly::AsyncSignalHandler {
 public:
@@ -202,9 +72,7 @@ int main(int argc, char* argv[]) {
       "moqx MoQ relay server\n\n"
       "Subcommands:\n"
       "  serve                Start the relay (default)\n" +
-      cfg::configSubcommandUsage() +
-      "  issue-cat-token      Issue a Catapult CAT4MOQ CWT for publishers\n"
-      "\nUsage: moqx [subcommand] --config <path>"
+      cfg::configSubcommandUsage() + "\nUsage: moqx [subcommand] --config <path>"
   );
   // Combine repeated --logging / --log-handler into one composite before
   // folly::Init — see docs/logging.md.
@@ -214,10 +82,6 @@ int main(int argc, char* argv[]) {
   std::string_view subcommand = kServeCommand;
   if (argc > 1) {
     subcommand = argv[1];
-  }
-
-  if (subcommand == kIssueCatTokenCommand) {
-    return runIssueCatTokenCommand(argv[0]);
   }
 
   auto result = cfg::handleConfigSubcommand(subcommand, FLAGS_config, FLAGS_strict_config, argv[0]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,15 +11,23 @@
 #include "admin/CachePurgeHandler.h"
 #include "admin/MetricsHandler.h"
 #include "admin/StateHandler.h"
+#include "auth/AuthTokenIssuer.h"
 #include "bpf/QuicReuseportSteering.h"
 #include "config/loader/ConfigInit.h"
 #include "logging/MLogSetup.h"
 #include "stats/StatsRegistry.h"
 
+#include <gflags/gflags.h>
+
 #include <csignal>
 
 #include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
 #include <thread>
+#include <vector>
 
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <folly/executors/thread_factory/NamedThreadFactory.h>
@@ -40,6 +48,22 @@ FOLLY_INIT_LOGGING_CONFIG(".=INFO;default:async=true,sync_level=WARN");
 
 DEFINE_string(config, "", "Path to config file (required)");
 DEFINE_bool(strict_config, false, "Reject unknown config fields");
+DEFINE_string(auth_service, "", "issue-cat-token: service name to read auth key from --config");
+DEFINE_string(auth_key_id, "", "issue-cat-token: HMAC key id; defaults to first configured key");
+DEFINE_string(auth_secret, "", "issue-cat-token: HMAC secret; bypasses --config key lookup");
+DEFINE_string(
+    auth_actions,
+    "client_setup,publish_namespace,publish",
+    "issue-cat-token: comma-separated CAT4MOQ actions"
+);
+DEFINE_string(auth_namespace, "", "issue-cat-token: slash-separated track namespace");
+DEFINE_string(auth_track, "", "issue-cat-token: optional track name");
+DEFINE_int32(auth_ttl_seconds, 3600, "issue-cat-token: token lifetime in seconds");
+DEFINE_string(
+    auth_output,
+    "base64-prefix",
+    "issue-cat-token: output encoding: base64-prefix, base64, hex, or raw"
+);
 
 using namespace openmoq::moqx;
 
@@ -48,6 +72,112 @@ namespace {
 namespace cfg = config;
 
 constexpr std::string_view kServeCommand = "serve";
+constexpr std::string_view kIssueCatTokenCommand = "issue-cat-token";
+
+std::string base64Encode(std::string_view bytes) {
+  static constexpr char kAlphabet[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::string out;
+  out.reserve(((bytes.size() + 2) / 3) * 4);
+  for (std::size_t i = 0; i < bytes.size(); i += 3) {
+    const auto b0 = static_cast<uint8_t>(bytes[i]);
+    const auto b1 = i + 1 < bytes.size() ? static_cast<uint8_t>(bytes[i + 1]) : uint8_t{0};
+    const auto b2 = i + 2 < bytes.size() ? static_cast<uint8_t>(bytes[i + 2]) : uint8_t{0};
+    out.push_back(kAlphabet[b0 >> 2]);
+    out.push_back(kAlphabet[((b0 & 0x03) << 4) | (b1 >> 4)]);
+    out.push_back(i + 1 < bytes.size() ? kAlphabet[((b1 & 0x0f) << 2) | (b2 >> 6)] : '=');
+    out.push_back(i + 2 < bytes.size() ? kAlphabet[b2 & 0x3f] : '=');
+  }
+  return out;
+}
+
+std::string hexEncode(std::string_view bytes) {
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(bytes.size() * 2);
+  for (auto c : bytes) {
+    const auto b = static_cast<uint8_t>(c);
+    out.push_back(kHex[b >> 4]);
+    out.push_back(kHex[b & 0x0f]);
+  }
+  return out;
+}
+
+auth::IssueTokenOptions makeIssueTokenOptions(const cfg::ResolvedConfig* resolvedConfig) {
+  std::string keyID = FLAGS_auth_key_id;
+  std::string secret = FLAGS_auth_secret;
+  if (secret.empty()) {
+    if (resolvedConfig == nullptr) {
+      throw std::invalid_argument(
+          "--auth-secret is required unless --config and --auth-service select a configured key"
+      );
+    }
+    if (FLAGS_auth_service.empty()) {
+      throw std::invalid_argument("--auth-service is required when issuing from --config");
+    }
+    const auto& services = resolvedConfig->config.services;
+    auto it = services.find(FLAGS_auth_service);
+    if (it == services.end()) {
+      throw std::invalid_argument("unknown auth service: " + FLAGS_auth_service);
+    }
+    auto key = auth::selectHmacKey(it->second.auth, FLAGS_auth_key_id);
+    keyID = std::move(key.id);
+    secret = std::move(key.secret);
+  } else if (keyID.empty()) {
+    keyID = "operator";
+  }
+
+  auth::IssueTokenOptions options{
+      .keyID = std::move(keyID),
+      .secret = std::move(secret),
+      .actions = auth::parseActions(FLAGS_auth_actions),
+      .ttl = std::chrono::seconds(FLAGS_auth_ttl_seconds),
+  };
+  if (!FLAGS_auth_namespace.empty()) {
+    options.trackNamespace = auth::parseTrackNamespace(FLAGS_auth_namespace);
+  }
+  if (!FLAGS_auth_track.empty()) {
+    options.trackName = FLAGS_auth_track;
+  }
+  return options;
+}
+
+int runIssueCatTokenCommand(const char* programName) {
+  std::optional<cfg::ResolvedConfig> resolvedConfig;
+  if (!FLAGS_config.empty()) {
+    auto result =
+        cfg::handleConfigSubcommand(kServeCommand, FLAGS_config, FLAGS_strict_config, programName);
+    if (result.hasError()) {
+      return result.error();
+    }
+    resolvedConfig = std::move(result.value());
+  }
+
+  try {
+    const auto token = auth::issueToken(
+        makeIssueTokenOptions(resolvedConfig.has_value() ? &resolvedConfig.value() : nullptr)
+    );
+    if (FLAGS_auth_output == "base64-prefix") {
+      std::cout << "base64:" << base64Encode(token.tokenValue) << '\n';
+    } else if (FLAGS_auth_output == "base64") {
+      std::cout << base64Encode(token.tokenValue) << '\n';
+    } else if (FLAGS_auth_output == "hex") {
+      std::cout << hexEncode(token.tokenValue) << '\n';
+    } else if (FLAGS_auth_output == "raw") {
+      std::cout.write(
+          token.tokenValue.data(),
+          static_cast<std::streamsize>(token.tokenValue.size())
+      );
+    } else {
+      throw std::invalid_argument("--auth-output must be base64-prefix, base64, hex, or raw");
+    }
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << '\n';
+    google::ShowUsageWithFlags(programName);
+    return 1;
+  }
+  return 0;
+}
 
 class ShutdownSignalHandler : public folly::AsyncSignalHandler {
 public:
@@ -72,7 +202,9 @@ int main(int argc, char* argv[]) {
       "moqx MoQ relay server\n\n"
       "Subcommands:\n"
       "  serve                Start the relay (default)\n" +
-      cfg::configSubcommandUsage() + "\nUsage: moqx [subcommand] --config <path>"
+      cfg::configSubcommandUsage() +
+      "  issue-cat-token      Issue a Catapult CAT4MOQ CWT for publishers\n"
+      "\nUsage: moqx [subcommand] --config <path>"
   );
   // Combine repeated --logging / --log-handler into one composite before
   // folly::Init — see docs/logging.md.
@@ -82,6 +214,10 @@ int main(int argc, char* argv[]) {
   std::string_view subcommand = kServeCommand;
   if (argc > 1) {
     subcommand = argv[1];
+  }
+
+  if (subcommand == kIssueCatTokenCommand) {
+    return runIssueCatTokenCommand(argv[0]);
   }
 
   auto result = cfg::handleConfigSubcommand(subcommand, FLAGS_config, FLAGS_strict_config, argv[0]);

--- a/test/AuthTest.cpp
+++ b/test/AuthTest.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "auth/Auth.h"
+#include "auth/AuthTokenIssuer.h"
 
 #include <folly/portability/GTest.h>
 
@@ -55,7 +56,7 @@ AuthToken
 makeToken(Grants grants, std::string_view secret = "secret", std::string_view keyID = "k1") {
   return AuthToken{
       .tokenType = 77,
-      .tokenValue = AuthTokenVerifier::signForTest(keyID, secret, grants),
+      .tokenValue = signGrants(keyID, secret, grants),
       .alias = AuthToken::DontRegister,
   };
 }

--- a/test/AuthTokenIssuerTest.cpp
+++ b/test/AuthTokenIssuerTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "auth/AuthTokenIssuer.h"
+
+#include "auth/Auth.h"
+
+#include <folly/portability/GTest.h>
+
+using namespace openmoq::moqx;
+using namespace openmoq::moqx::auth;
+using namespace moxygen;
+
+TEST(AuthTokenIssuerTest, IssuesSetupAndPublishTokenAcceptedByVerifier) {
+  const std::string secret = "operator-test-secret-with-enough-entropy";
+  IssueTokenOptions options{
+      .keyID = "cat-dev",
+      .secret = secret,
+      .actions = {Action::ClientSetup, Action::PublishNamespace, Action::Publish},
+      .trackNamespace = TrackNamespace{{"cat4moq.example"}},
+      .trackName = "video",
+      .ttl = std::chrono::seconds(3600),
+      .now = std::chrono::system_clock::time_point(std::chrono::seconds(1'800'000'000)),
+  };
+
+  auto issued = issueToken(options);
+
+  AuthTokenVerifier verifier(config::AuthConfig{
+      .enabled = true,
+      .tokenType = 16,
+      .hmacKeys = {config::AuthConfig::HmacKey{.id = "cat-dev", .secret = secret}},
+      .requireSetupToken = true,
+      .allowRequestTokenOverride = true,
+  });
+  auto grants = verifier.verify(AuthToken{
+      .tokenType = 16,
+      .tokenValue = issued.tokenValue,
+      .alias = AuthToken::DontRegister,
+  });
+
+  ASSERT_TRUE(grants.hasValue());
+  EXPECT_TRUE(allows(grants.value(), Action::ClientSetup, TrackNamespace{}));
+  EXPECT_TRUE(allows(grants.value(), Action::PublishNamespace, TrackNamespace{{"cat4moq.example"}})
+  );
+  EXPECT_TRUE(allows(
+      grants.value(),
+      Action::Publish,
+      FullTrackName{TrackNamespace{{"cat4moq.example"}}, "video"}
+  ));
+  EXPECT_FALSE(allows(
+      grants.value(),
+      Action::Publish,
+      FullTrackName{TrackNamespace{{"cat4moq.example"}}, "audio"}
+  ));
+}
+
+TEST(AuthTokenIssuerTest, ParsesOperatorActionNames) {
+  auto actions = parseActions("client_setup,publish_namespace,publish");
+
+  ASSERT_EQ(actions.size(), 3);
+  EXPECT_EQ(actions[0], Action::ClientSetup);
+  EXPECT_EQ(actions[1], Action::PublishNamespace);
+  EXPECT_EQ(actions[2], Action::Publish);
+}
+
+TEST(AuthTokenIssuerTest, ParsesSlashSeparatedNamespace) {
+  auto ns = parseTrackNamespace("live/event/main");
+
+  ASSERT_EQ(ns.trackNamespace.size(), 3);
+  EXPECT_EQ(ns.trackNamespace[0], "live");
+  EXPECT_EQ(ns.trackNamespace[1], "event");
+  EXPECT_EQ(ns.trackNamespace[2], "main");
+}
+
+TEST(AuthTokenIssuerTest, SelectsConfiguredHmacKeyByID) {
+  config::AuthConfig auth{
+      .enabled = true,
+      .tokenType = 16,
+      .hmacKeys =
+          {
+              config::AuthConfig::HmacKey{.id = "old", .secret = "old-secret"},
+              config::AuthConfig::HmacKey{.id = "active", .secret = "active-secret"},
+          },
+  };
+
+  auto key = selectHmacKey(auth, "active");
+
+  EXPECT_EQ(key.id, "active");
+  EXPECT_EQ(key.secret, "active-secret");
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,6 +169,15 @@ target_link_libraries(moqx_auth_test PRIVATE
 )
 gtest_discover_tests(moqx_auth_test)
 
+add_executable(moqx_auth_token_issuer_test
+  AuthTokenIssuerTest.cpp
+)
+target_link_libraries(moqx_auth_token_issuer_test PRIVATE
+  moqx_core
+  GTest::gtest_main
+)
+gtest_discover_tests(moqx_auth_token_issuer_test)
+
 # CborReader unit tests (header-only decoder, tested in isolation)
 add_executable(moqx_cbor_reader_test
   CborReaderTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,6 +165,7 @@ add_executable(moqx_auth_test
 )
 target_link_libraries(moqx_auth_test PRIVATE
   moqx_core
+  moqx_issuer_lib
   GTest::gtest_main
 )
 gtest_discover_tests(moqx_auth_test)
@@ -174,6 +175,7 @@ add_executable(moqx_auth_token_issuer_test
 )
 target_link_libraries(moqx_auth_token_issuer_test PRIVATE
   moqx_core
+  moqx_issuer_lib
   GTest::gtest_main
 )
 gtest_discover_tests(moqx_auth_token_issuer_test)


### PR DESCRIPTION
## Summary

- Add a moqx issue-cat-token operator command for issuing CAT4MOQ CWT tokens from relay config or an explicit local secret.
- Allow the Docker image entrypoint to run the token issuer utility for deployment and local-dev workflows.
- Add focused token issuer coverage and document auth setup, token issuance, moqxr usage, Docker usage, and operational key handling.

## Validation

- Dockerized moqx validate-config against config.example.yaml: Config is valid.
- Dockerized moqx issue-cat-token smoke command emitted a base64-prefixed CAT token.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/468)
<!-- Reviewable:end -->
