### PR TITLE
feat: implement rendezvous timeout feature in MoqxRelay

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -144,12 +144,23 @@ checkRangeNotInPast(moxygen::MoQForwarder& fwd, const moxygen::SubscribeRequest&
   return std::nullopt;
 }
 
+bool isV18Plus(const std::shared_ptr<moxygen::MoQSession>& session) {
+  auto version = session ? session->getNegotiatedVersion() : std::optional<uint64_t>{};
+  return version.has_value() && moxygen::getDraftMajorVersion(*version) >= 18;
+}
+
 // Derives the upstream SubscribeRequest from a downstream one: fetch from latest at
 // upstream priority/default group order, session-assigned requestID, caller's forward.
-moxygen::SubscribeRequest makeUpstreamSubReq(moxygen::SubscribeRequest base, bool forward) {
-  // RENDEZVOUS_TIMEOUT (key 0x04) is unconditionally stripped here as message params are not
-  // meant to be forwarded (Section 10.2.1)
-  base.params.eraseAllParamsOfType(moxygen::TrackRequestParamKey::RENDEZVOUS_TIMEOUT);
+moxygen::SubscribeRequest makeUpstreamSubReq(
+    moxygen::SubscribeRequest base,
+    bool forward,
+    const std::shared_ptr<moxygen::MoQSession>& upstreamSession
+) {
+  // Below v18 key 0x04 is MAX_CACHE_DURATION and forwardable; a v18 upstream would
+  // misread it as RENDEZVOUS_TIMEOUT.
+  if (isV18Plus(upstreamSession)) {
+    base.params.eraseAllParamsOfType(moxygen::TrackRequestParamKey::RENDEZVOUS_TIMEOUT);
+  }
   base.priority = kDefaultUpstreamPriority;
   base.groupOrder = moxygen::GroupOrder::Default;
   base.locType = moxygen::LocationType::LargestObject;
@@ -2269,7 +2280,8 @@ MoqxRelay::joinOrPrepareUpstreamSubscription(SubscribeRequest subReq) {
   if (auto* first = std::get_if<SubscriptionRegistry::FirstSubscriber>(&firstOrSubsequent)) {
     const auto clientRequestID = subReq.requestID;
     // forward updated to its real value in attachNewLocalForwarderOnRelayExec.
-    SubscribeRequest upstreamSubReq = makeUpstreamSubReq(subReq, /*forward=*/false);
+    SubscribeRequest upstreamSubReq =
+        makeUpstreamSubReq(subReq, /*forward=*/false, upstreamSession);
 
     // first->consumer is the publisher forwarder (lives on publisherExec == upstreamSession's
     // executor). No cross-exec wrapping — upstream delivers on that executor directly.
@@ -2309,10 +2321,10 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
   const auto& ftn = subReq.fullTrackName;
   auto* localReg = &localRegistry();
 
-  // Resolve (or wait out our own rendezvous) before touching any per-thread or
-  // relay-global commitment state; Must run on relayExec_: it
-  // reads/mutates registry_/namespaceTree_/pendingRendezvousRoot_ directly.
-  if (auto rendezvousTimeout = requestedRendezvousTimeout(subReq, session);
+  // Park before claiming this thread's forwarder, so a later SUBSCRIBE for the same
+  // ftn is never bound to our timeout. The gate keeps the relayExec_ hop off the
+  // common path: a ready local forwarder means a publisher already resolved.
+  if (auto rendezvousTimeout = takeRendezvousTimeout(subReq, session);
       rendezvousTimeout && !localReg->getIfReady(ftn)) {
     if (auto rendezvousErr = co_await folly::coro::co_withExecutor(
             folly::getKeepAliveToken(relayExec_),
@@ -2449,7 +2461,7 @@ MoqxRelay::subscribeImpl(SubscribeRequest subReq, std::shared_ptr<TrackConsumer>
   // Resolve (or wait out our own rendezvous) before ever committing a
   // FirstSubscriber/SubsequentSubscriber entry, so a concurrent SUBSCRIBE for the
   // same ftn is never bound to our RENDEZVOUS_TIMEOUT.
-  if (auto rendezvousTimeout = requestedRendezvousTimeout(subReq, session)) {
+  if (auto rendezvousTimeout = takeRendezvousTimeout(subReq, session)) {
     if (auto rendezvousErr =
             co_await rendezvousWithPublisherOrTimeout(subReq, *rendezvousTimeout)) {
       co_return folly::makeUnexpected(std::move(*rendezvousErr));
@@ -2505,8 +2517,11 @@ MoqxRelay::subscribeImpl(SubscribeRequest subReq, std::shared_ptr<TrackConsumer>
     // Subscribe upstream with forward set only while we have forwarding
     // subscribers, so an idle relay doesn't pull data it won't deliver.
     const auto clientRequestID = subReq.requestID;
-    subReq =
-        makeUpstreamSubReq(std::move(subReq), first->forwarder->numForwardingSubscribers() > 0);
+    subReq = makeUpstreamSubReq(
+        std::move(subReq),
+        first->forwarder->numForwardingSubscribers() > 0,
+        upstreamSession
+    );
 
     // Upstream subscribe + apply OK to the forwarder (NGR recorded without firing).
     // pending destructor fires on the error path.
@@ -3217,17 +3232,19 @@ void MoqxRelay::wakePendingRendezvousUnderNamespace(const TrackNamespace& ns) {
   });
 }
 
-std::optional<std::chrono::milliseconds> MoqxRelay::requestedRendezvousTimeout(
-    const SubscribeRequest& subReq,
+std::optional<std::chrono::milliseconds> MoqxRelay::takeRendezvousTimeout(
+    SubscribeRequest& subReq,
     const std::shared_ptr<MoQSession>& session
 ) const {
-  auto version = session ? session->getNegotiatedVersion() : std::optional<uint64_t>{};
-  if (!version.has_value() || getDraftMajorVersion(*version) < 18) {
+  // Below v18 key 0x04 is MAX_CACHE_DURATION, which is not ours to read or consume.
+  if (!isV18Plus(session)) {
     return std::nullopt;
   }
   auto ms =
       moxygen::getFirstIntParam(subReq.params, moxygen::TrackRequestParamKey::RENDEZVOUS_TIMEOUT);
-  if (!ms.has_value() || *ms <= 0) {
+  // Per-hop param: consume it so it can never reach the upstream request.
+  subReq.params.eraseAllParamsOfType(moxygen::TrackRequestParamKey::RENDEZVOUS_TIMEOUT);
+  if (!ms.has_value() || *ms == 0) {
     return std::nullopt;
   }
 
@@ -3235,15 +3252,15 @@ std::optional<std::chrono::milliseconds> MoqxRelay::requestedRendezvousTimeout(
   // can park a waiter, regardless of the client-requested RENDEZVOUS_TIMEOUT.
   constexpr auto kMaxMs = static_cast<uint64_t>(kMaxRendezvousTimeout.count());
   if (*ms > kMaxMs) {
-    XLOG(WARN) << "Clamping RENDEZVOUS_TIMEOUT for " << subReq.fullTrackName << " from " << *ms
+    XLOG(DBG1) << "Clamping RENDEZVOUS_TIMEOUT for " << subReq.fullTrackName << " from " << *ms
                << "ms to " << kMaxMs << "ms";
   }
   return std::chrono::milliseconds(std::min(*ms, kMaxMs));
 }
 
-// Parks (at most once) until either a publisher resolves for ftn or the
-// RENDEZVOUS_TIMEOUT elapses. TOCTOU window is gracefully handled in both
-// callers by rechecking the registry_/namespaceTree_
+// Parks (at most once) until a publisher resolves for ftn or `timeout` elapses. A wake
+// is only a hint: if the publisher is gone again by the time we resume, the caller's
+// ordinary no-publisher path reports it.
 folly::coro::Task<std::optional<SubscribeError>> MoqxRelay::rendezvousWithPublisherOrTimeout(
     const SubscribeRequest& subReq,
     std::chrono::milliseconds timeout
@@ -3258,7 +3275,7 @@ folly::coro::Task<std::optional<SubscribeError>> MoqxRelay::rendezvousWithPublis
   addPendingRendezvous(ftn, waiter);
   auto cleanup = folly::makeGuard([this, ftn, waiter] { erasePendingRendezvous(ftn, waiter); });
 
-  auto waitRes = co_await folly::coro::co_awaitTry(waiter->wait(timeout));
+  auto waitRes = co_await folly::coro::co_awaitTry(waiter->wait(timeout, timekeeper_.get()));
 
   if (waitRes.hasException()) {
     if (waitRes.template hasException<folly::FutureTimeout>()) {

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -20,6 +20,7 @@
 #include "relay/TrackEventCallback.h"
 #include "relay/TrackStatsFilter.h"
 #include "relay/WeakRelayForwarderCallback.h"
+#include <algorithm>
 #include <folly/Random.h>
 #include <folly/container/F14Set.h>
 #include <folly/coro/Collect.h>
@@ -146,6 +147,9 @@ checkRangeNotInPast(moxygen::MoQForwarder& fwd, const moxygen::SubscribeRequest&
 // Derives the upstream SubscribeRequest from a downstream one: fetch from latest at
 // upstream priority/default group order, session-assigned requestID, caller's forward.
 moxygen::SubscribeRequest makeUpstreamSubReq(moxygen::SubscribeRequest base, bool forward) {
+  // RENDEZVOUS_TIMEOUT (key 0x04) is unconditionally stripped here as message params are not
+  // meant to be forwarded (Section 10.2.1)
+  base.params.eraseAllParamsOfType(moxygen::TrackRequestParamKey::RENDEZVOUS_TIMEOUT);
   base.priority = kDefaultUpstreamPriority;
   base.groupOrder = moxygen::GroupOrder::Default;
   base.locType = moxygen::LocationType::LargestObject;
@@ -457,6 +461,7 @@ std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespac
       }
     }
   }
+  wakePendingRendezvousUnderNamespace(pubNs.trackNamespace);
   return nodePtr;
 }
 
@@ -924,6 +929,10 @@ MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
   // (PropertyRanking needs objects to evaluate property values for ranking).
   // When subscribers join later via subscribeNamespace, forwardChanged() sends REQUEST_UPDATE.
   bool shouldForward = (nSubscribers > 0) || hasTrackFilterSub;
+
+  // Wake any SUBSCRIBE that's parked waiting for this exact track (draft 18+
+  // RENDEZVOUS_TIMEOUT).
+  wakePendingRendezvousForTrack(pub.fullTrackName);
 
   return PublishSetup{
       publishEntry.consumer,
@@ -2298,9 +2307,22 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
     folly::Executor* subscriberExec
 ) {
   const auto& ftn = subReq.fullTrackName;
+  auto* localReg = &localRegistry();
+
+  // Resolve (or wait out our own rendezvous) before touching any per-thread or
+  // relay-global commitment state; Must run on relayExec_: it
+  // reads/mutates registry_/namespaceTree_/pendingRendezvousRoot_ directly.
+  if (auto rendezvousTimeout = requestedRendezvousTimeout(subReq, session);
+      rendezvousTimeout && !localReg->getIfReady(ftn)) {
+    if (auto rendezvousErr = co_await folly::coro::co_withExecutor(
+            folly::getKeepAliveToken(relayExec_),
+            rendezvousWithPublisherOrTimeout(subReq, *rendezvousTimeout)
+        )) {
+      co_return folly::makeUnexpected(std::move(*rendezvousErr));
+    }
+  }
 
   // Join before the relay hop: serializes same-iothread races.
-  auto* localReg = &localRegistry();
   auto joined = localReg->join(ftn, [&] { return std::make_shared<MoQForwarder>(ftn); });
 
   consumer =
@@ -2422,6 +2444,16 @@ MoqxRelay::subscribeImpl(SubscribeRequest subReq, std::shared_ptr<TrackConsumer>
     co_return folly::makeUnexpected(
         SubscribeError({subReq.requestID, SubscribeErrorCode::DOES_NOT_EXIST, "namespace required"})
     );
+  }
+
+  // Resolve (or wait out our own rendezvous) before ever committing a
+  // FirstSubscriber/SubsequentSubscriber entry, so a concurrent SUBSCRIBE for the
+  // same ftn is never bound to our RENDEZVOUS_TIMEOUT.
+  if (auto rendezvousTimeout = requestedRendezvousTimeout(subReq, session)) {
+    if (auto rendezvousErr =
+            co_await rendezvousWithPublisherOrTimeout(subReq, *rendezvousTimeout)) {
+      co_return folly::makeUnexpected(std::move(*rendezvousErr));
+    }
   }
 
   // TOCTOU fix: if we might be the first subscriber, wait for the upstream
@@ -3056,6 +3088,197 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
     });
     visitor.onCacheEnd();
   }
+}
+
+// === Pending rendezvous tree ===
+
+MoqxRelay::PendingRendezvousNode&
+MoqxRelay::findOrCreatePendingRendezvousNode(const TrackNamespace& ns) {
+  auto* node = &pendingRendezvousRoot_;
+  for (const auto& part : ns.trackNamespace) {
+    auto& child = node->children[part];
+    if (!child) {
+      child = std::make_unique<PendingRendezvousNode>();
+    }
+    node = child.get();
+  }
+  return *node;
+}
+
+void MoqxRelay::addPendingRendezvous(
+    const FullTrackName& ftn,
+    const std::shared_ptr<moxygen::TimedBaton>& waiter
+) {
+  auto& node = findOrCreatePendingRendezvousNode(ftn.trackNamespace);
+  node.waitersByTrack[ftn.trackName].push_back(waiter);
+}
+
+void MoqxRelay::erasePendingRendezvous(
+    const FullTrackName& ftn,
+    const std::shared_ptr<moxygen::TimedBaton>& waiter
+) {
+  erasePendingRendezvousFromNode(pendingRendezvousRoot_, ftn, /*namespaceIndex=*/0, waiter);
+}
+
+void MoqxRelay::erasePendingRendezvousFromNode(
+    PendingRendezvousNode& node,
+    const FullTrackName& ftn,
+    size_t namespaceIndex,
+    const std::shared_ptr<moxygen::TimedBaton>& waiter
+) {
+  if (namespaceIndex < ftn.trackNamespace.trackNamespace.size()) {
+    const auto& part = ftn.trackNamespace.trackNamespace[namespaceIndex];
+    auto childIt = node.children.find(part);
+    if (childIt == node.children.end()) {
+      return;
+    }
+    erasePendingRendezvousFromNode(*childIt->second, ftn, namespaceIndex + 1, waiter);
+    if (childIt->second->empty()) {
+      node.children.erase(childIt);
+    }
+    return;
+  }
+
+  auto waitersIt = node.waitersByTrack.find(ftn.trackName);
+  if (waitersIt == node.waitersByTrack.end()) {
+    return;
+  }
+  auto& waiters = waitersIt->second;
+  waiters.erase(std::remove(waiters.begin(), waiters.end(), waiter), waiters.end());
+  if (waiters.empty()) {
+    node.waitersByTrack.erase(waitersIt);
+  }
+}
+
+// Signals every waiter in this subtree (namespace-level publish/publishNamespace)
+// and clears it out, since all of it is now resolved.
+void MoqxRelay::wakePendingRendezvousSubtree(PendingRendezvousNode& node) {
+  for (auto& [_, trackWaiters] : node.waitersByTrack) {
+    for (auto& waiter : trackWaiters) {
+      waiter->signal();
+    }
+  }
+  for (auto& [_, child] : node.children) {
+    wakePendingRendezvousSubtree(*child);
+  }
+  node.waitersByTrack.clear();
+  node.children.clear();
+}
+
+// Walks down to the node at `ns`, applies `onNode`, then prunes any now-empty
+// ancestors on the way back up.
+void MoqxRelay::applyFnAtNamespaceNode(
+    const TrackNamespace& ns,
+    folly::FunctionRef<void(PendingRendezvousNode&)> onNode
+) {
+  auto* node = &pendingRendezvousRoot_;
+  std::vector<std::pair<PendingRendezvousNode*, std::string>> path;
+  bool foundNamespace = true;
+  for (const auto& part : ns.trackNamespace) {
+    auto childIt = node->children.find(part);
+    if (childIt == node->children.end()) {
+      foundNamespace = false;
+      break;
+    }
+    path.emplace_back(node, part);
+    node = childIt->second.get();
+  }
+
+  if (foundNamespace) {
+    onNode(*node);
+  }
+  // defensive clean up after waking
+  for (auto it = path.rbegin(); it != path.rend() && node->empty(); ++it) {
+    auto* parent = it->first;
+    parent->children.erase(it->second);
+    node = parent;
+  }
+}
+
+// Wakes only waiters for this exact track (a PUBLISH landed). Waiters for
+// other tracks under the same namespace node are left parked.
+void MoqxRelay::wakePendingRendezvousForTrack(const FullTrackName& ftn) {
+  applyFnAtNamespaceNode(ftn.trackNamespace, [&ftn](PendingRendezvousNode& node) {
+    auto waitersIt = node.waitersByTrack.find(ftn.trackName);
+    if (waitersIt != node.waitersByTrack.end()) {
+      for (auto& waiter : waitersIt->second) {
+        waiter->signal();
+      }
+      node.waitersByTrack.erase(waitersIt);
+    }
+  });
+}
+
+// Wakes every waiter under this namespace (a PUBLISH_NAMESPACE landed) — any
+// track under it may now be resolvable.
+void MoqxRelay::wakePendingRendezvousUnderNamespace(const TrackNamespace& ns) {
+  applyFnAtNamespaceNode(ns, [](PendingRendezvousNode& node) {
+    wakePendingRendezvousSubtree(node);
+  });
+}
+
+std::optional<std::chrono::milliseconds> MoqxRelay::requestedRendezvousTimeout(
+    const SubscribeRequest& subReq,
+    const std::shared_ptr<MoQSession>& session
+) const {
+  auto version = session ? session->getNegotiatedVersion() : std::optional<uint64_t>{};
+  if (!version.has_value() || getDraftMajorVersion(*version) < 18) {
+    return std::nullopt;
+  }
+  auto ms =
+      moxygen::getFirstIntParam(subReq.params, moxygen::TrackRequestParamKey::RENDEZVOUS_TIMEOUT);
+  if (!ms.has_value() || *ms <= 0) {
+    return std::nullopt;
+  }
+
+  // Hardcoded ceiling: bounds how long a rendezvous SUBSCRIBE
+  // can park a waiter, regardless of the client-requested RENDEZVOUS_TIMEOUT.
+  constexpr auto kMaxMs = static_cast<uint64_t>(kMaxRendezvousTimeout.count());
+  if (*ms > kMaxMs) {
+    XLOG(WARN) << "Clamping RENDEZVOUS_TIMEOUT for " << subReq.fullTrackName << " from " << *ms
+               << "ms to " << kMaxMs << "ms";
+  }
+  return std::chrono::milliseconds(std::min(*ms, kMaxMs));
+}
+
+// Parks (at most once) until either a publisher resolves for ftn or the
+// RENDEZVOUS_TIMEOUT elapses. TOCTOU window is gracefully handled in both
+// callers by rechecking the registry_/namespaceTree_
+folly::coro::Task<std::optional<SubscribeError>> MoqxRelay::rendezvousWithPublisherOrTimeout(
+    const SubscribeRequest& subReq,
+    std::chrono::milliseconds timeout
+) {
+  const auto& ftn = subReq.fullTrackName;
+
+  if (registry_.exists(ftn) || namespaceTree_.findPublisherSession(ftn.trackNamespace)) {
+    co_return std::nullopt;
+  }
+
+  auto waiter = std::make_shared<moxygen::TimedBaton>();
+  addPendingRendezvous(ftn, waiter);
+  auto cleanup = folly::makeGuard([this, ftn, waiter] { erasePendingRendezvous(ftn, waiter); });
+
+  auto waitRes = co_await folly::coro::co_awaitTry(waiter->wait(timeout));
+
+  if (waitRes.hasException()) {
+    if (waitRes.template hasException<folly::FutureTimeout>()) {
+      co_return SubscribeError{
+          subReq.requestID,
+          SubscribeErrorCode::TIMEOUT,
+          "rendezvous timeout expired"
+      };
+    }
+    if (waitRes.template hasException<folly::OperationCancelled>()) {
+      co_yield folly::coro::co_stopped_may_throw;
+    }
+    co_return SubscribeError{
+        subReq.requestID,
+        SubscribeErrorCode::INTERNAL_ERROR,
+        folly::to<std::string>("rendezvous wait failed: ", waitRes.exception().what().toStdString())
+    };
+  }
+
+  co_return std::nullopt;
 }
 
 } // namespace openmoq::moqx

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -21,8 +21,11 @@
 #include "relay/RelayExecUtil.h"
 #include "stats/TrackStatsRegistry.h"
 #include <moxygen/MoQSession.h>
+#include <moxygen/events/MoQFollyExecutorImpl.h>
 #include <moxygen/relay/MoQForwarder.h>
 #include <moxygen/util/TimedBaton.h>
+
+#include <folly/futures/ThreadWheelTimekeeper.h>
 
 #include <folly/Executor.h>
 #include <folly/ThreadLocal.h>
@@ -136,6 +139,12 @@ public:
         useLocalForwarders_(useLocalForwarders), maxDeselected_(maxDeselected),
         idleTimeout_(idleTimeout), activityThreshold_(activityThreshold) {
     XCHECK_LE(relayHopID_, kMaxRelayHopID);
+    // Park timers fire on the relay's own EventBase instead of folly's global
+    // timekeeper thread. Null (SingleThread mode, or a non-folly exec) falls back to it.
+    if (auto* follyExec = dynamic_cast<moxygen::MoQFollyExecutorImpl*>(relayExec_)) {
+      timekeeper_ =
+          std::make_unique<folly::EventBaseThreadTimekeeper>(*follyExec->getBackingEventBase());
+    }
     if (cache.maxCachedTracks > 0) {
       cache_ = std::make_unique<MoqxCache>(cache.maxCachedTracks, cache.maxCachedGroupsPerTrack);
       cache_->setMaxCachedBytes(static_cast<size_t>(cache.maxCachedMb) * 1024 * 1024);
@@ -621,6 +630,7 @@ private:
   );
 
   std::shared_ptr<folly::Executor> ownedRelayExec_;
+  std::unique_ptr<folly::EventBaseThreadTimekeeper> timekeeper_;
   folly::Executor* relayExec_{nullptr};
   // Only set in single-threaded mode (relayExec_ == null); used as the
   // coroutine start executor for fire-and-forget tasks like doSubscribeUpdate.
@@ -667,7 +677,7 @@ private:
   // === Pending rendezvous (draft 18+ SUBSCRIBE with RENDEZVOUS_TIMEOUT) ===
   // Subscribers waiting on a namespace/track that isn't published yet, indexed
   // by namespace prefix. Woken by doPublishNamespace()/publishWithSession() when
-  // matching content arrives; otherwise PendingRendezvous::baton times out.
+  // matching content arrives; otherwise each waiter's baton times out.
 
   struct PendingRendezvousNode {
     using WaiterList = std::vector<std::shared_ptr<moxygen::TimedBaton>>;
@@ -703,12 +713,15 @@ private:
   void wakePendingRendezvousForTrack(const moxygen::FullTrackName& ftn);
   void wakePendingRendezvousUnderNamespace(const moxygen::TrackNamespace& ns);
 
-  std::optional<std::chrono::milliseconds> requestedRendezvousTimeout(
-      const moxygen::SubscribeRequest& subReq,
+  // Clamped timeout if this SUBSCRIBE asks for a rendezvous, else nullopt; consumes the
+  // param. Reads no relay state, so callers may screen on any exec before hopping.
+  std::optional<std::chrono::milliseconds> takeRendezvousTimeout(
+      moxygen::SubscribeRequest& subReq,
       const std::shared_ptr<moxygen::MoQSession>& session
   ) const;
 
-  // Runs on relayExec_ (or inline in SingleThread mode). Pure existence check + wait;
+  // Existence check, then park. Callers screen first. Must run on relayExec_ (inline
+  // in SingleThread mode): touches registry_/namespaceTree_/pendingRendezvousRoot_.
   folly::coro::Task<std::optional<moxygen::SubscribeError>> rendezvousWithPublisherOrTimeout(
       const moxygen::SubscribeRequest& subReq,
       std::chrono::milliseconds timeout

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -22,6 +22,7 @@
 #include "stats/TrackStatsRegistry.h"
 #include <moxygen/MoQSession.h>
 #include <moxygen/relay/MoQForwarder.h>
+#include <moxygen/util/TimedBaton.h>
 
 #include <folly/Executor.h>
 #include <folly/ThreadLocal.h>
@@ -114,6 +115,7 @@ public:
   static constexpr uint64_t kDefaultMaxDeselected = 0;
   static constexpr std::chrono::milliseconds kDefaultIdleTimeout{10'000};
   static constexpr std::chrono::milliseconds kDefaultActivityThreshold{2'000};
+  static constexpr std::chrono::milliseconds kMaxRendezvousTimeout{30'000};
 
   // relayExec, when set, is owned by the relay and isolates all state on it;
   // null runs everything on the calling thread. useLocalForwarders (requires
@@ -661,6 +663,56 @@ private:
 
   std::unique_ptr<MoqxCache> cache_;
   uint64_t maxDeselected_{kDefaultMaxDeselected};
+
+  // === Pending rendezvous (draft 18+ SUBSCRIBE with RENDEZVOUS_TIMEOUT) ===
+  // Subscribers waiting on a namespace/track that isn't published yet, indexed
+  // by namespace prefix. Woken by doPublishNamespace()/publishWithSession() when
+  // matching content arrives; otherwise PendingRendezvous::baton times out.
+
+  struct PendingRendezvousNode {
+    using WaiterList = std::vector<std::shared_ptr<moxygen::TimedBaton>>;
+
+    bool empty() const { return children.empty() && waitersByTrack.empty(); }
+
+    folly::F14FastMap<std::string, std::unique_ptr<PendingRendezvousNode>> children;
+    folly::F14FastMap<std::string, WaiterList> waitersByTrack;
+  };
+
+  PendingRendezvousNode pendingRendezvousRoot_;
+
+  PendingRendezvousNode& findOrCreatePendingRendezvousNode(const moxygen::TrackNamespace& ns);
+  void addPendingRendezvous(
+      const moxygen::FullTrackName& ftn,
+      const std::shared_ptr<moxygen::TimedBaton>& waiter
+  );
+  void erasePendingRendezvous(
+      const moxygen::FullTrackName& ftn,
+      const std::shared_ptr<moxygen::TimedBaton>& waiter
+  );
+  void erasePendingRendezvousFromNode(
+      PendingRendezvousNode& node,
+      const moxygen::FullTrackName& ftn,
+      size_t namespaceIndex,
+      const std::shared_ptr<moxygen::TimedBaton>& waiter
+  );
+  static void wakePendingRendezvousSubtree(PendingRendezvousNode& node);
+  void applyFnAtNamespaceNode(
+      const moxygen::TrackNamespace& ns,
+      folly::FunctionRef<void(PendingRendezvousNode&)> onNode
+  );
+  void wakePendingRendezvousForTrack(const moxygen::FullTrackName& ftn);
+  void wakePendingRendezvousUnderNamespace(const moxygen::TrackNamespace& ns);
+
+  std::optional<std::chrono::milliseconds> requestedRendezvousTimeout(
+      const moxygen::SubscribeRequest& subReq,
+      const std::shared_ptr<moxygen::MoQSession>& session
+  ) const;
+
+  // Runs on relayExec_ (or inline in SingleThread mode). Pure existence check + wait;
+  folly::coro::Task<std::optional<moxygen::SubscribeError>> rendezvousWithPublisherOrTimeout(
+      const moxygen::SubscribeRequest& subReq,
+      std::chrono::milliseconds timeout
+  );
 
   std::chrono::milliseconds idleTimeout_{kDefaultIdleTimeout};
   std::chrono::milliseconds activityThreshold_{kDefaultActivityThreshold};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,7 @@ moqx_add_gtest(moqx_relay_test
     MoqxRelayTracksTests.cpp
     MoqxRelayTrackStatsTests.cpp
     MoqxRelayStateTests.cpp
+    MoqxRelayRendezvousTests.cpp
     MoqxRelayTestModes.cpp
   LIBS moqx_test_fixture moqx_test_main
 )

--- a/test/MoqxRelayRendezvousTests.cpp
+++ b/test/MoqxRelayRendezvousTests.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Draft 18+: SUBSCRIBE with RENDEZVOUS_TIMEOUT relay tests.
+//
+// Basic sanity coverage for the rendezvous-timeout feature (parking a
+// SUBSCRIBE that arrives before any matching PUBLISH/PUBLISH_NAMESPACE, and
+// resolving or timing it out later).
+//
+// Covers all three relay modes: MoqxRelay::subscribeImpl (SingleThread /
+// MultiThread) and MoqxRelay::joinOrPrepareUpstreamSubscription
+// (LocalForwarderMT) both implement the same rendezvous parking/wake/timeout
+// flow.
+
+#include "MoqxRelayTestFixture.h"
+
+namespace openmoq::moqx::test {
+
+class MoqxRelayRendezvousTest : public MoQRelayTest {
+protected:
+  // Like createMockSession() but reports draft 18 for the negotiated version,
+  // required for a downstream SUBSCRIBE to be rendezvous-eligible.
+  std::shared_ptr<MockMoQSession> createV18Session() {
+    auto session = std::make_shared<NiceMock<MockMoQSession>>(exec_);
+    ON_CALL(*session, getNegotiatedVersion())
+        .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft18)));
+    getOrCreateMockState(session);
+    return session;
+  }
+
+  static SubscribeRequest
+  makeRendezvousSubscribeRequest(const FullTrackName& ftn, uint64_t timeoutMs) {
+    SubscribeRequest sub;
+    sub.fullTrackName = ftn;
+    sub.requestID = RequestID(1);
+    sub.locType = LocationType::LargestObject;
+    sub.params.setMajorVersion(getDraftMajorVersion(kVersionDraft18));
+    EXPECT_TRUE(
+        sub.params
+            .insertParam(
+                Parameter(folly::to_underlying(TrackRequestParamKey::RENDEZVOUS_TIMEOUT), timeoutMs)
+            )
+            .hasValue()
+    );
+    return sub;
+  }
+};
+
+// Pre-draft-18 sessions aren't rendezvous-eligible: a SUBSCRIBE for a track
+// with no publisher fails immediately instead of parking.
+TEST_P(MoqxRelayRendezvousTest, PreV18SessionRejectedImmediately) {
+  auto subSession = createMockSession(); // defaults to kVersionDraftCurrent (< 18)
+  auto consumer = createMockConsumer();
+  auto sub = makeRendezvousSubscribeRequest(kTestTrackName, /*timeoutMs=*/1000);
+
+  auto result = withSessionContext(subSession, [&]() {
+    auto task = publisherInterface()->subscribe(std::move(sub), consumer);
+    return folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error().errorCode, SubscribeErrorCode::DOES_NOT_EXIST);
+
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// RENDEZVOUS_TIMEOUT=0 is treated the same as not being present: reject
+// immediately rather than parking.
+TEST_P(MoqxRelayRendezvousTest, ZeroTimeoutRejectedImmediately) {
+  auto subSession = createV18Session();
+  auto consumer = createMockConsumer();
+  auto sub = makeRendezvousSubscribeRequest(kTestTrackName, /*timeoutMs=*/0);
+
+  auto result = withSessionContext(subSession, [&]() {
+    auto task = publisherInterface()->subscribe(std::move(sub), consumer);
+    return folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error().errorCode, SubscribeErrorCode::DOES_NOT_EXIST);
+
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// Core happy path: a rendezvous-eligible SUBSCRIBE for a not-yet-published
+// track parks, and a subsequent PUBLISH of that exact track wakes it up and
+// completes the subscription.
+TEST_P(MoqxRelayRendezvousTest, ResolvesWhenTrackPublished) {
+  auto subSession = createV18Session();
+  auto pubSession = createMockSession();
+  auto consumer = createMockConsumer();
+  auto sub = makeRendezvousSubscribeRequest(kTestTrackName, /*timeoutMs=*/5000);
+
+  auto future = withSessionContext(subSession, [&]() {
+    auto task = publisherInterface()->subscribe(std::move(sub), consumer);
+    return co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(task))
+        .start();
+  });
+
+  exec_->driveFor(10);
+  ASSERT_FALSE(future.isReady()) << "subscribe should be parked awaiting rendezvous";
+
+  doPublish(pubSession, kTestTrackName);
+
+  exec_->driveFor(20);
+  ASSERT_TRUE(future.isReady()) << "PUBLISH of the exact track should wake the parked subscribe";
+  auto result = std::move(future).value();
+  ASSERT_TRUE(result.hasValue());
+
+  result.value()->unsubscribe();
+  removeSession(pubSession);
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// If nothing ever publishes the track, the parked SUBSCRIBE fails with
+// TIMEOUT once RENDEZVOUS_TIMEOUT elapses.
+TEST_P(MoqxRelayRendezvousTest, TimesOutWithoutPublish) {
+  auto subSession = createV18Session();
+  auto consumer = createMockConsumer();
+  auto sub = makeRendezvousSubscribeRequest(kTestTrackName, /*timeoutMs=*/50);
+
+  auto result = withSessionContext(subSession, [&]() {
+    auto task = publisherInterface()->subscribe(std::move(sub), consumer);
+    return folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error().errorCode, SubscribeErrorCode::TIMEOUT);
+
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// A rendezvous-eligible SUBSCRIBE for a track that's already published must
+// resolve immediately instead of parking
+TEST_P(MoqxRelayRendezvousTest, AlreadyPublishedResolvesImmediately) {
+  auto pubSession = createMockSession();
+  doPublish(pubSession, kTestTrackName);
+  driveIfMultiThread();
+
+  auto subSession = createV18Session();
+  auto consumer = createMockConsumer();
+  auto sub = makeRendezvousSubscribeRequest(kTestTrackName, /*timeoutMs=*/5000);
+
+  auto result = withSessionContext(subSession, [&]() {
+    auto task = publisherInterface()->subscribe(std::move(sub), consumer);
+    return folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  ASSERT_TRUE(result.hasValue()
+  ) << "subscribe to an already-published track should resolve immediately, not park";
+
+  result.value()->unsubscribe();
+  removeSession(subSession);
+  removeSession(pubSession);
+  driveIfMultiThread();
+}
+
+// Regression test for the blocking SUBSCRIBEs for the same
+// not-yet-published ftn arrive on the same iothread, one with a long
+// RENDEZVOUS_TIMEOUT and one with a short one. Each waiter's deadline must be
+// independent — the short one has to resolve on its own timeout instead of being
+// serialized behind (or otherwise coupled to) the long one's wait.
+TEST_P(MoqxRelayRendezvousTest, IndependentTimeoutsOnSameIothread) {
+  auto longSubSession = createV18Session();
+  auto shortSubSession = createV18Session();
+  auto longConsumer = createMockConsumer();
+  auto shortConsumer = createMockConsumer();
+
+  auto longSub = makeRendezvousSubscribeRequest(kTestTrackName, /*timeoutMs=*/4000);
+  auto shortSub = makeRendezvousSubscribeRequest(kTestTrackName, /*timeoutMs=*/50);
+
+  auto longFuture = withSessionContext(longSubSession, [&]() {
+    auto task = publisherInterface()->subscribe(std::move(longSub), longConsumer);
+    return co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(task))
+        .start();
+  });
+  auto shortFuture = withSessionContext(shortSubSession, [&]() {
+    auto task = publisherInterface()->subscribe(std::move(shortSub), shortConsumer);
+    return co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(task))
+        .start();
+  });
+
+  exec_->driveFor(10);
+  ASSERT_FALSE(longFuture.isReady()) << "long-timeout subscribe should be parked";
+  ASSERT_FALSE(shortFuture.isReady()) << "short-timeout subscribe should be parked";
+
+  auto start = std::chrono::steady_clock::now();
+  auto deadline = start + std::chrono::seconds(2);
+  while (!shortFuture.isReady() && std::chrono::steady_clock::now() < deadline) {
+    exec_->drive();
+  }
+  ASSERT_TRUE(shortFuture.isReady()) << "short-timeout subscribe never resolved";
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  EXPECT_LT(elapsed, std::chrono::milliseconds(2000))
+      << "short-timeout subscribe should resolve near its own 50ms deadline, not be "
+      << "serialized behind the long-timeout subscribe's 4s wait on the same iothread";
+
+  auto shortResult = std::move(shortFuture).value();
+  ASSERT_TRUE(shortResult.hasError());
+  EXPECT_EQ(shortResult.error().errorCode, SubscribeErrorCode::TIMEOUT);
+
+  ASSERT_FALSE(longFuture.isReady())
+      << "long-timeout subscribe must remain independently parked; it must not be "
+      << "resolved or otherwise disturbed as a side effect of the short one timing out";
+
+  // Resolve the long-timeout subscribe too, proving it still wakes correctly
+  auto pubSession = createMockSession();
+  doPublish(pubSession, kTestTrackName);
+  ASSERT_TRUE(driveUntil([&] { return longFuture.isReady(); }))
+      << "long-timeout subscribe should wake on PUBLISH";
+  auto longResult = std::move(longFuture).value();
+  ASSERT_TRUE(longResult.hasValue());
+  longResult.value()->unsubscribe();
+
+  removeSession(pubSession);
+  removeSession(shortSubSession);
+  removeSession(longSubSession);
+  driveIfMultiThread();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllModes,
+    MoqxRelayRendezvousTest,
+    ::testing::Values(RelayMode::SingleThread, RelayMode::MultiThread, RelayMode::LocalForwarderMT),
+    [](const ::testing::TestParamInfo<RelayMode>& info) -> std::string {
+      switch (info.param) {
+      case RelayMode::SingleThread:
+        return "SingleThread";
+      case RelayMode::MultiThread:
+        return "MultiThread";
+      case RelayMode::LocalForwarderMT:
+        return "LocalForwarderMT";
+      }
+      return "Unknown";
+    }
+);
+
+} // namespace openmoq::moqx::test

--- a/test/MoqxRelayRendezvousTests.cpp
+++ b/test/MoqxRelayRendezvousTests.cpp
@@ -11,9 +11,8 @@
 // resolving or timing it out later).
 //
 // Covers all three relay modes: MoqxRelay::subscribeImpl (SingleThread /
-// MultiThread) and MoqxRelay::joinOrPrepareUpstreamSubscription
-// (LocalForwarderMT) both implement the same rendezvous parking/wake/timeout
-// flow.
+// MultiThread) and MoqxRelay::subscribeFromSubscriberExec (LocalForwarderMT)
+// both implement the same rendezvous parking/wake/timeout flow.
 
 #include "MoqxRelayTestFixture.h"
 
@@ -55,6 +54,24 @@ protected:
     sub.requestID = RequestID(1);
     sub.locType = LocationType::LargestObject;
     sub.params.setMajorVersion(getDraftMajorVersion(kVersionDraft18));
+    return sub;
+  }
+
+  // Key 0x04 on a pre-v18 SUBSCRIBE, where it means MAX_CACHE_DURATION rather than
+  // RENDEZVOUS_TIMEOUT.
+  static SubscribeRequest
+  makeMaxCacheDurationSubscribeRequest(const FullTrackName& ftn, uint64_t durationMs) {
+    SubscribeRequest sub;
+    sub.fullTrackName = ftn;
+    sub.requestID = RequestID(1);
+    sub.locType = LocationType::LargestObject;
+    sub.params.setMajorVersion(getDraftMajorVersion(kVersionDraftCurrent));
+    EXPECT_TRUE(sub.params
+                    .insertParam(Parameter(
+                        folly::to_underlying(TrackRequestParamKey::MAX_CACHE_DURATION),
+                        durationMs
+                    ))
+                    .hasValue());
     return sub;
   }
 
@@ -274,6 +291,176 @@ TEST_P(MoqxRelayRendezvousTest, IndependentTimeoutsOnSameIothread) {
   removeSession(pubSession);
   removeSession(shortSubSession);
   removeSession(longSubSession);
+  driveIfMultiThread();
+}
+
+// A PUBLISH_NAMESPACE for the waiter's own namespace resolves it: any track under
+// that namespace becomes reachable via the new publisher.
+TEST_P(MoqxRelayRendezvousTest, PublishNamespaceWakesParkedSubscribe) {
+  auto subSession = createV18Session();
+  auto pubSession = createMockSession();
+  auto consumer = createMockConsumer();
+  bool sawUpstream = false;
+  expectUpstreamSubscribe(pubSession, sawUpstream);
+
+  auto future =
+      startSubscribe(subSession, makeRendezvousSubscribeRequest(kTestTrackName, 5000), consumer);
+  exec_->driveFor(10);
+  ASSERT_FALSE(future.isReady()) << "subscribe should be parked awaiting rendezvous";
+
+  doPublishNamespace(pubSession, kTestNamespace);
+
+  ASSERT_TRUE(driveUntil([&] { return future.isReady(); }))
+      << "PUBLISH_NAMESPACE for the waiter's namespace should wake it";
+  auto result = std::move(future).value();
+  ASSERT_TRUE(result.hasValue()) << "woken subscribe should resolve via the new publisher";
+  EXPECT_TRUE(sawUpstream);
+
+  result.value()->unsubscribe();
+  removeSession(pubSession);
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// findPublisherSession() is a prefix match, so a publisher at an ancestor namespace
+// serves deeper tracks. The subtree wake has to reach them.
+TEST_P(MoqxRelayRendezvousTest, AncestorPublishNamespaceWakesDeeperWaiter) {
+  const TrackNamespace deepNs{{"test", "namespace", "deep"}};
+  const FullTrackName deepTrack{deepNs, "track1"};
+
+  auto subSession = createV18Session();
+  auto pubSession = createMockSession();
+  auto consumer = createMockConsumer();
+  bool sawUpstream = false;
+  expectUpstreamSubscribe(pubSession, sawUpstream);
+
+  auto future =
+      startSubscribe(subSession, makeRendezvousSubscribeRequest(deepTrack, 5000), consumer);
+  exec_->driveFor(10);
+  ASSERT_FALSE(future.isReady()) << "subscribe should be parked awaiting rendezvous";
+
+  // Announce the ancestor, not the waiter's own namespace.
+  doPublishNamespace(pubSession, kTestNamespace);
+
+  ASSERT_TRUE(driveUntil([&] { return future.isReady(); }))
+      << "ancestor PUBLISH_NAMESPACE should wake a waiter parked deeper in the trie";
+  auto result = std::move(future).value();
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_TRUE(sawUpstream);
+
+  result.value()->unsubscribe();
+  removeSession(pubSession);
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// PUBLISH registers only that track, so it must not wake waiters for a sibling
+// track: addPublish() writes publishes_, not publisherSession_, so the namespace
+// is still unresolvable for them.
+TEST_P(MoqxRelayRendezvousTest, PublishOfDifferentTrackDoesNotWake) {
+  auto subSession = createV18Session();
+  auto pubSession = createMockSession();
+  auto consumer = createMockConsumer();
+
+  auto future =
+      startSubscribe(subSession, makeRendezvousSubscribeRequest(kTestTrackName, 4000), consumer);
+  exec_->driveFor(10);
+  ASSERT_FALSE(future.isReady());
+
+  doPublish(pubSession, FullTrackName{kTestNamespace, "track2"});
+  exec_->driveFor(20);
+  EXPECT_FALSE(future.isReady()
+  ) << "a PUBLISH of a sibling track must not resolve a waiter for track1";
+
+  // Now publish the real track so the test doesn't wait out the 4s timeout.
+  doPublish(pubSession, kTestTrackName);
+  ASSERT_TRUE(driveUntil([&] { return future.isReady(); }));
+  auto result = std::move(future).value();
+  ASSERT_TRUE(result.hasValue());
+
+  result.value()->unsubscribe();
+  removeSession(pubSession);
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// The case the parking was moved ahead of localReg->join() for: a SUBSCRIBE with no
+// RENDEZVOUS_TIMEOUT must fail immediately rather than inherit a parked waiter's
+// deadline, and must not disturb that waiter.
+TEST_P(MoqxRelayRendezvousTest, NoTimeoutSubscriberFailsWhileAnotherIsParked) {
+  auto parkedSession = createV18Session();
+  auto plainSession = createV18Session();
+  auto parkedConsumer = createMockConsumer();
+  auto plainConsumer = createMockConsumer();
+
+  auto parkedFuture = startSubscribe(
+      parkedSession,
+      makeRendezvousSubscribeRequest(kTestTrackName, 4000),
+      parkedConsumer
+  );
+  exec_->driveFor(10);
+  ASSERT_FALSE(parkedFuture.isReady()) << "first subscribe should be parked";
+
+  auto start = std::chrono::steady_clock::now();
+  auto plainResult = withSessionContext(plainSession, [&]() {
+    auto task = publisherInterface()->subscribe(
+        makePlainV18SubscribeRequest(kTestTrackName),
+        plainConsumer
+    );
+    return folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  ASSERT_TRUE(plainResult.hasError());
+  EXPECT_EQ(plainResult.error().errorCode, SubscribeErrorCode::DOES_NOT_EXIST);
+  EXPECT_LT(elapsed, std::chrono::milliseconds(1000))
+      << "a no-timeout SUBSCRIBE must not be serialized behind the parked one's 4s wait";
+  EXPECT_FALSE(parkedFuture.isReady())
+      << "the parked waiter must survive the other subscriber's failure";
+
+  auto pubSession = createMockSession();
+  doPublish(pubSession, kTestTrackName);
+  ASSERT_TRUE(driveUntil([&] { return parkedFuture.isReady(); }))
+      << "parked waiter should still wake on PUBLISH after the failed neighbour";
+  auto parked = std::move(parkedFuture).value();
+  ASSERT_TRUE(parked.hasValue());
+
+  parked.value()->unsubscribe();
+  removeSession(pubSession);
+  removeSession(plainSession);
+  removeSession(parkedSession);
+  driveIfMultiThread();
+}
+
+// makeUpstreamSubReq() erases key 0x04 unconditionally. Below draft 18 that key is
+// MAX_CACHE_DURATION, a legal SUBSCRIBE parameter, so a pre-v18 client's value is
+// dropped on the way upstream. moxygen gates the same erase on either side being v18+.
+TEST_P(MoqxRelayRendezvousTest, UpstreamSubReqDropsPreV18MaxCacheDuration) {
+  auto pubSession = createMockSession(); // draft 14
+  auto subSession = createMockSession(); // draft 14
+  doPublishNamespace(pubSession, kTestNamespace);
+
+  bool sawUpstream = false;
+  bool sawKey04 = false;
+  expectUpstreamSubscribe(pubSession, sawUpstream, &sawKey04);
+
+  auto consumer = createMockConsumer();
+  auto result = withSessionContext(subSession, [&]() {
+    auto task = publisherInterface()->subscribe(
+        makeMaxCacheDurationSubscribeRequest(kTestTrackName, /*durationMs=*/30'000),
+        consumer
+    );
+    return folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_TRUE(sawUpstream) << "relay should have issued an upstream subscribe";
+  EXPECT_TRUE(sawKey04) << "MAX_CACHE_DURATION must survive a pre-v18 hop; key 0x04 only means "
+                           "RENDEZVOUS_TIMEOUT at draft 18+";
+
+  result.value()->unsubscribe();
+  removeSession(subSession);
+  removeSession(pubSession);
   driveIfMultiThread();
 }
 

--- a/test/MoqxRelayRendezvousTests.cpp
+++ b/test/MoqxRelayRendezvousTests.cpp
@@ -47,6 +47,58 @@ protected:
     );
     return sub;
   }
+
+  // A v18 SUBSCRIBE with no RENDEZVOUS_TIMEOUT: eligible session, ineligible request.
+  static SubscribeRequest makePlainV18SubscribeRequest(const FullTrackName& ftn) {
+    SubscribeRequest sub;
+    sub.fullTrackName = ftn;
+    sub.requestID = RequestID(1);
+    sub.locType = LocationType::LargestObject;
+    sub.params.setMajorVersion(getDraftMajorVersion(kVersionDraft18));
+    return sub;
+  }
+
+  // Answers the relay's upstream SUBSCRIBE with a canned OK, recording whether the
+  // request still carried key 0x04.
+  void expectUpstreamSubscribe(
+      const std::shared_ptr<MockMoQSession>& publisherSession,
+      bool& sawUpstream,
+      bool* sawKey04 = nullptr
+  ) {
+    SubscribeOk upstreamOk;
+    upstreamOk.requestID = RequestID(1);
+    upstreamOk.trackAlias = TrackAlias(1);
+    upstreamOk.expires = std::chrono::milliseconds(0);
+    upstreamOk.groupOrder = GroupOrder::OldestFirst;
+    EXPECT_CALL(*publisherSession, subscribe(_, _))
+        .WillRepeatedly([&sawUpstream,
+                         sawKey04,
+                         upstreamOk](const SubscribeRequest& req, std::shared_ptr<TrackConsumer>) {
+          sawUpstream = true;
+          if (sawKey04) {
+            *sawKey04 =
+                req.params.getFirstParam(TrackRequestParamKey::MAX_CACHE_DURATION) != nullptr;
+          }
+          auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+          return folly::coro::makeTask<Publisher::SubscribeResult>(
+              folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(handle)
+          );
+        });
+  }
+
+  // Starts a SUBSCRIBE on exec_ without waiting for it, so the test can assert it
+  // is still parked.
+  auto startSubscribe(
+      const std::shared_ptr<MockMoQSession>& session,
+      SubscribeRequest sub,
+      const std::shared_ptr<MockTrackConsumer>& consumer
+  ) {
+    return withSessionContext(session, [&]() {
+      auto task = publisherInterface()->subscribe(std::move(sub), consumer);
+      return co_withExecutor(static_cast<folly::DrivableExecutor*>(exec_.get()), std::move(task))
+          .start();
+    });
+  }
 };
 
 // Pre-draft-18 sessions aren't rendezvous-eligible: a SUBSCRIBE for a track
@@ -222,6 +274,106 @@ TEST_P(MoqxRelayRendezvousTest, IndependentTimeoutsOnSameIothread) {
   removeSession(pubSession);
   removeSession(shortSubSession);
   removeSession(longSubSession);
+  driveIfMultiThread();
+}
+
+// A publisher announcing the empty namespace claims every track, so waking the whole
+// trie is right and each waiter must then route to it. It does not: findNode() refuses
+// to prefix-match at the root (`nodePtr.get() != &root_`), so findPublisherSession()
+// answers null and the woken waiter fails DOES_NOT_EXIST. moxygen's
+// findPublishNamespaceSession() seeds deepestPublisher from the root instead.
+TEST_P(MoqxRelayRendezvousTest, EmptyNamespacePublishNamespaceResolvesWaiters) {
+  relay_->setAllowedNamespacePrefix(TrackNamespace{});
+
+  auto subSession = createV18Session();
+  auto pubSession = createMockSession();
+  auto consumer = createMockConsumer();
+  bool sawUpstream = false;
+  expectUpstreamSubscribe(pubSession, sawUpstream);
+
+  auto future =
+      startSubscribe(subSession, makeRendezvousSubscribeRequest(kTestTrackName, 4000), consumer);
+  exec_->driveFor(10);
+  ASSERT_FALSE(future.isReady());
+
+  doPublishNamespace(pubSession, TrackNamespace{});
+
+  ASSERT_TRUE(driveUntil([&] { return future.isReady(); }))
+      << "a root publisher claims every namespace, so the waiter should wake";
+  auto result = std::move(future).value();
+  EXPECT_TRUE(result.hasValue()
+  ) << "a root publisher can serve this track, so the woken waiter must route to it";
+
+  if (result.hasValue()) {
+    result.value()->unsubscribe();
+  }
+  removeSession(pubSession);
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
+// Port of moxygen a682b57a ("Route SUBSCRIBE past publisher-less namespace nodes"):
+// PUBLISH and SUBSCRIBE_NAMESPACE also create nodes, and those carry no publisher, so
+// a SUBSCRIBE descending through one must still reach the ancestor that does publish.
+// Two variants, matching the two upstream tests.
+TEST_P(MoqxRelayRendezvousTest, SubscribeRoutesPastPublishCreatedNode) {
+  auto pubSession = createMockSession();
+  auto otherPubSession = createMockSession();
+  auto subSession = createMockSession();
+  bool sawUpstream = false;
+  expectUpstreamSubscribe(pubSession, sawUpstream);
+
+  doPublishNamespace(pubSession, kAllowedPrefix);
+  // A PUBLISH under "test/namespace" materialises that node with no publisher on it.
+  doPublish(otherPubSession, FullTrackName{kTestNamespace, "other"});
+
+  auto consumer = createMockConsumer();
+  auto result = withSessionContext(subSession, [&]() {
+    auto task =
+        publisherInterface()->subscribe(makePlainV18SubscribeRequest(kTestTrackName), consumer);
+    return folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  EXPECT_TRUE(result.hasValue()
+  ) << "a PUBLISH-created node must not hide the publisher at the ancestor";
+
+  if (result.hasValue()) {
+    result.value()->unsubscribe();
+  }
+  removeSession(subSession);
+  removeSession(otherPubSession);
+  removeSession(pubSession);
+  driveIfMultiThread();
+}
+
+TEST_P(MoqxRelayRendezvousTest, SubscribeRoutesPastSubscribeNamespaceCreatedNode) {
+  auto pubSession = createMockSession();
+  auto nsSubSession = createMockSession();
+  auto subSession = createMockSession();
+  bool sawUpstream = false;
+  expectUpstreamSubscribe(pubSession, sawUpstream);
+
+  // Publisher owns the "test" prefix; the track sits a level below it.
+  doPublishNamespace(pubSession, kAllowedPrefix);
+  // A namespace subscriber materialises "test/namespace" carrying no publisher.
+  doSubscribeNamespace(nsSubSession, kTestNamespace);
+
+  auto consumer = createMockConsumer();
+  auto result = withSessionContext(subSession, [&]() {
+    auto task =
+        publisherInterface()->subscribe(makePlainV18SubscribeRequest(kTestTrackName), consumer);
+    return folly::coro::blockingWait(std::move(task), exec_.get());
+  });
+
+  EXPECT_TRUE(result.hasValue()
+  ) << "an empty intermediate node must not hide the publisher at the ancestor";
+
+  if (result.hasValue()) {
+    result.value()->unsubscribe();
+  }
+  removeSession(subSession);
+  removeSession(nsSubSession);
+  removeSession(pubSession);
   driveIfMultiThread();
 }
 


### PR DESCRIPTION
- Introduce PendingRendezvous structure to manage parked subscriptions.
- Add support for RENDEZVOUS_TIMEOUT in subscription handling.
- Implement wake and erase functions for pending rendezvous.
- Add tests for rendezvous timeout scenarios in MoqxRelayRendezvousTests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/549)
<!-- Reviewable:end -->
