### PR TITLE
auth: support multiple AUTHORIZATION_TOKEN in single message

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -179,27 +179,43 @@ folly::Expected<Grants, AuthError> AuthTokenVerifier::verify(const AuthToken& to
   return folly::makeUnexpected(AuthError::BadSignature);
 }
 
-folly::Expected<std::shared_ptr<const Grants>, AuthError>
+folly::Expected<std::shared_ptr<const std::vector<Grants>>, AuthError>
 authenticateSetup(const AuthTokenVerifier& verifier, const Parameters& setupParams) {
   if (!verifier.enabled()) {
-    return std::shared_ptr<const Grants>{};
+    return std::shared_ptr<const std::vector<Grants>>{};
   }
-  if (auto token = findAuthToken(setupParams, verifier.tokenType())) {
-    auto verified = verifier.verify(*token);
+
+  auto tokens = findAuthTokens(setupParams, verifier.tokenType());
+  std::vector<Grants> verifiedGrants;
+  std::optional<AuthError> firstError;
+  for (const auto& token : tokens) {
+    auto verified = verifier.verify(token);
     if (verified.hasError()) {
-      return folly::makeUnexpected(verified.error());
+      if (!firstError) {
+        firstError = verified.error();
+      }
+      continue;
     }
-    if (!allows(verified.value(), Action::ClientSetup, TrackNamespace{})) {
-      return folly::makeUnexpected(AuthError::Forbidden);
-    }
-    return std::make_shared<const Grants>(std::move(verified.value()));
+    verifiedGrants.push_back(std::move(verified.value()));
   }
+
+  if (!tokens.empty()) {
+    // At least one setup token was presented; the session is authorized iff
+    // any of the verified ones grants ClientSetup. All verified tokens' other
+    // scopes still pool into the session grants below, not just the one that
+    // happened to grant ClientSetup.
+    if (!allowsAny(verifiedGrants, Action::ClientSetup, TrackNamespace{})) {
+      return folly::makeUnexpected(firstError.value_or(AuthError::Forbidden));
+    }
+    return std::make_shared<const std::vector<Grants>>(std::move(verifiedGrants));
+  }
+
   if (verifier.requireSetupToken()) {
     return folly::makeUnexpected(AuthError::Missing);
   }
-  // No setup token but not required: connect with empty grants; requests must
-  // then carry their own tokens to be authorized.
-  return std::make_shared<const Grants>();
+  // No setup token but not required: connect with empty session grants;
+  // requests must then carry their own tokens to be authorized (see authorize()).
+  return std::make_shared<const std::vector<Grants>>();
 }
 
 folly::Expected<folly::Unit, AuthError> authorize(
@@ -207,57 +223,54 @@ folly::Expected<folly::Unit, AuthError> authorize(
     Action action,
     const Parameters& params,
     const TrackNamespace& ns,
-    const Grants& sessionGrants,
+    const std::vector<Grants>& sessionGrants,
     std::optional<std::string_view> trackName
 ) {
   if (!verifier.enabled()) {
     return folly::unit;
   }
 
-  auto token = findAuthToken(params, verifier.tokenType());
-  if (token && !verifier.allowRequestTokenOverride()) {
-    // Request carried a per-request token but override is disabled, so the
-    // session-setup grants govern; log rather than fail.
-    XLOG(DBG1) << "authorize: ignoring request AUTHORIZATION_TOKEN for action="
-               << static_cast<uint64_t>(action) << " (allow_request_token_override is disabled)";
-    token.reset();
-  }
-
-  // Resolve grants from exactly one source (request token or session).
-  const Grants* grants = nullptr;
-  Grants verified;
-  if (token) {
-    auto res = verifier.verify(*token);
-    if (res.hasError()) {
-      XLOG(DBG1) << "authorize: request token verification failed for action="
-                 << static_cast<uint64_t>(action) << ": " << toString(res.error());
-      return folly::makeUnexpected(res.error());
+  std::vector<Grants> requestGrants;
+  std::optional<AuthError> firstError;
+  if (verifier.allowRequestTokenOverride()) {
+    for (const auto& token : findAuthTokens(params, verifier.tokenType())) {
+      auto res = verifier.verify(token);
+      if (res.hasError()) {
+        // Dropped as a non-viable candidate — another request token or a
+        // session grant may still cover the action.
+        if (!firstError) {
+          firstError = res.error();
+        }
+        continue;
+      }
+      requestGrants.push_back(std::move(res.value()));
     }
-    verified = std::move(res.value());
-    grants = &verified;
-  } else {
-    grants = &sessionGrants;
+  } else if (!findAuthTokens(params, verifier.tokenType()).empty()) {
+    XLOG(DBG1) << "authorize: ignoring request AUTHORIZATION_TOKEN(s) for action="
+               << static_cast<uint64_t>(action) << " (allow_request_token_override is disabled)";
   }
 
-  const bool permitted = trackName
-                             ? allows(*grants, action, FullTrackName{ns, std::string(*trackName)})
-                             : allows(*grants, action, ns);
+  const bool permitted =
+      trackName ? (allowsAny(requestGrants, action, FullTrackName{ns, std::string(*trackName)}) ||
+                   allowsAny(sessionGrants, action, FullTrackName{ns, std::string(*trackName)}))
+                : (allowsAny(requestGrants, action, ns) || allowsAny(sessionGrants, action, ns));
   if (!permitted) {
     XLOG(DBG1) << "authorize: action=" << static_cast<uint64_t>(action)
                << " not permitted for ns=" << ns;
-    return folly::makeUnexpected(AuthError::Forbidden);
+    return folly::makeUnexpected(firstError.value_or(AuthError::Forbidden));
   }
   return folly::unit;
 }
 
-std::optional<AuthToken> findAuthToken(const Parameters& params, uint64_t tokenType) {
+std::vector<AuthToken> findAuthTokens(const Parameters& params, uint64_t tokenType) {
   const auto authKey = folly::to_underlying(TrackRequestParamKey::AUTHORIZATION_TOKEN);
+  std::vector<AuthToken> tokens;
   for (const auto& param : params) {
     if (param.key == authKey && param.asAuthToken.tokenType == tokenType) {
-      return param.asAuthToken;
+      tokens.push_back(param.asAuthToken);
     }
   }
-  return std::nullopt;
+  return tokens;
 }
 
 namespace {
@@ -322,6 +335,28 @@ bool allows(
     std::chrono::system_clock::time_point now
 ) {
   return allowsImpl(grants, action, ftn.trackNamespace, std::string_view(ftn.trackName), now);
+}
+
+bool allowsAny(
+    const std::vector<Grants>& grantsList,
+    Action action,
+    const TrackNamespace& ns,
+    std::chrono::system_clock::time_point now
+) {
+  return std::any_of(grantsList.begin(), grantsList.end(), [&](const Grants& grants) {
+    return allows(grants, action, ns, now);
+  });
+}
+
+bool allowsAny(
+    const std::vector<Grants>& grantsList,
+    Action action,
+    const FullTrackName& ftn,
+    std::chrono::system_clock::time_point now
+) {
+  return std::any_of(grantsList.begin(), grantsList.end(), [&](const Grants& grants) {
+    return allows(grants, action, ftn, now);
+  });
 }
 
 const char* toString(AuthError error) {

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -87,8 +87,11 @@ private:
   std::unordered_map<std::string, std::size_t> keyIdIndex_;
 };
 
-std::optional<moxygen::AuthToken>
-findAuthToken(const moxygen::Parameters& params, uint64_t tokenType);
+// Returns every AUTHORIZATION_TOKEN parameter matching tokenType, not just the
+// first — a message may carry more than one, and a request is authorized if
+// any one of them verifies and covers the action (see authorize()).
+std::vector<moxygen::AuthToken>
+findAuthTokens(const moxygen::Parameters& params, uint64_t tokenType);
 
 // Namespace-level authorization (e.g. PublishNamespace, SubscribeNamespace, setup).
 bool allows(
@@ -106,21 +109,40 @@ bool allows(
     std::chrono::system_clock::time_point now = std::chrono::system_clock::now()
 );
 
+// True if any element of grantsList allows the action (namespace-level).
+bool allowsAny(
+    const std::vector<Grants>& grantsList,
+    Action action,
+    const moxygen::TrackNamespace& ns,
+    std::chrono::system_clock::time_point now = std::chrono::system_clock::now()
+);
+
+// True if any element of grantsList allows the action (track-level).
+bool allowsAny(
+    const std::vector<Grants>& grantsList,
+    Action action,
+    const moxygen::FullTrackName& ftn,
+    std::chrono::system_clock::time_point now = std::chrono::system_clock::now()
+);
+
 const char* toString(AuthError error);
 
-// Verifies the setup AUTHORIZATION_TOKEN. Returns null grants when auth is
-// disabled; shared grants (possibly empty) to gate the session otherwise.
-folly::Expected<std::shared_ptr<const Grants>, AuthError>
+// Verifies the setup AUTHORIZATION_TOKEN(s). Returns a null pointer when auth
+// is disabled; otherwise a shared vector of every successfully-verified
+// setup token's grants (possibly empty), gating the session on whether any
+// of them permits Action::ClientSetup.
+folly::Expected<std::shared_ptr<const std::vector<Grants>>, AuthError>
 authenticateSetup(const AuthTokenVerifier& verifier, const moxygen::Parameters& setupParams);
 
-// Authorizes a request against session grants, or a per-request token when
-// allow_request_token_override is set. Returns Unit when permitted.
+// Authorizes a request against session grants, or per-request token(s) when
+// allow_request_token_override is set. Permitted if any verified request
+// token, or any session grant, covers the action. Returns Unit when permitted.
 folly::Expected<folly::Unit, AuthError> authorize(
     const AuthTokenVerifier& verifier,
     Action action,
     const moxygen::Parameters& params,
     const moxygen::TrackNamespace& ns,
-    const Grants& sessionGrants,
+    const std::vector<Grants>& sessionGrants,
     std::optional<std::string_view> trackName = std::nullopt
 );
 

--- a/src/relay/AuthFilters.h
+++ b/src/relay/AuthFilters.h
@@ -23,7 +23,7 @@ public:
   AuthPublisherFilter(
       std::shared_ptr<moxygen::Publisher> downstream,
       std::shared_ptr<const auth::AuthTokenVerifier> verifier,
-      std::shared_ptr<const auth::Grants> grants,
+      std::shared_ptr<const std::vector<auth::Grants>> grants,
       bool peeringEnabled
   )
       : downstream_(std::move(downstream)), verifier_(std::move(verifier)),
@@ -54,7 +54,7 @@ public:
 private:
   std::shared_ptr<moxygen::Publisher> downstream_;
   std::shared_ptr<const auth::AuthTokenVerifier> verifier_;
-  std::shared_ptr<const auth::Grants> grants_;
+  std::shared_ptr<const std::vector<auth::Grants>> grants_;
   bool peeringEnabled_;
 };
 
@@ -65,7 +65,7 @@ public:
   AuthSubscriberFilter(
       std::shared_ptr<moxygen::Subscriber> downstream,
       std::shared_ptr<const auth::AuthTokenVerifier> verifier,
-      std::shared_ptr<const auth::Grants> grants
+      std::shared_ptr<const std::vector<auth::Grants>> grants
   )
       : downstream_(std::move(downstream)), verifier_(std::move(verifier)),
         grants_(std::move(grants)) {}
@@ -85,7 +85,7 @@ public:
 private:
   std::shared_ptr<moxygen::Subscriber> downstream_;
   std::shared_ptr<const auth::AuthTokenVerifier> verifier_;
-  std::shared_ptr<const auth::Grants> grants_;
+  std::shared_ptr<const std::vector<auth::Grants>> grants_;
 };
 
 } // namespace openmoq::moqx

--- a/test/AuthTest.cpp
+++ b/test/AuthTest.cpp
@@ -134,7 +134,32 @@ TEST(AuthTest, AllowsRejectsEmptyScopesAndExpiredGrants) {
   );
 }
 
-TEST(AuthTest, FindAuthTokenSelectsMatchingAuthorizationToken) {
+TEST(AuthTest, AllowsAnyPermitsWhenAnyElementAllows) {
+  TrackNamespace ns{{"live"}};
+  std::vector<Grants> grantsList{
+      makeGrants({Action::Publish}, {}, {}),
+      makeGrants({Action::Subscribe}, {}, {}),
+  };
+  EXPECT_TRUE(allowsAny(grantsList, Action::Subscribe, ns));
+  EXPECT_TRUE(allowsAny(grantsList, Action::Subscribe, FullTrackName{ns, "video"}));
+  EXPECT_FALSE(allowsAny(grantsList, Action::Fetch, ns));
+}
+
+TEST(AuthTest, AllowsAnyDeniesWhenNoElementAllows) {
+  std::vector<Grants> grantsList{makeGrants({Action::Publish}, {}, {})};
+  TrackNamespace ns{{"live"}};
+  EXPECT_FALSE(allowsAny(grantsList, Action::Subscribe, ns));
+  EXPECT_FALSE(allowsAny(grantsList, Action::Subscribe, FullTrackName{ns, "video"}));
+}
+
+TEST(AuthTest, AllowsAnyOnEmptyVectorIsFalse) {
+  std::vector<Grants> empty;
+  TrackNamespace ns{{"live"}};
+  EXPECT_FALSE(allowsAny(empty, Action::Subscribe, ns));
+  EXPECT_FALSE(allowsAny(empty, Action::Subscribe, FullTrackName{ns, "video"}));
+}
+
+TEST(AuthTest, FindAuthTokensSelectsMatchingAuthorizationToken) {
   Parameters params(FrameType::SUBSCRIBE);
   ASSERT_TRUE(
       params
@@ -153,10 +178,45 @@ TEST(AuthTest, FindAuthTokenSelectsMatchingAuthorizationToken) {
           .hasValue()
   );
 
-  auto token = findAuthToken(params, 77);
-  ASSERT_TRUE(token.has_value());
-  EXPECT_EQ(token->tokenValue, "right");
-  EXPECT_FALSE(findAuthToken(params, 78).has_value());
+  auto tokens = findAuthTokens(params, 77);
+  ASSERT_EQ(tokens.size(), 1);
+  EXPECT_EQ(tokens[0].tokenValue, "right");
+  EXPECT_TRUE(findAuthTokens(params, 78).empty());
+}
+
+TEST(AuthTest, FindAuthTokensReturnsAllMatchingTokens) {
+  Parameters params(FrameType::SUBSCRIBE);
+  ASSERT_TRUE(
+      params
+          .insertParam(Parameter(
+              static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),
+              AuthToken{.tokenType = 77, .tokenValue = "first", .alias = AuthToken::DontRegister}
+          ))
+          .hasValue()
+  );
+  ASSERT_TRUE(params
+                  .insertParam(Parameter(
+                      static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),
+                      AuthToken{
+                          .tokenType = 76,
+                          .tokenValue = "other-type",
+                          .alias = AuthToken::DontRegister
+                      }
+                  ))
+                  .hasValue());
+  ASSERT_TRUE(
+      params
+          .insertParam(Parameter(
+              static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),
+              AuthToken{.tokenType = 77, .tokenValue = "second", .alias = AuthToken::DontRegister}
+          ))
+          .hasValue()
+  );
+
+  auto tokens = findAuthTokens(params, 77);
+  ASSERT_EQ(tokens.size(), 2);
+  EXPECT_EQ(tokens[0].tokenValue, "first");
+  EXPECT_EQ(tokens[1].tokenValue, "second");
 }
 
 TEST(AuthTest, RejectsBadSignature) {
@@ -251,4 +311,167 @@ TEST(AuthTest, MultiRuleCompoundMatchRoundtripsViaCwt) {
   EXPECT_TRUE(allows(result.value(), Action::Subscribe, FullTrackName{ns, "live-stream.mp4"}));
   EXPECT_FALSE(allows(result.value(), Action::Subscribe, FullTrackName{ns, "live-stream.ts"}));
   EXPECT_FALSE(allows(result.value(), Action::Subscribe, FullTrackName{ns, "vod-stream.mp4"}));
+}
+
+// --- authorize(): multi-token, any-satisfies pooling ---
+
+namespace {
+
+Parameters withAuthToken(FrameType frameType, AuthToken token) {
+  Parameters params(frameType);
+  auto ok = params.insertParam(
+      Parameter(static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN), std::move(token))
+  );
+  EXPECT_TRUE(ok.hasValue());
+  return params;
+}
+
+} // namespace
+
+TEST(AuthTest, AuthorizeRequestTokenGrantsWhenSessionGrantsDoNot) {
+  TrackNamespace ns{{"live"}};
+  AuthTokenVerifier verifier(makeConfig());
+  auto params =
+      withAuthToken(FrameType::SUBSCRIBE, makeToken(makeGrants({Action::Subscribe}, {}, {})));
+
+  std::vector<Grants> sessionGrants; // empty: session alone doesn't cover Subscribe
+  auto result = authorize(verifier, Action::Subscribe, params, ns, sessionGrants, "video");
+  EXPECT_TRUE(result.hasValue());
+}
+
+TEST(AuthTest, AuthorizeSessionGrantsGrantWhenNoRequestToken) {
+  TrackNamespace ns{{"live"}};
+  AuthTokenVerifier verifier(makeConfig());
+  Parameters params(FrameType::SUBSCRIBE); // no request-level token
+  std::vector<Grants> sessionGrants{makeGrants({Action::Subscribe}, {}, {})};
+
+  auto result = authorize(verifier, Action::Subscribe, params, ns, sessionGrants, "video");
+  EXPECT_TRUE(result.hasValue());
+}
+
+TEST(AuthTest, AuthorizeGarbageRequestTokenDoesNotBlockSessionGrants) {
+  TrackNamespace ns{{"live"}};
+  AuthTokenVerifier verifier(makeConfig());
+  auto params = withAuthToken(
+      FrameType::SUBSCRIBE,
+      AuthToken{
+          .tokenType = 77,
+          .tokenValue = std::string("\xde\xad\xbe\xef", 4),
+          .alias = AuthToken::DontRegister
+      }
+  );
+  std::vector<Grants> sessionGrants{makeGrants({Action::Subscribe}, {}, {})};
+
+  auto result = authorize(verifier, Action::Subscribe, params, ns, sessionGrants, "video");
+  EXPECT_TRUE(result.hasValue());
+}
+
+TEST(AuthTest, AuthorizeReturnsMostSpecificErrorWhenNothingPermits) {
+  TrackNamespace ns{{"live"}};
+  AuthTokenVerifier verifier(makeConfig());
+  auto badToken = makeToken(makeGrants({Action::Subscribe}, {}, {}));
+  badToken.tokenValue.back() ^= 0x01; // corrupt signature
+  auto params = withAuthToken(FrameType::SUBSCRIBE, std::move(badToken));
+  std::vector<Grants> sessionGrants; // doesn't cover the action either
+
+  auto result = authorize(verifier, Action::Subscribe, params, ns, sessionGrants, "video");
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error(), AuthError::BadSignature);
+}
+
+TEST(AuthTest, AuthorizeReturnsForbiddenWhenNothingCoversAction) {
+  TrackNamespace ns{{"live"}};
+  AuthTokenVerifier verifier(makeConfig());
+  Parameters params(FrameType::SUBSCRIBE);                                  // no request token
+  std::vector<Grants> sessionGrants{makeGrants({Action::Publish}, {}, {})}; // different action
+
+  auto result = authorize(verifier, Action::Subscribe, params, ns, sessionGrants, "video");
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error(), AuthError::Forbidden);
+}
+
+// --- authenticateSetup(): multi-token, any-satisfies pooling ---
+
+TEST(AuthTest, AuthenticateSetupAcceptsAnyOfMultipleSetupTokens) {
+  AuthTokenVerifier verifier(makeConfig());
+  auto badToken = makeToken(makeGrants({Action::ClientSetup}, {}, {}));
+  badToken.tokenValue.back() ^= 0x01; // corrupt signature
+
+  Parameters params(FrameType::CLIENT_SETUP);
+  ASSERT_TRUE(
+      params
+          .insertParam(
+              Parameter(static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN), badToken)
+          )
+          .hasValue()
+  );
+  ASSERT_TRUE(params
+                  .insertParam(Parameter(
+                      static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),
+                      makeToken(makeGrants({Action::ClientSetup}, {}, {}))
+                  ))
+                  .hasValue());
+
+  auto result = authenticateSetup(verifier, params);
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_TRUE(result.value());
+  // Only the token that actually verified pools; the corrupted one is dropped.
+  EXPECT_EQ(result.value()->size(), 1u);
+}
+
+TEST(AuthTest, AuthenticateSetupPoolsAllVerifiedTokensRegardlessOfWhichGrantsClientSetup) {
+  AuthTokenVerifier verifier(makeConfig());
+  Parameters params(FrameType::CLIENT_SETUP);
+  ASSERT_TRUE(params
+                  .insertParam(Parameter(
+                      static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),
+                      makeToken(makeGrants({Action::ClientSetup}, {}, {}))
+                  ))
+                  .hasValue());
+  ASSERT_TRUE(params
+                  .insertParam(Parameter(
+                      static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),
+                      makeToken(makeGrants({Action::Subscribe}, {}, {}))
+                  ))
+                  .hasValue());
+
+  auto result = authenticateSetup(verifier, params);
+  ASSERT_TRUE(result.hasValue());
+  ASSERT_TRUE(result.value());
+  ASSERT_EQ(result.value()->size(), 2u);
+  EXPECT_TRUE(allowsAny(*result.value(), Action::Subscribe, TrackNamespace{}));
+}
+
+TEST(AuthTest, AuthenticateSetupRejectsWhenNoTokenGrantsClientSetup) {
+  AuthTokenVerifier verifier(makeConfig());
+  Parameters params(FrameType::CLIENT_SETUP);
+  ASSERT_TRUE(params
+                  .insertParam(Parameter(
+                      static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN),
+                      makeToken(makeGrants({Action::Subscribe}, {}, {}))
+                  ))
+                  .hasValue());
+
+  auto result = authenticateSetup(verifier, params);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error(), AuthError::Forbidden);
+}
+
+TEST(AuthTest, AuthenticateSetupSurfacesMostSpecificErrorWhenNothingGrantsClientSetup) {
+  AuthTokenVerifier verifier(makeConfig());
+  auto badToken = makeToken(makeGrants({Action::ClientSetup}, {}, {}));
+  badToken.tokenValue.back() ^= 0x01; // corrupt signature
+
+  Parameters params(FrameType::CLIENT_SETUP);
+  ASSERT_TRUE(
+      params
+          .insertParam(
+              Parameter(static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN), badToken)
+          )
+          .hasValue()
+  );
+
+  auto result = authenticateSetup(verifier, params);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error(), AuthError::BadSignature);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -273,6 +273,18 @@ target_link_libraries(moqx_auth_token_issuer_test PRIVATE
 )
 gtest_discover_tests(moqx_auth_token_issuer_test)
 
