### PR TITLE
relay: give subscribe-initiated forwarders the LF publisher chain + tl slot

### DIFF
--- a/docs/dev/local-forwarder-flow.md
+++ b/docs/dev/local-forwarder-flow.md
@@ -135,6 +135,8 @@ upstream work, and nests a single sortie to `[Pub]` to wire the channel sub.
 [Relay]                 ├─▶ joinOrPrepareUpstreamSubscription()  # registry: first vs subsequent
 [Relay]                 ├─▶ buildLocalToPublisherCallbacks()
 [Relay]                 └─▶ ⇢⇢▶ [Pub]  single sortie:
+[Pub]                        ├─ if FIRST subscriber:
+[Pub]                        │    └─▶ installPublisherForwarderCallbackChain()  # chain + tlForwarders_ slot
 [Pub]                        ├─▶ installChannelSubscriber(localFwd ↔ publisherFwd)
 [Pub]                        └─ if FIRST subscriber:
 [Pub]                             ├─▶ addChannelSubscriber(relayChain, passive)
@@ -151,9 +153,20 @@ upstream work, and nests a single sortie to `[Pub]` to wire the channel sub.
 ```
 
 The first subscriber does the heavy lifting (upstream subscribe + installing the relay chain,
-the same passive cache/Top-N chain described in [Data flow](#data-flow)). Subsequent
-subscribers on the same thread hit the `attachSubscriber` fast path; on other threads they take
-only the `installChannelSubscriber` half of the sortie.
+the same passive cache/Top-N chain described in [Data flow](#data-flow)). It also installs the
+publisher-forwarder control chain and claims the `tlForwarders_` slot via
+`installPublisherForwarderCallbackChain` — the **same** wiring the publish path uses, so a
+subscribe-initiated publisher forwarder is symmetric with a publish-initiated one. Subsequent
+subscribers on the same thread hit the `attachSubscriber` fast path (now also for
+subscribe-initiated tracks); on other threads they take only the `installChannelSubscriber` half
+of the sortie.
+
+The forwarder is created on `relayExec_` (in `joinOrPrepareUpstreamSubscription`) with a **null**
+callback, then gets its real callback + tl slot installed on `[Pub]` in the first-subscriber
+sortie — `tlForwarders_.get()` must run on the forwarder's own exec. It uses `removeOnEmpty=true`
+(subscribe-initiated tracks drop on empty, unlike publish): `LocalForwarderCallback` vacates the
+tl slot on `[Pub]` when the last subscriber leaves, while `onEmptyImpl` unsubscribes upstream and
+removes the registry entry on `[Relay]`.
 
 ### Why each guard exists
 
@@ -250,8 +263,10 @@ The reusable adapter layers:
 
 ### Publisher forwarder → relay state
 
-Built by `createPublisherForwarder`. Lifecycle events on the publisher's own forwarder must
-reach relay-global state on `relayExec_`:
+Built by `installPublisherForwarderCallbackChain` for both publish-initiated (via
+`createPublisherForwarder`) and subscribe-initiated (via `attachNewLocalForwarderOnRelayExec`'s
+first-subscriber sortie) tracks. Lifecycle events on the publisher's own forwarder must reach
+relay-global state on `relayExec_`:
 
 ```
 [Pub]  publisherFwd fires onEmpty / forwardChanged / newGroupRequested

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -14,6 +14,7 @@
 #include "relay/PublisherCrossExecFilter.h"
 #include "relay/SubscriberCrossExecFilter.h"
 #include "relay/WeakRelayForwarderCallback.h"
+#include <folly/ScopeGuard.h>
 #include <folly/container/F14Set.h>
 #include <moxygen/MoQFilters.h>
 #include <moxygen/MoQTrackProperties.h>
@@ -451,9 +452,36 @@ MoqxRelay::validatePublishNamespace(const FullTrackName& ftn, RequestID requestI
   return std::nullopt;
 }
 
