### PR TITLE
build: support Ubuntu/Debian derivatives natively, fix from-source setup

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -11,6 +11,7 @@ formatting, and CI.
 |----------|--------|-------|
 | Ubuntu 22.04 (Jammy) | Tested in CI | Primary dev/CI platform |
 | Debian 12 (Bookworm) | Tested (Docker build) | Docker image base |
+| Ubuntu/Debian derivatives (Mint, Pop!_OS, ...) | Supported | Detected via `ID_LIKE`, mapped to the Ubuntu/Debian base artifacts; override with `MOQX_PLATFORM` if detection is wrong |
 | Fedora / RHEL | TBD | `install-system-deps.sh` has dnf support; not yet CI-tested |
 | macOS (Homebrew) | TBD | `install-system-deps.sh` has brew support; not yet CI-tested |
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -151,6 +151,28 @@ check_system_deps() {
     fi
   fi
 
+  # Boost component libs — packaged separately on Debian/Ubuntu (headers via
+  # libboost-dev do NOT include them). folly's cmake config find_package()s
+  # each component, so a missing one fails configure with an opaque
+  # "boost_context-config.cmake not found" error. Probe for the dev artifacts
+  # (unversioned .a/.so — runtime-only packages ship just .so.N.NN.N).
+  # Homebrew's boost is monolithic, so this is Linux-only.
+  if [[ "$(uname)" == "Linux" ]]; then
+    local comp
+    for comp in context filesystem program_options regex thread; do
+      if ! find /usr/lib /usr/lib64 /usr/local/lib \
+             \( -name "libboost_${comp}.a" -o -name "libboost_${comp}.so" \) \
+             2>/dev/null | grep -q .; then
+        missing+=("libboost-${comp//_/-}-dev")
+      fi
+    done
+
+    # double-conversion — no pkg-config file on Debian/Ubuntu; probe header
+    if ! find /usr/include /usr/local/include -path "*double-conversion/double-conversion.h" 2>/dev/null | grep -q .; then
+      missing+=("libdouble-conversion-dev")
+    fi
+  fi
+
   # NOTE: CMake version is enforced by require_cmake_version() — kept
   # separate so we can give a clean, focused error if cmake is missing or
   # too old before any other dep checks run.

--- a/scripts/detect-platform.sh
+++ b/scripts/detect-platform.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# detect-platform.sh — Resolve the moxygen artifact platform string for this
+# host (e.g. ubuntu-22.04-amd64, bookworm-arm64, macos-15-arm64).
+#
+# Sourced by setup-deps-tarball.sh and setup-deps-dev-artifact.sh so both
+# use identical naming; can also be executed directly to print the platform.
+#
+# Ubuntu derivatives (Linux Mint, Pop!_OS, elementary, ...) report their own
+# ID/VERSION_ID in /etc/os-release (e.g. linuxmint/22.3), so ID alone can't
+# name an artifact. For those we consult ID_LIKE and map the Ubuntu base
+# release via UBUNTU_CODENAME (or /etc/upstream-release/lsb-release).
+# Debian and Debian derivatives map to the bookworm artifacts, matching how
+# plain Debian is handled. Override with MOQX_PLATFORM if detection is wrong.
+
+detect_platform() {
+    local os arch
+    os=$(uname -s)
+    arch=$(uname -m)
+
+    local darch="${arch/x86_64/amd64}"
+    darch="${darch/aarch64/arm64}"
+
+    if [[ "$os" == "Darwin" ]]; then
+        local ver
+        ver=$(sw_vers -productVersion | cut -d. -f1)
+        echo "macos-${ver}-arm64"
+        return 0
+    fi
+
+    if [[ "$os" != "Linux" ]]; then
+        echo "Error: unsupported OS: $os" >&2
+        return 1
+    fi
+
+    if [[ ! -f /etc/os-release ]]; then
+        echo "Error: cannot detect Linux distro (no /etc/os-release)" >&2
+        return 1
+    fi
+
+    local id id_like version_id ubuntu_codename
+    id=$(. /etc/os-release && echo "${ID:-}")
+    id_like=$(. /etc/os-release && echo "${ID_LIKE:-}")
+    version_id=$(. /etc/os-release && echo "${VERSION_ID:-}")
+    ubuntu_codename=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-}")
+
+    case "$id" in
+        ubuntu)
+            echo "ubuntu-${version_id}-${darch}"
+            return 0
+            ;;
+        debian)
+            echo "bookworm-${darch}"
+            return 0
+            ;;
+    esac
+
+    # Ubuntu derivative: VERSION_ID is the derivative's own (Mint 22.3), so
+    # resolve the Ubuntu base release from the codename instead.
+    if [[ " $id_like " == *" ubuntu "* ]]; then
+        local base_ver=""
+        case "$ubuntu_codename" in
+            jammy) base_ver="22.04" ;;
+            noble) base_ver="24.04" ;;
+        esac
+        if [[ -z "$base_ver" && -f /etc/upstream-release/lsb-release ]]; then
+            base_ver=$(. /etc/upstream-release/lsb-release && echo "${DISTRIB_RELEASE:-}")
+        fi
+        if [[ -n "$base_ver" ]]; then
+            echo "ubuntu-${base_ver}-${darch}"
+            return 0
+        fi
+        echo "Error: Ubuntu derivative '$id' with unrecognized base codename '${ubuntu_codename:-unset}'." >&2
+        echo "       Set MOQX_PLATFORM explicitly (e.g. MOQX_PLATFORM=ubuntu-22.04-${darch})." >&2
+        return 1
+    fi
+
+    if [[ " $id_like " == *" debian "* ]]; then
+        echo "bookworm-${darch}"
+        return 0
+    fi
+
+    echo "Error: unsupported Linux distro: $id (ID_LIKE='${id_like}')" >&2
+    echo "       Set MOQX_PLATFORM explicitly (e.g. MOQX_PLATFORM=ubuntu-22.04-${darch})." >&2
+    return 1
+}
+
+# Print the platform when executed directly (not sourced).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    detect_platform
+fi

