### PR TITLE
stats: name PUBLISH counters by relay role

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -78,11 +78,10 @@ receive PUBLISH from an upstream publisher.
 
 | Metric | Description |
 |--------|-------------|
-| `moqx_moqPublishSuccess_total` | Relay sent PUBLISH and received PUBLISH_OK back |
-| `moqx_moqPublishError_total` | Relay sent PUBLISH and received PUBLISH_ERROR back |
-| `moqx_moqPublishReceived_total` | PUBLISH received from an upstream publisher |
-| `moqx_moqPublishOkSent_total` | PUBLISH_OK sent to an upstream publisher |
-| `moqx_subPublishError_total` | PUBLISH_ERROR sent to an upstream publisher (rejected) |
+| `moqx_pubPublishSuccess_total` | Relay sent PUBLISH and received PUBLISH_OK back |
+| `moqx_pubPublishError_total` | Relay sent PUBLISH and received PUBLISH_ERROR back |
+| `moqx_subPublishSuccess_total` | Relay received PUBLISH and sent PUBLISH_OK back |
+| `moqx_subPublishError_total` | Relay received PUBLISH and sent PUBLISH_ERROR back (rejected) |
 
 ## MoQ Application Layer — Gauges
 
@@ -146,7 +145,7 @@ Counters with per-code breakdowns:
 - `moqx_pubFetchError_by_code_total`
 - `moqx_pubPublishNamespaceError_by_code_total`
 - `moqx_pubSubscribeNamespaceError_by_code_total`
-- `moqx_moqPublishError_by_code_total`
+- `moqx_pubPublishError_by_code_total`
 - `moqx_subSubscribeError_by_code_total`
 - `moqx_subFetchError_by_code_total`
 - `moqx_subPublishNamespaceError_by_code_total`

