### PR TITLE
sync: git add --force for ignore=all submodule (git 2.54)

### DIFF
--- a/.github/workflows/moxygen-sync.yml
+++ b/.github/workflows/moxygen-sync.yml
@@ -174,7 +174,9 @@ jobs:
           # Update submodule to target SHA
           git -C deps/moxygen fetch origin
           git -C deps/moxygen checkout "$TARGET_SHA"
-          git add deps/moxygen
+          # --force: deps/moxygen has ignore=all in .gitmodules, and git >= 2.54
+          # skips ignored submodules even on explicit add
+          git add --force deps/moxygen
           git commit -m "sync: update moxygen submodule to ${SHORT_SHA}"
           git push -u origin "$BRANCH"
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,8 @@
 	branch = main
 	# "all": pointer drift never shows in status/diff, so bulk git add can't
 	# sweep an accidental pin bump into a feature commit. Intentional bumps
-	# (sync PRs) still stage with an explicit `git add deps/moxygen`.
+	# (sync PRs) stage with `git add --force deps/moxygen` (git >= 2.54
+	# skips ignored submodules even on explicit add).
 	ignore = all
 [submodule "deps/catapult"]
 	path = deps/catapult

--- a/scripts/setup-deps-tarball.sh
+++ b/scripts/setup-deps-tarball.sh
@@ -111,7 +111,7 @@ if [[ "$SNAPSHOT_SHA" != "$SUBMODULE_SHA" ]]; then
         echo "       Options:" >&2
         echo "         scripts/build.sh setup --from-source     # build pinned SHA from source" >&2
         echo "         scripts/build.sh setup --use-latest      # use snapshot anyway" >&2
-        echo "         git submodule update --remote deps/moxygen && git add deps/moxygen" >&2
+        echo "         git submodule update --remote deps/moxygen && git add --force deps/moxygen" >&2
         exit 1
     fi
 fi


### PR DESCRIPTION
## Problem

The scheduled `moxygen sync` run [#187](https://github.com/openmoq/moqx/actions/runs/30086286602) failed: `git add deps/moxygen` staged nothing ("Skipping submodule due to ignore=all ... Use --force"), so `git commit` had nothing to commit and the job exited 1. The sync PR for moxygen `578abd0` was never created.

Root cause is a version interaction, not the sync logic: #480 changed `deps/moxygen` to `ignore = all` in `.gitmodules` (deliberately, to keep accidental pin bumps out of feature commits), relying on explicit `git add deps/moxygen` still staging intentional bumps. That held on older git, but the runner image now ships **git 2.54.0**, which honors `ignore=all` on explicit adds too and requires `--force`.

## Fix

- `moxygen-sync.yml`: `git add --force deps/moxygen` (no-op difference on older git, so safe everywhere)
- `.gitmodules`: correct the now-stale comment
- `scripts/setup-deps-tarball.sh`: same `--force` in the printed hint

## Validation

Reproduced in an `alpine/git` container with git 2.54.0: plain `git add` on an `ignore=all` submodule stages nothing (identical hint text to the CI log); `git add --force` stages and commits correctly.

After merge, re-run the sync via workflow_dispatch to pick up moxygen `578abd0`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/512)
<!-- Reviewable:end -->