+// Installs the publisher-forwarder callback chain (Weak -> CrossExec(relayExec_) ->
+// LocalForwarder) and claims the tlForwarders_ slot. Must run on the forwarder's exec.
+void MoqxRelay::installPublisherForwarderCallbackChain(
+    const FullTrackName& ftn,
+    const std::shared_ptr<MoQForwarder>& publisherFwd,
+    bool removeOnEmpty
+) {
+  if (!tlForwarders_.get()) {
+    tlForwarders_.reset(new LocalForwarderRegistry());
+  }
+  auto relayAdapter = std::make_shared<WeakRelayForwarderCallback>(weak_from_this());
+  auto crossExec = std::make_shared<CrossExecForwarderCallback>(
+      relayExec_,
+      publisherFwd,
+      std::move(relayAdapter)
+  );
+  publisherFwd->setCallback(std::make_shared<LocalForwarderCallback>(
+      tlForwarders_.get(),
+      ftn,
+      std::move(crossExec),
+      removeOnEmpty
+  ));
+  // Authoritative slot claim; displaces any stale subscribe-path local forwarder so
+  // same-thread subscribers reuse THIS forwarder via the fast path. A publish forwarder
+  // is attachable at once; a subscribe-initiated one only after the upstream OK.
+  tlForwarders_->set(ftn, publisherFwd, /*ready=*/!removeOnEmpty);
+}
+
 // Constructs the publisher's local forwarder and installs its callback chain (Weak ->
 // CrossExec -> LocalForwarder) on publisherExec, before the reply hops to relayExec_.
-// tlForwarders_ must already be initialized.
 std::shared_ptr<MoQForwarder> MoqxRelay::createPublisherForwarder(const PublishRequest& pub) {
   const auto& ftn = pub.fullTrackName;
   auto localPubFwd = std::make_shared<MoQForwarder>(ftn, pub.largest);
@@ -461,18 +489,7 @@ std::shared_ptr<MoQForwarder> MoqxRelay::createPublisherForwarder(const PublishR
 
   // removeOnEmpty=false: the publisher's forwarder must survive subscriber churn, so
   // LocalForwarderCallback removes it from tlForwarders_ only when the source ends.
-  auto relayAdapter = std::make_shared<WeakRelayForwarderCallback>(weak_from_this());
-  auto crossExec = std::make_shared<CrossExecForwarderCallback>(
-      relayExec_,
-      localPubFwd,
-      std::move(relayAdapter)
-  );
-  localPubFwd->setCallback(std::make_shared<LocalForwarderCallback>(
-      tlForwarders_.get(),
-      ftn,
-      std::move(crossExec),
-      /*removeOnEmpty=*/false
-  ));
+  installPublisherForwarderCallbackChain(ftn, localPubFwd, /*removeOnEmpty=*/false);
 
   return localPubFwd;
 }
@@ -488,16 +505,8 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
     return folly::makeUnexpected(std::move(*err));
   }
 
-  if (!tlForwarders_.get()) {
-    tlForwarders_.reset(new LocalForwarderRegistry());
-  }
-
+  // createPublisherForwarder claims the tlForwarders_ slot on this exec.
   auto localPubFwd = createPublisherForwarder(pub);
-
-  // The publisher's forwarder is authoritative — claim the slot, displacing any
-  // stale subscribe-path local forwarder so same-thread subscribers reuse THIS
-  // forwarder via the fast path.
-  tlForwarders_->set(pub.fullTrackName, localPubFwd);
 
   // crossExecFilter is a channel subscriber for the relay exec
   // regulsterPublishOnRelay exec completes wiring the chain (topNFilter → terminationFilter →
