### PR TITLE
version release: fix finalize isLatest check

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -454,8 +454,8 @@ jobs:
             xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" --repo "$REPO" {} --clobber
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Finalize: mark release as latest once all uploads succeeded.
-  # Tolerates portable-build being skipped (has_portable=false).
+  # Finalize: confirm the release is fully published once all uploads
+  # succeeded. Tolerates portable-build being skipped (has_portable=false).
   # ════════════════════════════════════════════════════════════════════════════
 
   finalize:
@@ -487,4 +487,8 @@ jobs:
           # would mark a hotfix patch from a release/vM.m branch as
           # latest even when a newer vM.(m+1) line exists.
           echo "Released: $TAG"
-          gh release view "$TAG" --repo "$REPO" --json isLatest,isPrerelease,name --jq '"isLatest=\(.isLatest) isPrerelease=\(.isPrerelease) name=\(.name)"'
+          # isLatest is not a --json field on `gh release view` (only on
+          # `gh release list`), so derive it from the releases/latest API.
+          gh release view "$TAG" --repo "$REPO" --json isPrerelease,name --jq '"isPrerelease=\(.isPrerelease) name=\(.name)"'
+          LATEST=$(gh api "repos/$REPO/releases/latest" --jq .tag_name)
+          echo "isLatest=$([ "$LATEST" = "$TAG" ] && echo true || echo false) (latest=$LATEST)"


### PR DESCRIPTION
Fixes #510. Port of openmoq/moxygen#331.

`isLatest` is not a supported `--json` field on `gh release view` (only on `gh release list`), so the finalize job's `Confirm release published` step always exited 1 after the release was already live — seen on the v0.2.1 run (https://github.com/openmoq/moqx/actions/runs/30053012201), where the release published fine with all 4 assets.

Changes:
- Keep `isPrerelease`/`name` from `gh release view`; derive latest-ness by comparing `$TAG` against `gh api repos/$REPO/releases/latest`. Still no `--latest` forcing — GitHub's auto-latest algorithm stays authoritative.
- Tighten the stale finalize header comment (the step confirms; latest-marking is GitHub's auto-latest, not this job).

Tested locally against v0.2.1:
```
isPrerelease=false name=moqx 0.2.1
isLatest=true (latest=v0.2.1)
```
YAML validated. v0.2.1 itself needs no re-cut.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/511)
<!-- Reviewable:end -->
