### PR TITLE
stats: widen object-ack latency histogram tail to 1s

### DIFF
--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -26,6 +26,9 @@ namespace openmoq::moqx::stats {
 inline constexpr std::array<uint64_t, 11> kLatencyBucketsUs =
     {10, 50, 100, 250, 500, 1000, 2000, 5000, 10000, 50000, 100000};
 
+inline constexpr std::array<uint64_t, 10> kObjectAckLatencyBucketsUs =
+    {500, 1000, 2000, 5000, 10000, 50000, 100000, 250000, 500000, 1000000};
+
 // RTT buckets in milliseconds (from onRttSample).
 inline constexpr std::array<uint64_t, 10> kRttBucketsMs =
     {1, 5, 10, 25, 50, 100, 250, 500, 1000, 5000};
@@ -253,7 +256,7 @@ inline constexpr std::array<std::string_view, kResetStreamErrorCodeCount>
   X(moqFetchLatency, kLatencyBucketsUs, "microseconds")                                            \
   X(moqPublishNamespaceLatency, kLatencyBucketsUs, "microseconds")                                 \
   X(moqPublishLatency, kLatencyBucketsUs, "microseconds")                                          \
-  X(moqObjectAckLatency, kLatencyBucketsUs, "microseconds")
+  X(moqObjectAckLatency, kObjectAckLatencyBucketsUs, "microseconds")
 
 // QUIC transport histograms — populated by QuicStatsCollector and PicoQuicStatsCollector.
 // Per-loop packet fields require an EventBaseStatsCollector loop observer to be wired up.


### PR DESCRIPTION
Give object-ack latency its own bucket array starting at 500us and extending through 250ms/500ms/1s, instead of sharing kLatencyBucketsUs which tops out at 100ms. Acks stretch well past 100ms under loss, so the old top bucket swallowed the tail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/478)
<!-- Reviewable:end -->