@@ -886,14 +895,17 @@ void teardownLocalForwarderOnFailure(
 // Single-threaded mode:
 //   forwarder.callback = MoqxRelay (direct, no hop)
 //
-// Multi-threaded — publisher forwarder (lives on publisherExec):
+// Multi-threaded — publisher forwarder (lives on publisherExec). Built by
+// installPublisherForwarderCallbackChain for BOTH publish-initiated (removeOnEmpty=false,
+// survives churn) and subscribe-initiated (removeOnEmpty=true, drops on empty) tracks:
 //   publisherFwd.callback =
-//     CrossExecForwarderCallback(relayExec_, publisherFwd,
-//       WeakRelayForwarderCallback(relay))
+//     LocalForwarderCallback(tlForwarders_, ftn,
+//       CrossExecForwarderCallback(relayExec_, publisherFwd,
+//         WeakRelayForwarderCallback(relay)))
 //
-//   [publisherExec] CrossExecForwarderCallback: captures ftn by value,
-//                 dispatches to relayExec_ fire-and-forget
-//       ↓
+//   [publisherExec] LocalForwarderCallback: removes from tlForwarders_ (onPublishDone
+//                 always; onEmpty if removeOnEmpty), passes the rest through
+//       ↓ (CrossExecForwarderCallback dispatches to relayExec_ fire-and-forget)
 //   [relayExec_]  WeakRelayForwarderCallback: recovers relay via weak_ptr,
 //                 calls onEmptyImpl / forwardChangedImpl / newGroupRequestedImpl
 //
@@ -1139,11 +1151,16 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
       }()
   );
 
