### PR TITLE
relay: install the local forwarder chain on subscribe-created tracks

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -458,20 +458,18 @@ MoqxRelay::validatePublishNamespace(const FullTrackName& ftn, RequestID requestI
 // source ends, so a chain over a forwarder that does not hold it has nothing to remove.
 LocalForwarderRegistry::Claim MoqxRelay::installPublisherForwarder(
     const FullTrackName& ftn,
-    const std::shared_ptr<MoQForwarder>& fwd
+    const std::shared_ptr<MoQForwarder>& fwd,
+    bool removeOnEmpty
 ) {
-  // removeOnEmpty=false: the publisher's forwarder must survive subscriber churn.
+  auto& localReg = localRegistry();
   auto relayAdapter = std::make_shared<WeakRelayForwarderCallback>(weak_from_this());
   auto crossExec =
       std::make_shared<CrossExecForwarderCallback>(relayExec_, fwd, std::move(relayAdapter));
-  fwd->setCallback(std::make_shared<LocalForwarderCallback>(
-      tlForwarders_.get(),
-      ftn,
-      std::move(crossExec),
-      /*removeOnEmpty=*/false
-  ));
+  fwd->setCallback(
+      std::make_shared<LocalForwarderCallback>(&localReg, ftn, std::move(crossExec), removeOnEmpty)
+  );
 
-  return tlForwarders_->replace(ftn, fwd);
+  return localReg.replace(ftn, fwd);
 }
 
 // Called from LocalPublishFilter::publish() on publisherExec. Creates the publisher's
@@ -485,12 +483,8 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
     return folly::makeUnexpected(std::move(*err));
   }
 
-  if (!tlForwarders_.get()) {
-    tlForwarders_.reset(new LocalForwarderRegistry());
-  }
-
   auto localPubFwd = std::make_shared<MoQForwarder>(pub.fullTrackName);
-  installPublisherForwarder(pub.fullTrackName, localPubFwd)
+  installPublisherForwarder(pub.fullTrackName, localPubFwd, /*removeOnEmpty=*/false)
       .markReady(InitialTrackState{pub.largest, pub.extensions});
 
   // crossExecFilter is a channel subscriber for the relay exec
@@ -1137,6 +1131,10 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
   );
 
   auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, initial);
+  if (!localFwd) {
+    // Setup for this track is in flight on this thread; drop the fanout.
+    co_return;
+  }
 
   auto p = startPublish(subscriberSession, localFwd, forward, pinned, nullptr);
   if (!p) {
@@ -1208,8 +1206,12 @@ MoqxRelay::acquireLocalForwarder(const FullTrackName& ftn, const InitialTrackSta
     return {std::move(localFwd), /*isNew=*/true, localReg};
   }
   auto* ready = std::get_if<LocalForwarderRegistry::Ready>(&joined);
-  XCHECK(ready) << "local forwarder entry still pending; a caller failed to resolve its claim: "
-                << ftn;
+  if (!ready) {
+    // A setup on this thread owns the entry and cannot be joined mid-flight. Drop the
+    // fanout rather than publishing over a subscribe that is still claiming the track.
+    XLOG(WARNING) << "local forwarder setup in flight, dropping publish fanout for " << ftn;
+    return {};
+  }
   return {ready->forwarder, /*isNew=*/false, localReg};
 }
 
@@ -1765,7 +1767,7 @@ std::optional<SubscribeError> MoqxRelay::completeUpstreamSubscription(
 // Runs on relayExec_. Registers the subscribe and wires the local forwarder to the
 // publisher; if it's a new subscription,also installs the passive relay chain, issues the
 // upstream subscribe, and completes the setup. The subscriberExec tail reads the
-// returned PublisherAttachment (handles upstreamOk).
+// returned PublisherAttachment.
 folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwarderOnRelayExec(
     const SubscribeRequest& subReq,
     LocalForwarderRegistry* localReg,
@@ -1809,6 +1811,12 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
   co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(attach.publisherExec),
       [&]() -> folly::coro::Task<void> {
+        LocalForwarderRegistry::Claim publisherClaim;
+        if (sr.firstSetup) {
+          publisherClaim =
+              installPublisherForwarder(ftn, attach.publisherFwd, /*removeOnEmpty=*/true);
+        }
+
         installChannelSubscriber(
             *cbs.channelCb,
             *attach.publisherFwd,
@@ -1837,7 +1845,14 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
               attach.publisherFwd,
               setup.clientRequestID
           );
+          if (upstreamResult->hasValue()) {
+            const auto& ok = upstreamResult->value();
+            publisherClaim.markReady(InitialTrackState{ok.largest, ok.extensions});
+          }
         }
+        // Capture largest/extensions on publisherExec to set the initial state for the
+        // subscriber.  Captured but ignored when the firstSetup returned an error.
+        attach.initial = InitialTrackState::capture(*attach.publisherFwd);
       }()
   );
   // Back on relayExec_.