--- a/src/stats/MoQStatsCollector.cpp
+++ b/src/stats/MoQStatsCollector.cpp
@@ -201,13 +201,13 @@ void MoQStatsCollector::PublisherCallback::recordPublishLatency(uint64_t latency
 
 void MoQStatsCollector::PublisherCallback::onPublishError(moxygen::PublishErrorCode errorCode) {
   // Relay sent PUBLISH; received PUBLISH_ERROR back.
-  ++parent_.moqPublishError_;
-  ++parent_.moqPublishErrorByCodes_[requestErrorCodeIndex(errorCode)];
+  ++parent_.pubPublishError_;
+  ++parent_.pubPublishErrorByCodes_[requestErrorCodeIndex(errorCode)];
 }
 
 void MoQStatsCollector::PublisherCallback::onPublishSuccess() {
   // Relay sent PUBLISH; received PUBLISH_OK back.
-  ++parent_.moqPublishSuccess_;
+  ++parent_.pubPublishSuccess_;
 }
 
 void MoQStatsCollector::PublisherCallback::onSubgroupReset(moxygen::ResetStreamErrorCode errorCode
@@ -334,14 +334,13 @@ void MoQStatsCollector::SubscriberCallback::recordFetchLatency(uint64_t latencyM
 }
 
 void MoQStatsCollector::SubscriberCallback::onPublish() {
-  // Relay received a PUBLISH request from an upstream publisher.
-  ++parent_.moqPublishReceived_;
+  // Arrival is implied by subPublishSuccess + subPublishError; nothing to count here.
 }
 
 void MoQStatsCollector::SubscriberCallback::onPublishOk() {
   // Relay sent PUBLISH_OK to an upstream publisher; it is now active.
   // onSubscriptionBegin fires after this and increments subActivePublishers_.
-  ++parent_.moqPublishOkSent_;
+  ++parent_.subPublishSuccess_;
 }
 
 void MoQStatsCollector::SubscriberCallback::onPublishError(moxygen::PublishErrorCode errorCode) {

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -149,7 +149,6 @@ inline constexpr std::array<std::string_view, kResetStreamErrorCodeCount>
 // uint64_t monotonically-increasing counters — MoQ application layer.
 // pub* = relay acting as publisher (serving downstream subscribers).
 // sub* = relay acting as subscriber (consuming from upstream publishers).
-// moq* = unambiguously tied to one role (no pub/sub prefix needed).
 #define STATS_MOQ_COUNTER_FIELDS(X)                                                                \
   /* Publisher-side: relay accepted/rejected subscription requests */                              \
   X(uint64_t, pubSubscribeSuccess)                                                                 \
@@ -169,9 +168,9 @@ inline constexpr std::array<std::string_view, kResetStreamErrorCodeCount>
   X(uint64_t, pubSubscriptionStreamClosed)                                                         \
   X(uint64_t, pubTrackStatus)                                                                      \
   X(uint64_t, pubRequestUpdate)                                                                    \
-  /* Publisher-only methods: relay sent PUBLISH, received PUBLISH_OK/ERROR back */                 \
-  X(uint64_t, moqPublishSuccess)                                                                   \
-  X(uint64_t, moqPublishError)                                                                     \
+  /* Relay sent PUBLISH upstream, received PUBLISH_OK/ERROR back */                                \
+  X(uint64_t, pubPublishSuccess)                                                                   \
+  X(uint64_t, pubPublishError)                                                                     \
   /* Subscriber-side: relay subscribed to / was rejected by upstream */                            \
   X(uint64_t, subSubscribeSuccess)                                                                 \
   X(uint64_t, subSubscribeError)                                                                   \
@@ -190,9 +189,8 @@ inline constexpr std::array<std::string_view, kResetStreamErrorCodeCount>
   X(uint64_t, subSubscriptionStreamClosed)                                                         \
   X(uint64_t, subTrackStatus)                                                                      \
   X(uint64_t, subRequestUpdate)                                                                    \
-  /* Subscriber-only methods: upstream publisher connected to relay */                             \
-  X(uint64_t, moqPublishReceived)                                                                  \
-  X(uint64_t, moqPublishOkSent)                                                                    \
+  /* Relay received PUBLISH from upstream, sent PUBLISH_OK/ERROR back */                           \
+  X(uint64_t, subPublishSuccess)                                                                   \
   X(uint64_t, subPublishError)
 
 // uint64_t monotonically-increasing counters — QUIC transport layer.
@@ -284,7 +282,7 @@ inline constexpr std::array<std::string_view, kResetStreamErrorCodeCount>
   X(pubFetchError)                                                                                 \
   X(pubPublishNamespaceError)                                                                      \
   X(pubSubscribeNamespaceError)                                                                    \
-  X(moqPublishError)                                                                               \
+  X(pubPublishError)                                                                               \
   X(subSubscribeError)                                                                             \
   X(subFetchError)                                                                                 \
   X(subPublishNamespaceError)                                                                      \

--- a/test/test_admin_metrics.sh
+++ b/test/test_admin_metrics.sh
@@ -93,7 +93,7 @@ EXPECTED_METRICS=(
   "moqx_moqActiveSessions"
   "moqx_pubActiveSubscriptions"
   "moqx_pubSubscribeSuccess_total"
-  "moqx_moqPublishSuccess_total"
+  "moqx_pubPublishSuccess_total"
   "moqx_moqSubscribeLatency_microseconds"
   "moqx_moqFetchLatency_microseconds"
   "moqx_quicPacketsSent_total"


### PR DESCRIPTION
PUBLISH counters now follow the same convention as SUBSCRIBE: the prefix is the relay's own role and Success/Error is the request outcome.

  moqPublishSuccess  -> pubPublishSuccess    (relay sent PUBLISH)
  moqPublishError    -> pubPublishError
  moqPublishOkSent   -> subPublishSuccess    (relay received PUBLISH)
  moqPublishReceived -> dropped

subPublishReceived is dropped rather than renamed: it counted request arrival, which no other handshake exposes, and its value is implied by subPublishSuccess + subPublishError.  onPublish() stays as a no-op override because moxygen declares it pure virtual.

Renames the exported Prometheus series, so external dashboards and alerts referencing the moqx_moqPublish* names need updating.

Fixes: #151

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/528)
<!-- Reviewable:end -->