--- a/scripts/setup-deps-dev-artifact.sh
+++ b/scripts/setup-deps-dev-artifact.sh
@@ -30,29 +30,13 @@ MOXYGEN_DIR="${PROJECT_ROOT}/deps/moxygen"
 INSTALL_DIR="${SCRATCH}/moxygen-install"
 
 # ── Platform detection ────────────────────────────────────────────────────────
-# Match the naming used by the omoq-dev-build workflow's `target` input:
-#   macos-15-arm64, ubuntu-22.04-amd64 (extend here as workflow adds targets)
-detect_platform() {
-    local os arch
-    case "$(uname -s)" in
-        Darwin) os="macos-15" ;;
-        Linux)
-            if [[ -f /etc/debian_version ]] && \
-               grep -q bookworm /etc/debian_version 2>/dev/null; then
-                os="bookworm"
-            else
-                os="ubuntu-22.04"
-            fi
-            ;;
-        *) echo "Error: unsupported OS $(uname -s)" >&2; exit 1 ;;
-    esac
-    case "$(uname -m)" in
-        arm64|aarch64) arch="arm64" ;;
-        x86_64) arch="amd64" ;;
-        *) echo "Error: unsupported arch $(uname -m)" >&2; exit 1 ;;
-    esac
-    echo "${os}-${arch}"
-}
+# Shared with setup-deps-tarball.sh so both resolve identical platform names
+# matching the omoq-dev-build workflow's `target` input (macos-15-arm64,
+# ubuntu-22.04-amd64, bookworm-amd64, ...), including Ubuntu/Debian
+# derivatives via ID_LIKE. See detect-platform.sh.
+
+# shellcheck source=scripts/detect-platform.sh
+source "$SCRIPT_DIR/detect-platform.sh"
 
 PLATFORM="${MOQX_PLATFORM:-$(detect_platform)}"
 

--- a/scripts/setup-deps-standalone.sh
+++ b/scripts/setup-deps-standalone.sh
@@ -141,6 +141,15 @@ esac
 BOOST_STATIC_ARG=(-DBoost_USE_STATIC_LIBS="${boost_static}")
 echo "==> Boost linking: ${boost_static} (static libs)"
 
+# Wipe any previous install BEFORE configuring, not just before installing.
+# CMake implicitly searches CMAKE_INSTALL_PREFIX for packages, so a stale
+# install tree (e.g. from a prior tarball setup) satisfies find_package()
+# probes with files this build then deletes — moxygen's gtest probe "found"
+# the tarball's GTestConfig.cmake here, skipped bundling GoogleTest, and the
+# final install shipped no GTest config, breaking moqx's configure.
+echo "==> Removing previous install at $INSTALL_DIR..."
+rm -rf "$INSTALL_DIR"
+
 echo "==> Configuring standalone moxygen build (profile: ${PROFILE})..."
 # BUILD_TESTS=ON: gates the GoogleTest FetchContent in moxygen's standalone
 # CMake. Without it, moxygen-install ships no GTest config and moqx's