-  auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, [&] {
-    auto fwd = std::make_shared<MoQForwarder>(ftn, seedLargest);
-    fwd->setExtensions(seedExtensions);
-    return fwd;
-  });
+  // ready: the forwarder is built from the publisher's snapshot, so no attacher waits.
+  auto [localFwd, isNew, localReg] = acquireLocalForwarder(
+      ftn,
+      [&] {
+        auto fwd = std::make_shared<MoQForwarder>(ftn, seedLargest);
+        fwd->setExtensions(seedExtensions);
+        return fwd;
+      },
+      /*ready=*/true
+  );
 
   auto p = startPublish(subscriberSession, localFwd, forward, pinned, nullptr);
   if (!p) {
@@ -1200,13 +1217,14 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
 // handle the fast path and install the PendingForwarderCallback (timing differs).
 MoqxRelay::LocalForwarderBootstrap MoqxRelay::acquireLocalForwarder(
     const FullTrackName& ftn,
-    folly::FunctionRef<std::shared_ptr<MoQForwarder>()> factory
+    folly::FunctionRef<std::shared_ptr<MoQForwarder>()> factory,
+    bool ready
 ) {
   if (!tlForwarders_.get()) {
     tlForwarders_.reset(new LocalForwarderRegistry());
   }
   auto* localReg = tlForwarders_.get();
-  auto [localFwd, isNew] = localReg->getOrCreate(ftn, factory);
+  auto [localFwd, isNew] = localReg->getOrCreate(ftn, factory, ready);
   return {std::move(localFwd), isNew, localReg};
 }
 
@@ -1762,6 +1780,7 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
     bool forward
 ) {
   // Runs on relayExec_.
+  XCHECK(mode() == Mode::LocalForwarder) << "subscribe-init chain install is LF-only";
   const auto& ftn = subReq.fullTrackName;
   PublisherAttachment attach;
 
@@ -1796,6 +1815,10 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
   co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(attach.publisherExec),
       [&]() -> folly::coro::Task<void> {
+        // First subscriber installs the publisher chain + tl slot before any sub is added.
+        if (sr.firstSetup) {
+          installPublisherForwarderCallbackChain(ftn, attach.publisherFwd, /*removeOnEmpty=*/true);
+        }
         installChannelSubscriber(
             *cbs.channelCb,
             *attach.publisherFwd,
@@ -1888,7 +1911,7 @@ MoqxRelay::joinOrPrepareUpstreamSubscription(SubscribeRequest subReq) {
 
   auto firstOrSubsequent = registry_.getOrCreateFromSubscribe(
       ftn,
-      shared_from_this(),
+      /*callback=*/nullptr,
       [this, &ftn](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(ftn, std::move(f)); }
   );
 
@@ -1948,18 +1971,35 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
 
   // getOrCreate before the relay hop: serializes same-iothread races. isNew=false means
   // the forwarder already exists (or a setup is in progress) on this thread — just attach.
-  auto [localFwd, isNew, localReg] =
-      acquireLocalForwarder(ftn, [&] { return std::make_shared<MoQForwarder>(ftn); });
+  // ready=false: not attachable until the upstream OK, so isNew=true owns the gate.
+  auto [localFwd, isNew, localReg] = acquireLocalForwarder(
+      ftn,
+      [&] { return std::make_shared<MoQForwarder>(ftn); },
+      /*ready=*/false
+  );
 
   if (!isNew) {
+    // Wait for an in-flight isNew=true setup to seed largest, else SUBSCRIBE_OK carries
+    // the pre-seeding value a client reads as a track restart.
+    if (auto ready = localReg->ready(ftn); ready && !ready->isFulfilled()) {
+      co_await ready->getSemiFuture();
+    }
     if (auto err = checkRangeNotInPast(*localFwd, subReq)) {
       co_return folly::makeUnexpected(std::move(*err));
     }
     co_return attachSubscriber(*localFwd, std::move(session), subReq, std::move(consumer));
   }
 
-  // isNew=true: this thread owns setup. Install PendingForwarderCallback first so
-  // forwardChanged/newGroupRequested/onEmpty events during setup are captured for replay.
+  // Fault attachers by default: every exit below abandons localFwd. Success overrides.
+  auto ready = localReg->ready(ftn);
+  auto signalReady = folly::makeGuard([&ready]() noexcept {
+    if (!ready->isFulfilled()) {
+      ready->setException(std::runtime_error("local forwarder setup failed"));
+    }
+  });
+
+  // Install PendingForwarderCallback first so forwardChanged/newGroupRequested/onEmpty
+  // events during setup are captured for replay.
   auto pendingCb = std::make_shared<PendingForwarderCallback>(localReg, ftn);
   localFwd->setCallback(pendingCb);
 
@@ -2033,6 +2073,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
   }
   replayPendingFowarderEvents(localFwd.get(), attach.finalCallback, *pendingCb, forward);
   localFwd->tryProcessNewGroupRequest(subReq.params);
+  ready->setValue();
   co_return sub;
 }
 

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -321,9 +321,11 @@ private:
     bool isNew{false};
     LocalForwarderRegistry* localReg{nullptr};
   };
+  // ready=false arms the attach gate; see LocalForwarderRegistry::getOrCreate.
   LocalForwarderBootstrap acquireLocalForwarder(
       const moxygen::FullTrackName& ftn,
-      folly::FunctionRef<std::shared_ptr<moxygen::MoQForwarder>()> factory
+      folly::FunctionRef<std::shared_ptr<moxygen::MoQForwarder>()> factory,
+      bool ready
   );
 
   bool addSubscriberAndPublish(
@@ -349,8 +351,15 @@ private:
   );
 
   // Constructs the publisher's local forwarder and installs its callback chain on
-  // publisherExec. tlForwarders_ must already be initialized.
+  // publisherExec.
   std::shared_ptr<moxygen::MoQForwarder> createPublisherForwarder(const moxygen::PublishRequest& pub
+  );
+
+  // Must run on the forwarder's exec; removeOnEmpty=false survives churn, true drops on empty.
+  void installPublisherForwarderCallbackChain(
+      const moxygen::FullTrackName& ftn,
+      const std::shared_ptr<moxygen::MoQForwarder>& publisherFwd,
+      bool removeOnEmpty
   );
 
   std::optional<moxygen::PublishError>

--- a/src/relay/LocalForwarderCallback.h
+++ b/src/relay/LocalForwarderCallback.h
@@ -22,10 +22,10 @@ namespace openmoq::moqx {
 // never clobber a newer one that has claimed the same track name.
 //
 // removeOnEmpty distinguishes the two roles:
-//   - subscribe-path local forwarder (removeOnEmpty=true): when its last
+//   - subscribe-path forwarders (removeOnEmpty=true): when the last
 //     subscriber leaves, its channel sub is pulled from the publisher and it is
 //     dead — remove on onEmpty as well as onPublishDone.
-//   - publisher's publisher forwarder (removeOnEmpty=false): it must survive
+//   - publish-initiated publisher forwarder (removeOnEmpty=false): it must survive
 //     subscriber churn (new subscribers may arrive while the publisher is
 //     live), so it is removed ONLY when the source terminates (onPublishDone).
 class LocalForwarderCallback : public moxygen::MoQForwarder::Callback {

--- a/src/relay/LocalForwarderRegistry.h
+++ b/src/relay/LocalForwarderRegistry.h
@@ -10,6 +10,7 @@
 #include <moxygen/relay/MoQForwarder.h>
 
 #include <folly/container/F14Map.h>
+#include <folly/futures/SharedPromise.h>
 
 namespace openmoq::moqx {
 
@@ -25,18 +26,33 @@ public:
     bool isNew;
   };
 
+  // ready resolves when the forwarder is safe for subscribers to attach to — not that
+  // largest is known, since SUBSCRIBE_OK and PUBLISH both carry it optionally. Non-null
+  // only while an isNew=true owner has promised to fulfill it.
+  struct Entry {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    std::shared_ptr<folly::SharedPromise<folly::Unit>> ready;
+  };
+
   // Returns the existing local forwarder for ftn, or calls factory() to create
   // one. factory() is called at most once per ftn per thread lifetime.
+  // ready=false arms the gate: an isNew=true caller owns setup and must fulfill
+  // ready(ftn) on every exit, or attachers hang.
   GetOrCreateResult getOrCreate(
       const moxygen::FullTrackName& ftn,
-      folly::FunctionRef<std::shared_ptr<moxygen::MoQForwarder>()> factory
+      folly::FunctionRef<std::shared_ptr<moxygen::MoQForwarder>()> factory,
+      bool ready
   ) {
     auto it = forwarders_.find(ftn);
     if (it != forwarders_.end()) {
-      return {it->second, /*isNew=*/false};
+      return {it->second.forwarder, /*isNew=*/false};
     }
     auto forwarder = factory();
-    forwarders_.emplace(ftn, forwarder);
+    auto& entry = forwarders_[ftn];
+    entry.forwarder = forwarder;
+    if (!ready) {
+      entry.ready = std::make_shared<folly::SharedPromise<folly::Unit>>();
+    }
     return {std::move(forwarder), /*isNew=*/true};
   }
 
@@ -45,16 +61,23 @@ public:
   // a stale subscribe-path local forwarder under the same name is displaced
   // here, and drains itself via the source-termination cascade (its identity-
   // checked removal then no-ops, since this forwarder now owns the slot).
+  // ready=true releases attachers now; false leaves them pending until the owner fulfills.
   std::shared_ptr<moxygen::MoQForwarder>
-  set(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQForwarder> forwarder) {
-    auto prev = std::move(forwarders_[ftn]);
-    forwarders_[ftn] = std::move(forwarder);
+  set(const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQForwarder> forwarder,
+      bool ready) {
+    auto& entry = forwarders_[ftn];
+    auto prev = std::move(entry.forwarder);
+    entry.forwarder = std::move(forwarder);
+    if (ready && entry.ready && !entry.ready->isFulfilled()) {
+      entry.ready->setValue();
+    }
     return prev;
   }
 
   std::shared_ptr<moxygen::MoQForwarder> get(const moxygen::FullTrackName& ftn) const {
     auto it = forwarders_.find(ftn);
-    return it != forwarders_.end() ? it->second : nullptr;
+    return it != forwarders_.end() ? it->second.forwarder : nullptr;
   }
 
   // Identity-checked removal: erase the entry for ftn only if it still points
@@ -64,18 +87,23 @@ public:
   // forwarder that has since claimed the same track name.
   void remove(const moxygen::FullTrackName& ftn, const moxygen::MoQForwarder* expected) {
     auto it = forwarders_.find(ftn);
-    if (it == forwarders_.end() || it->second.get() != expected) {
+    if (it == forwarders_.end() || it->second.forwarder.get() != expected) {
       return;
     }
     forwarders_.erase(it);
   }
 
+  // isNew=false attachers await this, so they never read a largest the owner has not
+  // seeded yet — a client sees that as a track restart. Null when no setup is in
+  // flight; only getOrCreate(ready=false) arms it.
+  std::shared_ptr<folly::SharedPromise<folly::Unit>> ready(const moxygen::FullTrackName& ftn
+  ) const {
+    auto it = forwarders_.find(ftn);
+    return it != forwarders_.end() ? it->second.ready : nullptr;
+  }
+
 private:
-  folly::F14FastMap<
-      moxygen::FullTrackName,
-      std::shared_ptr<moxygen::MoQForwarder>,
-      moxygen::FullTrackName::hash>
-      forwarders_;
+  folly::F14FastMap<moxygen::FullTrackName, Entry, moxygen::FullTrackName::hash> forwarders_;
 };
 
 } // namespace openmoq::moqx

--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -451,6 +451,9 @@ TEST_P(MoQRelayTest, PublishReconnectDuringSubscribeScopeGuardCrash) {
   // Relay state mutations must run on the relay executor; doPublishNamespaceDone
   // touches the namespace tree, which publishDone also cleans up via relayEvb_.
   verifyOnRelayExec([&] { relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2); });
+  // Drain the subscriber exec so the detached failure-teardown coro runs and
+  // releases the subscriber session it holds (else: leaked mock at exit).
+  driveIfMultiThread();
 }
 
 // Same reconnect scenario but the upstream subscribe returns OK instead of an

--- a/test/MoqxRelaySubscribeTests.cpp
+++ b/test/MoqxRelaySubscribeTests.cpp
@@ -8,6 +8,9 @@
 
 #include "MoqxRelayTestFixture.h"
 
+#include <folly/coro/Baton.h>
+#include <folly/coro/Invoke.h>
+
 namespace moxygen::test {
 
 // Test: forwardChanged must not crash when called after the publisher has
@@ -201,6 +204,205 @@ TEST_P(MoQRelayTest, FirstSubscriberViaUpstreamSubscribeReceivesData) {
 
   removeSession(publisherSession);
   removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// Regression: a second subscriber that arrives while a first subscriber's upstream
+// SUBSCRIBE is still in flight must observe the upstream-seeded largest. In
+// LocalForwarderMT the second takes the acquireLocalForwarder isNew=false fast path
+// and, without a readiness gate, reads the not-yet-seeded localFwd largest (empty),
+// which a client reads as a track restart. ST/MT wait on the registry promise and
+// were already correct, so this passes in every mode and regresses only LF.
+TEST_P(MoQRelayTest, SubsequentSubscriberWaitsForUpstreamLargestSeeding) {
+  auto publisherSession = createMockSession();
+  auto subSession1 = createMockSession();
+  auto subSession2 = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  const AbsoluteLocation kLargest{3, 0};
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(1);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+  upstreamOk.largest = kLargest;
+
+  // Hold the upstream SUBSCRIBE in flight so the second subscriber races in while the
+  // first subscriber's largest is still unseeded.
+  folly::coro::Baton upstreamGate;
+  std::atomic<bool> upstreamSubscribeCalled{false};
+  std::shared_ptr<TrackConsumer> upstreamConsumer;
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce(
+          [&](const SubscribeRequest&, std::shared_ptr<TrackConsumer> consumer
+          ) -> folly::coro::Task<Publisher::SubscribeResult> {
+            upstreamConsumer = std::move(consumer);
+            upstreamSubscribeCalled.store(true);
+            co_await upstreamGate;
+            auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+            co_return folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(handle);
+          }
+      );
+
+  // driveUntil caps SingleThread at one loopOnce; pump explicitly so the synchronous
+  // cascades complete in every mode.
+  auto pump = [&](auto pred) {
+    for (int i = 0; i < 1000 && !pred(); ++i) {
+      exec_->drive();
+    }
+    return pred();
+  };
+  auto launchSubscribe = [&](std::shared_ptr<MoQSession> session,
+                             std::shared_ptr<TrackConsumer> consumer,
+                             RequestID requestID,
+                             std::shared_ptr<std::optional<Publisher::SubscribeResult>> out) {
+    withSessionContext(session, [&]() {
+      SubscribeRequest sub;
+      sub.fullTrackName = kTestTrackName;
+      sub.requestID = requestID;
+      sub.locType = LocationType::LargestObject;
+      auto task = publisherInterface()->subscribe(std::move(sub), std::move(consumer));
+      co_withExecutor(
+          static_cast<folly::DrivableExecutor*>(exec_.get()),
+          folly::coro::co_invoke([t = std::move(task), out]() mutable -> folly::coro::Task<void> {
+            *out = co_await std::move(t);
+          })
+      ).start();
+    });
+  };
+
+  // First subscriber: creates the shared localFwd in acquireLocalForwarder, then
+  // suspends inside the gated upstream SUBSCRIBE.
+  auto firstResult = std::make_shared<std::optional<Publisher::SubscribeResult>>();
+  launchSubscribe(subSession1, createMockConsumer(), RequestID(0), firstResult);
+  ASSERT_TRUE(pump([&] { return upstreamSubscribeCalled.load(); }))
+      << "relay should issue an upstream subscribe and suspend in it";
+
+  // Second subscriber, while the first's seeding is still pending. Drive it to its
+  // steady state (LF without the gate attaches immediately; ST/MT/LF-with-gate wait)
+  // before releasing the upstream OK, so a captured result reflects the race.
+  auto secondResult = std::make_shared<std::optional<Publisher::SubscribeResult>>();
+  launchSubscribe(subSession2, createMockConsumer(), RequestID(2), secondResult);
+  for (int i = 0; i < 200; ++i) {
+    exec_->drive();
+  }
+
+  upstreamGate.post();
+  ASSERT_TRUE(pump([&] { return firstResult->has_value() && secondResult->has_value(); }));
+
+  ASSERT_TRUE(firstResult->value().hasValue());
+  EXPECT_EQ(firstResult->value().value()->subscribeOk().largest, kLargest);
+  ASSERT_TRUE(secondResult->value().hasValue());
+  EXPECT_EQ(secondResult->value().value()->subscribeOk().largest, kLargest)
+      << "subsequent subscriber must observe the upstream-seeded largest, not a "
+         "pre-seeding value a client reads as a track restart";
+
+  // Track the handles so cleanupMockSession tears down the subscriptions (else the
+  // held consumers/sessions leak as unverified mocks at exit).
+  getOrCreateMockState(subSession1)->subscribeHandles.push_back(firstResult->value().value());
+  getOrCreateMockState(subSession2)->subscribeHandles.push_back(secondResult->value().value());
+
+  removeSession(publisherSession);
+  removeSession(subSession1);
+  removeSession(subSession2);
+  driveIfMultiThread();
+}
+
+// Regression: when the first subscriber's upstream SUBSCRIBE *fails*, a second
+// subscriber that raced in behind it must fail too. In LocalForwarderMT the second took
+// the isNew=false path and awaited the ready gate, which the first fulfills with
+// setValue() on every exit — including failure. The second then attached to a localFwd
+// that setup had already removed from the registry and that has no upstream, so it got a
+// SUBSCRIBE_OK for a track that can never deliver an object.
+TEST_P(MoQRelayTest, SubsequentSubscriberFailsWhenUpstreamSubscribeFails) {
+  auto publisherSession = createMockSession();
+  auto subSession1 = createMockSession();
+  auto subSession2 = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Hold the upstream SUBSCRIBE in flight so the second subscriber races in, then reject
+  // it — the first subscriber's setup fails after the second is already waiting.
+  folly::coro::Baton upstreamGate;
+  std::atomic<bool> upstreamSubscribeCalled{false};
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce(
+          [&](const SubscribeRequest&,
+              std::shared_ptr<TrackConsumer>) -> folly::coro::Task<Publisher::SubscribeResult> {
+            upstreamSubscribeCalled.store(true);
+            co_await upstreamGate;
+            co_return folly::makeUnexpected(SubscribeError{
+                RequestID(0),
+                SubscribeErrorCode::INTERNAL_ERROR,
+                "upstream rejected"
+            });
+          }
+      );
+
+  auto pump = [&](auto pred) {
+    for (int i = 0; i < 1000 && !pred(); ++i) {
+      exec_->drive();
+    }
+    return pred();
+  };
+  auto launchSubscribe = [&](std::shared_ptr<MoQSession> session,
+                             std::shared_ptr<TrackConsumer> consumer,
+                             RequestID requestID,
+                             std::shared_ptr<std::optional<Publisher::SubscribeResult>> out) {
+    withSessionContext(session, [&]() {
+      SubscribeRequest sub;
+      sub.fullTrackName = kTestTrackName;
+      sub.requestID = requestID;
+      sub.locType = LocationType::LargestObject;
+      auto task = publisherInterface()->subscribe(std::move(sub), std::move(consumer));
+      // ST/MT signal first-subscriber failure by throwing out of the SubsequentSubscriber
+      // task; normalize to an error result so both shapes are comparable.
+      co_withExecutor(
+          static_cast<folly::DrivableExecutor*>(exec_.get()),
+          folly::coro::co_invoke([t = std::move(task), out]() mutable -> folly::coro::Task<void> {
+            try {
+              *out = co_await std::move(t);
+            } catch (const std::exception& e) {
+              *out = folly::makeUnexpected(
+                  SubscribeError{RequestID(0), SubscribeErrorCode::INTERNAL_ERROR, e.what()}
+              );
+            }
+          })
+      ).start();
+    });
+  };
+
+  auto firstResult = std::make_shared<std::optional<Publisher::SubscribeResult>>();
+  launchSubscribe(subSession1, createMockConsumer(), RequestID(0), firstResult);
+  ASSERT_TRUE(pump([&] { return upstreamSubscribeCalled.load(); }))
+      << "relay should issue an upstream subscribe and suspend in it";
+
+  // Second subscriber, parked on the ready gate while the first is still in flight.
+  auto secondResult = std::make_shared<std::optional<Publisher::SubscribeResult>>();
+  launchSubscribe(subSession2, createMockConsumer(), RequestID(2), secondResult);
+  for (int i = 0; i < 200; ++i) {
+    exec_->drive();
+  }
+
+  upstreamGate.post();
+  ASSERT_TRUE(pump([&] { return firstResult->has_value() && secondResult->has_value(); }));
+
+  EXPECT_FALSE(firstResult->value().hasValue()) << "upstream rejected the subscribe";
+  EXPECT_FALSE(secondResult->value().hasValue())
+      << "a subscriber released by a FAILED setup must get an error, not a SUBSCRIBE_OK "
+         "for a forwarder with no upstream";
+
+  if (firstResult->value().hasValue()) {
+    getOrCreateMockState(subSession1)->subscribeHandles.push_back(firstResult->value().value());
+  }
+  if (secondResult->value().hasValue()) {
+    getOrCreateMockState(subSession2)->subscribeHandles.push_back(secondResult->value().value());
+  }
+
+  removeSession(publisherSession);
+  removeSession(subSession1);
+  removeSession(subSession2);
   driveIfMultiThread();
 }
 


### PR DESCRIPTION
In LF mode a subscribe-triggered upstream subscription created its publisher forwarder on relayExec_ with a MoqxRelay-direct callback and never placed it in tlForwarders_. That forwarder lives on the upstream session's iothread, so its onEmpty/forwardChanged/newGroupRequested ran there and touched registry_ off relayExec_, and same-thread subscribers missed the zero-hop fast path.

Factor the publisher-forwarder callback chain (Weak -> CrossExec -> Local) and tlForwarders_ slot claim out of createPublisherForwarder into a shared installPublisherForwarderCallbackChain helper. The first subscriber now installs that same Weak->CrossExec(relayExec_)->Local chain and claims the tl slot on the publisher's exec (removeOnEmpty=true, since subscribe-initiated tracks drop on empty). getOrCreateFromSubscribe accepts a null callback so the LF caller installs the real chain on the forwarder's exec; non-LF still passes the relay directly.

Document the resulting symmetry in the callback-chain overview and dev doc: subscribe-initiated now uses the same chain as publish-initiated, with the removeOnEmpty contract differing (true vs false).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/521)
<!-- Reviewable:end -->
