### PR TITLE
relay: add ForwarderRef, an owner-thread handle to a MoQForwarder

### DIFF
--- a/src/relay/ForwarderRef.h
+++ b/src/relay/ForwarderRef.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <moxygen/relay/MoQForwarder.h>
+
+#include <folly/Executor.h>
+#include <folly/coro/Task.h>
+#include <folly/logging/xlog.h>
+
+#include <memory>
+#include <optional>
+#include <type_traits>
+
+namespace openmoq::moqx {
+
+// A track and the executor its forwarder lives on.  The receiver of this ref
+// can hop back to exec to get the latest publisher for this track.
+struct TrackRef {
+  moxygen::FullTrackName ftn;
+  folly::Executor* exec{nullptr};
+};
+
+// A reference to a MoQForwarder that may be held on any thread.  Two modes, fixed
+// at construction:
+//
+//   owned    SingleThread/RelayExec: one executor owns every forwarder and the
+//            holder runs on it, so the forwarder is available synchronously.
+//   remote   LocalForwarder: the forwarder lives on another executor, whose
+//            registry keeps it alive.  Holds weak + that executor, and never yields
+//            a pointer: post() and co_with() carry the work there rather than
+//            bringing the forwarder here.
+//
+// getIfOwned() returns null for a remote ref, so a caller on the relay executor
+// cannot reach a forwarder that lives elsewhere.  Code already running on the owner
+// holds its own weak_ptr rather than asking a ref to hand one over.
+//
+// The track name and owning executor are cached by value, so track() still answers
+// after the forwarder dies and a holder can still name what it was pointed at.
+class ForwarderRef {
+public:
+  ForwarderRef() = default;
+
+  ForwarderRef(const ForwarderRef&) = default;
+  ForwarderRef& operator=(const ForwarderRef&) = default;
+
+  // Leaves the source empty
+  ForwarderRef(ForwarderRef&& other) noexcept { *this = std::move(other); }
+  ForwarderRef& operator=(ForwarderRef&& other) noexcept {
+    if (this != &other) {
+      mode_ = std::exchange(other.mode_, Mode::Empty);
+      strong_ = std::move(other.strong_);
+      weak_ = std::move(other.weak_);
+      owner_ = std::move(other.owner_);
+      ftn_ = std::move(other.ftn_);
+    }
+    return *this;
+  }
+
+  // Non-LF modes, where the caller's executor is the only one that owns forwarders.
+  static ForwarderRef owned(std::shared_ptr<moxygen::MoQForwarder> forwarder) {
+    XCHECK(forwarder) << "owned() with a null forwarder";
+    ForwarderRef ref;
+    ref.mode_ = Mode::Owned;
+    ref.ftn_ = forwarder->fullTrackName();
+    ref.strong_ = std::move(forwarder);
+    return ref;
+  }
+
+  // LF mode. Minted where a strong ref is legitimately in hand, but only the weak survives in the
+  // ref.
+  static ForwarderRef remote(
+      const std::shared_ptr<moxygen::MoQForwarder>& forwarder,
+      folly::Executor::KeepAlive<> ownerExec
+  ) {
+    XCHECK(forwarder) << "remote() with a null forwarder";
+    XCHECK(ownerExec) << "remote() with no owner executor";
+    ForwarderRef ref;
+    ref.mode_ = Mode::Remote;
+    ref.ftn_ = forwarder->fullTrackName();
+    ref.weak_ = forwarder;
+    ref.owner_ = std::move(ownerExec);
+    return ref;
+  }
+
+  // A publication was referenced, whether or not it is still alive.
+  explicit operator bool() const { return mode_ != Mode::Empty; }
+
+  TrackRef track() const {
+    XCHECK(mode_ != Mode::Empty) << "track() on an empty ForwarderRef";
+    return TrackRef{ftn_, owner_.get()};
+  }
+
+  // Null in owned mode, where the holder is already on the owning executor.
+  folly::Executor* ownerExec() const { return owner_.get(); }
+
+  // Null unless this is an owned ref, where the caller owns the forwarder by
+  // construction.  Refuses in remote mode so a relay-exec caller cannot reach a
+  // forwarder that lives elsewhere.
+  std::shared_ptr<moxygen::MoQForwarder> getIfOwned() const { return strong_; }
+
+  // Fire-and-forget on the owner. Remote: enqueued, and fn runs only if the
+  // forwarder is still alive when the message arrives — liveness is judged on
+  // the owner thread. Owned: inline.
+  void post(folly::Function<void(moxygen::MoQForwarder&)> fn) const {
+    XCHECK(mode_ != Mode::Empty) << "post() on an empty ForwarderRef";
+    if (mode_ == Mode::Owned) {
+      fn(*strong_);
+      return;
+    }
+    owner_->add([weak = weak_, fn = std::move(fn)]() mutable {
+      if (auto fwd = weak.lock()) {
+        fn(*fwd);
+      }
+    });
+  }
+
+  // Round trip to the owner; nullopt if the forwarder died first. Not a coroutine -- it returns an
+  // awaitable Task. Every read of the ref happens now, and the callee's frame owns everything the
+  // Task touches later.
+  template <class Fn>
+  auto co_with(Fn fn) const
+      -> folly::coro::Task<std::optional<std::invoke_result_t<Fn&, moxygen::MoQForwarder&>>> {
+    using R = std::invoke_result_t<Fn&, moxygen::MoQForwarder&>;
+    static_assert(!std::is_void_v<R>, "co_with() returns a value; use post() for fire-and-forget");
+    XCHECK(mode_ != Mode::Empty) << "co_with() on an empty ForwarderRef";
+    if (mode_ == Mode::Owned) {
+      return runInline<Fn, R>(strong_, std::move(fn));
+    }
+    return lockAndRunOn<Fn, R>(owner_.copy(), weak_, std::move(fn));
+  }
+
+private:
+  enum class Mode { Empty, Owned, Remote };
+
+  template <class Fn, class R>
+  static folly::coro::Task<std::optional<R>>
+  lockAndRun(std::weak_ptr<moxygen::MoQForwarder> weak, Fn fn) {
+    auto fwd = weak.lock();
+    if (!fwd) {
+      co_return std::nullopt;
+    }
+    co_return fn(*fwd);
+  }
+
+  // Owns the hop as well as the lock, so co_with() need not be a coroutine.
+  template <class Fn, class R>
+  static folly::coro::Task<std::optional<R>> lockAndRunOn(
+      folly::Executor::KeepAlive<> owner,
+      std::weak_ptr<moxygen::MoQForwarder> weak,
+      Fn fn
+  ) {
+    co_return co_await folly::coro::co_withExecutor(
+        std::move(owner),
+        lockAndRun<Fn, R>(std::move(weak), std::move(fn))
+    );
+  }
+
+  // The holder's thread is the owner, so there is no hop, but the strong ref still has to move into
+  // a frame the Task owns.
+  template <class Fn, class R>
+  static folly::coro::Task<std::optional<R>>
+  runInline(std::shared_ptr<moxygen::MoQForwarder> fwd, Fn fn) {
+    co_return fn(*fwd);
+  }
+
+  Mode mode_{Mode::Empty};
+  std::shared_ptr<moxygen::MoQForwarder> strong_; // Owned only
+  std::weak_ptr<moxygen::MoQForwarder> weak_;     // Remote only
+  folly::Executor::KeepAlive<> owner_;            // Remote only
+  moxygen::FullTrackName ftn_;
+};
+
+} // namespace openmoq::moqx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -291,6 +291,12 @@ moqx_add_gtest(moqx_local_forwarder_registry_test
   LIBS moqx_core moqx_test_main GTest::gmock
 )
 