@@ -1882,7 +1897,6 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
     attach.error = folly::makeUnexpected(std::move(*err));
     co_return attach;
   }
-  attach.upstreamOk = std::move(upstreamOk);
   co_return attach;
 }
 
@@ -1900,7 +1914,9 @@ MoqxRelay::joinOrPrepareUpstreamSubscription(SubscribeRequest subReq) {
 
   auto firstOrSubsequent = registry_.getOrCreateFromSubscribe(
       ftn,
-      shared_from_this(),
+      // installPublisherForwarder puts the real chain on the forwarder's own exec instead;
+      // a relay-direct callback would run there and touch registry_ off relayExec_.
+      std::shared_ptr<MoQForwarder::Callback>(nullptr),
       [this, &ftn](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(ftn, std::move(f)); }
   );
 
@@ -2055,15 +2071,9 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
     co_return std::move(*attach.error);
   }
 
-  // Only the first subscriber has an upstream OK. A subsequent one leaves this empty and
-  // marks the entry ready with no largest (a bug fixed in a subsequent commit)
-  InitialTrackState initial;
-  if (attach.upstreamOk) {
-    initial = InitialTrackState{attach.upstreamOk->largest, attach.upstreamOk->extensions};
-    // Also on the subscriber, so a post-SUBSCRIBE_OK joining fetch resolves.
-    initial.applyTo(*sub);
-  }
-  claim.setInitialState(initial);
+  claim.setInitialState(attach.initial);
+  // Also on the subscriber, so a post-SUBSCRIBE_OK joining fetch resolves.
+  attach.initial.applyTo(*sub);
   replayPendingFowarderEvents(localFwd.get(), attach.finalCallback, *pendingCb, forward);
   localFwd->tryProcessNewGroupRequest(subReq.params);
   claim.markReady();

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -366,10 +366,12 @@ private:
       std::shared_ptr<moxygen::MoQSession> session
   );
 
-  // Runs on fwd's exec; the returned Claim owes a markReady/fail.
+  // Runs on fwd's exec; the returned Claim owes a markReady/fail. removeOnEmpty=false for a
+  // publish-initiated forwarder, which must survive subscriber churn.
   LocalForwarderRegistry::Claim installPublisherForwarder(
       const moxygen::FullTrackName& ftn,
-      const std::shared_ptr<moxygen::MoQForwarder>& fwd
+      const std::shared_ptr<moxygen::MoQForwarder>& fwd,
+      bool removeOnEmpty
   );
 
   std::optional<moxygen::PublishError>
@@ -491,7 +493,8 @@ private:
     folly::Executor* publisherExec{nullptr};
     bool ownsRelayChain{false}; // firstSetup path installed the passive relay chain
     std::shared_ptr<moxygen::MoQForwarder::Callback> finalCallback;
-    std::optional<UpstreamOk> upstreamOk;
+    // Captured off the publisher forwarder on its own exec, the only race-free place.
+    InitialTrackState initial;
     std::optional<SubscribeResult> error; // set => bail
   };
 

--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -451,6 +451,9 @@ TEST_P(MoQRelayTest, PublishReconnectDuringSubscribeScopeGuardCrash) {
   // Relay state mutations must run on the relay executor; doPublishNamespaceDone
   // touches the namespace tree, which publishDone also cleans up via relayEvb_.
   verifyOnRelayExec([&] { relay_->doPublishNamespaceDone(kTestNamespace, publisherSession2); });
+  // The publisher forwarder reaches the relay through relayExec_, so it drops its session
+  // refs a hop after the calls above.
+  driveIfMultiThread();
 }
 
 // Same reconnect scenario but the upstream subscribe returns OK instead of an

