### PR TITLE
test: eliminate intermittent macOS gtest-discovery build failure

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,11 @@
 find_package(GTest REQUIRED CONFIG)
 include(GoogleTest)
 
+# Discover tests at ctest startup (serial) instead of POST_BUILD (parallel).
+# Parallel POST_BUILD discovery races on a shared JSON file under cmake 4.4.0,
+# intermittently failing macOS builds with "JSON failed parsing".
+set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
+
 add_library(moqx_test_utils STATIC
   TestUtils.cpp
 )


### PR DESCRIPTION
## Problem

The macos job intermittently fails at build time with:

```
CMake Error at /opt/homebrew/share/cmake/Modules/GoogleTest/ParseTestList.cmake:96 (string):
  string sub-command JSON failed parsing json string:
  * Line 1, Column 1
    Syntax error: value, object or array expected.
```

(e.g. [this run](https://github.com/openmoq/moqx/actions/runs/31426525256/job/93579483228) on #533 — passed on rerun, unrelated to the PR's changes.)

## Root cause

CMake **4.4.0** (current Homebrew) has a regression in the GoogleTest module refactor: the generated `*_discovery.cmake` scripts omit `TEST_TARGET`, so the per-target hash that keys the discovery JSON file is computed from the empty string. Every test target in `build/test` therefore shares **one** file, `cmake_test_discovery_e3b0c44298.json` (`sha256("")`), defeating the race protection that hash exists for.

In default POST_BUILD mode, discovery runs right after each test binary links — and Ninja links many test binaries near-simultaneously (the failing run linked three within 0.2 s). Concurrent discoveries then race on the shared file: one truncates/removes it while another parses → empty JSON → the error above. Intermittent by nature; the losing target varies. Fixed upstream in cmake 4.4.1, which Homebrew doesn't ship yet.

## Fix

Switch discovery to `PRE_TEST` mode (one `set()` before the `gtest_discover_tests()` calls). Discovery then runs serially at ctest startup — immune to the race on any cmake version.

## Cost

- **Build step:** slightly faster — the ~28 post-link discovery executions disappear from the build.
- **Test step:** +0.8 s measured to enumerate all 772 tests on first `ctest` invocation; cached via an `IS_NEWER_THAN` guard thereafter (measured 0.12 s), re-discovering only binaries that actually relinked.

## Validation (local, linux, cmake 4.2.3)

- Reconfigured + full build: discovery steps gone from the build graph; generated `*_include.cmake` files now carry the guarded `gtest_discover_tests_impl` call.
- `ctest -N`: all 772 tests enumerated.
- Targeted run of 306 tests: all pass. (`UpstreamProviderTest` network tests fail/hang on this dev box with or without the change — pre-existing local-env issue; CI is the gate for those.)

Note for #519: `moqx_add_gtest()` there still uses default POST_BUILD discovery, so this line should survive the rework (or move into the helper as `DISCOVERY_MODE PRE_TEST`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/556)
<!-- Reviewable:end -->