+add_executable(moqx_auth_filters_test
+  relay/AuthFiltersTest.cpp
+)
+target_link_libraries(moqx_auth_filters_test PRIVATE
+  moqx_core
+  moqx_issuer_lib
+  GTest::gtest_main
+  GTest::gmock
+  moxygen::moqtest_utils
+)
+gtest_discover_tests(moqx_auth_filters_test)
+
 # CborReader unit tests (header-only decoder, tested in isolation)
 add_executable(moqx_cbor_reader_test
   CborReaderTest.cpp

--- a/test/relay/AuthFiltersTest.cpp
+++ b/test/relay/AuthFiltersTest.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/AuthFilters.h"
+
+#include "auth/AuthTokenIssuer.h"
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <moxygen/test/Mocks.h>
+
+using testing::_;
+using testing::NiceMock;
+using namespace moxygen;
+using namespace openmoq::moqx;
+using namespace openmoq::moqx::auth;
+
+namespace {
+
+config::AuthConfig makeVerifierConfig() {
+  return config::AuthConfig{
+      .enabled = true,
+      .tokenType = 77,
+      .hmacKeys = {config::AuthConfig::HmacKey{.id = "k1", .secret = "secret"}},
+      .requireSetupToken = true,
+      .allowRequestTokenOverride = true,
+  };
+}
+
+Grants makeGrants(std::vector<Action> actions) {
+  Grants grants;
+  grants.expiresAt = std::chrono::system_clock::now() + std::chrono::hours(1);
+  grants.scopes.push_back(
+      Scope{.actions = std::move(actions), .namespaceMatches = {}, .trackMatches = {}}
+  );
+  return grants;
+}
+
+AuthToken makeSignedToken(std::vector<Action> actions) {
+  return AuthToken{
+      .tokenType = 77,
+      .tokenValue = signGrants("k1", "secret", makeGrants(std::move(actions))),
+      .alias = AuthToken::DontRegister,
+  };
+}
+
+Parameters withAuthToken(FrameType frameType, AuthToken token) {
+  Parameters params(frameType);
+  auto ok = params.insertParam(
+      Parameter(static_cast<uint64_t>(TrackRequestParamKey::AUTHORIZATION_TOKEN), std::move(token))
+  );
+  EXPECT_TRUE(ok.hasValue());
+  return params;
+}
+
+class AuthFiltersTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    verifier_ = std::make_shared<const AuthTokenVerifier>(makeVerifierConfig());
+    publisherInner_ = std::make_shared<NiceMock<MockPublisher>>();
+    subscriberInner_ = std::make_shared<NiceMock<MockSubscriber>>();
+  }
+
+  std::shared_ptr<AuthPublisherFilter> makePublisherFilter(std::vector<Grants> sessionGrants) {
+    return std::make_shared<AuthPublisherFilter>(
+        publisherInner_,
+        verifier_,
+        std::make_shared<const std::vector<Grants>>(std::move(sessionGrants)),
+        /*peeringEnabled=*/false
+    );
+  }
+
+  std::shared_ptr<AuthSubscriberFilter> makeSubscriberFilter(std::vector<Grants> sessionGrants) {
+    return std::make_shared<AuthSubscriberFilter>(
+        subscriberInner_,
+        verifier_,
+        std::make_shared<const std::vector<Grants>>(std::move(sessionGrants))
+    );
+  }
+
+  std::shared_ptr<const AuthTokenVerifier> verifier_;
+  std::shared_ptr<NiceMock<MockPublisher>> publisherInner_;
+  std::shared_ptr<NiceMock<MockSubscriber>> subscriberInner_;
+};
+
+} // namespace
+
+// Two session-grants entries where only the second covers Subscribe: the
+// filter must permit it (any pool element satisfying is enough).
+TEST_F(AuthFiltersTest, SubscribeSucceedsWhenAnySessionGrantCoversIt) {
+  auto filter =
+      makePublisherFilter({makeGrants({Action::Publish}), makeGrants({Action::Subscribe})});
+
+  SubscribeOk ok;
+  ok.requestID = RequestID(1);
+  auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(ok);
+  EXPECT_CALL(*publisherInner_, subscribe(_, _))
+      .WillOnce(
+          [handle](SubscribeRequest, std::shared_ptr<TrackConsumer>)
+              -> folly::coro::Task<Publisher::SubscribeResult> {
+            co_return folly::makeExpected<SubscribeError>(std::shared_ptr<SubscriptionHandle>(handle
+            ));
+          }
+      );
+
+  SubscribeRequest sub;
+  sub.requestID = RequestID(1);
+  sub.fullTrackName = FullTrackName{TrackNamespace{{"live"}}, "video"};
+  auto result = folly::coro::blockingWait(filter->subscribe(std::move(sub), nullptr));
+  EXPECT_TRUE(result.hasValue());
+}
+
+TEST_F(AuthFiltersTest, SubscribeFailsWhenNoSessionGrantCoversIt) {
+  auto filter = makePublisherFilter({makeGrants({Action::Publish})});
+
+  SubscribeRequest sub;
+  sub.requestID = RequestID(2);
+  sub.fullTrackName = FullTrackName{TrackNamespace{{"live"}}, "video"};
+  auto result = folly::coro::blockingWait(filter->subscribe(std::move(sub), nullptr));
+  ASSERT_FALSE(result.hasValue());
+  EXPECT_EQ(result.error().errorCode, SubscribeErrorCode::UNAUTHORIZED);
+}
+
+// A malformed per-request token must be dropped as a non-viable candidate,
+// not block a still-valid session grant from permitting the request.
+TEST_F(AuthFiltersTest, SubscribeGarbageRequestTokenDoesNotBlockSessionGrant) {
+  auto filter = makePublisherFilter({makeGrants({Action::Subscribe})});
+
+  SubscribeOk ok;
+  ok.requestID = RequestID(3);
+  auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(ok);
+  EXPECT_CALL(*publisherInner_, subscribe(_, _))
+      .WillOnce(
+          [handle](SubscribeRequest, std::shared_ptr<TrackConsumer>)
+              -> folly::coro::Task<Publisher::SubscribeResult> {
+            co_return folly::makeExpected<SubscribeError>(std::shared_ptr<SubscriptionHandle>(handle
+            ));
+          }
+      );
+
+  SubscribeRequest sub;
+  sub.requestID = RequestID(3);
+  sub.fullTrackName = FullTrackName{TrackNamespace{{"live"}}, "video"};
+  sub.params = withAuthToken(
+      FrameType::SUBSCRIBE,
+      AuthToken{
+          .tokenType = 77,
+          .tokenValue = std::string("\xde\xad\xbe\xef", 4),
+          .alias = AuthToken::DontRegister
+      }
+  );
+  auto result = folly::coro::blockingWait(filter->subscribe(std::move(sub), nullptr));
+  EXPECT_TRUE(result.hasValue());
+}
+
+TEST_F(AuthFiltersTest, PublishRejectedWhenNoSessionGrantCoversIt) {
+  auto filter = makeSubscriberFilter({makeGrants({Action::Subscribe})});
+
+  PublishRequest pub;
+  pub.requestID = RequestID(4);
+  pub.fullTrackName = FullTrackName{TrackNamespace{{"live"}}, "video"};
+  auto result = filter->publish(std::move(pub), nullptr);
+  ASSERT_FALSE(result.hasValue());
+  EXPECT_EQ(result.error().errorCode, PublishErrorCode::UNAUTHORIZED);
+}
+
+// A per-request token additively unlocks Publish even though the session
+// grants alone (Subscribe only) don't cover it.
+TEST_F(AuthFiltersTest, PublishSucceedsWithRequestTokenWhenSessionGrantsDoNotCoverIt) {
+  auto filter = makeSubscriberFilter({makeGrants({Action::Subscribe})});
+
+  EXPECT_CALL(*subscriberInner_, publish(_, _))
+      .WillOnce(
+          [](PublishRequest pub, std::shared_ptr<SubscriptionHandle>) -> Subscriber::PublishResult {
+            PublishOk ok;
+            ok.requestID = pub.requestID;
+            return Subscriber::PublishConsumerAndReplyTask{
+                .consumer = nullptr,
+                .reply =
+                    folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(std::move(ok)),
+            };
+          }
+      );
+
+  PublishRequest pub;
+  pub.requestID = RequestID(5);
+  pub.fullTrackName = FullTrackName{TrackNamespace{{"live"}}, "video"};
+  pub.params = withAuthToken(FrameType::PUBLISH, makeSignedToken({Action::Publish}));
+  auto result = filter->publish(std::move(pub), nullptr);
+  EXPECT_TRUE(result.hasValue());
+}


### PR DESCRIPTION
Preparation for #530 

Related:
- https://github.com/moq-wg/moq-transport/issues/1838

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/552)
<!-- Reviewable:end -->
