### PR TITLE
version release: recursive submodule checkout for portable build

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -287,7 +287,9 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          # recursive: deps/catapult carries nested submodules (libcbor,
+          # doctest, spdlog, nlohmann_json) that the top-level build needs.
+          submodules: recursive
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
Fixes #503.

The portable jobs in `version-release.yml` checked out with `submodules: true` (one level deep). `deps/catapult` (CAT token auth, #286) carries nested submodules — `external/libcbor`, `doctest`, `spdlog`, `nlohmann_json` — so configure failed at `add_subdirectory(external/libcbor)` on the v0.2.0 release run (https://github.com/openmoq/moqx/actions/runs/30038942303), leaving v0.2.0 with 2/4 assets.

One-line fix: `submodules: true` → `submodules: recursive` (plus a comment saying why). Every other build path was already covered — `ci-pr`/`ci-main` use recursive checkout, and `dev-build`/`perf-test` go through `scripts/build.sh` whose `check_submodule` self-heals with a recursive catapult init. This was the only raw-checkout cmake path.

After merge: dispatch v0.2.1 as the complete release (v0.2.0 stays incomplete; can be deleted separately if desired).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/504)
<!-- Reviewable:end -->