@@ -160,7 +169,6 @@ echo "==> Building ($NPROC jobs)..."
 cmake --build "$BUILD_DIR" -j"$NPROC"
 
 echo "==> Installing to $INSTALL_DIR..."
-rm -rf "$INSTALL_DIR"
 cmake --install "$BUILD_DIR"
 
 # ── Write cmake_prefix_path.txt ───────────────────────────────────────────────

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -52,40 +52,11 @@ if [[ ! -e "$MOXYGEN_DIR/.git" ]]; then
 fi
 
 # ── Platform detection ────────────────────────────────────────────────────────
+# Shared with setup-deps-dev-artifact.sh; handles Ubuntu/Debian derivatives
+# (Linux Mint, Pop!_OS, ...) via ID_LIKE. See detect-platform.sh.
 
-detect_platform() {
-    local os arch
-    os=$(uname -s)
-    arch=$(uname -m)
-
-    if [[ "$os" == "Darwin" ]]; then
-        local ver
-        ver=$(sw_vers -productVersion | cut -d. -f1)
-        echo "macos-${ver}-arm64"
-    elif [[ "$os" == "Linux" ]]; then
-        if [[ ! -f /etc/os-release ]]; then
-            echo "Error: cannot detect Linux distro (no /etc/os-release)" >&2
-            exit 1
-        fi
-        # shellcheck disable=SC1091
-        local ID VERSION_ID
-        ID=$(. /etc/os-release && echo "$ID")
-        VERSION_ID=$(. /etc/os-release && echo "${VERSION_ID:-}")
-        local darch="${arch/x86_64/amd64}"
-        darch="${darch/aarch64/arm64}"
-        case "$ID" in
-            ubuntu) echo "ubuntu-${VERSION_ID}-${darch}" ;;
-            debian) echo "bookworm-${darch}" ;;
-            *)
-                echo "Error: unsupported Linux distro: $ID" >&2
-                exit 1
-                ;;
-        esac
-    else
-        echo "Error: unsupported OS: $os" >&2
-        exit 1
-    fi
-}
+# shellcheck source=scripts/detect-platform.sh
+source "$SCRIPT_DIR/detect-platform.sh"
 
 PLATFORM="${MOQX_PLATFORM:-$(detect_platform)}"
 echo "==> Platform: $PLATFORM"


### PR DESCRIPTION
Makes the native (non-Docker) build path work beyond exactly Ubuntu 22.04 / Debian 12. Companion moxygen PR: openmoq/moxygen#309 (ID_LIKE installer dispatch, ubuntu-24.04-amd64 tarballs, CONFIG-mode gtest probe).

## Problem

Native builds only worked on Ubuntu 22.04, Debian 12, or macOS 15:

- Platform detection switched on os-release `ID` alone, so derivatives (Linux Mint reports `ID=linuxmint`) died at step one with "unsupported Linux distro" — in both the tarball fetcher and the dev-artifact fallback (which had a second, divergent detector).
- `check_system_deps` passed even when required boost component libs were absent, leaving an opaque `boost_context-config.cmake not found` configure failure instead of naming the missing packages.
- The from-source fallback configured moxygen while a stale tarball install was still present at `CMAKE_INSTALL_PREFIX` (which CMake searches implicitly), so the gtest probe found the tarball's GTestConfig.cmake, skipped bundling GoogleTest, deleted that tree at install time, and left moqx unable to configure (`find_package(GTest REQUIRED CONFIG)` failure).

## Changes

- New `scripts/detect-platform.sh`, shared by `setup-deps-tarball.sh` and `setup-deps-dev-artifact.sh`. Honors `ID_LIKE`: Ubuntu derivatives map to the Ubuntu base release via `UBUNTU_CODENAME` (or `/etc/upstream-release/lsb-release`), Debian derivatives map to bookworm. Errors suggest the `MOQX_PLATFORM` override.
- `build.sh check_system_deps`: probe each required boost component (context, filesystem, program_options, regex, thread) and the double-conversion header; missing deps now surface as named apt packages before configure.
- `setup-deps-standalone.sh`: wipe the install tree before configuring, not just before installing.
- BUILD.md: document derivative support.

## Verification

On Linux Mint 22.3 (noble base): detection resolves `ubuntu-24.04-amd64`; tarball fetch fails over cleanly (the asset exists once openmoq/moxygen#309 lands and the snapshot regenerates); from-source setup, full build, and test suite run. 691/711 tests pass; the 20 failures are UpstreamProviderTest/RelayUpstreamSubscribeRaceTest QUIC-loopback connect timeouts that occur on this host in both dependency modes — environmental, unrelated to this diff (no C++ touched).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/485)
<!-- Reviewable:end -->
