### PR TITLE
relay: let LocalForwarderRegistry park a displaced forwarder

### DIFF
--- a/src/relay/LocalForwarderRegistry.h
+++ b/src/relay/LocalForwarderRegistry.h
@@ -16,6 +16,7 @@
 #include <folly/logging/xlog.h>
 
 #include <variant>
+#include <vector>
 
 namespace openmoq::moqx {
 
@@ -138,10 +139,45 @@ public:
     for (const auto& [ftn, entry] : forwarders_) {
       XCHECK(!entry.ready) << "pending entry outlived its registry: " << ftn;
     }
+    for (const auto& [ftn, parked] : displaced_) {
+      XCHECK(parked.empty()) << "displaced forwarder outlived its registry: " << ftn;
+    }
   }
 
   LocalForwarderRegistry(const LocalForwarderRegistry&) = delete;
   LocalForwarderRegistry& operator=(const LocalForwarderRegistry&) = delete;
+
+  // Names the occupant a replaceAndPark() call evicted, and is the only way to
+  // reach it again. Move-only, and the destructor aborts on an unredeemed ticket,
+  // so a dropped obligation. Empty when nothing was displaced.
+  class ParkTicket {
+  public:
+    ParkTicket() = default;
+    ParkTicket(ParkTicket&& other) noexcept : key_(std::exchange(other.key_, nullptr)) {}
+    ParkTicket& operator=(ParkTicket&& other) noexcept {
+      if (this != &other) {
+        XCHECK(!key_) << "park ticket overwritten without takeDisplaced()";
+        key_ = std::exchange(other.key_, nullptr);
+      }
+      return *this;
+    }
+    ParkTicket(const ParkTicket&) = delete;
+    ParkTicket& operator=(const ParkTicket&) = delete;
+    ~ParkTicket() { XCHECK(!key_) << "park ticket dropped without takeDisplaced()"; }
+
+    explicit operator bool() const { return key_ != nullptr; }
+
+  private:
+    friend class LocalForwarderRegistry;
+    explicit ParkTicket(const void* key) : key_(key) {}
+
+    const void* key_{nullptr};
+  };
+
+  struct ParkResult {
+    Claim claim;
+    ParkTicket displaced;
+  };
 
   // factory() runs only when the entry is absent, at most once per entry lifetime.
   JoinResult join(
@@ -156,25 +192,32 @@ public:
     }
     auto forwarder = factory();
     XCHECK(forwarder) << "join() factory returned null for " << ftn;
-    return makePending(ftn, std::move(forwarder));
+    return makePending(ftn, std::move(forwarder), Park::No).claim;
   }
 
   // The publisher's forwarder is authoritative for a track on its thread; the
   // displaced one drains itself via the source-termination cascade, and its
-  // identity-checked removal then no-ops.
+  // identity-checked removal then no-ops. Dropping its last ref here is safe
+  // precisely because this call is already on the thread that owns it.
   //
   // A displaced entry's waiters are failed rather than inherited: releasing them
   // onto a forwarder that no longer owns the entry is the restart this type exists
   // to prevent.
   Claim
   replace(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQForwarder> forwarder) {
-    XCHECK(forwarder) << "replace() with a null forwarder for " << ftn;
-    if (auto it = forwarders_.find(ftn); it != forwarders_.end() && it->second.ready) {
-      XCHECK(it->second.forwarder != forwarder)
-          << "replace() re-seats a forwarder that already owns a pending entry: " << ftn;
-      it->second.ready->setException(std::runtime_error("local forwarder displaced"));
-    }
-    return makePending(ftn, std::move(forwarder));
+    return replaceImpl(ftn, std::move(forwarder), Park::No).claim;
+  }
+
+  // replace(), but the displaced occupant is held for takeDisplaced() instead of
+  // dropped. For a caller whose decision about it arrives from another thread:
+  // parking anchors the last ref here while the answer travels. The returned ticket owes exactly
+  // one takeDisplaced(); ~LocalForwarderRegistry is the backstop for one redeemed against the wrong
+  // track.
+  ParkResult replaceAndPark(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQForwarder> forwarder
+  ) {
+    return replaceImpl(ftn, std::move(forwarder), Park::Yes);
   }
 
   // A pending entry reads as absent — see the class comment.
@@ -196,6 +239,33 @@ public:
     return it != forwarders_.end() ? it->second.forwarder : nullptr;
   }
 
