### PR TITLE
ci: retire the moqx-000 legacy alias

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -592,9 +592,6 @@ jobs:
     runs-on: [self-hosted, linode]
     env:
       DOMAIN: moqx-main.ci.openmoq.org
-      # Legacy alias retained for the interop-runner (which still targets
-      # moqx-000) until that upstream config is updated. Drop when unused.
-      DOMAIN_ALIAS: moqx-000.ci.openmoq.org
       RELAY_PORT: 4433
       ADMIN_PORT: 8000
     steps:
@@ -612,25 +609,16 @@ jobs:
             echo "::error::Could not determine runner public IP"
             exit 1
           fi
-          echo "Ensuring A records: $DOMAIN → $IP, $DOMAIN_ALIAS → $IP"
+          echo "Ensuring A record: $DOMAIN → $IP"
           CHANGE_FILE=$(mktemp)
           cat > "$CHANGE_FILE" <<EOF
           {
-            "Comment": "moqx auto-deploy: $DOMAIN (+ alias $DOMAIN_ALIAS)",
+            "Comment": "moqx auto-deploy: $DOMAIN",
             "Changes": [
               {
                 "Action": "UPSERT",
                 "ResourceRecordSet": {
                   "Name": "$DOMAIN",
-                  "Type": "A",
-                  "TTL": 300,
-                  "ResourceRecords": [{"Value": "$IP"}]
-                }
-              },
-              {
-                "Action": "UPSERT",
-                "ResourceRecordSet": {
-                  "Name": "$DOMAIN_ALIAS",
                   "Type": "A",
                   "TTL": 300,
                   "ResourceRecords": [{"Value": "$IP"}]
@@ -659,17 +647,14 @@ jobs:
           elif ! sudo openssl x509 -in "$CERT" -noout -checkend 2592000 2>/dev/null; then
             echo "::warning::Cert for ${DOMAIN} expires within 30 days — renewing"
             need_issue=true
-          elif ! sudo openssl x509 -in "$CERT" -noout -text | grep -qE "DNS:${DOMAIN_ALIAS}( |$|,)"; then
-            echo "::warning::Cert for ${DOMAIN} missing alias SAN ${DOMAIN_ALIAS} — expanding"
-            need_issue=true
           else
-            echo "Cert for ${DOMAIN} is valid and includes ${DOMAIN_ALIAS}"
+            echo "Cert for ${DOMAIN} is valid"
           fi
 
           if $need_issue; then
-            sudo -E certbot certonly --dns-route53 --expand \
+            sudo -E certbot certonly --dns-route53 \
               --cert-name "$DOMAIN" \
-              -d "$DOMAIN" -d "$DOMAIN_ALIAS" \
+              -d "$DOMAIN" \
               --non-interactive --agree-tos \
               --email gmarzot@openmoq.org
           fi

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -19,7 +19,7 @@ artifact publishing, and relay deployment across the openmoq organization.
 │                                                             │
 │  ci main ──► Docker image (ghcr.io/openmoq/moqx)          │
 │              + binary tarball                                │
-│              + auto-deploy to moqx-000                       │
+│              + auto-deploy to moqx-main                      │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -50,7 +50,7 @@ facebookexperimental/moxygen  (upstream commit lands)
    Docker image pushed to GHCR, binary tarball released
         │
         ▼  deploy job (automatic)
-   moqx-000.ci.openmoq.org updated with new image
+   moqx-main.ci.openmoq.org updated with new image
 ```
 
 The full chain from upstream commit to deployed relay is fully automated.
@@ -128,12 +128,12 @@ Format check must pass before build runs.
 **Trigger:** push to main | **Time:** ~10 min
 
 ```
-check-format + build ──► publish (Docker) ──► release ──► deploy (moqx-000) ──► notify
+check-format + build ──► publish (Docker) ──► release ──► deploy (moqx-main) ──► notify
 ```
 
 - Publish builds a multi-stage Docker image (bookworm), runs smoke test, pushes to GHCR
 - Release creates/updates `snapshot-latest` with binary tarball
-- Deploy automatically updates moqx-000.ci.openmoq.org with the new image
+- Deploy automatically updates moqx-main.ci.openmoq.org with the new image
 - Notify sends Slack + email with per-job status
 
 ### 3. `moxygen sync` — Automated submodule update
@@ -159,7 +159,7 @@ Deploys a specific image tag to a named instance. Handles TLS cert
 provisioning/renewal via Route53, health check verification, Slack notification.
 
 Reserved instances:
-- `moqx-000` — CI auto-deploy target (updated automatically by `ci main`)
+- `moqx-main` — CI auto-deploy target (updated automatically by `ci main`)
 
 Developer instances (`moqx-001+`) can be added to the instance list for manual
 testing deployments.


### PR DESCRIPTION
The interop runner no longer targets `moqx-000`, so `ci-main`'s auto-deploy no longer needs to keep the alias alive.

**`ci-main.yml` deploy job** — remove the `DOMAIN_ALIAS` wiring:
- the second Route53 A-record `UPSERT` (alias → runner IP)
- the alias-SAN check in the cert step
- the extra `-d "$DOMAIN_ALIAS"` (and now-unneeded `--expand`) on `certbot certonly`

The relay identity stays `moqx-main.ci.openmoq.org`.

**`docs/ci-architecture.md`** — it still called `moqx-000` the auto-deploy target; updated to `moqx-main`.

### Sequencing / safety
- Interop runner: already off `moqx-000` (confirmed).
- `moqx-analytics`: repointed to `moqx-main` in gmarzot/moqx-analytics#1 — **merge that + redeploy the log pipeline before/around this**, since dropping the alias means its cert SAN and DNS stop being refreshed.
- This does **not** delete the existing `moqx-000` Route53 A record or force-shrink the current cert — those persist until they age out; `moqx-000` TLS simply drops at the next renewal. Manual DNS record deletion can follow later.

Separate from the docker stats/jemalloc PR (#480).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/484)
<!-- Reviewable:end -->
