### PR TITLE
moq_decode: request_id cleanup

### DIFF
--- a/tools/moq_decode.py
+++ b/tools/moq_decode.py
@@ -517,8 +517,8 @@ def parse_subscribe(cursor, annot, draft, payload_end=None):
 
 
 def parse_subscribe_ok(cursor, annot, draft, payload_end):
-    # Draft 18+: request_id is implicit from the bidi request stream context.
-    if draft < 18:
+    # Draft 17+: request_id is implicit from the bidi request stream context.
+    if draft < 17:
         val, s = cursor.read_varint()
         annot.add(s, cursor.pos, "request_id", str(val))
     val, s = cursor.read_varint()
@@ -545,9 +545,9 @@ def parse_subscribe_ok(cursor, annot, draft, payload_end):
 
 
 def parse_request_error(cursor, annot, draft, payload_end):
-    # Draft 18+: request_id is implicit from the bidi request stream context;
+    # Draft 17+: request_id is implicit from the bidi request stream context;
     # the receiver FIFO-correlates errors with outstanding requests.
-    if draft < 18:
+    if draft < 17:
         val, s = cursor.read_varint()
         annot.add(s, cursor.pos, "request_id", str(val))
     val, s = cursor.read_varint()
@@ -569,8 +569,8 @@ def parse_publish_namespace(cursor, annot, draft, payload_end):
 
 
 def parse_request_ok(cursor, annot, draft, payload_end):
-    # Draft 18+: request_id is implicit (per-stream).
-    if draft < 18:
+    # Draft 17+: request_id is implicit (per-stream).
+    if draft < 17:
         val, s = cursor.read_varint()
         annot.add(s, cursor.pos, "request_id", str(val))
     if draft > 14:
@@ -610,8 +610,10 @@ def parse_unsubscribe(cursor, annot, draft, payload_end):
 
 
 def parse_publish_done(cursor, annot, draft, payload_end):
-    val, s = cursor.read_varint()
-    annot.add(s, cursor.pos, "request_id", str(val))
+    # Draft 17+: request_id is implicit from the bidi request stream context.
+    if draft < 17:
+        val, s = cursor.read_varint()
+        annot.add(s, cursor.pos, "request_id", str(val))
     val, s = cursor.read_varint()
     annot.add(s, cursor.pos, "status_code", str(val))
     val, s = cursor.read_varint()
@@ -777,8 +779,10 @@ def parse_fetch_cancel(cursor, annot, draft, payload_end):
 
 
 def parse_fetch_ok(cursor, annot, draft, payload_end):
-    val, s = cursor.read_varint()
-    annot.add(s, cursor.pos, "request_id", str(val))
+    # Draft 17+: request_id is implicit from the bidi request stream context.
+    if draft < 17:
+        val, s = cursor.read_varint()
+        annot.add(s, cursor.pos, "request_id", str(val))
 
     if draft < 15:
         val, s = cursor.read_uint8()


### PR DESCRIPTION
Request ID was removed from the response-side control messages in **draft-17** (not 18): PUBLISH_DONE, SUBSCRIBE_OK, REQUEST_OK, REQUEST_ERROR and FETCH_OK carry no explicit Request ID from 17 on — it is implicit from the bidi request stream context. Confirmed against the draft-17 spec text (Figures 8/11/15 etc.).

The tool had two problems:

- **PUBLISH_DONE and FETCH_OK** read `request_id` unconditionally — misdecoding at the default `--version 18` (as reported by a user inspecting PUBLISH_DONE).
- **SUBSCRIBE_OK / REQUEST_OK / REQUEST_ERROR** were gated at `draft < 18`, copied from MoQFramer. That works for moxygen traffic only because moxygen never negotiates draft 17 (`kSupportedVersions = {14,15,16,18}`), making its `< 18` gates behave as `<= 16`. For a spec decoder with an explicit `--version` flag, `< 17` is the correct boundary.

All five gates now sit at `draft < 17`.

Verified locally:
- `0b 00 03 00 02 00` at `--version 17` and `18` → status_code/stream_count/reason_phrase, no request_id
- `0b 00 04 05 00 02 00` at `--version 16` → request_id=5 still decoded
- FETCH_OK `18 00 04 00 01 00 00` at draft 18 → parses cleanly with no request_id

Note: frames from moxygen builds older than 2026-06-16 (`5194cf41`, which stripped the wire requestID) speaking draft-18 contain MoQ varints *plus* a request_id — a transitional non-conformant shape that no `--version` value decodes after this change. That is intended; the annotator's error offset shows where parsing diverges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/496)
<!-- Reviewable:end -->