+  // Redeems a ticket, releasing the parked occupant, or null. Consuming the ticket is what makes
+  // the obligation exactly-once. Never invokes publishDone, that decision is made elsewhere.
+  // subscribers would otherwise wait forever.
+  std::shared_ptr<moxygen::MoQForwarder>
+  takeDisplaced(const moxygen::FullTrackName& ftn, ParkTicket ticket) {
+    const void* expected = std::exchange(ticket.key_, nullptr);
+    if (!expected) {
+      return nullptr;
+    }
+    auto it = displaced_.find(ftn);
+    if (it == displaced_.end()) {
+      return nullptr;
+    }
+    auto& parked = it->second;
+    for (auto pit = parked.begin(); pit != parked.end(); ++pit) {
+      if (pit->get() == expected) {
+        auto forwarder = std::move(*pit);
+        parked.erase(pit);
+        if (parked.empty()) {
+          displaced_.erase(it);
+        }
+        return forwarder;
+      }
+    }
+    return nullptr;
+  }
+
   // Called from a forwarder's onPublishDone, which fires on this thread. The identity
   // check makes teardown order-independent: a terminated forwarder can only vacate its
   // own entry, so it never clobbers a newer forwarder that has since claimed the same
@@ -213,6 +283,8 @@ public:
   }
 
 private:
+  enum class Park { No, Yes };
+
   struct Entry {
     std::shared_ptr<moxygen::MoQForwarder> forwarder;
     // Non-null iff the entry is pending; it is the state discriminator.
@@ -226,14 +298,38 @@ private:
     return Ready{entry.forwarder};
   }
 
-  Claim
-  makePending(const moxygen::FullTrackName& ftn, std::shared_ptr<moxygen::MoQForwarder> forwarder) {
+  ParkResult replaceImpl(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQForwarder> forwarder,
+      Park park
+  ) {
+    XCHECK(forwarder) << "replace() with a null forwarder for " << ftn;
+    if (auto it = forwarders_.find(ftn); it != forwarders_.end()) {
+      XCHECK(it->second.forwarder != forwarder)
+          << "replace() re-seats the forwarder that already holds the entry: " << ftn;
+      if (it->second.ready) {
+        it->second.ready->setException(std::runtime_error("local forwarder displaced"));
+      }
+    }
+    return makePending(ftn, std::move(forwarder), park);
+  }
+
+  ParkResult makePending(
+      const moxygen::FullTrackName& ftn,
+      std::shared_ptr<moxygen::MoQForwarder> forwarder,
+      Park park
+  ) {
     auto& entry = forwarders_[ftn];
     // Outlive the entry update: dropping the last ref here would run ~MoQForwarder,
     // which reenters the registry through its callback, against a half-written entry.
     auto displaced = std::exchange(entry.forwarder, forwarder);
+    const void* parked = nullptr;
+    if (displaced && park == Park::Yes) {
+      parked = displaced.get();
+      displaced_[ftn].push_back(std::move(displaced));
+    }
     entry.ready = std::make_shared<folly::SharedPromise<folly::Unit>>();
-    return Claim(this, ftn, std::move(forwarder));
+    return {Claim(this, ftn, std::move(forwarder)), ParkTicket(parked)};
   }
 
   // A pending entry's promise is unfulfilled by construction: markReady and fail both
@@ -275,6 +371,13 @@ private:
   }
 
   Map forwarders_;
+  // Occupants evicted by replaceAndPark(), awaiting takeDisplaced(). One vector per ftn:
+  // a track can be displaced again before the previous displacement is claimed.
+  folly::F14FastMap<
+      moxygen::FullTrackName,
+      std::vector<std::shared_ptr<moxygen::MoQForwarder>>,
+      moxygen::FullTrackName::hash>
+      displaced_;
 };
 
 } // namespace openmoq::moqx

--- a/test/LocalForwarderRegistryTest.cpp
+++ b/test/LocalForwarderRegistryTest.cpp
@@ -22,10 +22,17 @@ using Ready = Registry::Ready;
 
 const TrackNamespace kTestNs{{"test", "namespace"}};
 const FullTrackName kFtn{kTestNs, "track1"};
+const FullTrackName kOtherFtn{kTestNs, "track2"};
 
 std::shared_ptr<MoQForwarder> makeForwarder() {
   return std::make_shared<MoQForwarder>(kFtn);
 }