+# Header-only executor-affine handle.
+moqx_add_gtest(moqx_forwarder_ref_test
+  SRCS ForwarderRefTest.cpp
+  LIBS moqx_core moqx_test_main GTest::gmock
+)
+
 moqx_add_gtest(moqx_topn_filter_test
   SRCS TopNFilterTest.cpp
   LIBS moqx_core GTest::gtest_main GTest::gmock

--- a/test/ForwarderRefTest.cpp
+++ b/test/ForwarderRefTest.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/ForwarderRef.h"
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+
+#include <vector>
+
+using namespace testing;
+using namespace moxygen;
+
+namespace {
+
+using openmoq::moqx::ForwarderRef;
+
+const TrackNamespace kTestNs{{"test", "namespace"}};
+const FullTrackName kFtn{kTestNs, "track1"};
+
+std::shared_ptr<MoQForwarder> makeForwarder() {
+  return std::make_shared<MoQForwarder>(kFtn);
+}
+
+// Queues work until drain(), for tests that assert what happens before delivery.
+class QueueExecutor : public folly::Executor {
+public:
+  void add(folly::Func f) override { queue_.push_back(std::move(f)); }
+  void drain() {
+    auto queue = std::move(queue_);
+    for (auto& f : queue) {
+      f();
+    }
+  }
+
+private:
+  std::vector<folly::Func> queue_;
+};
+
+std::thread::id evbThreadId(folly::ScopedEventBaseThread& evbThread) {
+  std::thread::id id;
+  evbThread.getEventBase()->runInEventBaseThreadAndWait([&] { id = std::this_thread::get_id(); });
+  return id;
+}
+
+TEST(ForwarderRefTest, EmptyRefIsFalsyAndYieldsNothing) {
+  ForwarderRef ref;
+  EXPECT_FALSE(static_cast<bool>(ref));
+  EXPECT_EQ(ref.getIfOwned(), nullptr);
+}
+
+TEST(ForwarderRefTest, OwnedPostRunsInlineOnTheSameForwarder) {
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::owned(fwd);
+
+  const MoQForwarder* seen = nullptr;
+  ref.post([&](MoQForwarder& f) { seen = &f; });
+
+  EXPECT_EQ(seen, fwd.get()) << "owned post must run inline, before post() returns";
+}
+
+TEST(ForwarderRefTest, OwnedCoWithReturnsValueInline) {
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::owned(fwd);
+
+  auto result =
+      folly::coro::blockingWait(ref.co_with([](MoQForwarder& f) { return f.fullTrackName(); }));
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, kFtn);
+}
+
+TEST(ForwarderRefTest, RemotePostRunsOnTheOwnerThread) {
+  folly::ScopedEventBaseThread evbThread("owner");
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::remote(fwd, folly::getKeepAliveToken(evbThread.getEventBase()));
+
+  std::thread::id ranOn;
+  const MoQForwarder* seen = nullptr;
+  folly::Baton<> done;
+  ref.post([&](MoQForwarder& f) {
+    ranOn = std::this_thread::get_id();
+    seen = &f;
+    done.post();
+  });
+
+  ASSERT_TRUE(done.try_wait_for(std::chrono::seconds(5)));
+  EXPECT_EQ(ranOn, evbThreadId(evbThread));
+  EXPECT_EQ(seen, fwd.get());
+}
+
+// Liveness is judged on the owner: a forwarder that dies between post() and
+// delivery means fn never runs, rather than fn racing the destruction.
+TEST(ForwarderRefTest, RemotePostAfterForwarderDeathIsANoOp) {
+  QueueExecutor owner;
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::remote(fwd, folly::getKeepAliveToken(&owner));
+
+  bool ran = false;
+  ref.post([&](MoQForwarder&) { ran = true; });
+  fwd.reset();
+  owner.drain();
+
+  EXPECT_FALSE(ran);
+}
+
+TEST(ForwarderRefTest, RemoteCoWithRoundTripsThroughTheOwnerThread) {
+  folly::ScopedEventBaseThread evbThread("owner");
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::remote(fwd, folly::getKeepAliveToken(evbThread.getEventBase()));
+
+  std::thread::id ranOn;
+  auto result = folly::coro::blockingWait(ref.co_with([&](MoQForwarder& f) {
+    ranOn = std::this_thread::get_id();
+    return f.fullTrackName();
+  }));
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, kFtn);
+  EXPECT_EQ(ranOn, evbThreadId(evbThread));
+}
+
+TEST(ForwarderRefTest, RemoteCoWithOnDeadForwarderReturnsNullopt) {
+  folly::ScopedEventBaseThread evbThread("owner");
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::remote(fwd, folly::getKeepAliveToken(evbThread.getEventBase()));
+  fwd.reset();
+
+  auto result =
+      folly::coro::blockingWait(ref.co_with([](MoQForwarder& f) { return f.fullTrackName(); }));
+
+  EXPECT_FALSE(result.has_value());
+}
+
+// co_with() must not be a coroutine. A Task is lazy, so a coroutine body would read
+// `this` after the ref that produced it is gone — and a temporary at the call site is
+// the natural way to use a cheap copyable handle.
+TEST(ForwarderRefTest, CoWithOutlivesATemporaryRef) {
+  folly::ScopedEventBaseThread evbThread("owner");
+  auto fwd = makeForwarder();
+
+  auto readName = [](MoQForwarder& f) { return f.fullTrackName(); };
+  auto owned = ForwarderRef::owned(fwd).co_with(readName);
+  auto remote = ForwarderRef::remote(fwd, folly::getKeepAliveToken(evbThread.getEventBase()))
+                    .co_with(readName);
+
+  // Both refs died at the end of their full-expression, before either Task started.
+  auto ownedResult = folly::coro::blockingWait(std::move(owned));
+  auto remoteResult = folly::coro::blockingWait(std::move(remote));
+
+  ASSERT_TRUE(ownedResult.has_value());
+  EXPECT_EQ(*ownedResult, kFtn);
+  ASSERT_TRUE(remoteResult.has_value());
+  EXPECT_EQ(*remoteResult, kFtn);
+}
+
+// The rule the type enforces: a remote ref never hands out a pointer, so relay-exec
+// code cannot reach a forwarder that lives on another thread.
+TEST(ForwarderRefTest, GetIfOwnedYieldsNothingForRemote) {
+  QueueExecutor owner;
+  auto fwd = makeForwarder();
+
+  EXPECT_EQ(ForwarderRef::owned(fwd).getIfOwned(), fwd);
+  EXPECT_EQ(ForwarderRef::remote(fwd, folly::getKeepAliveToken(&owner)).getIfOwned(), nullptr);
+}
+
+// A moved-from ref must not keep claiming to be a live owned handle: mode_ travels by
+// copy under an implicit move, which would leave it answering true over a null strong_.
+TEST(ForwarderRefTest, MovedFromRefReadsEmpty) {
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::owned(fwd);
+  auto moved = std::move(ref);
+
+  EXPECT_FALSE(static_cast<bool>(ref));
+  EXPECT_EQ(ref.getIfOwned(), nullptr);
+
+  EXPECT_TRUE(static_cast<bool>(moved));
+  EXPECT_EQ(moved.getIfOwned(), fwd);
+}
+
+TEST(ForwarderRefTest, TrackSurvivesForwarderDeath) {
+  QueueExecutor owner;
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::remote(fwd, folly::getKeepAliveToken(&owner));
+
+  auto track = ref.track();
+  fwd.reset();
+
+  // The coordinate is what a holder posts with, so it must outlast the forwarder.
+  EXPECT_TRUE(static_cast<bool>(ref));
+  EXPECT_EQ(track.ftn, kFtn);
+  EXPECT_EQ(track.exec, &owner);
+  EXPECT_EQ(ref.track().ftn, kFtn) << "still nameable after the forwarder is gone";
+}
+
+TEST(ForwarderRefTest, OwnedTrackHasNoExec) {
+  auto fwd = makeForwarder();
+  auto ref = ForwarderRef::owned(fwd);
+
+  EXPECT_EQ(ref.track().ftn, kFtn);
+  EXPECT_EQ(ref.track().exec, nullptr);
+}
+
+} // namespace


### PR DESCRIPTION
A MoQForwarder belongs to the executor that created it, but we hand shared_ptrs to it across threads, where a holder can dereference it or run its destructor off that executor. ForwarderRef can be held anywhere and only used on the owner: post() and co_with() send work there, and pinOnOwner() gives scoped strong access that debug-checks the calling thread. There is no get() and no operator->, so there is no way to reach the forwarder from the wrong thread. identityKey() names a forwarder by its address plus a generation the type mints itself, which keeps a dead publication nameable and stops a later forwarder that reuses the address from comparing equal to it.

Nothing uses it yet; the call sites land in subsequent commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/574)
<!-- Reviewable:end -->