--- a/test/MoqxRelaySubscribeTests.cpp
+++ b/test/MoqxRelaySubscribeTests.cpp
@@ -402,4 +402,358 @@ TEST_P(MoQRelayTest, SubsequentSubscriberFailsWhenUpstreamSubscribeFails) {
   removeSession(subSession2);
   driveIfMultiThread();
 }
+
+// The publisher-exec slot claim arms a gate in the PUBLISHER thread's
+// tlForwarders_, which the subscriber-side signalReady guard cannot reach. If the upstream
+// subscribe throws rather than returning an error, the openReady/failReady pair after it is
+// skipped and any subscriber parked on that gate never wakes.
+TEST_P(MoQRelayTest, UpstreamSubscribeThrowDoesNotStrandGate) {
+  if (relayMode() != RelayMode::LocalForwarderMT) {
+    GTEST_SKIP() << "only LF has a per-thread registry to strand";
+  }
+
+  folly::ScopedEventBaseThread pubThread("pub-iothread");
+  auto* pubEvb = pubThread.getEventBase();
+  auto pubExec = std::make_shared<MoQFollyExecutorImpl>(pubEvb);
+
+  auto makeSessionOnPubThread = [&] {
+    auto session = std::make_shared<NiceMock<MockMoQSession>>(pubExec);
+    ON_CALL(*session, getNegotiatedVersion())
+        .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));
+    getOrCreateMockState(session);
+    return session;
+  };
+  auto publisherSession = makeSessionOnPubThread();
+  auto subSessionOnPubThread = makeSessionOnPubThread();
+  auto subSession1 = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  folly::coro::Baton upstreamGate;
+  std::atomic<bool> upstreamSubscribeCalled{false};
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce(
+          [&](const SubscribeRequest&,
+              std::shared_ptr<TrackConsumer>) -> folly::coro::Task<Publisher::SubscribeResult> {
+            upstreamSubscribeCalled.store(true);
+            co_await upstreamGate;
+            throw std::runtime_error("upstream session blew up");
+          }
+      );
+  auto releaseGate = folly::makeGuard([&]() noexcept { upstreamGate.post(); });
+
+  auto pump = [&](auto pred) {
+    for (int i = 0; i < 1000 && !pred(); ++i) {
+      exec_->drive();
+      pubEvb->runInEventBaseThreadAndWait([] {});
+    }
+    return pred();
+  };
+
+  std::atomic<bool> firstDone{false};
+  withSessionContext(subSession1, [&]() {
+    SubscribeRequest sub;
+    sub.fullTrackName = kTestTrackName;
+    sub.requestID = RequestID(0);
+    sub.locType = LocationType::LargestObject;
+    auto task = publisherInterface()->subscribe(std::move(sub), createMockConsumer());
+    co_withExecutor(
+        static_cast<folly::DrivableExecutor*>(exec_.get()),
+        folly::coro::co_invoke(
+            [t = std::move(task), &firstDone]() mutable -> folly::coro::Task<void> {
+              auto r = co_await folly::coro::co_awaitTry(std::move(t));
+              firstDone.store(true);
+            }
+        )
+    ).start();
+  });
+  ASSERT_TRUE(pump([&] { return upstreamSubscribeCalled.load(); }));
+
+  auto secondConsumer = createMockConsumer();
+  folly::Baton<> secondDone;
+  pubEvb->runInEventBaseThreadAndWait([&]() {
+    withSessionContext(subSessionOnPubThread, [&]() {
+      SubscribeRequest sub;
+      sub.fullTrackName = kTestTrackName;
+      sub.requestID = RequestID(2);
+      sub.locType = LocationType::LargestObject;
+      auto task = publisherInterface()->subscribe(std::move(sub), secondConsumer);
+      co_withExecutor(
+          folly::getKeepAliveToken(pubEvb),
+          folly::coro::co_invoke(
+              [t = std::move(task), &secondDone]() mutable -> folly::coro::Task<void> {
+                auto r = co_await folly::coro::co_awaitTry(std::move(t));
+                secondDone.post();
+              }
+          )
+      ).start();
+    });
+  });
+  pubEvb->runInEventBaseThreadAndWait([]() {});
+
+  releaseGate.dismiss();
+  upstreamGate.post();
+  ASSERT_TRUE(pump([&] { return firstDone.load(); })) << "first subscribe never unwound";
+  EXPECT_TRUE(pump([&] { return secondDone.try_wait_for(std::chrono::milliseconds(0)); }))
+      << "subscriber parked on the publisher-thread ready gate never woke";
+
+  removeSession(publisherSession);
+  removeSession(subSession1);
+  removeSession(subSessionOnPubThread);
+  for (int i = 0; i < 4; ++i) {
+    driveIfMultiThread();
+    pubEvb->runInEventBaseThreadAndWait([]() {});
+  }
+}
+// Cross-thread sibling of SubsequentSubscriberWaitsForUpstreamLargestSeeding: sub2 on its own
+// OS thread is gated by the registry awaitSubsequent future (not the per-thread readiness gate).
+TEST_P(MoQRelayTest, CrossThreadSubsequentSubscriberSeedingRace) {
+  auto publisherSession = createMockSession(); // upstream/publisher on exec_
+  auto subSession1 = createMockSession();      // first subscriber on exec_
+
+  // Second subscriber on a dedicated OS thread => distinct thread-local tlForwarders_.
+  folly::ScopedEventBaseThread subThread("sub2-thread");
+  auto subExec = std::make_shared<MoQFollyExecutorImpl>(subThread.getEventBase());
+  auto subSession2 = std::make_shared<NiceMock<MockMoQSession>>(subExec);
+  ON_CALL(*subSession2, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));
+  getOrCreateMockState(subSession2);
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  const AbsoluteLocation kLargest{3, 0};
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(1);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+  upstreamOk.largest = kLargest;
+
+  // Hold the upstream SUBSCRIBE in flight so sub2 races in while sub1's largest is unseeded.
+  folly::coro::Baton upstreamGate;
+  std::atomic<bool> upstreamSubscribeCalled{false};
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce(
+          [&](const SubscribeRequest&,
+              std::shared_ptr<TrackConsumer>) -> folly::coro::Task<Publisher::SubscribeResult> {
+            upstreamSubscribeCalled.store(true);
+            co_await upstreamGate;
+            auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+            co_return folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(handle);
+          }
+      );
+
+  // The cross-exec sortie runs on exec_; drive it and flush the sub2 thread each iteration.
+  auto pumpExec = [&](auto pred) {
+    for (int i = 0; i < 2000 && !pred(); ++i) {
+      exec_->drive();
+      subThread.getEventBase()->runInEventBaseThreadAndWait([] {});
+    }
+    return pred();
+  };
+
+  auto launchSubscribe = [&](std::shared_ptr<MoQSession> session,
+                             folly::Executor* startExec,
+                             RequestID requestID,
+                             std::shared_ptr<std::optional<Publisher::SubscribeResult>> out,
+                             std::atomic<bool>* done) {
+    withSessionContext(session, [&]() {
+      SubscribeRequest sub;
+      sub.fullTrackName = kTestTrackName;
+      sub.requestID = requestID;
+      sub.locType = LocationType::LargestObject;
+      auto task = publisherInterface()->subscribe(std::move(sub), createMockConsumer());
+      co_withExecutor(
+          startExec,
+          folly::coro::co_invoke(
+              [t = std::move(task), out, done]() mutable -> folly::coro::Task<void> {
+                *out = co_await std::move(t);
+                if (done) {
+                  done->store(true);
+                }
+              }
+          )
+      ).start();
+    });
+  };
+
+  // First subscriber on exec_: becomes firstSetup, suspends in the gated upstream SUBSCRIBE.
+  auto firstResult = std::make_shared<std::optional<Publisher::SubscribeResult>>();
+  launchSubscribe(
+      subSession1,
+      static_cast<folly::DrivableExecutor*>(exec_.get()),
+      RequestID(0),
+      firstResult,
+      nullptr
+  );
+  ASSERT_TRUE(pumpExec([&] { return upstreamSubscribeCalled.load(); }))
+      << "relay should issue an upstream subscribe and suspend in it";
+
+  // Second subscriber on its own thread, while the first's seeding is still pending.
+  std::atomic<bool> sub2Done{false};
+  auto secondResult = std::make_shared<std::optional<Publisher::SubscribeResult>>();
+  launchSubscribe(subSession2, subExec.get(), RequestID(2), secondResult, &sub2Done);
+
+  // sub2 must stay blocked on awaitSubsequent until the upstream OK seeds largest; resolving
+  // early would return an empty largest a client reads as a track restart.
+  EXPECT_FALSE(pumpExec([&] { return sub2Done.load(); }))
+      << "cross-thread subsequent subscriber resolved before the upstream OK seeded largest";
+
+  upstreamGate.post();
+  ASSERT_TRUE(pumpExec([&] { return firstResult->has_value() && sub2Done.load(); }));
+
+  ASSERT_TRUE(firstResult->value().hasValue());
+  EXPECT_EQ(firstResult->value().value()->subscribeOk().largest, kLargest);
+  ASSERT_TRUE(secondResult->value().hasValue());
+  // Post-OK the established largest must hold regardless of when sub2 resolved.
+  EXPECT_EQ(secondResult->value().value()->subscribeOk().largest, kLargest);
+
+  getOrCreateMockState(subSession1)->subscribeHandles.push_back(firstResult->value().value());
+  getOrCreateMockState(subSession2)->subscribeHandles.push_back(secondResult->value().value());
+
+  removeSession(publisherSession);
+  removeSession(subSession1);
+  removeSession(subSession2);
+  driveIfMultiThread();
+  subThread.getEventBase()->runInEventBaseThreadAndWait([] {});
+}
+
+// Regression: a PUBLISH that fans out to a thread where a SUBSCRIBE for the same track is
+// parked mid-setup must not join that thread's registry entry while it is Pending. The
+// entry stays Pending for the whole upstream SUBSCRIBE round trip, and acquireLocalForwarder
+// XCHECKed on Pending instead of handling it, aborting the process. The parked subscribe
+// owns the track, so the fanout drops rather than publishing over it.
+TEST_P(MoQRelayTest, PublishFanoutDuringParkedSubscribeSetup) {
+  if (relayMode() != RelayMode::LocalForwarderMT) {
+    GTEST_SKIP() << "only LF has a per-thread registry that can be mid-setup";
+  }
+
+  // Publisher on its own iothread, so its installPublisherForwarder lands in that thread's
+  // registry and leaves the subscriber thread's entry Pending for the fanout to find.
+  folly::ScopedEventBaseThread pubThread("pub-iothread");
+  auto* pubEvb = pubThread.getEventBase();
+  auto pubExec = std::make_shared<MoQFollyExecutorImpl>(pubEvb);
+  auto publisherSession = std::make_shared<NiceMock<MockMoQSession>>(pubExec);
+  ON_CALL(*publisherSession, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));
+  getOrCreateMockState(publisherSession);
+
+  // One session on exec_ holding both the SUBSCRIBE_NAMESPACE that makes it a fanout
+  // target and the SUBSCRIBE that parks.
+  auto subSession = createMockSession();
+  setupPublishSucceeds(subSession);
+  doPublishNamespace(publisherSession, kTestNamespace);
+  doSubscribeNamespace(subSession, kTestNamespace);
+
+  // The parked subscribe owns the track; the fanout must drop rather than publish over it.
+  EXPECT_CALL(*subSession, publish(_, _)).Times(0);
+
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(1);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+
+  // Hold the upstream SUBSCRIBE so the subscribe keeps its registry claim open.
+  folly::coro::Baton upstreamGate;
+  std::atomic<bool> upstreamSubscribeCalled{false};
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce(
+          [&](const SubscribeRequest&,
+              std::shared_ptr<TrackConsumer>) -> folly::coro::Task<Publisher::SubscribeResult> {
+            upstreamSubscribeCalled.store(true);
+            co_await upstreamGate;
+            auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+            co_return folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(handle);
+          }
+      );
+  auto releaseGate = folly::makeGuard([&]() noexcept { upstreamGate.post(); });
+
+  auto pump = [&](auto pred) {
+    for (int i = 0; i < 1000 && !pred(); ++i) {
+      exec_->drive();
+      pubEvb->runInEventBaseThreadAndWait([] {});
+    }
+    return pred();
+  };
+
+  auto subConsumer = createMockConsumer();
+  auto subResult = std::make_shared<std::optional<Publisher::SubscribeResult>>();
+  std::atomic<bool> subscribeDone{false};
+  withSessionContext(subSession, [&]() {
+    SubscribeRequest sub;
+    sub.fullTrackName = kTestTrackName;
+    sub.requestID = RequestID(0);
+    sub.locType = LocationType::LargestObject;
+    auto task = publisherInterface()->subscribe(std::move(sub), subConsumer);
+    co_withExecutor(
+        static_cast<folly::DrivableExecutor*>(exec_.get()),
+        folly::coro::co_invoke(
+            [t = std::move(task), subResult, &subscribeDone]() mutable -> folly::coro::Task<void> {
+              *subResult = co_await std::move(t);
+              subscribeDone.store(true);
+            }
+        )
+    ).start();
+  });
+  ASSERT_TRUE(pump([&] { return upstreamSubscribeCalled.load(); }))
+      << "subscribe should park in the gated upstream SUBSCRIBE";
+
+  // The racing PUBLISH, issued from the publisher's own thread.
+  std::shared_ptr<TrackConsumer> pubConsumer;
+  pubEvb->runInEventBaseThreadAndWait([&]() {
+    withSessionContext(publisherSession, [&]() {
+      PublishRequest pub;
+      pub.fullTrackName = kTestTrackName;
+      auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
+      EXPECT_TRUE(res.hasValue());
+      if (res.hasValue()) {
+        pubConsumer = res->consumer;
+        co_withExecutor(folly::getKeepAliveToken(pubEvb), std::move(res->reply)).start();
+      }
+    });
+  });
+  ASSERT_NE(pubConsumer, nullptr);
+
+  // Run the fanout to completion while the entry is still Pending — this is where the
+  // XCHECK fired — before the gate opens and the entry goes Ready.
+  for (int i = 0; i < 50; ++i) {
+    exec_->drive();
+    pubEvb->runInEventBaseThreadAndWait([] {});
+  }
+
+  releaseGate.dismiss();
+  upstreamGate.post();
+  ASSERT_TRUE(pump([&] { return subscribeDone.load(); })) << "parked subscribe never unwound";
+  // The publish replaced the registry entry the subscribe was still setting up, so the
+  // subscribe loses. Both racers resolving is what matters; neither aborts the process.
+  EXPECT_FALSE(subResult->value().hasValue());
+
+  // The track is left usable: a fresh subscribe attaches to the publish and delivers.
+  auto sg = createMockSubgroupConsumer();
+  std::atomic<bool> gotSubgroup{false};
+  auto retryConsumer = createMockConsumer();
+  EXPECT_CALL(*retryConsumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&sg, &gotSubgroup](uint64_t, uint64_t, uint8_t, moxygen::BeginSubgroupOptions) {
+        gotSubgroup.store(true);
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+  ASSERT_NE(subscribeToTrack(subSession, kTestTrackName, retryConsumer, RequestID(1)), nullptr);
+  pubEvb->runInEventBaseThreadAndWait([&]() {
+    auto sgRes = pubConsumer->beginSubgroup(0, 0, 0);
+    EXPECT_TRUE(sgRes.hasValue());
+    if (sgRes.hasValue()) {
+      EXPECT_TRUE(sgRes.value()->endOfSubgroup().hasValue());
+    }
+  });
+  EXPECT_TRUE(pump([&] { return gotSubgroup.load(); }))
+      << "track unusable after the publish/subscribe race";
+
+  removeSession(publisherSession);
+  removeSession(subSession);
+  for (int i = 0; i < 4; ++i) {
+    driveIfMultiThread();
+    pubEvb->runInEventBaseThreadAndWait([] {});
+  }
+}
 } // namespace openmoq::moqx::test


### PR DESCRIPTION
A track created by its first subscriber left no entry in the publisher thread's LocalForwarderRegistry, so a subscriber landing on that thread joined a separate local forwarder instead of the publisher's. First subscriber setup now calls installPublisherForwarder on the publisher executor with removeOnEmpty=true, so the entry is there to find and is dropped with the last subscriber.

The initial state for the requesting subscriber is captured from the publisher forwarder, so subscribers joining an existing attachment also get the most recent largest and extensions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/546)
<!-- Reviewable:end -->
