### PR TITLE
perf-test: publish Pages deployment as omoq-sync-bot

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -290,5 +290,16 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # Create the Pages deployment as the omoq-sync-bot App rather than under
+      # the personal actor GitHub attributes scheduled runs to. Keeps the
+      # deployments list owned by the bot, consistent with the rest of the org
+      # automation. Requires the App installation to have Pages: write.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
       - id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What

The nightly perf-dashboard Pages publish (`deploy` job in `perf-test.yml`) currently creates its GitHub **deployment** owned by a personal actor. GitHub attributes `schedule`-triggered runs to whoever last modified the cron, and the deploy step uses the ambient `GITHUB_TOKEN`, so the deployments at `.../deployments` read as personally owned rather than bot-owned.

## Change

In the `deploy` job, mint an `omoq-sync-bot` App installation token and pass it to `actions/deploy-pages@v4` via its `token:` input. New deployments then read `omoq-sync-bot[bot]`, consistent with the rest of the org automation. Existing deployment records are immutable and age out as new nightly runs supersede them.

## Requirements / verification

- The **omoq-sync-bot App installation must have `Pages: write`** (plus Deployments: write). It's currently provisioned for PR create/approve — if Pages write isn't granted, the deploy step will 403 and this needs the scope added in App settings first.
- The OIDC id-token that `deploy-pages` uses to prove workflow identity to Pages is separate from the API `token`, so swapping the token should not affect gating — but worth confirming on the first nightly (or a manual dispatch) that the site still publishes and the creator flips to the bot.

Site published by this workflow: https://openmoq.org/moqx/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/483)
<!-- Reviewable:end -->
