### PR TITLE
relay: send track name across executors, not forwarder refs

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -15,6 +15,7 @@
 #include "relay/NullConsumers.h"
 #include "relay/PublisherCrossExecFilter.h"
 #include "relay/SubscriberCrossExecFilter.h"
+#include "relay/TrackEventCallback.h"
 #include "relay/TrackStatsFilter.h"
 #include "relay/WeakRelayForwarderCallback.h"
 #include <folly/Random.h>
@@ -622,7 +623,7 @@ LocalForwarderRegistry::Claim MoqxRelay::installPublisherForwarder(
   auto& localReg = localRegistry();
   auto relayAdapter = std::make_shared<WeakRelayForwarderCallback>(weak_from_this());
   auto crossExec =
-      std::make_shared<CrossExecForwarderCallback>(relayExec_, fwd, std::move(relayAdapter));
+      std::make_shared<CrossExecForwarderCallback>(relayExec_, std::move(relayAdapter));
   fwd->setCallback(
       std::make_shared<LocalForwarderCallback>(&localReg, ftn, std::move(crossExec), removeOnEmpty)
   );
@@ -1039,7 +1040,7 @@ void teardownLocalForwarderOnFailure(
 //
 // Multi-threaded — publisher forwarder (lives on publisherExec):
 //   publisherFwd.callback =
-//     CrossExecForwarderCallback(relayExec_, publisherFwd,
+//     CrossExecForwarderCallback(relayExec_,
 //       WeakRelayForwarderCallback(relay))
 //
 //   [publisherExec] CrossExecForwarderCallback: captures ftn by value,
@@ -1056,7 +1057,7 @@ void teardownLocalForwarderOnFailure(
 //   After setup:
 //     localFwd.callback =
 //       LocalForwarderCallback(localReg, ftn,
-//         CrossExecForwarderCallback(publisherExec, localFwd,
+//         CrossExecForwarderCallback(publisherExec,
 //           ChannelForwarderCallback(publisherFwd, subscriberExec, publisherExec)))
 //
 //   [subscriberExec] LocalForwarderCallback: removes from localReg on onEmpty,
@@ -1071,10 +1072,8 @@ void teardownLocalForwarderOnFailure(
 // Weak-ptr discipline:
 //   WeakRelayForwarderCallback holds weak_ptr<relay> to break the cycle
 //   registry → forwarder → callback → relay → registry.
-//   CrossExecForwarderCallback holds weak_ptr<forwarder> to avoid a permanent
-//   ownership cycle; it locks eagerly on the calling thread (where the forwarder
-//   is alive) and moves the shared_ptr into the lambda to keep it alive across
-//   the executor hop.
+//   CrossExecForwarderCallback reads the track name from the forwarder that invoked it
+//   — on the owner thread, where the forwarder is alive.
 
 // Captures forwardChanged/newGroupRequested/onEmpty during setup (getOrCreate→setCallback window)
 // so they can be replayed once the real callback is installed.
@@ -1104,7 +1103,7 @@ public:
 
 // Runs on the publisher forwarder's executor (publisher's iothread). Propagates
 // channel-subscriber lifecycle events to the publisher and upstream handle.
-class ChannelForwarderCallback : public moxygen::MoQForwarder::Callback {
+class ChannelForwarderCallback : public openmoq::moqx::TrackEventCallback {
 public:
   ChannelForwarderCallback(
       std::weak_ptr<moxygen::MoQForwarder> weakPublisher,
@@ -1123,7 +1122,7 @@ public:
   // letting in-flight this-capturing lambdas there run first (FIFO).
   void setFilter(std::shared_ptr<CrossExecFilter> filter) { crossExecFilter_ = std::move(filter); }
 
-  void onEmpty(moxygen::MoQForwarder* /*localFwd*/) override {
+  void onEmpty(const moxygen::FullTrackName& /*ftn*/) override {
     auto publisher = weakPublisher_.lock();
     if (publisher) {
       publisher->removeChannelSubscriberByExec(subscriberExec_);
@@ -1139,19 +1138,22 @@ public:
     }
   }
 
-  void forwardChanged(moxygen::MoQForwarder*, bool forward) override {
+  void forwardChanged(const moxygen::FullTrackName&, bool forward) override {
     if (!handle_) {
       return;
     }
     launchUpdate(publisherExec_, doSubscribeUpdate(handle_, forward));
   }
 
-  void newGroupRequested(moxygen::MoQForwarder*, uint64_t group) override {
+  void newGroupRequested(const moxygen::FullTrackName&, uint64_t group) override {
     if (!handle_) {
       return;
     }
     launchUpdate(publisherExec_, doNewGroupRequestUpdate(handle_, group));
   }
+
+  // publishDone drains the subscribers, so onEmpty follows and does the teardown.
+  void onPublishDone(const moxygen::FullTrackName& /*ftn*/) override {}
 
 private:
   std::weak_ptr<moxygen::MoQForwarder> weakPublisher_;
@@ -1170,15 +1172,13 @@ struct LocalToPublisherCallbacks {
 LocalToPublisherCallbacks buildLocalToPublisherCallbacks(
     openmoq::moqx::LocalForwarderRegistry* localReg,
     moxygen::FullTrackName ftn,
-    const std::shared_ptr<moxygen::MoQForwarder>& localFwd,
     const std::shared_ptr<moxygen::MoQForwarder>& publisherFwd,
     folly::Executor* publisherExec,
     folly::Executor* subscriberExec
 ) {
   auto channelCb =
       std::make_shared<ChannelForwarderCallback>(publisherFwd, subscriberExec, publisherExec);
-  auto crossExecCb =
-      std::make_shared<CrossExecForwarderCallback>(publisherExec, localFwd, channelCb);
+  auto crossExecCb = std::make_shared<CrossExecForwarderCallback>(publisherExec, channelCb);
   auto finalCallback =
       std::make_shared<LocalForwarderCallback>(localReg, std::move(ftn), std::move(crossExecCb));
   return {std::move(channelCb), std::move(finalCallback)};
@@ -1205,7 +1205,6 @@ void installChannelSubscriber(
 folly::coro::Task<std::shared_ptr<moxygen::MoQForwarder::Callback>> addLocalForwarderToPublisher(
     openmoq::moqx::LocalForwarderRegistry* localReg,
     moxygen::FullTrackName ftn,
-    std::shared_ptr<moxygen::MoQForwarder> localFwd,
     std::shared_ptr<moxygen::MoQForwarder> publisherFwd,
     folly::Executor* publisherExec,
     folly::Executor* subscriberExec,
@@ -1215,7 +1214,6 @@ folly::coro::Task<std::shared_ptr<moxygen::MoQForwarder::Callback>> addLocalForw
   auto cbs = buildLocalToPublisherCallbacks(
       localReg,
       std::move(ftn),
-      localFwd,
       publisherFwd,
       publisherExec,
       subscriberExec
@@ -1318,7 +1316,6 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
   auto finalCallback = co_await addLocalForwarderToPublisher(
       localReg,
       ftn,
-      localFwd,
       publisherFwd,
       publisherExec,
       subscriberExec,
@@ -1950,7 +1947,7 @@ std::optional<SubscribeError> MoqxRelay::completeUpstreamSubscription(
 folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwarderOnRelayExec(
     const SubscribeRequest& subReq,
     LocalForwarderRegistry* localReg,
-    std::shared_ptr<MoQForwarder> localFwd,
+    std::shared_ptr<MoQForwarder> /*localFwd*/,
     folly::Executor* subscriberExec,
     std::shared_ptr<CrossExecFilter> crossExecFilter,
     bool forward
@@ -1977,7 +1974,6 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
   auto cbs = buildLocalToPublisherCallbacks(
       localReg,
       ftn,
-      localFwd,
       attach.publisherFwd,
       attach.publisherExec,
       subscriberExec

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -324,6 +324,8 @@ private:
   void forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) override;
   void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override;
 
+  friend class WeakRelayForwarderCallback;
+
   // FTN-keyed impl variants — called by the MoQForwarder::Callback overrides
   // above (single-thread) or by WeakRelayForwarderCallback on relay exec.
   void onEmptyImpl(const moxygen::FullTrackName& ftn);

--- a/src/relay/CrossExecForwarderCallback.cpp
+++ b/src/relay/CrossExecForwarderCallback.cpp
@@ -8,49 +8,30 @@
 
 namespace openmoq::moqx {
 
-void CrossExecForwarderCallback::onEmpty(moxygen::MoQForwarder* /*forwarder*/) {
-  auto f = forwarder_.lock();
-  if (!f) {
-    return;
-  }
-  targetExec_->add([f = std::move(f), downstream = downstream_]() mutable {
-    downstream->onEmpty(f.get());
+void CrossExecForwarderCallback::onEmpty(moxygen::MoQForwarder* forwarder) {
+  targetExec_->add([ftn = forwarder->fullTrackName(), downstream = downstream_]() mutable {
+    downstream->onEmpty(ftn);
   });
 }
 
-void CrossExecForwarderCallback::onPublishDone(moxygen::MoQForwarder* /*forwarder*/) {
-  auto f = forwarder_.lock();
-  if (!f) {
-    return;
-  }
-  targetExec_->add([f = std::move(f), downstream = downstream_]() mutable {
-    downstream->onPublishDone(f.get());
+void CrossExecForwarderCallback::onPublishDone(moxygen::MoQForwarder* forwarder) {
+  targetExec_->add([ftn = forwarder->fullTrackName(), downstream = downstream_]() mutable {
+    downstream->onPublishDone(ftn);
   });
 }
 
-void CrossExecForwarderCallback::forwardChanged(
-    moxygen::MoQForwarder* /*forwarder*/,
-    bool forward
-) {
-  auto f = forwarder_.lock();
-  if (!f) {
-    return;
-  }
-  targetExec_->add([f = std::move(f), downstream = downstream_, forward]() mutable {
-    downstream->forwardChanged(f.get(), forward);
+void CrossExecForwarderCallback::forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) {
+  targetExec_->add([ftn = forwarder->fullTrackName(), downstream = downstream_, forward]() mutable {
+    downstream->forwardChanged(ftn, forward);
   });
 }
 
 void CrossExecForwarderCallback::newGroupRequested(
-    moxygen::MoQForwarder* /*forwarder*/,
+    moxygen::MoQForwarder* forwarder,
     uint64_t group
 ) {
-  auto f = forwarder_.lock();
-  if (!f) {
-    return;
-  }
-  targetExec_->add([f = std::move(f), downstream = downstream_, group]() mutable {
-    downstream->newGroupRequested(f.get(), group);
+  targetExec_->add([ftn = forwarder->fullTrackName(), downstream = downstream_, group]() mutable {
+    downstream->newGroupRequested(ftn, group);
   });
 }
 

--- a/src/relay/CrossExecForwarderCallback.h
+++ b/src/relay/CrossExecForwarderCallback.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "relay/TrackEventCallback.h"
+
 #include <folly/Executor.h>
 #include <memory>
 #include <moxygen/relay/MoQForwarder.h>
@@ -13,18 +15,15 @@
 namespace openmoq::moqx {
 
 // Dispatches MoQForwarder::Callback methods to a target executor (fire-and-forget).
-// Locks the weak_ptr on the calling thread (where the forwarder is guaranteed alive)
-// and moves the resulting shared_ptr into the lambda, keeping the forwarder alive
-// across the executor hop without forming a permanent ownership cycle.
+// Reads the track name on the calling thread (the forwarder's owner) and sends that
+// across threads, so no reference to the forwarder can be released off its owner.
 class CrossExecForwarderCallback final : public moxygen::MoQForwarder::Callback {
 public:
   CrossExecForwarderCallback(
       folly::Executor* targetExec,
-      std::weak_ptr<moxygen::MoQForwarder> forwarder,
-      std::shared_ptr<moxygen::MoQForwarder::Callback> downstream
+      std::shared_ptr<TrackEventCallback> downstream
   )
-      : targetExec_(targetExec), forwarder_(std::move(forwarder)),
-        downstream_(std::move(downstream)) {}
+      : targetExec_(targetExec), downstream_(std::move(downstream)) {}
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
   void onPublishDone(moxygen::MoQForwarder* forwarder) override;
@@ -33,8 +32,7 @@ public:
 
 private:
   folly::Executor* targetExec_;
-  std::weak_ptr<moxygen::MoQForwarder> forwarder_;
-  std::shared_ptr<moxygen::MoQForwarder::Callback> downstream_;
+  std::shared_ptr<TrackEventCallback> downstream_;
 };
 
 } // namespace openmoq::moqx

--- a/src/relay/TrackEventCallback.h
+++ b/src/relay/TrackEventCallback.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <moxygen/relay/MoQForwarder.h>
+
+namespace openmoq::moqx {
+
+// TrackName based version of MoQForwarder::Callback.  Identifies the forwarder by track
+// name in cases where the forwarder itself may not be available.
+class TrackEventCallback {
+public:
+  virtual ~TrackEventCallback() = default;
+
+  virtual void onEmpty(const moxygen::FullTrackName& ftn) = 0;
+  virtual void forwardChanged(const moxygen::FullTrackName& ftn, bool forward) = 0;
+  virtual void newGroupRequested(const moxygen::FullTrackName& ftn, uint64_t group) = 0;
+  virtual void onPublishDone(const moxygen::FullTrackName& ftn) = 0;
+};
+
+} // namespace openmoq::moqx

--- a/src/relay/WeakRelayForwarderCallback.cpp
+++ b/src/relay/WeakRelayForwarderCallback.cpp
@@ -5,27 +5,48 @@
  */
 
 #include "WeakRelayForwarderCallback.h"
+
+#include "MoqxRelay.h"
+
 namespace openmoq::moqx {
 
 void WeakRelayForwarderCallback::onEmpty(moxygen::MoQForwarder* forwarder) {
-  if (auto r = relay_.lock()) {
-    r->onEmpty(forwarder);
-  }
+  onEmpty(forwarder->fullTrackName());
 }
 
 void WeakRelayForwarderCallback::forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) {
-  if (auto r = relay_.lock()) {
-    r->forwardChanged(forwarder, forward);
-  }
+  forwardChanged(forwarder->fullTrackName(), forward);
 }
 
 void WeakRelayForwarderCallback::newGroupRequested(
     moxygen::MoQForwarder* forwarder,
     uint64_t group
 ) {
+  newGroupRequested(forwarder->fullTrackName(), group);
+}
+
+void WeakRelayForwarderCallback::onEmpty(const moxygen::FullTrackName& ftn) {
   if (auto r = relay_.lock()) {
-    r->newGroupRequested(forwarder, group);
+    r->onEmptyImpl(ftn);
   }
 }
+
+void WeakRelayForwarderCallback::forwardChanged(const moxygen::FullTrackName& ftn, bool forward) {
+  if (auto r = relay_.lock()) {
+    r->forwardChangedImpl(ftn, forward);
+  }
+}
+
+void WeakRelayForwarderCallback::newGroupRequested(
+    const moxygen::FullTrackName& ftn,
+    uint64_t group
+) {
+  if (auto r = relay_.lock()) {
+    r->newGroupRequestedImpl(ftn, group);
+  }
+}
+
+// TerminationFilter already drives MoqxRelay::onPublishDone; delegating here would double it.
+void WeakRelayForwarderCallback::onPublishDone(const moxygen::FullTrackName& /*ftn*/) {}
 
 } // namespace openmoq::moqx

--- a/src/relay/WeakRelayForwarderCallback.h
+++ b/src/relay/WeakRelayForwarderCallback.h
@@ -6,27 +6,38 @@
 
 #pragma once
 
+#include "relay/TrackEventCallback.h"
+
 #include <memory>
 #include <moxygen/relay/MoQForwarder.h>
 
 namespace openmoq::moqx {
 
-// Relay-side MoQForwarder::Callback target. Holds a weak_ptr to the relay
-// (as its MoQForwarder::Callback base) to avoid a reference cycle
-// (registry → forwarder → callback → relay). Intended to be used as the
-// downstream of CrossExecForwarderCallback, which handles cross-exec
-// dispatch and forwarder pointer recovery.
-class WeakRelayForwarderCallback final : public moxygen::MoQForwarder::Callback {
+class MoqxRelay;
+
+// Relay-side sink for forwarder lifecycle events. Holds a weak_ptr to the relay to
+// avoid the cycle registry → forwarder → callback → relay.
+//
+// Installed directly on the forwarder in SingleThread/RelayExec and used as the
+// downstream of CrossExecForwarderCallback in LocalForwarder mode. The
+// MoQForwarder::Callback overrides only extract the track name and delegate, so both paths
+// run identical logic.
+class WeakRelayForwarderCallback final : public moxygen::MoQForwarder::Callback,
+                                         public TrackEventCallback {
 public:
-  explicit WeakRelayForwarderCallback(std::weak_ptr<moxygen::MoQForwarder::Callback> relay)
-      : relay_(std::move(relay)) {}
+  explicit WeakRelayForwarderCallback(std::weak_ptr<MoqxRelay> relay) : relay_(std::move(relay)) {}
 
   void onEmpty(moxygen::MoQForwarder* forwarder) override;
   void forwardChanged(moxygen::MoQForwarder* forwarder, bool forward) override;
   void newGroupRequested(moxygen::MoQForwarder* forwarder, uint64_t group) override;
 
+  void onEmpty(const moxygen::FullTrackName& ftn) override;
+  void forwardChanged(const moxygen::FullTrackName& ftn, bool forward) override;
+  void newGroupRequested(const moxygen::FullTrackName& ftn, uint64_t group) override;
+  void onPublishDone(const moxygen::FullTrackName& ftn) override;
+
 private:
-  std::weak_ptr<moxygen::MoQForwarder::Callback> relay_;
+  std::weak_ptr<MoqxRelay> relay_;
 };
 
 } // namespace openmoq::moqx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -341,6 +341,15 @@ moqx_add_gtest(moqx_cross_exec_filter_test
     Folly::folly_executors_manual_executor
 )
 
+moqx_add_gtest(moqx_cross_exec_forwarder_callback_test
+  SRCS CrossExecForwarderCallbackTest.cpp
+  LIBS
+    moqx_core
+    GTest::gtest_main
+    GTest::gmock
+    Folly::folly_executors_manual_executor
+)
+
 moqx_add_gtest(moqx_publisher_cross_exec_filter_test
   SRCS PublisherCrossExecFilterTest.cpp
   LIBS

--- a/test/CrossExecForwarderCallbackTest.cpp
+++ b/test/CrossExecForwarderCallbackTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/CrossExecForwarderCallback.h"
+
+#include <folly/executors/ManualExecutor.h>
+#include <folly/portability/GTest.h>
+
+#include <functional>
+#include <optional>
+#include <vector>
+
+using namespace testing;
+using namespace moxygen;
+using namespace openmoq::moqx;
+
+namespace {
+
+const TrackNamespace kTestNs{{"test", "namespace"}};
+const FullTrackName kFtn{kTestNs, "track1"};
+
+struct RecordingTrackEventCallback : public TrackEventCallback {
+  void onEmpty(const FullTrackName& ftn) override { onEmptyFtn = ftn; }
+
+  void forwardChanged(const FullTrackName& ftn, bool forward) override {
+    forwardChangedFtn = ftn;
+    lastForward = forward;
+  }
+
+  void newGroupRequested(const FullTrackName& ftn, uint64_t group) override {
+    newGroupFtn = ftn;
+    lastGroup = group;
+  }
+
+  void onPublishDone(const FullTrackName& ftn) override { publishDoneFtn = ftn; }
+
+  std::optional<FullTrackName> onEmptyFtn;
+  std::optional<FullTrackName> forwardChangedFtn;
+  std::optional<FullTrackName> newGroupFtn;
+  std::optional<FullTrackName> publishDoneFtn;
+  std::optional<bool> lastForward;
+  std::optional<uint64_t> lastGroup;
+};
+
+class CrossExecForwarderCallbackTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    downstream_ = std::make_shared<RecordingTrackEventCallback>();
+    cb_ = std::make_shared<CrossExecForwarderCallback>(&target_, downstream_);
+  }
+
+  folly::ManualExecutor target_;
+  std::shared_ptr<RecordingTrackEventCallback> downstream_;
+  std::shared_ptr<CrossExecForwarderCallback> cb_;
+};
+
+// All four callbacks post the same lambda shape, so all four must capture nothing that keeps the
+// forwarder alive.
+TEST_F(CrossExecForwarderCallbackTest, QueuedEventsCarryTheNameNotTheForwarder) {
+  using Fire = std::function<void(CrossExecForwarderCallback&, MoQForwarder*)>;
+  const std::pair<const char*, Fire> cases[] = {
+      {"onEmpty", [](CrossExecForwarderCallback& cb, MoQForwarder* f) { cb.onEmpty(f); }},
+      {"forwardChanged",
+       [](CrossExecForwarderCallback& cb, MoQForwarder* f) { cb.forwardChanged(f, true); }},
+      {"newGroupRequested",
+       [](CrossExecForwarderCallback& cb, MoQForwarder* f) { cb.newGroupRequested(f, 7); }},
+      {"onPublishDone", [](CrossExecForwarderCallback& cb, MoQForwarder* f) { cb.onPublishDone(f); }
+      }
+  };
+
+  // One callback per case, so no case can be perturbed by state a previous one left.
+  std::vector<std::shared_ptr<CrossExecForwarderCallback>> callbacks;
+  for (const auto& [name, fire] : cases) {
+    SCOPED_TRACE(name);
+    auto& cb =
+        callbacks.emplace_back(std::make_shared<CrossExecForwarderCallback>(&target_, downstream_));
+    auto forwarder = std::make_shared<MoQForwarder>(kFtn);
+    std::weak_ptr<MoQForwarder> weak = forwarder;
+    fire(*cb, forwarder.get());
+    // The owner thread drops its last ref once the registry entry is vacated.
+    forwarder.reset();
+    EXPECT_TRUE(weak.expired()) << "queued event must not keep the forwarder alive";
+  }
+
+  EXPECT_EQ(target_.run(), std::size(cases));
+  EXPECT_EQ(downstream_->onEmptyFtn, kFtn);
+  EXPECT_EQ(downstream_->forwardChangedFtn, kFtn);
+  EXPECT_EQ(downstream_->lastForward, true);
+  EXPECT_EQ(downstream_->newGroupFtn, kFtn);
+  EXPECT_EQ(downstream_->lastGroup, 7);
+  EXPECT_EQ(downstream_->publishDoneFtn, kFtn);
+}
+
+// The name is read where the forwarder is alive, but the downstream call runs on the target.
+TEST_F(CrossExecForwarderCallbackTest, DeliveryIsDeferredToTheTargetExecutor) {
+  auto forwarder = std::make_shared<MoQForwarder>(kFtn);
+  cb_->onEmpty(forwarder.get());
+
+  EXPECT_FALSE(downstream_->onEmptyFtn.has_value()) << "must not run inline on the caller";
+  EXPECT_EQ(target_.run(), 1);
+  EXPECT_TRUE(downstream_->onEmptyFtn.has_value());
+}
+
+} // namespace


### PR DESCRIPTION
CrossExecForwarderCallback locked its weak_ptr on the source thread and moved the resulting shared_ptr into the lambda it posted to the target executor. folly destroys that lambda after invoking it, on the target thread, so when that ref was the last one ~MoQForwarder ran off its owner. The destructor detaches subgroups, which resets QUIC streams and trips EventBase's evbTid == curTid check (moqx-io0 vs moqx-relay0). Under ASan, relay_chain aborted during teardown on the first iteration.

No consumer needed the forwarder: every downstream either read only fullTrackName() or ignored the pointer entirely, and onPublishDone reached a no-op base method. Read the name off the forwarder that invoked the callback, on its owner thread where it is alive, and send only that; recipients re-resolve by name.

Adds TrackEventCallback as the name-based downstream interface. WeakRelayForwarderCallback implements both it and MoQForwarder::Callback, since SingleThread/RelayExec install it directly on the forwarder with no hop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/573)
<!-- Reviewable:end -->
