### PR TITLE
docs: trim badge row, advertise MOQT draft-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@
 <div align="center">
 
 [![ci main](https://github.com/openmoq/moqx/actions/workflows/ci-main.yml/badge.svg)](https://github.com/openmoq/moqx/actions/workflows/ci-main.yml)
-[![ci pr](https://github.com/openmoq/moqx/actions/workflows/ci-pr.yml/badge.svg)](https://github.com/openmoq/moqx/actions/workflows/ci-pr.yml)
 [![Latest release](https://img.shields.io/github/v/release/openmoq/moqx?display_name=tag&sort=semver&logo=github)](https://github.com/openmoq/moqx/releases/latest)
 [![License](https://img.shields.io/github/license/openmoq/moqx)](LICENSE)
 [![Last commit](https://img.shields.io/github/last-commit/openmoq/moqx)](https://github.com/openmoq/moqx/commits/main)
 [![Open issues](https://img.shields.io/github/issues/openmoq/moqx)](https://github.com/openmoq/moqx/issues)
 [![Open PRs](https://img.shields.io/github/issues-pr/openmoq/moqx)](https://github.com/openmoq/moqx/pulls)
-[![MOQT](https://img.shields.io/badge/MOQT-draft--16-blue)](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/)
+[![MOQT](https://img.shields.io/badge/MOQT-draft--18-blue)](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/)
 
 </div>
 


### PR DESCRIPTION
Two independent README fixes.

## Badge row width

GitHub emits the badges as a single inline `<p>` — verified against both the API render and the repo landing page payload. No `<br>`, and no rule in `primer-*.css` / `github-*.css` that would break the line. So the row is plain inline flow that wraps on width.

Summed intrinsic widths of the eight badge SVGs: **890px**, plus seven inter-badge word-spaces ≈ **921px**. The README column is ~920px — provable, since `docs/banner.png` is 5072px intrinsic and `max-width:100%` pins it to exactly the container width. The row had drifted onto the wrap threshold on its own: `release` widened with the version tag, `issues` gained a digit.

Dropping `ci pr` (~110px) brings it to ~810px with margin. `ci main` already covers build health; `last commit` is kept for the freshness signal.

## MOQT draft version

The badge advertised `draft-16`. Per `deps/moxygen/moxygen/MoQVersions.h`:

```cpp
constexpr std::array<uint64_t, 4> kSupportedVersions{
    kVersionDraft14, kVersionDraft15, kVersionDraft16, kVersionDraft18};
```

with `kAlpnMoqtDraft18 = "moqt-18"`. Badge now reads `draft-18`.

## Open question

This does not fully explain a report of the badges rendering **one per line**. Geometry says a 921px row in a 920px column wraps to two lines, not eight, and the stacking reproduced in incognito so it is not a browser extension. Landing this narrows the variable: if the row goes horizontal, it was width. If seven badges still stack, something is forcing breaks and needs a separate look.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/526)
<!-- Reviewable:end -->
