### PR TITLE
config: serialize LoggingConfig in serializeConfig()

### DIFF
--- a/src/config/ConfigSerializer.h
+++ b/src/config/ConfigSerializer.h
@@ -200,6 +200,27 @@ inline void serializeAuth(ConfigSink& s, const AuthConfig& a) {
   s.endObject();
 }
 
+inline void serializeLogging(ConfigSink& s, const LoggingConfig& l) {
+  s.beginObject("logging");
+  if (l.mlog) {
+    s.beginObject("mlog");
+    s.stringField("dir", l.mlog->dir);
+    s.doubleField("sample_rate", l.mlog->sampleRate);
+    s.endObject();
+  } else {
+    s.nullField("mlog");
+  }
+  if (l.qlog) {
+    s.beginObject("qlog");
+    s.stringField("dir", l.qlog->dir);
+    s.doubleField("sample_rate", l.qlog->sampleRate);
+    s.endObject();
+  } else {
+    s.nullField("qlog");
+  }
+  s.endObject();
+}
+
 inline void serializeUpstream(ConfigSink& s, const UpstreamConfig& u) {
   s.beginObject("upstream");
   s.stringField("url", u.url);
@@ -274,6 +295,12 @@ inline void serializeConfig(const Config& cfg, ConfigSink& s) {
     s.endObject();
   }
   s.endObject();
+
+  if (cfg.logging) {
+    serializeLogging(s, *cfg.logging);
+  } else {
+    s.nullField("logging");
+  }
 
   s.endObject();
 }

--- a/test/config/ConfigSerializerTest.cpp
+++ b/test/config/ConfigSerializerTest.cpp
@@ -23,7 +23,7 @@
 namespace {
 using namespace openmoq::moqx::config;
 
-static_assert(rfl::internal::num_fields<Config> == 8, "Config changed — update serializeConfig()");
+static_assert(rfl::internal::num_fields<Config> == 9, "Config changed — update serializeConfig()");
 static_assert(
     rfl::internal::num_fields<ListenerConfig> == 8,
     "ListenerConfig changed — update serializeConfig()"
@@ -91,6 +91,18 @@ static_assert(
 static_assert(
     rfl::internal::num_fields<AdminConfig> == 2,
     "AdminConfig changed — update serializeConfig()"
+);
+static_assert(
+    rfl::internal::num_fields<LoggingConfig> == 2,
+    "LoggingConfig changed — update serializeLogging()"
+);
+static_assert(
+    rfl::internal::num_fields<MLogConfig> == 2,
+    "MLogConfig changed — update serializeLogging()"
+);
+static_assert(
+    rfl::internal::num_fields<QLogConfig> == 2,
+    "QLogConfig changed — update serializeLogging()"
 );
 
 // Sink that records every emitted scalar leaf as a flat path -> value map, so
@@ -180,6 +192,10 @@ Config makeFullConfig() {
   svc.upstream->tls.caCertFile = "/etc/ca.pem";
   cfg.services.emplace("default", std::move(svc));
 
+  cfg.logging = LoggingConfig{};
+  cfg.logging->mlog = MLogConfig{"/var/log/mlog", 0.5f};
+  cfg.logging->qlog = QLogConfig{"/var/log/qlog", 1.0f};
+
   return cfg;
 }
 
@@ -204,6 +220,10 @@ TEST(ConfigSerializerTest, VisitsAllSections) {
   EXPECT_EQ(sink.scalars["services.default.match.*.path.prefix"], "/");
   EXPECT_EQ(sink.scalars["services.default.upstream.url"], "https://upstream.example/relay");
   EXPECT_EQ(sink.scalars["services.default.upstream.tls.ca_cert_file"], "/etc/ca.pem");
+
+  EXPECT_EQ(sink.scalars["logging.mlog.dir"], "/var/log/mlog");
+  EXPECT_EQ(sink.scalars["logging.mlog.sample_rate"], "0.500000");
+  EXPECT_EQ(sink.scalars["logging.qlog.dir"], "/var/log/qlog");
 }
 
 TEST(ConfigSerializerTest, RedactsHmacSecret) {


### PR DESCRIPTION
The rebase added a 9th Config field (std::optional<LoggingConfig> logging), which tripped the field-count drift guard in ConfigSerializerTest. Add serializeLogging() to emit the mlog/qlog sub-objects (dir + sample_rate, or null when absent), bump the Config assert to 9, and add drift-guard asserts for LoggingConfig/MLogConfig/QLogConfig. Exercise the new paths in makeFullConfig() with value assertions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/474)
<!-- Reviewable:end -->
