### PR TITLE
admin: report start_time and uptime_seconds from /info

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -109,7 +109,7 @@ moqx --config c.yaml --log_backtrace_at "MoQForwarder.cpp:819"
 
 ```bash
 curl http://localhost:8000/info
-# {"service":"moqx","version":"0.1.0"}
+# {"service":"moqx","version":"0.1.0","start_time":1754870400,"uptime_seconds":42}
 ```
 
 ## Diagnosing Issues

--- a/docker/json-exporter/json-exporter.yml
+++ b/docker/json-exporter/json-exporter.yml
@@ -40,9 +40,10 @@ modules:
           relay_id: '{.relay_id}'
         values:
           active_sessions: '{.active_sessions}'
-  # Relay build info from the admin /info ({"service":"moqx","version":"x.y.z"}).
-  # The value is the jsonpath literal 1 — this is a labels-only info metric
-  # (moqx_build_info{service,version} 1), standard build-info gauge pattern.
+  # Relay build info from the admin /info ({"service","version","start_time",
+  # "uptime_seconds"}). The info value is the jsonpath literal 1 — a labels-only
+  # info metric (moqx_build_info{service,version} 1), standard build-info gauge
+  # pattern. uptime/start_time make relay (not host) uptime graphable.
   moqx_info:
     metrics:
       - name: moqx_build
@@ -54,3 +55,5 @@ modules:
           version: '{.version}'
         values:
           info: '1'
+          uptime: '{.uptime_seconds}'
+          start_time: '{.start_time}'

--- a/docs/config.md
+++ b/docs/config.md
@@ -454,7 +454,7 @@ Prometheus a series set that reshuffles between scrapes.  See [docs/metrics.md] 
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/info` | Returns `{"service":"moqx","version":"..."}`. |
+| `GET` | `/info` | Returns `{"service":"moqx","version":"...","start_time":<epoch seconds>,"uptime_seconds":<n>}`. |
 | `GET` | `/metrics` | Prometheus-format metrics. See [docs/metrics.md](metrics.md) (pending PR #137). |
 | `GET` | `/metrics/track` | Per-track Prometheus metrics for live tracks. See [docs/metrics.md](metrics.md). |
 | `GET` | `/state` | Relay state: connected peers, active subscriptions, namespace tree, and cache stats. Pending PR #146. |

--- a/src/admin/BuiltinRoutes.cpp
+++ b/src/admin/BuiltinRoutes.cpp
@@ -6,6 +6,9 @@
 
 #include "admin/BuiltinRoutes.h"
 
+#include <chrono>
+
+#include <folly/Conv.h>
 #include <folly/io/IOBuf.h>
 #include <proxygen/httpserver/ResponseBuilder.h>
 #include <proxygen/lib/http/HTTPMessage.h>
@@ -16,15 +19,34 @@
 namespace openmoq::moqx::admin {
 
 void registerBuiltinRoutes(AdminServer& server) {
+  // Registration happens once during startup, so this is the process start for
+  // dashboard purposes. steady_clock drives uptime so wall-clock jumps (NTP)
+  // can't make it go backwards.
+  const auto startWall = std::chrono::system_clock::now();
+  const auto startSteady = std::chrono::steady_clock::now();
+  const auto startEpoch =
+      std::chrono::duration_cast<std::chrono::seconds>(startWall.time_since_epoch()).count();
+
   server.addRoute(
       "GET",
       "/info",
-      [](auto /*req*/, auto /*body*/, auto* downstream, auto /*cancelToken*/) {
+      [startEpoch,
+       startSteady](auto /*req*/, auto /*body*/, auto* downstream, auto /*cancelToken*/) {
+        const auto uptime = std::chrono::duration_cast<std::chrono::seconds>(
+                                std::chrono::steady_clock::now() - startSteady
+        )
+                                .count();
+        auto body = folly::to<std::string>(
+            "{\"service\":\"moqx\",\"version\":\"" MOQX_VERSION "\",\"start_time\":",
+            startEpoch,
+            ",\"uptime_seconds\":",
+            uptime,
+            "}\n"
+        );
         proxygen::ResponseBuilder(downstream)
             .status(200, proxygen::HTTPMessage::getDefaultReason(200))
             .header("Content-Type", "application/json")
-            .body(folly::IOBuf::copyBuffer("{\"service\":\"moqx\",\"version\":\"" MOQX_VERSION
-                                           "\"}\n"))
+            .body(folly::IOBuf::copyBuffer(body))
             .sendWithEOM();
       }
   );

--- a/test/test_admin_info.sh
+++ b/test/test_admin_info.sh
@@ -55,4 +55,14 @@ if ! grep -q '"version":' <<<"$RESPONSE"; then
   exit 1
 fi
 
+if ! grep -qE '"start_time":[0-9]{10}' <<<"$RESPONSE"; then
+  echo "FAIL: missing/implausible \"start_time\" field in response" >&2
+  exit 1
+fi
+
+if ! grep -qE '"uptime_seconds":[0-9]+' <<<"$RESPONSE"; then
+  echo "FAIL: missing \"uptime_seconds\" field in response" >&2
+  exit 1
+fi
+
 echo "PASS"


### PR DESCRIPTION
Prometheus has no view of relay process start (no cAdvisor, no process_start_time_seconds in /metrics), so dashboards can only show host uptime. Serve both from /info and map them in the moqx_info json-exporter module.

The dashboard side is left alone on purpose: the banner UPTIME line is three expressions (days/hours/minutes) off node_boot_time_seconds, and pointing them at moqx_build_uptime changes what that card means from host to relay.

Fixes: #507

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/572)
<!-- Reviewable:end -->
