### PR TITLE
relay: give LocalForwarderRegistry a three-state entry

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -459,8 +459,8 @@ MoqxRelay::validatePublishNamespace(const FullTrackName& ftn, RequestID requestI
 // tlForwarders_ must already be initialized.
 std::shared_ptr<MoQForwarder> MoqxRelay::createPublisherForwarder(const PublishRequest& pub) {
   const auto& ftn = pub.fullTrackName;
-  auto localPubFwd = std::make_shared<MoQForwarder>(ftn, pub.largest);
-  localPubFwd->setExtensions(pub.extensions);
+  // Returned uninitialized; the caller's Claim applies the initial state.
+  auto localPubFwd = std::make_shared<MoQForwarder>(ftn);
 
   // removeOnEmpty=false: the publisher's forwarder must survive subscriber churn, so
   // LocalForwarderCallback removes it from tlForwarders_ only when the source ends.
@@ -497,10 +497,11 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
 
   auto localPubFwd = createPublisherForwarder(pub);
 
-  // The publisher's forwarder is authoritative — claim the slot, displacing any
+  // The publisher's forwarder is authoritative — claim the entry, displacing any
   // stale subscribe-path local forwarder so same-thread subscribers reuse THIS
   // forwarder via the fast path.
-  tlForwarders_->set(pub.fullTrackName, localPubFwd);
+  tlForwarders_->replace(pub.fullTrackName, localPubFwd)
+      .markReady(InitialTrackState{pub.largest, pub.extensions});
 
   // crossExecFilter is a channel subscriber for the relay exec
   // regulsterPublishOnRelay exec completes wiring the chain (topNFilter → terminationFilter →
@@ -1125,7 +1126,7 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
 
   // Fast path: local forwarder already exists on this thread.
   if (auto* localReg = tlForwarders_.get()) {
-    if (auto localFwd = localReg->get(ftn)) {
+    if (auto localFwd = localReg->getIfReady(ftn)) {
       auto p = startPublish(subscriberSession, localFwd, forward, pinned, nullptr);
       if (p) {
         co_await awaitPublishReply(localFwd, std::move(p->subscriber), std::move(p->reply));
@@ -1145,11 +1146,7 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
       }()
   );
 
-  auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, [&] {
-    auto fwd = std::make_shared<MoQForwarder>(ftn);
-    initial.applyTo(*fwd);
-    return fwd;
-  });
+  auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, initial);
 
   auto p = startPublish(subscriberSession, localFwd, forward, pinned, nullptr);
   if (!p) {
@@ -1201,19 +1198,25 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
   co_await awaitPublishReply(localFwd, std::move(p->subscriber), std::move(p->reply));
 }
 
-// Slow-path local-forwarder bootstrap shared by the publish and subscribe LF paths:
-// ensures the thread-local registry, then getOrCreates the forwarder for ftn. Callers
-// handle the fast path and install the PendingForwarderCallback (timing differs).
-MoqxRelay::LocalForwarderBootstrap MoqxRelay::acquireLocalForwarder(
-    const FullTrackName& ftn,
-    folly::FunctionRef<std::shared_ptr<MoQForwarder>()> factory
-) {
+// Slow-path local-forwarder bootstrap shared by the publish and subscribe LF paths.
+// Callers handle the fast path and install the PendingForwarderCallback themselves,
+// because the timing differs.
+MoqxRelay::LocalForwarderBootstrap
+MoqxRelay::acquireLocalForwarder(const FullTrackName& ftn, const InitialTrackState& initial) {
   if (!tlForwarders_.get()) {
     tlForwarders_.reset(new LocalForwarderRegistry());
   }
   auto* localReg = tlForwarders_.get();
-  auto [localFwd, isNew] = localReg->getOrCreate(ftn, factory);
-  return {std::move(localFwd), isNew, localReg};
+  auto joined = localReg->join(ftn, [&] { return std::make_shared<MoQForwarder>(ftn); });
+  if (auto* claim = std::get_if<LocalForwarderRegistry::Claim>(&joined)) {
+    auto localFwd = claim->forwarder();
+    claim->markReady(initial);
+    return {std::move(localFwd), /*isNew=*/true, localReg};
+  }
+  auto* ready = std::get_if<LocalForwarderRegistry::Ready>(&joined);
+  XCHECK(ready) << "local forwarder entry still pending; a caller failed to resolve its claim: "
+                << ftn;
+  return {ready->forwarder, /*isNew=*/false, localReg};
 }
 
 class MoqxRelay::NamespaceSubscription : public Publisher::SubscribeNamespaceHandle {
@@ -1961,10 +1964,9 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
 ) {
   const auto& ftn = subReq.fullTrackName;
 
-  // getOrCreate before the relay hop: serializes same-iothread races. isNew=false means
-  // the forwarder already exists (or a setup is in progress) on this thread — just attach.
-  auto [localFwd, isNew, localReg] =
-      acquireLocalForwarder(ftn, [&] { return std::make_shared<MoQForwarder>(ftn); });
+  // Join before the relay hop: serializes same-iothread races. No initial state yet —
+  // the upstream OK has not arrived, so an attacher can read a too-early largest here.
+  auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, InitialTrackState{});
 
   consumer =
       wrapWithTrackStats(trackStats_, ftn, std::move(consumer), stats::TrackDirection::Egress);
@@ -2176,7 +2178,7 @@ MoqxRelay::trackStatusOnSubscriberExec(const TrackStatus& req) {
     return std::nullopt;
   }
   auto* localReg = tlForwarders_.get();
-  auto localFwd = localReg ? localReg->get(req.fullTrackName) : nullptr;
+  auto localFwd = localReg ? localReg->getIfReady(req.fullTrackName) : nullptr;
   if (!localFwd || localFwd->numForwardingSubscribers() == 0) {
     return std::nullopt;
   }
@@ -2190,7 +2192,7 @@ Fetch MoqxRelay::fetchOnSubscriberExec(Fetch fetch, const std::shared_ptr<MoQSes
     return fetch;
   }
   auto* localReg = tlForwarders_.get();
-  auto localFwd = localReg ? localReg->get(fetch.fullTrackName) : nullptr;
+  auto localFwd = localReg ? localReg->getIfReady(fetch.fullTrackName) : nullptr;
   if (localFwd) {
     auto res = localFwd->resolveJoiningFetch(session, *joining);
     if (res.hasValue()) {
@@ -2272,7 +2274,7 @@ MoqxRelay::fetchImpl(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
 folly::coro::Task<std::optional<TrackStatusOk>>
 MoqxRelay::readPublisherForwarderStatus(bool hasHandle, TrackStatus req) {
   auto* localReg = tlForwarders_.get();
-  auto forwarder = localReg ? localReg->get(req.fullTrackName) : nullptr;
+  auto forwarder = localReg ? localReg->getIfReady(req.fullTrackName) : nullptr;
   if (!forwarder || forwarder->numForwardingSubscribers() == 0) {
     co_return std::nullopt;
   }
@@ -2591,7 +2593,7 @@ void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSess
     // publisher forwarder; evict it on its owning exec.
     folly::via(session->getExecutor(), [this, ftn, evict = std::move(evict)]() {
       auto* localReg = tlForwarders_.get();
-      evict(localReg ? localReg->get(ftn) : nullptr);
+      evict(localReg ? localReg->getForEviction(ftn) : nullptr);
     });
     return;
   }

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -338,10 +338,8 @@ private:
     bool isNew{false};
     LocalForwarderRegistry* localReg{nullptr};
   };
-  LocalForwarderBootstrap acquireLocalForwarder(
-      const moxygen::FullTrackName& ftn,
-      folly::FunctionRef<std::shared_ptr<moxygen::MoQForwarder>()> factory
-  );
+  LocalForwarderBootstrap
+  acquireLocalForwarder(const moxygen::FullTrackName& ftn, const InitialTrackState& initial);
 
   bool addSubscriberAndPublish(
       std::shared_ptr<moxygen::MoQSession> subscriberSession,

--- a/src/relay/LocalForwarderRegistry.h
+++ b/src/relay/LocalForwarderRegistry.h
@@ -6,76 +6,275 @@
 
 #pragma once
 
+#include "relay/InitialTrackState.h"
+
 #include <moxygen/MoQLocation.h>
 #include <moxygen/relay/MoQForwarder.h>
 
 #include <folly/container/F14Map.h>
+#include <folly/futures/SharedPromise.h>
+#include <folly/logging/xlog.h>
+
+#include <variant>
 
 namespace openmoq::moqx {
 
 // Thread-local registry mapping FullTrackName → local MoQForwarder on one
 // iothread. All methods must be called on the owning thread. One instance per
 // iothread, stored in MoqxRelay::tlForwarders_.
+//
+// An entry is in exactly one of three states:
+//
+//   absent           no forwarder for this track on this thread
+//   pending(fwd, p)  fwd is installed but its largest/extensions are not yet
+//                    set from upstream. Attaching now would publish a largest
+//                    from before that, which a client reads as a track
+//                    restart. Exactly one Claim owns the entry and owes a
+//                    resolution.
+//   ready(fwd)       the owner declared it attachable
+//
+// Pending deliberately does not expose the forwarder: only the Claim holder can
+// reach one before its initial state is set, so a reader has nothing to check.
 class LocalForwarderRegistry {
 public:
-  struct GetOrCreateResult {
-    std::shared_ptr<moxygen::MoQForwarder> localForwarder;
-    // true only on first creation; caller must cross-exec to publisher thread
-    // and add a CrossExecFilter subscriber to the publisher forwarder.
-    bool isNew;
+  struct Absent {};
+  struct Pending {
+    // Fails if the setup fails, the entry is displaced, or the owner drops its Claim.
+    folly::SemiFuture<folly::Unit> ready;
+  };
+  struct Ready {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+  };
+  using State = std::variant<Absent, Pending, Ready>;
+
+  // Sole handle on a pending entry. Move-only; must not outlive the registry or
+  // leave its thread. The destructor fails an unresolved claim, so an abandoned
+  // setup wakes its waiters instead of stranding them.
+  class Claim {
+  public:
+    Claim() = default;
+    Claim(Claim&& other) noexcept { *this = std::move(other); }
+    Claim& operator=(Claim&& other) noexcept {
+      if (this != &other) {
+        resolveIfEngaged(std::runtime_error("local forwarder claim overwritten"));
+        registry_ = std::exchange(other.registry_, nullptr);
+        ftn_ = std::move(other.ftn_);
+        forwarder_ = std::move(other.forwarder_);
+        initialStateSet_ = std::exchange(other.initialStateSet_, false);
+      }
+      return *this;
+    }
+    ~Claim() { resolveIfEngaged(std::runtime_error("local forwarder claim dropped")); }
+
+    explicit operator bool() const { return registry_ != nullptr; }
+
+    // Copy this out before resolving if the forwarder is needed afterwards.
+    const std::shared_ptr<moxygen::MoQForwarder>& forwarder() const {
+      XCHECK(registry_) << "forwarder() on a resolved or empty Claim";
+      return forwarder_;
+    }
+
+    // Separate from markReady() so a caller with setup to finish can order it before
+    // waiters are released.
+    void setInitialState(const InitialTrackState& initial) {
+      XCHECK(registry_) << "setInitialState() on a resolved or empty Claim";
+      initial.applyTo(*forwarder_);
+      initialStateSet_ = true;
+    }
+
+    void markReady() {
+      if (registry_) {
+        XCHECK(initialStateSet_) << "markReady() before setInitialState() for " << ftn_;
+        registry_->markReady(ftn_, forwarder_.get());
+        registry_ = nullptr;
+      }
+    }
+
+    void markReady(const InitialTrackState& initial) {
+      setInitialState(initial);
+      markReady();
+    }
+
+    // pending → absent: a failed setup must not leave a forwarder behind that reads
+    // as ready without ever having had its initial state set.
+    void fail(folly::exception_wrapper ew) {
+      if (registry_) {
+        registry_->fail(ftn_, forwarder_.get(), std::move(ew));
+        registry_ = nullptr;
+      }
+    }
+
+  private:
+    friend class LocalForwarderRegistry;
+
+    Claim(
+        LocalForwarderRegistry* registry,
+        moxygen::FullTrackName ftn,
+        std::shared_ptr<moxygen::MoQForwarder> forwarder
+    )
+        : registry_(registry), ftn_(std::move(ftn)), forwarder_(std::move(forwarder)) {}
+
+    void resolveIfEngaged(folly::exception_wrapper ew) noexcept {
+      if (registry_) {
+        registry_->fail(ftn_, forwarder_.get(), std::move(ew));
+        registry_ = nullptr;
+      }
+    }
+
+    LocalForwarderRegistry* registry_{nullptr};
+    moxygen::FullTrackName ftn_;
+    std::shared_ptr<moxygen::MoQForwarder> forwarder_;
+    bool initialStateSet_{false};
   };
 
-  // Returns the existing local forwarder for ftn, or calls factory() to create
-  // one. factory() is called at most once per ftn per thread lifetime.
-  GetOrCreateResult getOrCreate(
+  // Engaged Claim ⇒ this call created the entry and owns setup. After awaiting a
+  // Pending, look up again rather than reusing a handle from before the suspend:
+  // the entry may have been displaced.
+  using JoinResult = std::variant<Claim, Pending, Ready>;
+
+  LocalForwarderRegistry() = default;
+
+  ~LocalForwarderRegistry() {
+    for (const auto& [ftn, entry] : forwarders_) {
+      XCHECK(!entry.ready) << "pending entry outlived its registry: " << ftn;
+    }
+  }
+
+  LocalForwarderRegistry(const LocalForwarderRegistry&) = delete;
+  LocalForwarderRegistry& operator=(const LocalForwarderRegistry&) = delete;
+
+  // factory() runs only when the entry is absent, at most once per entry lifetime.
+  JoinResult join(
       const moxygen::FullTrackName& ftn,
       folly::FunctionRef<std::shared_ptr<moxygen::MoQForwarder>()> factory
   ) {
-    auto it = forwarders_.find(ftn);
-    if (it != forwarders_.end()) {
-      return {it->second, /*isNew=*/false};
+    if (auto it = forwarders_.find(ftn); it != forwarders_.end()) {
+      if (it->second.ready) {
+        return Pending{it->second.ready->getSemiFuture()};
+      }
+      return Ready{it->second.forwarder};
     }
     auto forwarder = factory();
-    forwarders_.emplace(ftn, forwarder);
-    return {std::move(forwarder), /*isNew=*/true};
+    XCHECK(forwarder) << "join() factory returned null for " << ftn;
+    return makePending(ftn, std::move(forwarder));
   }
 
-  // Claim the slot for ftn unconditionally, returning the previous occupant (if
-  // any). The publisher's forwarder is authoritative for a track on its thread:
-  // a stale subscribe-path local forwarder under the same name is displaced
-  // here, and drains itself via the source-termination cascade (its identity-
-  // checked removal then no-ops, since this forwarder now owns the slot).
-  std::shared_ptr<moxygen::MoQForwarder>
-  set(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQForwarder> forwarder) {
-    auto prev = std::move(forwarders_[ftn]);
-    forwarders_[ftn] = std::move(forwarder);
-    return prev;
+  // The publisher's forwarder is authoritative for a track on its thread; the
+  // displaced one drains itself via the source-termination cascade, and its
+  // identity-checked removal then no-ops.
+  //
+  // A displaced entry's waiters are failed rather than inherited: releasing them
+  // onto a forwarder that no longer owns the entry is the restart this type exists
+  // to prevent.
+  Claim
+  replace(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQForwarder> forwarder) {
+    XCHECK(forwarder) << "replace() with a null forwarder for " << ftn;
+    if (auto it = forwarders_.find(ftn); it != forwarders_.end() && it->second.ready) {
+      XCHECK(it->second.forwarder != forwarder)
+          << "replace() re-seats a forwarder that already owns a pending entry: " << ftn;
+      it->second.ready->setException(std::runtime_error("local forwarder displaced"));
+    }
+    return makePending(ftn, std::move(forwarder));
   }
 
-  std::shared_ptr<moxygen::MoQForwarder> get(const moxygen::FullTrackName& ftn) const {
+  // A pending entry reads as absent — see the class comment.
+  std::shared_ptr<moxygen::MoQForwarder> getIfReady(const moxygen::FullTrackName& ftn) const {
     auto it = forwarders_.find(ftn);
-    return it != forwarders_.end() ? it->second : nullptr;
+    return (it != forwarders_.end() && !it->second.ready) ? it->second.forwarder : nullptr;
   }
 
-  // Identity-checked removal: erase the entry for ftn only if it still points
-  // at `expected`. Called from a forwarder's onPublishDone, which fires on this
-  // thread. The identity check makes teardown order-independent: a terminated
-  // forwarder can only vacate its own slot, so it never clobbers a newer
-  // forwarder that has since claimed the same track name.
+  State lookup(const moxygen::FullTrackName& ftn) const {
+    auto it = forwarders_.find(ftn);
+    return it != forwarders_.end() ? stateOf(it->second) : State{Absent{}};
+  }
+
+  // The one sanctioned way to reach a forwarder without holding its Claim before it is
+  // ready: the caller is tearing it down rather than attaching to it. Every other reader
+  // uses getIfReady/lookup.
+  std::shared_ptr<moxygen::MoQForwarder> getForEviction(const moxygen::FullTrackName& ftn) const {
+    auto it = forwarders_.find(ftn);
+    return it != forwarders_.end() ? it->second.forwarder : nullptr;
+  }
+
+  // Called from a forwarder's onPublishDone, which fires on this thread. The identity
+  // check makes teardown order-independent: a terminated forwarder can only vacate its
+  // own entry, so it never clobbers a newer forwarder that has since claimed the same
+  // track name.
   void remove(const moxygen::FullTrackName& ftn, const moxygen::MoQForwarder* expected) {
     auto it = forwarders_.find(ftn);
-    if (it == forwarders_.end() || it->second.get() != expected) {
+    if (it == forwarders_.end() || it->second.forwarder.get() != expected) {
       return;
+    }
+    // Erasing destroys the promise, so anyone parked on it must be woken first.
+    if (it->second.ready) {
+      it->second.ready->setException(std::runtime_error("local forwarder removed"));
     }
     forwarders_.erase(it);
   }
 
 private:
-  folly::F14FastMap<
-      moxygen::FullTrackName,
-      std::shared_ptr<moxygen::MoQForwarder>,
-      moxygen::FullTrackName::hash>
-      forwarders_;
+  struct Entry {
+    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    // Non-null iff the entry is pending; it is the state discriminator.
+    std::shared_ptr<folly::SharedPromise<folly::Unit>> ready;
+  };
+
+  static State stateOf(const Entry& entry) {
+    if (entry.ready) {
+      return Pending{entry.ready->getSemiFuture()};
+    }
+    return Ready{entry.forwarder};
+  }
+
+  Claim
+  makePending(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQForwarder> forwarder) {
+    auto& entry = forwarders_[ftn];
+    // Outlive the entry update: dropping the last ref here would run ~MoQForwarder,
+    // which reenters the registry through its callback, against a half-written entry.
+    auto displaced = std::exchange(entry.forwarder, forwarder);
+    entry.ready = std::make_shared<folly::SharedPromise<folly::Unit>>();
+    return Claim(this, ftn, std::move(forwarder));
+  }
+
+  // A pending entry's promise is unfulfilled by construction: markReady and fail both
+  // clear the entry, so neither can run twice against the same promise. The
+  // identity check is what makes that hold across displacement — a stale owner
+  // finds an entry that is no longer its own and does nothing.
+  void markReady(const moxygen::FullTrackName& ftn, const moxygen::MoQForwarder* owner) {
+    auto it = findPendingOwnedBy(ftn, owner);
+    if (it == forwarders_.end()) {
+      return;
+    }
+    it->second.ready->setValue();
+    it->second.ready.reset();
+  }
+
+  void fail(
+      const moxygen::FullTrackName& ftn,
+      const moxygen::MoQForwarder* owner,
+      folly::exception_wrapper ew
+  ) {
+    auto it = findPendingOwnedBy(ftn, owner);
+    if (it == forwarders_.end()) {
+      return;
+    }
+    it->second.ready->setException(std::move(ew));
+    forwarders_.erase(it);
+  }
+
+  using Map = folly::F14FastMap<moxygen::FullTrackName, Entry, moxygen::FullTrackName::hash>;
+
+  // end() unless ftn's entry is pending and still holds `owner`.
+  Map::iterator
+  findPendingOwnedBy(const moxygen::FullTrackName& ftn, const moxygen::MoQForwarder* owner) {
+    auto it = forwarders_.find(ftn);
+    if (it == forwarders_.end() || !it->second.ready || it->second.forwarder.get() != owner) {
+      return forwarders_.end();
+    }
+    return it;
+  }
+
+  Map forwarders_;
 };
 
 } // namespace openmoq::moqx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -393,6 +393,17 @@ target_link_libraries(moqx_initial_track_state_test PRIVATE
 )
 gtest_discover_tests(moqx_initial_track_state_test)
 
+# LocalForwarderRegistry unit tests
+add_executable(moqx_local_forwarder_registry_test
+  LocalForwarderRegistryTest.cpp
+)
+target_link_libraries(moqx_local_forwarder_registry_test PRIVATE
+  moqx_core
+  moqx_test_main
+  GTest::gmock
+)
+gtest_discover_tests(moqx_local_forwarder_registry_test)
+
 # TopNFilter unit tests
 add_executable(moqx_topn_filter_test
   TopNFilterTest.cpp

--- a/test/LocalForwarderRegistryTest.cpp
+++ b/test/LocalForwarderRegistryTest.cpp
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ */
+
+#include "relay/LocalForwarderRegistry.h"
+
+#include <folly/executors/InlineExecutor.h>
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+
+using namespace testing;
+using namespace moxygen;
+
+namespace {
+
+using openmoq::moqx::InitialTrackState;
+using Registry = openmoq::moqx::LocalForwarderRegistry;
+using Claim = Registry::Claim;
+using Absent = Registry::Absent;
+using Pending = Registry::Pending;
+using Ready = Registry::Ready;
+
+const TrackNamespace kTestNs{{"test", "namespace"}};
+const FullTrackName kFtn{kTestNs, "track1"};
+
+std::shared_ptr<MoQForwarder> makeForwarder() {
+  return std::make_shared<MoQForwarder>(kFtn);
+}
+
+Registry::JoinResult joinWith(Registry& reg, const std::shared_ptr<MoQForwarder>& fwd) {
+  return reg.join(kFtn, [&] { return fwd; });
+}
+
+Claim claimWith(Registry& reg, const std::shared_ptr<MoQForwarder>& fwd) {
+  auto result = joinWith(reg, fwd);
+  EXPECT_TRUE(std::holds_alternative<Claim>(result));
+  return std::move(std::get<Claim>(result));
+}
+
+// A waiter's view of the entry, taken while it is pending.
+folly::SemiFuture<folly::Unit> waiterOn(Registry& reg) {
+  auto state = reg.lookup(kFtn);
+  EXPECT_TRUE(std::holds_alternative<Pending>(state));
+  return std::move(std::get<Pending>(state).ready);
+}
+
+// The registry resolves inline, so a ready future needs no executor to inspect.
+folly::Try<folly::Unit> settled(folly::SemiFuture<folly::Unit> f) {
+  EXPECT_TRUE(f.isReady());
+  return std::move(f).getTry();
+}
+
+// === States and transitions ===
+
+TEST(LocalForwarderRegistryTest, EmptyRegistryReadsAbsent) {
+  Registry reg;
+  EXPECT_TRUE(std::holds_alternative<Absent>(reg.lookup(kFtn)));
+  EXPECT_EQ(reg.getIfReady(kFtn), nullptr);
+  EXPECT_EQ(reg.getForEviction(kFtn), nullptr);
+}
+
+TEST(LocalForwarderRegistryTest, JoinOnAbsentClaimsAPendingEntry) {
+  Registry reg;
+  auto fwd = makeForwarder();
+  auto claim = claimWith(reg, fwd);
+
+  EXPECT_TRUE(static_cast<bool>(claim));
+  EXPECT_EQ(claim.forwarder(), fwd);
+  EXPECT_TRUE(std::holds_alternative<Pending>(reg.lookup(kFtn)));
+
+  claim.markReady(InitialTrackState{});
+}
+
+// The invariant the type exists for: a reader cannot obtain a forwarder before it is ready.
+TEST(LocalForwarderRegistryTest, PendingForwarderIsInvisibleToReaders) {
+  Registry reg;
+  auto claim = claimWith(reg, makeForwarder());
+
+  EXPECT_EQ(reg.getIfReady(kFtn), nullptr);
+  auto state = reg.lookup(kFtn);
+  EXPECT_TRUE(std::holds_alternative<Pending>(state));
+
+  claim.markReady(InitialTrackState{});
+}
+
+TEST(LocalForwarderRegistryTest, SecondJoinWhilePendingWaitsRatherThanAttaching) {
+  Registry reg;
+  auto claim = claimWith(reg, makeForwarder());
+
+  bool secondFactoryRan = false;
+  auto joined = reg.join(kFtn, [&] {
+    secondFactoryRan = true;
+    return makeForwarder();
+  });
+  EXPECT_FALSE(secondFactoryRan);
+  ASSERT_TRUE(std::holds_alternative<Pending>(joined));
+  EXPECT_FALSE(std::get<Pending>(joined).ready.isReady());
+
+  claim.markReady(InitialTrackState{});
+  EXPECT_TRUE(settled(std::move(std::get<Pending>(joined).ready)).hasValue());
+}
+
+// The reason markReady() takes the state: a waiter released by it can never observe the
+// forwarder before its initial state was set.
+TEST(LocalForwarderRegistryTest, MarkReadyAppliesInitialStateBeforeReleasingWaiters) {
+  Registry reg;
+  auto fwd = makeForwarder();
+  auto claim = claimWith(reg, fwd);
+  auto waiter = waiterOn(reg);
+  ASSERT_FALSE(fwd->largest().has_value());
+
+  // Inline executor: the continuation runs inside markReady()'s setValue, so it samples the
+  // forwarder at the instant waiters are released rather than afterwards.
+  std::optional<AbsoluteLocation> seenByWaiter;
+  auto observed =
+      std::move(waiter).via(&folly::InlineExecutor::instance()).thenValue([&](folly::Unit) {
+        seenByWaiter = fwd->largest();
+      });
+
+  claim.markReady(InitialTrackState{AbsoluteLocation{5, 2}, Extensions{}});
+
+  ASSERT_TRUE(observed.isReady());
+  EXPECT_EQ(seenByWaiter, (AbsoluteLocation{5, 2}));
+}
+
+// The two are separate so a caller can finish setup in between; the assert keeps them ordered.
+TEST(LocalForwarderRegistryTest, SetInitialStateThenMarkReadyReleasesWaiters) {
+  Registry reg;
+  auto fwd = makeForwarder();
+  auto claim = claimWith(reg, fwd);
+  auto waiter = waiterOn(reg);
+
+  claim.setInitialState(InitialTrackState{AbsoluteLocation{9, 1}, Extensions{}});
+  EXPECT_FALSE(waiter.isReady());
+  EXPECT_EQ(reg.getIfReady(kFtn), nullptr);
+
+  claim.markReady();
+
+  EXPECT_TRUE(settled(std::move(waiter)).hasValue());
+  EXPECT_EQ(fwd->largest(), (AbsoluteLocation{9, 1}));
+}
+
+TEST(LocalForwarderRegistryDeathTest, MarkReadyWithoutInitialStateAborts) {
+  EXPECT_DEATH(
+      {
+        Registry reg;
+        claimWith(reg, makeForwarder()).markReady();
+      },
+      "markReady\\(\\) before setInitialState\\(\\)"
+  );
+}
+
+TEST(LocalForwarderRegistryTest, MarkReadyExposesForwarderAndReleasesWaiters) {
+  Registry reg;
+  auto fwd = makeForwarder();
+  auto claim = claimWith(reg, fwd);
+  auto waiter = waiterOn(reg);
+
+  claim.markReady(InitialTrackState{});
+
+  EXPECT_TRUE(settled(std::move(waiter)).hasValue());
+  EXPECT_EQ(reg.getIfReady(kFtn), fwd);
+  auto state = reg.lookup(kFtn);
+  ASSERT_TRUE(std::holds_alternative<Ready>(state));
+  EXPECT_EQ(std::get<Ready>(state).forwarder, fwd);
+}
+
+// A failed setup vacates the entry: leaving the forwarder behind would make it
+// indistinguishable from a ready one to every later reader.
+TEST(LocalForwarderRegistryTest, FailMakesEntryAbsentAndFailsWaiters) {
+  Registry reg;
+  auto claim = claimWith(reg, makeForwarder());
+  auto waiter = waiterOn(reg);
+
+  claim.fail(std::runtime_error("upstream subscribe failed"));
+
+  EXPECT_TRUE(settled(std::move(waiter)).hasException());
+  EXPECT_TRUE(std::holds_alternative<Absent>(reg.lookup(kFtn)));
+  EXPECT_EQ(reg.getIfReady(kFtn), nullptr);
+  EXPECT_EQ(reg.getForEviction(kFtn), nullptr);
+}
+
+TEST(LocalForwarderRegistryTest, JoinAfterFailedSetupRebuildsTheEntry) {
+  Registry reg;
+  claimWith(reg, makeForwarder()).fail(std::runtime_error("setup failed"));
+
+  auto second = makeForwarder();
+  auto claim = claimWith(reg, second);
+  EXPECT_EQ(claim.forwarder(), second);
+  claim.markReady(InitialTrackState{});
+  EXPECT_EQ(reg.getIfReady(kFtn), second);
+}
+
+// An abandoned setup must not strand the waiters parked on it.
+TEST(LocalForwarderRegistryTest, DroppedClaimFailsWaiters) {
+  Registry reg;
+  auto waiter = folly::SemiFuture<folly::Unit>::makeEmpty();
+  {
+    auto claim = claimWith(reg, makeForwarder());
+    waiter = waiterOn(reg);
+  }
+  EXPECT_TRUE(settled(std::move(waiter)).hasException());
+  EXPECT_TRUE(std::holds_alternative<Absent>(reg.lookup(kFtn)));
+}
+
+TEST(LocalForwarderRegistryTest, JoinOnReadyEntryAttachesWithoutCallingFactory) {
+  Registry reg;
+  auto fwd = makeForwarder();
+  claimWith(reg, fwd).markReady(InitialTrackState{});
+
+  bool factoryRan = false;
+  auto joined = reg.join(kFtn, [&] {
+    factoryRan = true;
+    return makeForwarder();
+  });
+  EXPECT_FALSE(factoryRan);
+  ASSERT_TRUE(std::holds_alternative<Ready>(joined));
+  EXPECT_EQ(std::get<Ready>(joined).forwarder, fwd);
+}
+
+// === Identity ===
+
+// The production displacement: a publisher's forwarder replaces a ready subscribe-path
+// one. Takes the branch where there are no waiters to fail.
+TEST(LocalForwarderRegistryTest, ReplaceOverReadyEntryInstallsSuccessor) {
+  Registry reg;
+  auto displaced = makeForwarder();
+  claimWith(reg, displaced).markReady(InitialTrackState{});
+
+  auto successor = makeForwarder();
+  reg.replace(kFtn, successor).markReady(InitialTrackState{AbsoluteLocation{3, 0}, Extensions{}});
+
+  EXPECT_EQ(reg.getIfReady(kFtn), successor);
+  EXPECT_EQ(successor->largest(), (AbsoluteLocation{3, 0}));
+
+  // The displaced forwarder drains later; its removal must not evict the successor.
+  reg.remove(kFtn, displaced.get());
+  EXPECT_EQ(reg.getIfReady(kFtn), successor);
+}
+
+TEST(LocalForwarderRegistryTest, ReplaceFailsDisplacedWaiters) {
+  Registry reg;
+  auto displaced = claimWith(reg, makeForwarder());
+  auto waiter = waiterOn(reg);
+
+  auto claim = reg.replace(kFtn, makeForwarder());
+
+  EXPECT_TRUE(settled(std::move(waiter)).hasException());
+  claim.markReady(InitialTrackState{});
+}
+
+// The bug identity checks exist for: a displaced owner must not release its
+// successor's waiters onto a forwarder that no longer owns the entry.
+TEST(LocalForwarderRegistryTest, StaleClaimMarkReadyDoesNotReleaseSuccessorsWaiters) {
+  Registry reg;
+  auto stale = claimWith(reg, makeForwarder());
+  auto successorFwd = makeForwarder();
+  auto successor = reg.replace(kFtn, successorFwd);
+  auto waiter = waiterOn(reg);
+
+  stale.markReady(InitialTrackState{});
+
+  EXPECT_FALSE(waiter.isReady());
+  EXPECT_TRUE(std::holds_alternative<Pending>(reg.lookup(kFtn)));
+
+  successor.markReady(InitialTrackState{});
+  EXPECT_TRUE(settled(std::move(waiter)).hasValue());
+  EXPECT_EQ(reg.getIfReady(kFtn), successorFwd);
+}
+
+TEST(LocalForwarderRegistryTest, StaleClaimFailDoesNotEvictSuccessor) {
+  Registry reg;
+  auto stale = claimWith(reg, makeForwarder());
+  auto successorFwd = makeForwarder();
+  auto successor = reg.replace(kFtn, successorFwd);
+
+  stale.fail(std::runtime_error("stale setup failed"));
+
+  EXPECT_TRUE(std::holds_alternative<Pending>(reg.lookup(kFtn)));
+  successor.markReady(InitialTrackState{});
+  EXPECT_EQ(reg.getIfReady(kFtn), successorFwd);
+}
+
+TEST(LocalForwarderRegistryTest, RemoveIsIdentityChecked) {
+  Registry reg;
+  auto fwd = makeForwarder();
+  claimWith(reg, fwd).markReady(InitialTrackState{});
+
+  auto other = makeForwarder();
+  reg.remove(kFtn, other.get());
+  EXPECT_EQ(reg.getIfReady(kFtn), fwd);
+
+  reg.remove(kFtn, fwd.get());
+  EXPECT_TRUE(std::holds_alternative<Absent>(reg.lookup(kFtn)));
+}
+
+TEST(LocalForwarderRegistryTest, RemoveOfPendingEntryWakesWaiters) {
+  Registry reg;
+  auto claim = claimWith(reg, makeForwarder());
+  auto waiter = waiterOn(reg);
+
+  reg.remove(kFtn, claim.forwarder().get());
+
+  EXPECT_TRUE(settled(std::move(waiter)).hasException());
+  EXPECT_TRUE(std::holds_alternative<Absent>(reg.lookup(kFtn)));
+  // The claim now owns nothing; resolving it must not resurrect the entry.
+  claim.markReady(InitialTrackState{});
+  EXPECT_TRUE(std::holds_alternative<Absent>(reg.lookup(kFtn)));
+}
+
+// === Escape hatch and handle mechanics ===
+
+TEST(LocalForwarderRegistryTest, GetForEvictionReachesAPendingForwarder) {
+  Registry reg;
+  auto fwd = makeForwarder();
+  auto claim = claimWith(reg, fwd);
+
+  EXPECT_EQ(reg.getForEviction(kFtn), fwd);
+  EXPECT_EQ(reg.getIfReady(kFtn), nullptr);
+
+  claim.markReady(InitialTrackState{});
+}
+
+// Assignment resolves what it overwrites; only the destructor path is otherwise covered.
+TEST(LocalForwarderRegistryTest, MoveAssignmentFailsOverwrittenClaim) {
+  Registry reg;
+  const FullTrackName otherFtn{kTestNs, "track2"};
+
+  auto claim = claimWith(reg, makeForwarder());
+  auto waiter = waiterOn(reg);
+
+  auto survivor = std::make_shared<MoQForwarder>(otherFtn);
+  auto joined = reg.join(otherFtn, [&] { return survivor; });
+  ASSERT_TRUE(std::holds_alternative<Claim>(joined));
+  claim = std::move(std::get<Claim>(joined));
+
+  EXPECT_TRUE(settled(std::move(waiter)).hasException());
+  EXPECT_TRUE(std::holds_alternative<Absent>(reg.lookup(kFtn)));
+
+  claim.markReady(InitialTrackState{});
+  EXPECT_EQ(reg.getIfReady(otherFtn), survivor);
+}
+
+TEST(LocalForwarderRegistryTest, MovedFromClaimDoesNotResolve) {
+  Registry reg;
+  auto fwd = makeForwarder();
+  {
+    auto original = claimWith(reg, fwd);
+    auto moved = std::move(original);
+    moved.markReady(InitialTrackState{});
+    EXPECT_FALSE(static_cast<bool>(original));
+    // ~original must not fail the entry `moved` just marked ready.
+  }
+  EXPECT_EQ(reg.getIfReady(kFtn), fwd);
+}
+
+// A pending entry at teardown means a Claim leaked — otherwise a waiter parked on
+// that promise hangs its thread forever. Abort loudly instead.
+TEST(LocalForwarderRegistryDeathTest, PendingEntryOutlivingRegistryAborts) {
+  EXPECT_DEATH(
+      {
+        Registry reg;
+        auto result = joinWith(reg, makeForwarder());
+        new Claim(std::move(std::get<Claim>(result)));
+      },
+      "pending entry outlived its registry"
+  );
+}
+
+} // namespace


### PR DESCRIPTION
The registry mapped a track name straight to a forwarder, which let a reader attach to one before its largest and extensions arrived from upstream.

An entry is now absent, pending, or ready, and a pending entry does not hand out its forwarder. Only the Claim that join() returns can reach it, and dropping that Claim fails the entry instead of stranding whoever waits on it.

Nothing observes the pending state yet, because both callers mark the entry ready on the next line; holding a claim open across setup is what the commits above this one do. LocalForwarderRegistryTest is new, and covers the three states, the identity checks, and the two asserts a caller can trip.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/542)
<!-- Reviewable:end -->