+
+struct DoneWatcher : public MoQForwarder::Callback {
+  void onEmpty(MoQForwarder*) override {}
+  void onPublishDone(MoQForwarder*) override { sawPublishDone = true; }
+  bool sawPublishDone{false};
+};
 
 Registry::JoinResult joinWith(Registry& reg, const std::shared_ptr<MoQForwarder>& fwd) {
   return reg.join(kFtn, [&] { return fwd; });
@@ -306,6 +313,160 @@ TEST(LocalForwarderRegistryTest, RemoveOfPendingEntryWakesWaiters) {
   // The claim now owns nothing; resolving it must not resurrect the entry.
   claim.markReady(InitialTrackState{});
   EXPECT_TRUE(std::holds_alternative<Absent>(reg.lookup(kFtn)));
+}
+
+// === Displacement parking ===
+
+// The entry holds the only long-lived ref, so parking is what keeps the displaced
+// occupant alive on this thread while its owner's decision travels to another one.
+TEST(LocalForwarderRegistryTest, ReplaceAndParkHoldsTheDisplacedForwarder) {
+  Registry reg;
+  auto first = makeForwarder();
+  claimWith(reg, first).markReady(InitialTrackState{});
+  std::weak_ptr<MoQForwarder> parked = first;
+  first.reset();
+
+  auto successor = reg.replaceAndPark(kFtn, makeForwarder());
+  EXPECT_FALSE(parked.expired());
+  EXPECT_TRUE(static_cast<bool>(successor.displaced)) << "the call hands back a live debt";
+
+  auto displaced = reg.takeDisplaced(kFtn, std::move(successor.displaced));
+  ASSERT_NE(displaced, nullptr);
+  EXPECT_EQ(displaced, parked.lock());
+  // Redeeming consumed the ticket, so taking twice is not expressible.
+  EXPECT_FALSE(static_cast<bool>(successor.displaced));
+
+  successor.claim.markReady(InitialTrackState{});
+}
+
+// Parking is opt-in: a caller already on the owning thread can drop the occupant itself,
+// and owes nothing afterwards.
+TEST(LocalForwarderRegistryTest, PlainReplaceParksNothing) {
+  Registry reg;
+  auto first = makeForwarder();
+  claimWith(reg, first).markReady(InitialTrackState{});
+  std::weak_ptr<MoQForwarder> dropped = first;
+  first.reset();
+
+  reg.replace(kFtn, makeForwarder()).markReady(InitialTrackState{});
+
+  EXPECT_TRUE(dropped.expired());
+  EXPECT_EQ(reg.takeDisplaced(kFtn, Registry::ParkTicket{}), nullptr);
+}
+
+// Parking an absent entry displaces nothing, so the ticket comes back empty. Callers
+// branch on that to decide whether they owe anything, and an empty one costs nothing
+// to drop.
+TEST(LocalForwarderRegistryTest, ParkingAnAbsentEntryOwesNothing) {
+  Registry reg;
+  auto result = reg.replaceAndPark(kFtn, makeForwarder());
+
+  EXPECT_FALSE(static_cast<bool>(result.displaced));
+  result.claim.markReady(InitialTrackState{});
+  // result.displaced goes out of scope here unredeemed, which must not abort.
+}
+
+// Displacing a pending entry is the intricate case: its waiters are failed, its
+// forwarder is parked, and the previous Claim is still out there holding a strong ref
+// and owing a resolution. That stale Claim must not disturb the park.
+TEST(LocalForwarderRegistryTest, ReplaceAndParkDisplacesAPendingEntry) {
+  Registry reg;
+  auto first = makeForwarder();
+  auto stale = claimWith(reg, first); // deliberately left pending
+  auto waiter = waiterOn(reg);
+  std::weak_ptr<MoQForwarder> parked = first;
+  first.reset();
+
+  auto successor = reg.replaceAndPark(kFtn, makeForwarder());
+  EXPECT_TRUE(settled(std::move(waiter)).hasException())
+      << "a displaced entry's waiters are failed, not inherited";
+
+  {
+    auto dropped = std::move(stale);
+  } // resolves against an entry it no longer owns
+  EXPECT_FALSE(parked.expired()) << "the park still anchors it";
+
+  auto displaced = reg.takeDisplaced(kFtn, std::move(successor.displaced));
+  ASSERT_NE(displaced, nullptr);
+  EXPECT_EQ(displaced, parked.lock());
+
+  successor.claim.markReady(InitialTrackState{});
+}
+
+// Each caller holds its own ticket, so two publishes racing on one thread reclaim
+// exactly what they parked, in whatever order their answers arrive.
+TEST(LocalForwarderRegistryTest, TicketsAreRedeemedIndependentlyOfOrder) {
+  Registry reg;
+  auto first = makeForwarder();
+  auto second = makeForwarder();
+  claimWith(reg, first).markReady(InitialTrackState{});
+  auto parkedFirst = reg.replaceAndPark(kFtn, second);
+  parkedFirst.claim.markReady(InitialTrackState{});
+  auto parkedSecond = reg.replaceAndPark(kFtn, makeForwarder());
+
+  // Out of park order: the second parker's answer arrives first.
+  EXPECT_EQ(reg.takeDisplaced(kFtn, std::move(parkedSecond.displaced)), second);
+  EXPECT_EQ(reg.takeDisplaced(kFtn, std::move(parkedFirst.displaced)), first);
+
+  parkedSecond.claim.markReady(InitialTrackState{});
+}
+
+// Draining is the caller's call, not the registry's: it cannot tell an old publisher that
+// owes its subscribers a PUBLISH_DONE from a forwarder the termination cascade will reach.
+TEST(LocalForwarderRegistryTest, TakeDisplacedDoesNotTerminateTheForwarder) {
+  Registry reg;
+  auto first = makeForwarder();
+  auto watcher = std::make_shared<DoneWatcher>();
+  first->setCallback(watcher);
+  claimWith(reg, first).markReady(InitialTrackState{});
+  auto successor = reg.replaceAndPark(kFtn, makeForwarder());
+  successor.claim.markReady(InitialTrackState{});
+
+  EXPECT_EQ(reg.takeDisplaced(kFtn, std::move(successor.displaced)), first);
+  EXPECT_FALSE(watcher->sawPublishDone);
+}
+
+// The debt is enforced where it is incurred: dropping the ticket aborts in that scope,
+// instead of surfacing later as a registry-teardown abort with no link to the cause.
+// Re-seating the occupant would park and install one object at once, leaving the ticket
+// pointing at the forwarder still serving the track. Guarded for ready entries as well as
+// pending ones, since only the parking form makes it harmful.
+TEST(LocalForwarderRegistryDeathTest, ReplaceAndParkWithTheSittingForwarderAborts) {
+  EXPECT_DEATH(
+      {
+        Registry reg;
+        auto fwd = makeForwarder();
+        claimWith(reg, fwd).markReady(InitialTrackState{});
+        auto result = reg.replaceAndPark(kFtn, fwd);
+      },
+      "re-seats the forwarder that already holds the entry"
+  );
+}
+
+TEST(LocalForwarderRegistryDeathTest, DroppingAParkTicketAborts) {
+  EXPECT_DEATH(
+      {
+        Registry reg;
+        claimWith(reg, makeForwarder()).markReady(InitialTrackState{});
+        reg.replaceAndPark(kFtn, makeForwarder()).claim.markReady(InitialTrackState{});
+      },
+      "park ticket dropped without takeDisplaced\\(\\)"
+  );
+}
+
+// The registry check is still the backstop: redeeming against the wrong track consumes
+// the ticket but leaves the occupant parked, so nothing else can catch it.
+TEST(LocalForwarderRegistryDeathTest, DisplacedForwarderOutlivingRegistryAborts) {
+  EXPECT_DEATH(
+      {
+        Registry reg;
+        claimWith(reg, makeForwarder()).markReady(InitialTrackState{});
+        auto successor = reg.replaceAndPark(kFtn, makeForwarder());
+        successor.claim.markReady(InitialTrackState{});
+        EXPECT_EQ(reg.takeDisplaced(kOtherFtn, std::move(successor.displaced)), nullptr);
+      },
+      "displaced forwarder outlived its registry"
+  );
 }
 
 // === Escape hatch and handle mechanics ===


### PR DESCRIPTION
replace() overwrites a registry entry and drops the last reference to the forwarder it displaced, so a caller that still needs the old one — usually to drain it — has no way to reach it. replaceAndPark() keeps that forwarder alive in a side map instead, and takeDisplaced() hands it back. This lets a decision about the old forwarder travel to another thread and come back, because the reference stays anchored on the owning thread and ~MoQForwarder cannot run off it. The park returns a move-only ParkTicket that takeDisplaced() consumes, so dropping the obligation aborts right where it was incurred instead of much later at iothread teardown, with nothing linking the abort to the call that stranded the forwarder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/576)
<!-- Reviewable:end -->
