### PR TITLE
relay: keep registry forwarders behind a ForwarderRef

### DIFF
--- a/docs/dev/local-forwarder-flow.md
+++ b/docs/dev/local-forwarder-flow.md
@@ -48,33 +48,61 @@ Executor legend used below:
 
 ## Publish
 
-A publisher's local forwarder **is** the publisher forwarder — the same object serves as the
-on-thread data-plane forwarder and as the registry's publisher entry (no second forwarder is
-constructed on `relayExec_`, unlike the `RelayExec`-mode branch in `publishWithSession`).
+A publisher's local forwarder **is** the publisher forwarder — a single forwarder serves the
+whole track, living on the publisher's executor rather than on `relayExec_`. Ownership lives in
+`tlForwarders_` on the publisher's executor, **not** in the registry: the registry entry keeps
+its subscription/namespace bookkeeping plus a *remote* `ForwarderRef` — weak + owner executor,
+which hands out no pointer at all (`getIfOwned()` returns null for it) — so `relayExec_` can
+neither read the forwarder nor run `~MoQForwarder`. Relay-side decisions about a forwarder travel
+to its executor as messages (`ForwarderRef::post`), never as pointers. The entry is named by a
+`SubscriptionRegistry::EntryEpoch` rather than by the forwarder, so a caller that suspends can
+tell its own entry from one a reconnecting publisher put in its place.
 
 ### Setup
 
 ```
 [Pub]   LocalPublishFilter::publish()
 [Pub]    └─▶ publishFromPublisherExec()
-[Pub]         ├─▶ createPublisherForwarder(pub)               # build forwarder + control chain
-[Pub]         │     └─ setCallback( LocalForwarderCallback )
-[Pub]         ├─▶ tlForwarders_->set(ftn, fwd)                # cache for same-thread reuse
+[Pub]         ├─▶ make_shared<MoQForwarder>(ftn)              # bare; the Claim sets its initial state
+[Pub]         ├─▶ installPublisherForwarder(ftn, fwd, InstallKind::FromPublish)
+[Pub]         │     ├─ setCallback( LocalForwarderCallback → CrossExec → Weak )  # removeOnEmpty=false
+[Pub]         │     └─ tlForwarders_->replaceAndPark(ftn, fwd)  # → {claim, displaced}: the Claim plus
+[Pub]         │                                                 #   the parked occupant's identity
+[Pub]         ├─▶ claim.markReady(InitialTrackState{largest, extensions})
 [Pub]         ├─▶ localPubFwd->addChannelSubscriber(passive)  # passive copy → [Relay]
-[Pub]         └─▶ co_invoke(reply) ⇢⇢▶ [Relay]
+[Pub]         ├─▶ co_invoke(reply) ⇢⇢▶ [Relay]               # runs in the background
+[Pub]         └─▶ return {consumer, replyTask}                # immediate; the publisher can write now
 [Relay]            └─▶ registerPublishOnRelayExec()
-[Relay]                 ├─▶ publishWithSession()              # registry + namespace tree
+[Relay]                 ├─▶ publishWithSession()              # registry (entry holds remote ForwarderRef) + namespace tree
 [Relay]                 │     └─▶ addSubscriberAndPublish()   # attach existing SUBSCRIBE_NAMESPACE subs (see Publish fan-out)
 [Relay]                 └─▶ relayChainFilter->setDownstream(topNFilter)
-[Pub]         return {consumer, replyTask}                    # immediate
+[Pub]         reply resumes ─▶ takeDisplaced(ftn, displaced)  # release the parked occupant
 ```
 
 The publisher starts writing into `localPubFwd` on `[Pub]` as soon as `publishFromPublisherExec`
 returns; `[Relay]` registration completes in parallel. FIFO ordering on `[Relay]` guarantees
 `relayChainFilter` is wired to `topNFilter` before any tapped object arrives.
 
-`createPublisherForwarder` also installs the forwarder's control chain (publisher forwarder →
+`installPublisherForwarder` also installs the forwarder's control chain (publisher forwarder →
 relay state); see [Control](#control-the-callback-flow).
+
+### Duplicate publisher (eviction)
+
+When a publish displaces a live entry, the old forwarder must be drained (its subscribers would
+otherwise wait forever) — but it lives on its own executor, which may not be this one. Two
+mechanisms cooperate, both identity-keyed:
+
+- **The drain is a message routed by the evicted entry's `ForwarderRef`**
+  (`evicted.forwarder.post(publishDone)` in `publishWithSession`): it runs on the old
+  forwarder's own exec and touches exactly the evicted forwarder, never whatever now occupies a
+  slot.
+- **Parking anchors the lifetime while the answer travels.** `replaceAndPark` keeps the
+  displaced occupant's last ref on its own thread; the publish reply — always resumed on the
+  publisher exec by `MoQSession::handlePublish` — releases it with
+  `takeDisplaced(ftn, displaced)`. The release is keyed by the displaced occupant's identity, so
+  concurrent same-track publishes each reclaim exactly what their own call parked. The park
+  never drains: any parked occupant that is not the evicted publisher's forwarder reaches
+  `publishDone` through its own source-termination cascade.
 
 ---
 
@@ -84,25 +112,30 @@ A session that sent `SUBSCRIBE_NAMESPACE` receives a `PUBLISH` for each matching
 track appears (or a namespace-subscriber arrives), the relay adds that session as a subscriber
 to the forwarder and starts publishing to it. This is publish-side flow, not the
 track-`subscribe()` path — but the LF variant mirrors `subscribeFromSubscriberExec`:
-`acquireLocalForwarder` → `startPublish` → buffer-and-replay → a single `[Pub]` sortie to wire
-the channel sub. The difference is the entry point (dispatched from `[Relay]` to the
-namespace-subscriber's `[Sub]`) and that there is no upstream/relay-chain setup here — that is
-already owned by the publisher's forwarder.
+`acquireLocalForwarder` → `startPublish` → buffer-and-replay → a `[Pub]` sortie to wire the
+channel sub, preceded by a resolve sortie because the dispatcher hands over only a `TrackRef`
+(name + owning exec), never the forwarder. The difference is the entry point (dispatched from
+`[Relay]` to the namespace-subscriber's `[Sub]`) and that there is no upstream/relay-chain setup
+here — that is already owned by the publisher's forwarder.
 
 ```
-[Relay] addSubscriberAndPublish()                          # dispatcher (LF variant vs startPublish)
-[Relay]  └─ LF mode ─▶ ⇢⇢▶ [Sub] addSubscriberAndPublishViaLocalForwarder()
-[Sub]         ├─ fast path: tlForwarders_->get(ftn) hit
+[Relay] addSubscriberAndPublish(publisherRef)              # dispatcher (LF variant vs startPublish)
+[Relay]  └─ LF mode ─▶ ⇢⇢▶ [Sub] addSubscriberAndPublishViaLocalForwarder(ref.track())
+[Sub]         ├─ fast path: tlForwarders_->getIfReady(ftn) hit
 [Sub]         │     └─▶ startPublish() ─▶ awaitPublishReply()   # zero hops
-[Sub]         ├─▶ acquireLocalForwarder(ftn)  getOrCreate       # shared with subscribe
+[Sub]         ├─▶ ⇢⇢▶ [Pub] resolvePublisherOnItsExec()         # getIfReady + capture InitialTrackState
+[Sub]         │     └─ no forwarder ─▶ return                   # torn down before the hop landed
+[Sub]         ├─▶ acquireLocalForwarder(ftn, initial)           # shared with subscribe
 [Sub]         ├─▶ startPublish()                                # issue PUBLISH to the sub
 [Sub]         ├─ NOT new ─▶ awaitPublishReply() ─▶ return
 [Sub]         └─ isNew ── this thread owns setup:
 [Sub]              ├─▶ setCallback( PendingForwarderCallback )   # buffer events during setup
 [Sub]              ├─▶ CrossExecFilter(subscriberExec, localFwd) # deep-copy per thread
-[Sub]              ├─▶ addLocalForwarderToPublisher()
-[Sub]              │     └─▶ ⇢⇢▶ [Pub] installChannelSubscriber(localFwd ↔ publisherFwd)
-[Sub]              ├─ sawOnEmpty? ─▶ teardownLocalForwarderOnFailure()
+[Sub]              ├─▶ publisherRef.co_with() ⇢⇢▶ [Pub]
+[Sub]              │     ├─▶ buildLocalToPublisherCallbacks()
+[Sub]              │     └─▶ installChannelSubscriber(localFwd ↔ publisherFwd)
+[Sub]              ├─ no finalCallback (publisher gone) or sawOnEmpty?
+[Sub]              │     └─▶ teardownLocalForwarderOnFailure() ─▶ return
 [Sub]              ├─▶ replayPendingFowarderEvents()             # drain buffered events
 [Sub]              └─▶ awaitPublishReply()
 ```
@@ -123,42 +156,65 @@ upstream work, and nests a single sortie to `[Pub]` to wire the channel sub.
 ```
 [Sub]   LocalSubscribeFilter::subscribe()
 [Sub]    └─▶ subscribeFromSubscriberExec()
-[Sub]         ├─▶ acquireLocalForwarder(ftn)  getOrCreate       # serializes same-thread races
+[Sub]         ├─▶ localRegistry().join(ftn)                     # serializes same-thread races
 [Sub]         │
-[Sub]         ├─ NOT new ─▶ attachSubscriber() ─▶ return        # fast path, zero hops
+[Sub]         ├─ Ready   ─▶ attachSubscriber() ─▶ return        # fast path, zero hops
+[Sub]         ├─ Pending ─▶ await the entry, re-resolve, attach # another setup owns it
 [Sub]         │
-[Sub]         └─ isNew ── this thread owns setup:
+[Sub]         └─ Claim ── this thread owns setup:
 [Sub]              ├─▶ setCallback( PendingForwarderCallback )   # buffer events during setup
 [Sub]              ├─▶ CrossExecFilter(subscriberExec, localFwd) # deep-copy per thread
 [Sub]              ├─▶ localFwd->addSubscriber()                 # so `forward` is right pre-hop
 [Sub]              └─▶ ⇢⇢▶ [Relay] attachNewLocalForwarderOnRelayExec()
 [Relay]                 ├─▶ joinOrPrepareUpstreamSubscription()  # registry: first vs subsequent
-[Relay]                 ├─▶ buildLocalToPublisherCallbacks()
-[Relay]                 └─▶ ⇢⇢▶ [Pub]  single sortie:
+[Relay]                 │     ├─ FIRST: refMaker finds the publisher session and builds the entry's
+[Relay]                 │     │         remote ForwarderRef; none ⇒ NoPublisher, nothing created,
+[Relay]                 │     │         DOES_NOT_EXIST
+[Relay]                 │     └─ SUBSEQUENT: await the first subscriber, take its publisherExec
+[Relay]                 └─▶ ⇢⇢▶ [Pub]  single sortie (the only strong-ref scope):
+[Pub]                        ├─ if SUBSEQUENT: publisherFwd = tlForwarders_->getIfReady(ftn)
+[Pub]                        │              # gone (publisher left or was displaced) ⇒ INTERNAL_ERROR
+[Pub]                        ├─ if FIRST: another forwarder already occupies the slot (a PUBLISH
+[Pub]                        │              raced this SUBSCRIBE) ⇒ INTERNAL_ERROR
+[Pub]                        ├─ if FIRST: installPublisherForwarder(InstallKind::FromSubscribe)
+[Pub]                        │              # chain + tl entry; publisher Claim held across setup
+[Pub]                        ├─▶ buildLocalToPublisherCallbacks()
 [Pub]                        ├─▶ installChannelSubscriber(localFwd ↔ publisherFwd)
-[Pub]                        └─ if FIRST subscriber:
-[Pub]                             ├─▶ addChannelSubscriber(relayChain, passive)
-[Pub]                             └─▶ subscribeUpstreamAndApplyOk()
+[Pub]                        ├─ if FIRST subscriber:
+[Pub]                        │    ├─▶ addChannelSubscriber(relayChain, passive)
+[Pub]                        │    ├─▶ subscribeUpstreamAndApplyOk()
+[Pub]                        │    └─▶ publisherClaim.markReady(InitialTrackState{ok})  # on OK only
+[Pub]                        └─▶ attach.initial = InitialTrackState::capture(publisherFwd)
 [Relay]                 ◀── back on relayExec_
 [Relay]                 ├─ if FIRST: relayChainFilter->setDownstream(topNFilter)
 [Relay]                 └─ if FIRST: completeUpstreamSubscription() pending.complete()
 [Sub]              ◀── back on subscriberExec (tail)
-[Sub]              ├─ sawOnEmpty? ─▶ teardownLocalForwarderOnFailure()
-[Sub]              ├─ error?      ─▶ publishDone + remove
-[Sub]              ├─▶ apply upstreamOk extensions / largest
+[Sub]              ├─ sawOnEmpty? ─▶ teardownLocalForwarderOnFailure()  # via attach.publisherRef
+[Sub]              ├─ error?      ─▶ teardownLocalForwarderOnFailure(localFwd)  # + publishDone;
+[Sub]              │                                                 #   ~Claim vacates the entry
+[Sub]              ├─▶ claim.setInitialState(attach.initial)
 [Sub]              ├─▶ replayPendingFowarderEvents()             # drain buffered events
-[Sub]              └─▶ return sub
+[Sub]              └─▶ claim.markReady() ─▶ return sub           # releases parked joiners
 ```
 
 The first subscriber does the heavy lifting (upstream subscribe + installing the relay chain,
 the same passive cache/Top-N chain described in [Data flow](#data-flow)). Subsequent
 subscribers on the same thread hit the `attachSubscriber` fast path; on other threads they take
-only the `installChannelSubscriber` half of the sortie.
+the non-first half of the sortie: resolve the live publisher forwarder from `tlForwarders_` on
+the publisher exec, install the channel sub, and read its established largest/extensions.
+
+The strong ref to the publisher forwarder exists only inside the sortie: the relay-side frame
+carries it in, the tl entry takes ownership, and on every exit — success, error, or throw — the
+frame's ref dies on the owning exec. What escapes to `[Relay]` and the tail is
+`attach.publisherRef`, a remote `ForwarderRef` used only to post teardown messages.
 
 ### Why each guard exists
 
-- **`acquireLocalForwarder` before the hop** — `getOrCreate` serializes same-thread subscribers
-  so only one runs setup; the rest see `isNew=false` and attach.
+- **`join` before the hop** — serializes same-thread subscribers so only one gets the `Claim`
+  and runs setup; the rest get `Ready` (attach) or `Pending` (await, then re-resolve).
+- **The `Claim` held across setup** — the entry stays unattachable until the upstream OK has
+  established `largest`, so a joiner never reads a value a client would see as a track restart.
+  Its destructor fails the entry on every exit that does not mark it ready.
 - **`PendingForwarderCallback` installed first** — events firing mid-setup are buffered, then
   replayed by `replayPendingFowarderEvents` so none are lost across the hops.
 - **`addSubscriber` before the hop** — `numForwardingSubscribers()` must be correct when
@@ -166,7 +222,8 @@ only the `installChannelSubscriber` half of the sortie.
 - **Single `[Pub]` sortie** — merges channel-sub install + relay chain + upstream subscribe
   into one round-trip instead of bouncing `[Relay]↔[Pub]` twice.
 - **`sawOnEmpty` check in the tail** — all subscribers may cancel during the hops; if so,
-  unwind the channel subs cleanly.
+  unwind the channel subs cleanly. The error path unwinds through the same call, additionally
+  draining `localFwd` with `publishDone`.
 
 ---
 
@@ -250,12 +307,13 @@ The reusable adapter layers:
 
 ### Publisher forwarder → relay state
 
-Built by `createPublisherForwarder`. Lifecycle events on the publisher's own forwarder must
-reach relay-global state on `relayExec_`:
+Built by `installPublisherForwarder`, on both the publish and subscribe paths. Lifecycle events
+on the publisher's own forwarder must reach relay-global state on `relayExec_`:
 
 ```
 [Pub]  publisherFwd fires onEmpty / forwardChanged / newGroupRequested
-        └─ LocalForwarderCallback              # owns tlForwarders_ removal (removeOnEmpty=false)
+        └─ LocalForwarderCallback              # owns tlForwarders_ removal
+           #   removeOnEmpty=false publish-initiated, true subscribe-initiated
              └─ CrossExecForwarderCallback ⇢⇢▶ [Relay]
 [Relay]           └─ WeakRelayForwarderCallback ──▶ MoqxRelay::onEmptyImpl / forwardChangedImpl / newGroupRequestedImpl
 ```
@@ -271,19 +329,22 @@ changes, the publisher on `[Pub]` must react:
         └─ LocalForwarderCallback              # owns localReg removal (removeOnEmpty=true)
              └─ CrossExecForwarderCallback ⇢⇢▶ [Pub]
 [Pub]           └─ ChannelForwarderCallback:
-                     onEmpty           → publisherFwd->removeChannelSubscriberByExec(subscriberExec)
+                     onEmpty           → channelSub.detach(subscriberExec)
+                                         # removeChannelSubscriberByExec on the publisher;
                                          # may cascade into the publisher chain above
                      forwardChanged    → requestUpdate(handle, forward)   # background coro
                      newGroupRequested → requestUpdate(handle, group)     # background coro
 ```
 
-`ChannelForwarderCallback` holds the channel `handle_` (so it can `requestUpdate` the publisher)
-and the `CrossExecFilter` ref; on `onEmpty` it posts the filter's destruction back to `[Sub]`
-so FIFO ordering lets any in-flight object lambdas there run before the filter is torn down.
+`ChannelForwarderCallback` reaches the publisher forwarder through a `ChannelSubscriber`, built
+on `[Pub]` where a strong ref is legitimately in hand. It also holds the channel `handle_` (so it
+can `requestUpdate` the publisher) and the `CrossExecFilter` ref; on `onEmpty` it posts the
+filter's destruction back to `[Sub]` so FIFO ordering lets any in-flight object lambdas there run
+before the filter is torn down.
 
 ### Setup window: `PendingForwarderCallback`
 
-Between `getOrCreate` and the real callback being installed, the forwarder can already fire
+Between `join` and the real callback being installed, the forwarder can already fire
 events. `PendingForwarderCallback` is installed first to capture them: it records the last
 `forwardChanged`, the max `newGroupRequested` group, and whether `onEmpty` fired. After setup,
 `replayPendingFowarderEvents` installs the real callback and replays the captured state; if
@@ -291,13 +352,23 @@ events. `PendingForwarderCallback` is installed first to capture them: it record
 
 ### Weak-ptr discipline
 
-Two ownership cycles are deliberately broken with `weak_ptr`:
+Ownership edges onto a forwarder are deliberately avoided with `weak_ptr`:
 
+- A remote `ForwarderRef` holds `weak_ptr<forwarder>`, so the registry entry on `[Relay]` never
+  keeps a publisher forwarder alive. It is only ever locked on the owner: `post()` locks inside
+  the lambda it hands to `owner_->add()`, and `co_with()` locks inside a `Task` scheduled with
+  `co_withExecutor(owner)`. The resulting strong ref lives and dies in a frame already running
+  there, which is why liveness is judged on the owner and why the ref itself hands out nothing.
 - `WeakRelayForwarderCallback` holds `weak_ptr<relay>` to break
   `registry → forwarder → callback → relay → registry`.
-- `CrossExecForwarderCallback` holds `weak_ptr<forwarder>` to avoid a permanent ownership
-  cycle; it locks eagerly on the calling thread (where the forwarder is known alive) and moves
-  the resulting `shared_ptr` into the dispatched lambda to keep it alive across the hop.
+- `ChannelSubscriber` holds `weak_ptr<forwarder>` for the publisher forwarder, so the subscriber
+  side never keeps it alive. It is built on `[Pub]` and keeps the weak private, so nothing off
+  that thread can lock it; `detach()` checks it is running on the thread it was built on.
+
+`CrossExecForwarderCallback` holds no reference to a forwarder at all. It reads
+`fullTrackName()` on the calling thread — the forwarder's owner, where it is known alive — and
+sends only the name, so nothing it dispatches can dereference or destroy a forwarder off its
+executor.
 
 ### Teardown
 

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "MoqxRelay.h"
+#include "relay/ChannelSubscriber.h"
 #include "relay/CrossExecFilter.h"
 #include "relay/CrossExecForwarderCallback.h"
 #include "relay/InitialTrackState.h"
@@ -404,9 +405,9 @@ std::shared_ptr<Subscriber::PublishNamespaceHandle> MoqxRelay::doPublishNamespac
     XLOG(WARNING) << "PublishNamespace: Existing session (" << replacedSession.get()
                   << ") has already published trackNamespace=" << pubNs.trackNamespace;
     // Remove ongoing subscriptions for the replaced publisher.
-    registry_.removeIf([&](const FullTrackName& ftn, const SubscriptionRegistry::EntryView& e) {
-      if (ftn.trackNamespace.startsWith(pubNs.trackNamespace) && e.upstream == replacedSession) {
-        XLOG(DBG4) << "Erasing subscription to " << ftn;
+    registry_.removeIf([&](const SubscriptionRegistry::EntryView& e) {
+      if (e.ftn.trackNamespace.startsWith(pubNs.trackNamespace) && e.upstream == replacedSession) {
+        XLOG(DBG4) << "Erasing subscription to " << e.ftn;
         return true;
       }
       return false;
@@ -592,8 +593,8 @@ void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
     registry_.remove(ftn);
   } else {
     // Clears handle + upstream; erases if no subscribers remain.
-    auto forwarder = registry_.onPublisherTerminated(ftn);
-    if (!forwarder) {
+    auto kept = registry_.onPublisherTerminated(ftn);
+    if (!kept) {
       XLOG(DBG1) << "Publisher terminated with no subscribers, cleaning up " << ftn;
     }
   }
@@ -615,20 +616,24 @@ MoqxRelay::validatePublishNamespace(const FullTrackName& ftn, RequestID requestI
 
 // Chain and entry claim are one call: LocalForwarderCallback vacates the entry when the
 // source ends, so a chain over a forwarder that does not hold it has nothing to remove.
-LocalForwarderRegistry::Claim MoqxRelay::installPublisherForwarder(
+LocalForwarderRegistry::ParkResult MoqxRelay::installPublisherForwarder(
     const FullTrackName& ftn,
     const std::shared_ptr<MoQForwarder>& fwd,
-    bool removeOnEmpty
+    InstallKind kind
 ) {
   auto& localReg = localRegistry();
   auto relayAdapter = std::make_shared<WeakRelayForwarderCallback>(weak_from_this());
   auto crossExec =
       std::make_shared<CrossExecForwarderCallback>(relayExec_, std::move(relayAdapter));
+  bool removeOnEmpty = kind == InstallKind::FromSubscribe;
   fwd->setCallback(
       std::make_shared<LocalForwarderCallback>(&localReg, ftn, std::move(crossExec), removeOnEmpty)
   );
 
-  return localReg.replace(ftn, fwd);
+  if (kind == InstallKind::FromPublish) {
+    return localReg.replaceAndPark(ftn, fwd);
+  }
+  return {localReg.replace(ftn, fwd), LocalForwarderRegistry::ParkTicket{}};
 }
 
 // Called from LocalPublishFilter::publish() on publisherExec. Creates the publisher's
@@ -643,11 +648,15 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
   }
 
   auto localPubFwd = std::make_shared<MoQForwarder>(pub.fullTrackName);
-  installPublisherForwarder(pub.fullTrackName, localPubFwd, /*removeOnEmpty=*/false)
-      .markReady(InitialTrackState{pub.largest, pub.extensions});
+  // Install the new forwarder and return the identity of the one that was displaced, if any.
+  // Either a publisher or a subscriber forwarder could be displaced. Either way, the relay exec
+  // hop below initiates publishDone on the publisher forwarder's exec in publishWithSession.
+  auto install =
+      installPublisherForwarder(pub.fullTrackName, localPubFwd, InstallKind::FromPublish);
+  install.claim.markReady(InitialTrackState{pub.largest, pub.extensions});
 
   // crossExecFilter is a channel subscriber for the relay exec
-  // regulsterPublishOnRelay exec completes wiring the chain (topNFilter → terminationFilter →
+  // registerPublishOnRelayExec completes wiring the chain (topNFilter → terminationFilter →
   // cache).
   auto crossExecFilter = std::make_shared<CrossExecFilter>(relayExec_, nullptr);
   // forward=true + passive=true: internal relay chain observes all objects but
@@ -655,24 +664,34 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
   localPubFwd
       ->addChannelSubscriber(relayExec_, /*forward=*/true, crossExecFilter, /*passive=*/true);
 
+  auto publisherRef = makeForwarderRef(localPubFwd, session->getExecutor());
+  auto ftn = pub.fullTrackName;
   auto reply = folly::coro::co_invoke(
       [exec = relayExec_,
        relay = shared_from_this(),
+       ftn = std::move(ftn),
+       displacedTicket = std::move(install.displaced),
        pub = std::move(pub),
        handle = std::move(handle),
        session = std::move(session),
-       localPubFwd,
+       publisherRef = std::move(publisherRef),
        crossExecFilter]() mutable -> folly::coro::Task<folly::Expected<PublishOk, PublishError>> {
-        co_return co_await folly::coro::co_withExecutor(
+        auto result = co_await folly::coro::co_awaitTry(folly::coro::co_withExecutor(
             folly::getKeepAliveToken(exec),
             relay->registerPublishOnRelayExec(
                 std::move(pub),
                 std::move(handle),
                 std::move(session),
-                std::move(localPubFwd),
+                std::move(publisherRef),
                 std::move(crossExecFilter)
             )
-        );
+        ));
+        // Now that the new forwarder has been registered on relayExec_, it's safe to discard the
+        // last strong reference to a displaced entry.
+        (void)relay->localRegistry().takeDisplaced(ftn, std::move(displacedTicket));
+
+        // This can throw if there was an error.
+        co_return std::move(result).value();
       }
   );
 
@@ -680,18 +699,22 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
   return PublishConsumerAndReplyTask{std::move(consumer), std::move(reply)};
 }
 
-// Runs on relayExec_. Registers publisherFwd in the registry and wires
+// Runs on relayExec_. Registers publisherRef in the registry and wires
 // relayChainFilter to the topN filter.
 folly::coro::Task<folly::Expected<PublishOk, PublishError>> MoqxRelay::registerPublishOnRelayExec(
     PublishRequest pub,
     std::shared_ptr<Publisher::SubscriptionHandle> handle,
     std::shared_ptr<MoQSession> session,
-    std::shared_ptr<MoQForwarder> publisherFwd,
+    ForwarderRef publisherRef,
     std::shared_ptr<CrossExecFilter> relayChainFilter
 ) {
   auto ftn = pub.fullTrackName;
-  auto setup =
-      publishWithSession(std::move(pub), std::move(handle), std::move(session), publisherFwd);
+  auto setup = publishWithSession(
+      std::move(pub),
+      std::move(handle),
+      std::move(session),
+      std::move(publisherRef)
+  );
   if (setup.hasError()) {
     co_return folly::makeUnexpected(setup.error());
   }
@@ -719,7 +742,15 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   XCHECK(mode() != Mode::LocalForwarder) << "publish() bypassed by LocalPublishFilter in LF mode";
 
   maybeSetSessionExec(*session);
-  auto setup = publishWithSession(std::move(pub), std::move(handle), std::move(session));
+  auto forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
+  forwarder->setExtensions(pub.extensions);
+  auto publisherRef = makeForwarderRef(forwarder, session->getExecutor());
+  auto setup = publishWithSession(
+      std::move(pub),
+      std::move(handle),
+      std::move(session),
+      std::move(publisherRef)
+  );
   if (setup.hasError()) {
     return folly::makeUnexpected(setup.error());
   }
@@ -735,43 +766,44 @@ MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
     PublishRequest pub,
     std::shared_ptr<Publisher::SubscriptionHandle> handle,
     std::shared_ptr<MoQSession> session,
-    std::shared_ptr<MoQForwarder> forwarder
+    ForwarderRef publisherRef
 ) {
-  // Handle duplicate publisher at relay level before registering in the tree.
-  if (!forwarder) {
-    forwarder = std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
-    forwarder->setExtensions(pub.extensions);
+  std::shared_ptr<MoQForwarder> chainForwarder;
+  if (mode() != Mode::LocalForwarder) {
+    // Strong ref to forwarder is allowed in non-LF modes
+    chainForwarder = publisherRef.getIfOwned();
   }
 
+  // Handle duplicate publisher at relay level before registering in the tree.
   auto publisherWrapped = maybeWrapPublisher(relayExec_, session);
   auto publishEntry = registry_.createFromPublish(
       pub.fullTrackName,
-      forwarder,
+      publisherRef,
       session,
       std::move(publisherWrapped),
       pub.requestID,
       std::move(handle),
-      [&](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(pub.fullTrackName, f); }
+      [&] { return buildFilterChain(pub.fullTrackName, chainForwarder); }
   );
 
   if (publishEntry.evicted) {
-    // A new publisher replaced a live one. createFromPublish already erased the old registry entry
-    // and handed us its last ref, so the onEmpty that publishDone may re-enter (via
-    // drainSubscriber) can't destroy the forwarder mid-forEachSubscriber.
     XLOG(DBG1) << "New publisher for existing subscription";
     auto& evicted = *publishEntry.evicted;
     // Null handle => previous publisher already terminated and onPublishDone() tore it down; skip.
     if (evicted.handle) {
-      // unsubscribe mutates the old publisher's session inline, so hop to its exec.
+      // Depending on mode, this is inline or a hop to publisherExec.
       runOnSessionExec(relayExec_, evicted.publisherExec, [h = evicted.handle] {
         h->unsubscribe();
       });
-      evicted.forwarder->publishDone(
-          {RequestID(0),
-           PublishDoneStatusCode::SUBSCRIPTION_ENDED,
-           0, // filled in by session
-           "upstream disconnect"}
-      );
+      PublishDone done{
+          RequestID(0),
+          PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+          0, // filled in by session
+          "upstream disconnect"
+      };
+      evicted.forwarder.post([done = std::move(done)](MoQForwarder& f) mutable {
+        f.publishDone(std::move(done));
+      });
     }
   }
 
@@ -802,7 +834,8 @@ MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
   case Mode::SingleThread:
   case Mode::RelayExec:
     // Weak ref breaks the registry → forwarder → callback → relay cycle.
-    forwarder->setCallback(std::make_shared<WeakRelayForwarderCallback>(weak_from_this()));
+    XCHECK(chainForwarder) << "publishWithSession: null chainForwarder in non-LF mode";
+    chainForwarder->setCallback(std::make_shared<WeakRelayForwarderCallback>(weak_from_this()));
     break;
   case Mode::LocalForwarder:
     // Local forwarder already had its CrossExecForwarderCallback installed by
@@ -822,15 +855,8 @@ MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
     if (outSession != session && (info.options == SubscribeNamespaceOptions::PUBLISH ||
                                   info.options == SubscribeNamespaceOptions::BOTH)) {
       nSubscribers++;
-      auto* publisherExec = relayExec_ ? session->getExecutor() : nullptr;
-      if (!addSubscriberAndPublish(
-              outSession,
-              forwarder,
-              info.forward,
-              /*pinned=*/true,
-              publisherExec
-          )) {
-        XLOG(ERR) << "addSubscriberAndPublish failed for " << forwarder->fullTrackName();
+      if (!addSubscriberAndPublish(outSession, publisherRef, info.forward, /*pinned=*/true)) {
+        XLOG(ERR) << "addSubscriberAndPublish failed for " << pub.fullTrackName;
         continue;
       }
     }
@@ -857,15 +883,8 @@ MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
   for (auto& [outSession, info] : tracksSessions) {
     if (outSession != session) {
       nSubscribers++;
-      auto* publisherExec = relayExec_ ? session->getExecutor() : nullptr;
-      if (!addSubscriberAndPublish(
-              outSession,
-              forwarder,
-              info.forward,
-              /*pinned=*/true,
-              publisherExec
-          )) {
-        XLOG(ERR) << "addSubscriberAndPublish failed for " << forwarder->fullTrackName();
+      if (!addSubscriberAndPublish(outSession, publisherRef, info.forward, /*pinned=*/true)) {
+        XLOG(ERR) << "addSubscriberAndPublish failed for " << pub.fullTrackName;
         continue;
       }
     }
@@ -959,20 +978,20 @@ std::optional<MoqxRelay::PreparedPublish> MoqxRelay::startPublish(
 // Returns false on synchronous failure.
 bool MoqxRelay::addSubscriberAndPublish(
     std::shared_ptr<MoQSession> subscriberSession,
-    std::shared_ptr<MoQForwarder> forwarder,
+    const ForwarderRef& publisherRef,
     bool forward,
-    bool pinned,
-    folly::Executor* publisherExec
+    bool pinned
 ) {
+  XCHECK(publisherRef) << "addSubscriberAndPublish: empty forwarder ref";
   if (mode() == Mode::LocalForwarder) {
-    XCHECK(publisherExec
-    ) << "addSubscriberAndPublish: publisherExec required in local-forwarder mode";
+    // TODO: we don't want to complete the publisher's replyTask until we've initiated
+    // publish and attached the consumer for every SUB_NS subscriber.  So .start()
+    // is not correct in LF mode.
     co_withExecutor(
         folly::getKeepAliveToken(subscriberSession->getExecutor()),
         addSubscriberAndPublishViaLocalForwarder(
             subscriberSession,
-            forwarder,
-            publisherExec,
+            publisherRef.track(),
             forward,
             pinned
         )
@@ -980,6 +999,8 @@ bool MoqxRelay::addSubscriberAndPublish(
         .start();
     return true;
   }
+  auto forwarder = publisherRef.getIfOwned();
+  XCHECK(forwarder) << "addSubscriberAndPublish: remote ref outside LocalForwarder mode";
   folly::Executor* subscriberExec = relayExec_ ? subscriberSession->getExecutor() : nullptr;
   auto p = startPublish(subscriberSession, forwarder, forward, pinned, subscriberExec);
   if (!p) {
@@ -997,30 +1018,27 @@ bool MoqxRelay::addSubscriberAndPublish(
 
 namespace {
 
-// Tears down an aborted local-forwarder setup: drops the channel sub(s) on the publisher (hopping
-// to publisherExec; the relayExec entry only when relayExec is non-null and drains localFwd via
-// publishDone if given.
+// Tears down an aborted local-forwarder setup: drops the channel sub(s) on the publisher
+// and drains subscriberLocalFwd via publishDone if given.  Only the first subscriber that
+// owns the relay chain can remove the relayExec's channel sub.
+// The drain runs inline, so a caller supplying subscriberLocalFwd must be on subscriberExec.
 void teardownLocalForwarderOnFailure(
-    folly::Executor* publisherExec,
-    std::shared_ptr<MoQForwarder> publisherFwd,
+    const openmoq::moqx::ForwarderRef& publisherRef,
     folly::Executor* subscriberExec,
     folly::Executor* relayExec,
-    const std::shared_ptr<MoQForwarder>& localFwd = nullptr,
+    const std::shared_ptr<MoQForwarder>& subscriberLocalFwd = nullptr,
     std::string publishDoneReason = {}
 ) {
-  if (publisherFwd && publisherExec) {
-    folly::via(
-        publisherExec,
-        [pf = std::move(publisherFwd), ex = subscriberExec, re = relayExec]() noexcept {
-          pf->removeChannelSubscriberByExec(ex);
-          if (re) {
-            pf->removeChannelSubscriberByExec(re);
-          }
-        }
-    );
+  if (publisherRef) {
+    publisherRef.post([ex = subscriberExec, re = relayExec](MoQForwarder& pf) {
+      pf.removeChannelSubscriberByExec(ex);
+      if (re) {
+        pf.removeChannelSubscriberByExec(re);
+      }
+    });
   }
-  if (localFwd) {
-    localFwd->publishDone(PublishDone{
+  if (subscriberLocalFwd) {
+    subscriberLocalFwd->publishDone(PublishDone{
         RequestID(0),
         PublishDoneStatusCode::INTERNAL_ERROR,
         0,
@@ -1040,12 +1058,13 @@ void teardownLocalForwarderOnFailure(
 //
 // Multi-threaded — publisher forwarder (lives on publisherExec):
 //   publisherFwd.callback =
-//     CrossExecForwarderCallback(relayExec_,
-//       WeakRelayForwarderCallback(relay))
+//     LocalForwarderCallback(localReg, ftn,
+//       CrossExecForwarderCallback(relayExec_,
+//         WeakRelayForwarderCallback(relay)))
 //
-//   [publisherExec] CrossExecForwarderCallback: captures ftn by value,
-//                 dispatches to relayExec_ fire-and-forget
-//       ↓
+//   [publisherExec] LocalForwarderCallback: removes from localReg on onEmpty
+//                 (removeOnEmpty=false when publish-initiated, true when subscribe-initiated)
+//       ↓ (CrossExecForwarderCallback dispatches to relayExec_ fire-and-forget)
 //   [relayExec_]  WeakRelayForwarderCallback: recovers relay via weak_ptr,
 //                 calls onEmptyImpl / forwardChangedImpl / newGroupRequestedImpl
 //
@@ -1058,7 +1077,7 @@ void teardownLocalForwarderOnFailure(
 //     localFwd.callback =
 //       LocalForwarderCallback(localReg, ftn,
 //         CrossExecForwarderCallback(publisherExec,
-//           ChannelForwarderCallback(publisherFwd, subscriberExec, publisherExec)))
+//           ChannelForwarderCallback(channelSub, subscriberExec)))
 //
 //   [subscriberExec] LocalForwarderCallback: removes from localReg on onEmpty,
 //                    passes through forwardChanged / newGroupRequested
@@ -1075,7 +1094,7 @@ void teardownLocalForwarderOnFailure(
 //   CrossExecForwarderCallback reads the track name from the forwarder that invoked it
 //   — on the owner thread, where the forwarder is alive.
 
-// Captures forwardChanged/newGroupRequested/onEmpty during setup (getOrCreate→setCallback window)
+// Captures forwardChanged/newGroupRequested/onEmpty during setup (join→setCallback window)
 // so they can be replayed once the real callback is installed.
 class PendingForwarderCallback : public moxygen::MoQForwarder::Callback {
 public:
@@ -1105,13 +1124,8 @@ public:
 // channel-subscriber lifecycle events to the publisher and upstream handle.
 class ChannelForwarderCallback : public openmoq::moqx::TrackEventCallback {
 public:
-  ChannelForwarderCallback(
-      std::weak_ptr<moxygen::MoQForwarder> weakPublisher,
-      folly::Executor* subscriberExec,
-      folly::Executor* publisherExec
-  )
-      : weakPublisher_(std::move(weakPublisher)), subscriberExec_(subscriberExec),
-        publisherExec_(publisherExec) {}
+  ChannelForwarderCallback(ChannelSubscriber channelSub, folly::Executor* subscriberExec)
+      : channelSub_(std::move(channelSub)), subscriberExec_(subscriberExec) {}
 
   // Called on publisherExec immediately after addChannelSubscriber returns.
   void setHandle(std::shared_ptr<moxygen::Publisher::SubscriptionHandle> h) {
@@ -1123,10 +1137,7 @@ public:
   void setFilter(std::shared_ptr<CrossExecFilter> filter) { crossExecFilter_ = std::move(filter); }
 
   void onEmpty(const moxygen::FullTrackName& /*ftn*/) override {
-    auto publisher = weakPublisher_.lock();
-    if (publisher) {
-      publisher->removeChannelSubscriberByExec(subscriberExec_);
-    }
+    channelSub_.detach(subscriberExec_);
     // handle_ pins the chain (localFwd → callbacks → handle_ → CrossExecFilter → localFwd).
     // removeChannelSubscriberByExec drops the publisher's ref but not this; in the replace
     // scenario it never ran, so reset handle_ unconditionally.
@@ -1142,29 +1153,29 @@ public:
     if (!handle_) {
       return;
     }
-    launchUpdate(publisherExec_, doSubscribeUpdate(handle_, forward));
+    launchUpdate(channelSub_.exec(), doSubscribeUpdate(handle_, forward));
   }
 
   void newGroupRequested(const moxygen::FullTrackName&, uint64_t group) override {
     if (!handle_) {
       return;
     }
-    launchUpdate(publisherExec_, doNewGroupRequestUpdate(handle_, group));
+    launchUpdate(channelSub_.exec(), doNewGroupRequestUpdate(handle_, group));
   }
 
   // publishDone drains the subscribers, so onEmpty follows and does the teardown.
   void onPublishDone(const moxygen::FullTrackName& /*ftn*/) override {}
 
 private:
-  std::weak_ptr<moxygen::MoQForwarder> weakPublisher_;
+  ChannelSubscriber channelSub_;
   folly::Executor* subscriberExec_;
-  folly::Executor* publisherExec_;
   std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle_;
   std::shared_ptr<CrossExecFilter> crossExecFilter_;
 };
 
 // Builds the local->publisher callback chain (Channel -> CrossExec -> LocalForwarder).
 // channelCb is wired with the channel handle/filter later, on publisherExec.
+// Must run on publisherExec: channelCb captures that thread at construction.
 struct LocalToPublisherCallbacks {
   std::shared_ptr<ChannelForwarderCallback> channelCb;
   std::shared_ptr<moxygen::MoQForwarder::Callback> finalCallback;
@@ -1172,12 +1183,12 @@ struct LocalToPublisherCallbacks {
 LocalToPublisherCallbacks buildLocalToPublisherCallbacks(
     openmoq::moqx::LocalForwarderRegistry* localReg,
     moxygen::FullTrackName ftn,
-    const std::shared_ptr<moxygen::MoQForwarder>& publisherFwd,
-    folly::Executor* publisherExec,
+    ChannelSubscriber channelSub,
     folly::Executor* subscriberExec
 ) {
+  auto* publisherExec = channelSub.exec();
   auto channelCb =
-      std::make_shared<ChannelForwarderCallback>(publisherFwd, subscriberExec, publisherExec);
+      std::make_shared<ChannelForwarderCallback>(std::move(channelSub), subscriberExec);
   auto crossExecCb = std::make_shared<CrossExecForwarderCallback>(publisherExec, channelCb);
   auto finalCallback =
       std::make_shared<LocalForwarderCallback>(localReg, std::move(ftn), std::move(crossExecCb));
@@ -1200,40 +1211,6 @@ void installChannelSubscriber(
   channelCb.setFilter(crossExecFilter);
 }
 
-// Wires localFwd to publisherFwd as a channel subscriber, hopping to publisherExec.
-// Returns the finalCallback to install on localFwd. Used by the publish LF path.
-folly::coro::Task<std::shared_ptr<moxygen::MoQForwarder::Callback>> addLocalForwarderToPublisher(
-    openmoq::moqx::LocalForwarderRegistry* localReg,
-    moxygen::FullTrackName ftn,
-    std::shared_ptr<moxygen::MoQForwarder> publisherFwd,
-    folly::Executor* publisherExec,
-    folly::Executor* subscriberExec,
-    std::shared_ptr<CrossExecFilter> crossExecFilter,
-    bool forward
-) {
-  auto cbs = buildLocalToPublisherCallbacks(
-      localReg,
-      std::move(ftn),
-      publisherFwd,
-      publisherExec,
-      subscriberExec
-  );
-  co_await folly::coro::co_withExecutor(
-      folly::getKeepAliveToken(publisherExec),
-      [&]() -> folly::coro::Task<void> {
-        installChannelSubscriber(
-            *cbs.channelCb,
-            *publisherFwd,
-            subscriberExec,
-            forward,
-            crossExecFilter
-        );
-        co_return;
-      }()
-  );
-  co_return cbs.finalCallback;
-}
-
 // Installs finalCallback on localFwd and replays any forwardChanged/newGroupRequested
 // events captured during setup. Must run on subscriberExec.
 void replayPendingFowarderEvents(
@@ -1252,17 +1229,31 @@ void replayPendingFowarderEvents(
 }
 } // namespace
 
-// Runs on subscriberExec. Gets or creates the thread-local forwarder for ftn, wires
-// it to publisherFwd as a channel subscriber (isNew path), and awaits the publish reply.
+folly::coro::Task<std::optional<MoqxRelay::ResolvedPublisher>>
+MoqxRelay::resolvePublisherOnItsExec(TrackRef track) {
+  auto* publisherReg = tlForwarders_.get();
+  auto publisherFwd = publisherReg ? publisherReg->getIfReady(track.ftn) : nullptr;
+  if (!publisherFwd) {
+    co_return std::nullopt;
+  }
+  co_return ResolvedPublisher{
+      ForwarderRef::remote(publisherFwd, folly::getKeepAliveToken(track.exec)),
+      ChannelSubscriber(publisherFwd, track.exec),
+      InitialTrackState::capture(*publisherFwd)
+  };
+}
+
+// Runs on subscriberExec. Gets or creates the thread-local forwarder, wires it to the publisher
+// forwarder as a channel subscriber (isNew path), and awaits the publish reply.
 folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
     std::shared_ptr<MoQSession> subscriberSession,
-    std::shared_ptr<MoQForwarder> publisherFwd,
-    folly::Executor* publisherExec,
+    TrackRef track,
     bool forward,
     bool pinned
 ) {
   auto* subscriberExec = subscriberSession->getExecutor();
-  const auto& ftn = publisherFwd->fullTrackName();
+  const auto& ftn = track.ftn;
+  auto* publisherExec = track.exec;
 
   // Fast path: local forwarder already exists on this thread.
   if (auto* localReg = tlForwarders_.get()) {
@@ -1275,18 +1266,15 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
     }
   }
 
-  // Capture largest/extensions on publisherExec; reading them on subscriberExec would
-  // race the publisher advancing largest_.
-  InitialTrackState initial;
-  co_await folly::coro::co_withExecutor(
+  auto publisher = co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(publisherExec),
-      [&]() -> folly::coro::Task<void> {
-        initial = InitialTrackState::capture(*publisherFwd);
-        co_return;
-      }()
+      resolvePublisherOnItsExec(track)
   );
+  if (!publisher) {
+    co_return; // torn down before the hop landed
+  }
 
-  auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, initial);
+  auto [localFwd, isNew, localReg] = acquireLocalForwarder(ftn, publisher->initial);
   if (!localFwd) {
     // Setup for this track is in flight on this thread; drop the fanout.
     co_return;
@@ -1313,32 +1301,58 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
   auto crossExecFilter = std::make_shared<CrossExecFilter>(subscriberExec, localFwd);
   bool hasForwardingSub = (localFwd->numForwardingSubscribers() > 0);
 
-  auto finalCallback = co_await addLocalForwarderToPublisher(
-      localReg,
-      ftn,
-      publisherFwd,
-      publisherExec,
-      subscriberExec,
-      crossExecFilter,
-      hasForwardingSub
-  );
+  // Wire localFwd in as a channel subscriber on the publisher's exec
+  auto finalCallback = co_await publisher->ref.co_with([&](MoQForwarder& publisherFwd) {
+    auto cbs = buildLocalToPublisherCallbacks(
+        localReg,
+        ftn,
+        std::move(publisher->channelSub),
+        subscriberExec
+    );
+    installChannelSubscriber(
+        *cbs.channelCb,
+        publisherFwd,
+        subscriberExec,
+        hasForwardingSub,
+        crossExecFilter
+    );
+    return cbs.finalCallback;
+  });
 
   // Natural unwind: back on subscriberExec.
 
-  if (pendingCb->sawOnEmpty_) {
+  // attached=0: the publisher went away before the channel sub was installed.
+  // sawOnEmpty=1: every subscriber cancelled while setup was in flight.
+  if (!finalCallback || pendingCb->sawOnEmpty_) {
+    auto reason = folly::to<std::string>(
+        "local forwarder setup failed: attached=",
+        finalCallback.has_value(),
+        " sawOnEmpty=",
+        pendingCb->sawOnEmpty_
+    );
+    XLOG(ERR) << reason << " ftn=" << ftn;
     teardownLocalForwarderOnFailure(
-        publisherExec,
-        publisherFwd,
+        publisher->ref,
         subscriberExec,
         /*relayExec=*/nullptr,
         localFwd,
-        "all subscribers cancelled during setup"
+        reason
     );
     co_return;
   }
 
-  replayPendingFowarderEvents(localFwd.get(), finalCallback, *pendingCb, hasForwardingSub);
+  replayPendingFowarderEvents(localFwd.get(), *finalCallback, *pendingCb, hasForwardingSub);
   co_await awaitPublishReply(localFwd, std::move(p->subscriber), std::move(p->reply));
+}
+
+ForwarderRef MoqxRelay::makeForwarderRef(
+    const std::shared_ptr<MoQForwarder>& forwarder,
+    folly::Executor* publisherExec
+) const {
+  if (mode() == Mode::LocalForwarder) {
+    return ForwarderRef::remote(forwarder, folly::getKeepAliveToken(publisherExec));
+  }
+  return ForwarderRef::owned(forwarder);
 }
 
 LocalForwarderRegistry& MoqxRelay::localRegistry() {
@@ -1672,7 +1686,7 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
         node->forEachPublish([&](const std::string& trackName,
                                  const std::shared_ptr<MoQSession>& publishSession) {
           FullTrackName ftn{prefix, trackName};
-          auto forwarder = registry_.getForwarder(ftn);
+          auto forwarder = registry_.getForwarderRef(ftn);
           if (!forwarder) {
             XLOG(ERR) << "Invalid state, no subscription for publish ftn=" << ftn;
             return;
@@ -1690,14 +1704,7 @@ folly::coro::Task<Publisher::SubscribeNamespaceResult> MoqxRelay::subscribeNames
               (subNs.options == SubscribeNamespaceOptions::BOTH ||
                subNs.options == SubscribeNamespaceOptions::PUBLISH)) {
             if (publishSession != session) {
-              auto* publisherExec = relayExec_ ? publishSession->getExecutor() : nullptr;
-              if (!addSubscriberAndPublish(
-                      session,
-                      forwarder,
-                      subNs.forward,
-                      /*pinned=*/true,
-                      publisherExec
-                  )) {
+              if (!addSubscriberAndPublish(session, forwarder, subNs.forward, /*pinned=*/true)) {
                 XLOG(ERR) << "addSubscriberAndPublish failed for " << ftn;
                 return;
               }
@@ -1788,18 +1795,11 @@ folly::coro::Task<Publisher::SubscribeTracksResult> MoqxRelay::subscribeTracks(
               return;
             }
             FullTrackName ftn{prefix, trackName};
-            auto forwarder = registry_.getForwarder(ftn);
+            auto forwarder = registry_.getForwarderRef(ftn);
             if (!forwarder) {
               return;
             }
-            auto* publisherExec = relayExec_ ? publishSession->getExecutor() : nullptr;
-            if (!addSubscriberAndPublish(
-                    session,
-                    forwarder,
-                    subTracks.forward,
-                    /*pinned=*/true,
-                    publisherExec
-                )) {
+            if (!addSubscriberAndPublish(session, forwarder, subTracks.forward, /*pinned=*/true)) {
               XLOG(ERR) << "addSubscriberAndPublish failed for " << ftn;
               return;
             }
@@ -1947,7 +1947,7 @@ std::optional<SubscribeError> MoqxRelay::completeUpstreamSubscription(
 folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwarderOnRelayExec(
     const SubscribeRequest& subReq,
     LocalForwarderRegistry* localReg,
-    std::shared_ptr<MoQForwarder> /*localFwd*/,
+    std::shared_ptr<MoQForwarder> localFwd,
     folly::Executor* subscriberExec,
     std::shared_ptr<CrossExecFilter> crossExecFilter,
     bool forward
@@ -1961,40 +1961,66 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
     attach.error = std::move(*sr.error);
     co_return attach; // pending dtor fires when sr is destroyed, cleaning the registry
   }
-  attach.publisherFwd = sr.publisherForwarder;
-  attach.publisherExec = sr.publisherExec;
-  if (!attach.publisherFwd || !attach.publisherExec) {
+  auto* publisherExec = sr.publisherExec;
+  if (!publisherExec) {
     co_return attach;
   }
-  attach.ownsRelayChain = sr.firstSetup.has_value();
-
-  // Single publisherExec sortie for all publisherFwd mutation: the local channel sub and,
-  // for the first subscriber, the passive relay chain + upstream subscribe. Merging the
-  // two installs drops a relayExec_ round-trip.
-  auto cbs = buildLocalToPublisherCallbacks(
-      localReg,
-      ftn,
-      attach.publisherFwd,
-      attach.publisherExec,
-      subscriberExec
-  );
-  attach.finalCallback = cbs.finalCallback;
-
   std::shared_ptr<CrossExecFilter> relayChainFilter;
   std::optional<folly::Expected<UpstreamOk, SubscribeError>> upstreamResult;
 
+  // One publisherExec sortie to setup the publisher forwarder on its exec.
+  // The first subscriber transfers ownership to the local registry, installs the
+  // relay chain, and subscribes upstream.  All subscribers install their channel
+  // subscriber, and capture the initialState.
   co_await folly::coro::co_withExecutor(
-      folly::getKeepAliveToken(attach.publisherExec),
+      folly::getKeepAliveToken(publisherExec),
       [&]() -> folly::coro::Task<void> {
+        std::shared_ptr<MoQForwarder> publisherFwd;
+        const char* failure = nullptr;
+        if (sr.firstSetup) {
+          auto* occupant = localRegistry().getForEviction(ftn).get();
+          if (occupant && occupant != localFwd.get()) {
+            // A PUBLISH here raced a SUBSCRIBE from another thread.
+            // TODO: join the publisher forwarder instead of failing the SUBSCRIBE.
+            failure = "publisher forwarder already installed";
+          } else {
+            publisherFwd = std::move(sr.firstSetup->publisherForwarder);
+          }
+        } else {
+          // Could be displaced by a reconnecting publisher, or the publisher could have gone away
+          publisherFwd = localRegistry().getIfReady(ftn);
+          if (!publisherFwd) {
+            failure = "publisher forwarder gone";
+          }
+        }
+        if (failure) {
+          XLOG(ERR) << failure << " during subscribe setup: " << ftn;
+          attach.error = folly::makeUnexpected(
+              SubscribeError{subReq.requestID, SubscribeErrorCode::INTERNAL_ERROR, failure}
+          );
+          co_return;
+        }
+        attach.publisherRef =
+            ForwarderRef::remote(publisherFwd, folly::getKeepAliveToken(publisherExec));
+
         LocalForwarderRegistry::Claim publisherClaim;
         if (sr.firstSetup) {
-          publisherClaim =
-              installPublisherForwarder(ftn, attach.publisherFwd, /*removeOnEmpty=*/true);
+          publisherClaim = std::move(
+              installPublisherForwarder(ftn, publisherFwd, InstallKind::FromSubscribe).claim
+          );
         }
+
+        auto cbs = buildLocalToPublisherCallbacks(
+            localReg,
+            ftn,
+            ChannelSubscriber(publisherFwd, publisherExec),
+            subscriberExec
+        );
+        attach.finalCallback = cbs.finalCallback;
 
         installChannelSubscriber(
             *cbs.channelCb,
-            *attach.publisherFwd,
+            *publisherFwd,
             subscriberExec,
             forward,
             crossExecFilter
@@ -2006,18 +2032,19 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
           // object, passive=true so it doesn't count as a forwarding subscriber or in the
           // onEmpty quorum (the publisher's onEmpty still fires when the last real sub leaves).
           relayChainFilter = std::make_shared<CrossExecFilter>(relayExec_, nullptr);
-          attach.publisherFwd->addChannelSubscriber(
+          publisherFwd->addChannelSubscriber(
               relayExec_,
               /*forward=*/true,
               relayChainFilter,
               /*passive=*/true
           );
+          attach.ownsRelayChain = true;
           setup.upstreamSubReq.forward = forward;
           upstreamResult = co_await subscribeUpstreamAndApplyOk(
               setup.upstreamSession,
               std::move(setup.upstreamSubReq),
               std::move(setup.upstreamConsumer),
-              attach.publisherFwd,
+              publisherFwd,
               setup.clientRequestID
           );
           if (upstreamResult->hasValue()) {
@@ -2027,24 +2054,19 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
         }
         // Capture largest/extensions on publisherExec to set the initial state for the
         // subscriber.  Captured but ignored when the firstSetup returned an error.
-        attach.initial = InitialTrackState::capture(*attach.publisherFwd);
+        attach.initial = InitialTrackState::capture(*publisherFwd);
       }()
   );
   // Back on relayExec_.
 
+  if (attach.error) {
+    co_return attach; // subsequent resolve failed in the sortie
+  }
   if (!sr.firstSetup) {
     co_return attach; // subsequent subscriber: wired to the live publisher, done
   }
 
   if (upstreamResult->hasError()) {
-    // Upstream subscribe failed: drop the channel sub(s) we installed (the relay-exec
-    // sub too, since firstSetup owns the relay chain). localFwd is drained by the tail.
-    teardownLocalForwarderOnFailure(
-        attach.publisherExec,
-        attach.publisherFwd,
-        subscriberExec,
-        relayChainFilter ? relayExec_ : nullptr
-    );
     attach.error = folly::makeUnexpected(std::move(upstreamResult->error()));
     co_return attach;
   }
@@ -2087,29 +2109,37 @@ MoqxRelay::joinOrPrepareUpstreamSubscription(SubscribeRequest subReq) {
     co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
   }
 
+  // upstreamSession is set by the factory for the first subscriber that needs to go upstream.
+  std::shared_ptr<MoQSession> upstreamSession;
   auto firstOrSubsequent = registry_.getOrCreateFromSubscribe(
       ftn,
       // installPublisherForwarder puts the real chain on the forwarder's own exec instead;
       // a relay-direct callback would run there and touch registry_ off relayExec_.
       std::shared_ptr<MoQForwarder::Callback>(nullptr),
-      [this, &ftn](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(ftn, std::move(f)); }
+      [this, &ftn](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(ftn, std::move(f)); },
+      [this, &ftn, &upstreamSession](const std::shared_ptr<MoQForwarder>& f
+      ) -> std::optional<ForwarderRef> {
+        upstreamSession = namespaceTree_.findPublisherSession(ftn.trackNamespace);
+        if (!upstreamSession) {
+          return std::nullopt;
+        }
+        return makeForwarderRef(f, upstreamSession->getExecutor());
+      }
   );
 
-  if (auto* first = std::get_if<SubscriptionRegistry::FirstSubscriber>(&firstOrSubsequent)) {
-    auto upstreamSession = namespaceTree_.findPublisherSession(ftn.trackNamespace);
-    if (!upstreamSession) {
-      co_return StatefulSubscribeResult{
-          nullptr,
-          nullptr,
-          folly::makeUnexpected(SubscribeError{
-              subReq.requestID,
-              SubscribeErrorCode::DOES_NOT_EXIST,
-              "no such namespace or track"
-          }),
-          std::nullopt
-      };
-    }
+  if (std::get_if<SubscriptionRegistry::NoPublisher>(&firstOrSubsequent)) {
+    co_return StatefulSubscribeResult{
+        nullptr,
+        folly::makeUnexpected(SubscribeError{
+            subReq.requestID,
+            SubscribeErrorCode::DOES_NOT_EXIST,
+            "no such namespace or track"
+        }),
+        std::nullopt
+    };
+  }
 
+  if (auto* first = std::get_if<SubscriptionRegistry::FirstSubscriber>(&firstOrSubsequent)) {
     const auto clientRequestID = subReq.requestID;
     // forward updated to its real value in attachNewLocalForwarderOnRelayExec.
     SubscribeRequest upstreamSubReq = makeUpstreamSubReq(subReq, /*forward=*/false);
@@ -2117,9 +2147,9 @@ MoqxRelay::joinOrPrepareUpstreamSubscription(SubscribeRequest subReq) {
     // first->consumer is the publisher forwarder (lives on publisherExec == upstreamSession's
     // executor). No cross-exec wrapping — upstream delivers on that executor directly.
     auto upstreamConsumer = first->consumer;
-    StatefulSubscribeResult
-        result{first->forwarder, upstreamSession->getExecutor(), std::nullopt, std::nullopt};
+    StatefulSubscribeResult result{upstreamSession->getExecutor(), std::nullopt, std::nullopt};
     result.firstSetup.emplace(StatefulSubscribeResult::FirstSubscriberSetup{
+        first->forwarder,
         upstreamSession,
         std::move(upstreamSubReq),
         std::move(upstreamConsumer),
@@ -2129,12 +2159,14 @@ MoqxRelay::joinOrPrepareUpstreamSubscription(SubscribeRequest subReq) {
     co_return result;
 
   } else {
+    // Wait for the first subscriber to complete setup
     auto sub = co_await std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
         std::move(firstOrSubsequent)
     );
     auto upstreamView = registry_.getUpstreamView(ftn);
     auto* publisherExec = upstreamView ? upstreamView->publisherExec : nullptr;
-    co_return StatefulSubscribeResult{sub.forwarder, publisherExec, std::nullopt, std::nullopt};
+    // Return the publisherExec to the subscriber thread to complete setup.
+    co_return StatefulSubscribeResult{publisherExec, std::nullopt, std::nullopt};
   }
 }
 
@@ -2224,8 +2256,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
     // PendingForwarderCallback::onEmpty). Drop the channel sub(s); the registry entry +
     // upstream sub remain, so a later subscribe takes the SubsequentSubscriber path.
     teardownLocalForwarderOnFailure(
-        attach.publisherExec,
-        attach.publisherFwd,
+        attach.publisherRef,
         subscriberExec,
         attach.ownsRelayChain ? relayExec_ : nullptr
     );
@@ -2237,12 +2268,13 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
   }
 
   if (attach.error) {
-    localFwd->publishDone(PublishDone{
-        RequestID(0),
-        PublishDoneStatusCode::INTERNAL_ERROR,
-        0,
+    teardownLocalForwarderOnFailure(
+        attach.publisherRef,
+        subscriberExec,
+        attach.ownsRelayChain ? relayExec_ : nullptr,
+        localFwd,
         attach.error->error().reasonPhrase
-    });
+    );
     co_return std::move(*attach.error);
   }
 
@@ -2284,19 +2316,29 @@ MoqxRelay::subscribeImpl(SubscribeRequest subReq, std::shared_ptr<TrackConsumer>
   consumer =
       wrapWithTrackStats(trackStats_, ftn, std::move(consumer), stats::TrackDirection::Egress);
 
+  // upstreamSession is set by the factory for the first subscriber that needs to go upstream.
+  std::shared_ptr<MoQSession> upstreamSession;
   auto firstOrSubsequent = registry_.getOrCreateFromSubscribe(
       ftn,
       shared_from_this(),
-      [this, &ftn](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(ftn, std::move(f)); }
+      [this, &ftn](std::shared_ptr<MoQForwarder> f) { return buildFilterChain(ftn, std::move(f)); },
+      [this, &ftn, &upstreamSession](const std::shared_ptr<MoQForwarder>& f
+      ) -> std::optional<ForwarderRef> {
+        upstreamSession = namespaceTree_.findPublisherSession(ftn.trackNamespace);
+        if (!upstreamSession) {
+          return std::nullopt;
+        }
+        return makeForwarderRef(f, upstreamSession->getExecutor());
+      }
   );
 
+  if (std::get_if<SubscriptionRegistry::NoPublisher>(&firstOrSubsequent)) {
+    co_return folly::makeUnexpected(SubscribeError(
+        {subReq.requestID, SubscribeErrorCode::DOES_NOT_EXIST, "no such namespace or track"}
+    ));
+  }
+
   if (auto* first = std::get_if<SubscriptionRegistry::FirstSubscriber>(&firstOrSubsequent)) {
-    auto upstreamSession = namespaceTree_.findPublisherSession(ftn.trackNamespace);
-    if (!upstreamSession) {
-      co_return folly::makeUnexpected(SubscribeError(
-          {subReq.requestID, SubscribeErrorCode::DOES_NOT_EXIST, "no such namespace or track"}
-      ));
-    } // pending destructor fires on early return above
     auto upstreamPublisher = maybeWrapPublisher(relayExec_, upstreamSession);
 
     // Add subscriber first (with the client's original request) in case objects
@@ -2346,11 +2388,14 @@ MoqxRelay::subscribeImpl(SubscribeRequest subReq, std::shared_ptr<TrackConsumer>
     auto sub = co_await std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
         std::move(firstOrSubsequent)
     );
-    // sub.forwarder is valid: promise was fulfilled by first subscriber
-    if (auto err = checkRangeNotInPast(*sub.forwarder, subReq)) {
+    // LocalPublishFilter routes LF-mode subscribes to subscribeFromSubscriberExec, so
+    // the entry's ref is owned here.
+    auto forwarder = sub.forwarder.getIfOwned();
+    XCHECK(forwarder) << "subscribeImpl reached with a remote forwarder ref";
+    if (auto err = checkRangeNotInPast(*forwarder, subReq)) {
       co_return folly::makeUnexpected(std::move(*err));
     }
-    co_return attachSubscriber(*sub.forwarder, std::move(session), subReq, std::move(consumer));
+    co_return attachSubscriber(*forwarder, std::move(session), subReq, std::move(consumer));
   }
 }
 
@@ -2430,7 +2475,10 @@ MoqxRelay::fetchImpl(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
           {fetch.requestID, FetchErrorCode::DOES_NOT_EXIST, "No subscription for joining fetch"}
       ));
     } else if (fetchView->isReady) {
-      auto res = fetchView->forwarder->resolveJoiningFetch(session, *joining);
+      // Non-LF only (guarded above): the entry's ref is owned here.
+      auto forwarder = fetchView->forwarder.getIfOwned();
+      XCHECK(forwarder) << "joining fetch against a remote-owned entry";
+      auto res = forwarder->resolveJoiningFetch(session, *joining);
       if (res.hasError()) {
         co_return folly::makeUnexpected(res.error());
       }
@@ -2512,11 +2560,12 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatusImpl(Track
           readPublisherForwarderStatus((bool)upstreamView->handle, trackStatus)
       );
     }
-  } else if (upstreamView && upstreamView->forwarder &&
-             upstreamView->forwarder->numForwardingSubscribers() > 0) {
+  } else if (upstreamView) {
     // Non-LF: relayExec_ (or the single thread) owns the sole forwarder; read it inline.
-    trackStatusOk =
-        buildTrackStatusOk(*upstreamView->forwarder, (bool)upstreamView->handle, trackStatus);
+    auto forwarder = upstreamView->forwarder.getIfOwned();
+    if (forwarder && forwarder->numForwardingSubscribers() > 0) {
+      trackStatusOk = buildTrackStatusOk(*forwarder, (bool)upstreamView->handle, trackStatus);
+    }
   }
   if (trackStatusOk) {
     XLOG(DBG1) << "Returning local track status for " << trackStatus.fullTrackName
@@ -2700,10 +2749,14 @@ std::shared_ptr<PropertyRanking> MoqxRelay::getOrCreateRanking(
             auto topNView = registry_.getTopNView(ftn);
             if (topNView) {
               lastObjectTime = topNView->lastObjectTime;
-              initialPropertyValue =
-                  topNView->forwarder->extensions().getIntExtension(propertyType);
-              // Wire value-change, track-ended, and activity observers on the existing TopNFilter.
+              if (auto forwarder = topNView->forwarder.getIfOwned()) {
+                initialPropertyValue = forwarder->extensions().getIntExtension(propertyType);
+              }
+              // else: (LF) the forwarder's extensions are not readable here, the ranking is built
+              // as new objects arrive.
               if (topNView->topNFilter) {
+                // Wire value-change, track-ended, and activity observers to the existing
+                // TopNFilter.
                 auto rankingPtr = ranking;
                 topNView->topNFilter->registerObserver(
                     propertyType,
@@ -2752,18 +2805,14 @@ void MoqxRelay::onTrackSelected(
     return;
   }
 
-  auto trackForwarder = registry_.getForwarder(ftn);
+  auto trackForwarder = registry_.getForwarderRef(ftn);
   if (!trackForwarder) {
-    XLOG(DBG4) << "onTrackSelected: no subscription/forwarder for " << ftn;
+    XLOG(DBG4) << "onTrackSelected: no subscription for " << ftn;
     return;
   }
 
-  auto upstreamView = registry_.getUpstreamView(ftn);
-  XCHECK(!relayExec_ || (upstreamView && upstreamView->publisherExec))
-      << "onTrackSelected: relayExec set but no publisherExec for " << ftn;
-  auto* publisherExec = relayExec_ ? upstreamView->publisherExec : nullptr;
   // TRACK_FILTER subscribers are unpinned so onTrackEvicted can remove them.
-  addSubscriberAndPublish(session, trackForwarder, forward, /*pinned=*/false, publisherExec);
+  addSubscriberAndPublish(session, trackForwarder, forward, /*pinned=*/false);
 }
 
 void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSession> session) {
@@ -2799,9 +2848,9 @@ void MoqxRelay::onTrackEvicted(const FullTrackName& ftn, std::shared_ptr<MoQSess
       auto* localReg = tlForwarders_.get();
       evict(localReg ? localReg->getForEviction(ftn) : nullptr);
     });
-    return;
+  } else {
+    evict(registry_.getForwarderRef(ftn).getIfOwned());
   }
-  evict(registry_.getForwarder(ftn));
 }
 
 MoqxRelay::TrackMatch
@@ -2839,13 +2888,17 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
     RelayStateVisitor::SubscriptionInfo info{
         .ftn = e.ftn,
         .isPublish = e.isPublish,
-        .subscribers = e.forwarder->subscriberCount(),
-        .forwardingSubscribers = e.forwarder->numForwardingSubscribers(),
-        .largest = e.forwarder->largest(),
-        .totalGroupsReceived = e.forwarder->totalGroupsReceived(),
-        .totalObjectsReceived = e.forwarder->totalObjectsReceived(),
         .sourceAddress = sourceAddr,
     };
+    if (auto forwarder = e.forwarder.getIfOwned()) {
+      info.subscribers = forwarder->subscriberCount();
+      info.forwardingSubscribers = forwarder->numForwardingSubscribers();
+      info.largest = forwarder->largest();
+      info.totalGroupsReceived = forwarder->totalGroupsReceived();
+      info.totalObjectsReceived = forwarder->totalObjectsReceived();
+    }
+    // else LF mode: forwarder is on the publisher exec, not accessible here.
+    // TODO: add LF mode stats to the visitor via a cross-exec callback.
     visitor.onSubscription(info);
   });
   visitor.onSubscriptionsEnd();

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -14,6 +14,8 @@
 #include "SubscriptionRegistry.h"
 #include "UpstreamProvider.h"
 #include "config/Config.h"
+#include "relay/ChannelSubscriber.h"
+#include "relay/ForwarderRef.h"
 #include "relay/LocalForwarderRegistry.h"
 #include "relay/PropertyRanking.h"
 #include "relay/RelayExecUtil.h"
@@ -66,11 +68,11 @@ public:
   struct SubscriptionInfo {
     const moxygen::FullTrackName& ftn;
     bool isPublish;
-    size_t subscribers;
-    uint64_t forwardingSubscribers;
+    size_t subscribers{0};
+    uint64_t forwardingSubscribers{0};
     std::optional<moxygen::AbsoluteLocation> largest;
-    uint64_t totalGroupsReceived;
-    uint64_t totalObjectsReceived;
+    uint64_t totalGroupsReceived{0};
+    uint64_t totalObjectsReceived{0};
     std::string_view sourceAddress;
   };
   virtual void onSubscription(const SubscriptionInfo& info) = 0;
@@ -353,6 +355,11 @@ private:
   // This thread's registry, created on first use.
   LocalForwarderRegistry& localRegistry();
 
+  ForwarderRef makeForwarderRef(
+      const std::shared_ptr<moxygen::MoQForwarder>& forwarder,
+      folly::Executor* publisherExec
+  ) const;
+
   struct LocalForwarderBootstrap {
     std::shared_ptr<moxygen::MoQForwarder> localFwd;
     bool isNew{false};
@@ -361,18 +368,27 @@ private:
   LocalForwarderBootstrap
   acquireLocalForwarder(const moxygen::FullTrackName& ftn, const InitialTrackState& initial);
 
+  // In LF mode the ref supplies only the track name and owning exec; the forwarder
+  // itself is resolved by name there, so it doesn't attach to a displaced one.
   bool addSubscriberAndPublish(
       std::shared_ptr<moxygen::MoQSession> subscriberSession,
-      std::shared_ptr<moxygen::MoQForwarder> forwarder,
+      const ForwarderRef& publisherRef,
       bool forward,
-      bool pinned,
-      folly::Executor* publisherExec = nullptr
+      bool pinned
   );
+
+  struct ResolvedPublisher {
+    ForwarderRef ref;
+    ChannelSubscriber channelSub;
+    InitialTrackState initial;
+  };
+  // Launch on track.exec: reads the publisher forwarder's state where it is stable to
+  // initialize a new subscriber forwarder during publish fan-out.
+  folly::coro::Task<std::optional<ResolvedPublisher>> resolvePublisherOnItsExec(TrackRef track);
 
   folly::coro::Task<void> addSubscriberAndPublishViaLocalForwarder(
       std::shared_ptr<moxygen::MoQSession> subscriberSession,
-      std::shared_ptr<moxygen::MoQForwarder> publisherFwd,
-      folly::Executor* publisherExec,
+      TrackRef track,
       bool forward,
       bool pinned
   );
@@ -383,12 +399,14 @@ private:
       std::shared_ptr<moxygen::MoQSession> session
   );
 
-  // Runs on fwd's exec; the returned Claim owes a markReady/fail. removeOnEmpty=false for a
-  // publish-initiated forwarder, which must survive subscriber churn.
-  LocalForwarderRegistry::Claim installPublisherForwarder(
+  // Called from publish path or first subscriber path on publisher's exec.
+  // The displaced forwarder (if any) is released on the publisher's exec after the
+  // new forwarder is registered with the relay's registry.
+  enum class InstallKind { FromPublish, FromSubscribe };
+  LocalForwarderRegistry::ParkResult installPublisherForwarder(
       const moxygen::FullTrackName& ftn,
       const std::shared_ptr<moxygen::MoQForwarder>& fwd,
-      bool removeOnEmpty
+      InstallKind kind
   );
 
   std::optional<moxygen::PublishError>
@@ -399,7 +417,7 @@ private:
       moxygen::PublishRequest pub,
       std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
       std::shared_ptr<moxygen::MoQSession> session,
-      std::shared_ptr<moxygen::MoQForwarder> publisherFwd,
+      ForwarderRef publisherRef,
       std::shared_ptr<CrossExecFilter> relayChainFilter
   );
 
@@ -473,14 +491,14 @@ private:
 
   // Result of joinOrPrepareUpstreamSubscription (runs on relayExec_).
   struct StatefulSubscribeResult {
-    std::shared_ptr<moxygen::MoQForwarder> publisherForwarder;
-    folly::Executor* publisherExec{nullptr}; // owning executor of publisherForwarder
+    folly::Executor* publisherExec{nullptr}; // owning executor of the publisher forwarder
     std::optional<SubscribeResult> error;    // set on failure
 
     // Set only for the FirstSubscriber path. Consumed by
     // attachNewLocalForwarderOnRelayExec's publisherExec sortie (passive relay chain +
     // upstream subscribe). Pending destructor fires on abandoned move.
     struct FirstSubscriberSetup {
+      std::shared_ptr<moxygen::MoQForwarder> publisherForwarder;
       std::shared_ptr<moxygen::MoQSession> upstreamSession;
       moxygen::SubscribeRequest upstreamSubReq;
       std::shared_ptr<moxygen::TrackConsumer> upstreamConsumer;
@@ -522,8 +540,7 @@ private:
   // chain filter is not exposed (setDownstream/teardown happen inside attach); the tail
   // needs only ownsRelayChain to gate the sawOnEmpty teardown.
   struct PublisherAttachment {
-    std::shared_ptr<moxygen::MoQForwarder> publisherFwd;
-    folly::Executor* publisherExec{nullptr};
+    ForwarderRef publisherRef;
     bool ownsRelayChain{false}; // firstSetup path installed the passive relay chain
     std::shared_ptr<moxygen::MoQForwarder::Callback> finalCallback;
     // Captured off the publisher forwarder on its own exec, the only race-free place.
@@ -582,7 +599,7 @@ private:
   // the reply coro (coPublish) can co_return the PublishOk immediately after
   // setup without waiting for any downstream peer handshake.
   struct PublishSetup {
-    std::shared_ptr<moxygen::TrackConsumer> consumer;
+    std::shared_ptr<moxygen::TrackConsumer> consumer; // Null in LF mode
     moxygen::PublishOk publishOk;
   };
   using PublishSetupResult = folly::Expected<PublishSetup, moxygen::PublishError>;
@@ -590,13 +607,11 @@ private:
   // Contains all the inline publish() logic, taking session explicitly so it
   // can be called from either the I/O thread (relayExec_==nullptr) or from
   // coPublish on relay exec (where getRequestSession() would return null).
-  // If forwarder is non-null it is used as-is (pre-created by publish()); otherwise
-  // a new forwarder is created from pub (single-threaded or subscribeNamespace path).
   PublishSetupResult publishWithSession(
       moxygen::PublishRequest pub,
       std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
       std::shared_ptr<moxygen::MoQSession> session,
-      std::shared_ptr<moxygen::MoQForwarder> forwarder = nullptr
+      ForwarderRef publisherRef
   );
 
   std::shared_ptr<folly::Executor> ownedRelayExec_;

--- a/src/SubscriptionRegistry.cpp
+++ b/src/SubscriptionRegistry.cpp
@@ -19,7 +19,7 @@ bool SubscriptionRegistry::UpstreamSubscribePending::complete(
   active_ = false;
   return registry_->completeSubscription(
       ftn_,
-      weakForwarder_,
+      epoch_,
       std::move(handle),
       requestID,
       std::move(upstreamSession),
@@ -29,7 +29,7 @@ bool SubscriptionRegistry::UpstreamSubscribePending::complete(
 
 SubscriptionRegistry::UpstreamSubscribePending::~UpstreamSubscribePending() {
   if (active_) {
-    registry_->failAndRemove(ftn_, weakForwarder_);
+    registry_->failAndRemove(ftn_, epoch_);
   }
 }
 
@@ -37,29 +37,37 @@ SubscriptionRegistry::UpstreamSubscribePending::~UpstreamSubscribePending() {
 
 std::variant<
     SubscriptionRegistry::FirstSubscriber,
-    folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>
+    folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>,
+    SubscriptionRegistry::NoPublisher>
 SubscriptionRegistry::getOrCreateFromSubscribe(
     const moxygen::FullTrackName& ftn,
     std::shared_ptr<moxygen::MoQForwarder::Callback> callback,
     folly::FunctionRef<FilterChainResult(std::shared_ptr<moxygen::MoQForwarder>)> chainBuilder,
+    folly::FunctionRef<std::optional<ForwarderRef>(const std::shared_ptr<moxygen::MoQForwarder>&)>
+        refMaker,
     std::optional<moxygen::AbsoluteLocation> largest
 ) {
   auto it = subscriptions_.find(ftn);
   if (it == subscriptions_.end()) {
     auto forwarder = std::make_shared<moxygen::MoQForwarder>(ftn, largest);
+    auto ref = refMaker(forwarder);
+    if (!ref) {
+      return NoPublisher{};
+    }
+    const EntryEpoch epoch = nextEpoch();
     forwarder->setCallback(std::move(callback));
     auto [consumer, topNFilter, chainHead] = chainBuilder(forwarder);
     auto [emplaceIt, inserted] = subscriptions_.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(ftn),
-        std::forward_as_tuple(forwarder, nullptr)
+        std::forward_as_tuple(*std::move(ref), nullptr, epoch)
     );
     emplaceIt->second.topNFilter = topNFilter;
     emplaceIt->second.chainHead = chainHead;
     return FirstSubscriber{
         forwarder,
         std::move(consumer),
-        UpstreamSubscribePending{this, ftn, forwarder}
+        UpstreamSubscribePending{this, ftn, epoch}
     };
   }
 
@@ -85,14 +93,14 @@ folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber> SubscriptionRegist
 
 bool SubscriptionRegistry::completeSubscription(
     const moxygen::FullTrackName& ftn,
-    std::weak_ptr<moxygen::MoQForwarder> weakForwarder,
+    EntryEpoch epoch,
     std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
     moxygen::RequestID requestID,
     std::shared_ptr<moxygen::MoQSession> upstreamSession,
     std::shared_ptr<moxygen::Publisher> publisher
 ) {
   auto it = subscriptions_.find(ftn);
-  if (it == subscriptions_.end() || it->second.forwarder != weakForwarder.lock()) {
+  if (it == subscriptions_.end() || it->second.epoch != epoch) {
     return false;
   }
   auto& rsub = it->second;
@@ -104,12 +112,9 @@ bool SubscriptionRegistry::completeSubscription(
   return true;
 }
 
-void SubscriptionRegistry::failAndRemove(
-    const moxygen::FullTrackName& ftn,
-    std::weak_ptr<moxygen::MoQForwarder> weakForwarder
-) {
+void SubscriptionRegistry::failAndRemove(const moxygen::FullTrackName& ftn, EntryEpoch epoch) {
   auto it = subscriptions_.find(ftn);
-  if (it != subscriptions_.end() && it->second.forwarder == weakForwarder.lock()) {
+  if (it != subscriptions_.end() && it->second.epoch == epoch) {
     it->second.promise.setException(std::runtime_error("upstream subscribe failed"));
     subscriptions_.erase(it);
   }
@@ -117,12 +122,12 @@ void SubscriptionRegistry::failAndRemove(
 
 SubscriptionRegistry::PublishEntry SubscriptionRegistry::createFromPublish(
     const moxygen::FullTrackName& ftn,
-    std::shared_ptr<moxygen::MoQForwarder> forwarder,
+    ForwarderRef forwarder,
     std::shared_ptr<moxygen::MoQSession> session,
     std::shared_ptr<moxygen::Publisher> publisher,
     moxygen::RequestID requestID,
     std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
-    folly::FunctionRef<FilterChainResult(std::shared_ptr<moxygen::MoQForwarder>)> chainBuilder
+    folly::FunctionRef<FilterChainResult()> chainBuilder
 ) {
   std::optional<Evicted> evicted;
 
@@ -139,7 +144,7 @@ SubscriptionRegistry::PublishEntry SubscriptionRegistry::createFromPublish(
   auto [emplaceIt, inserted] = subscriptions_.emplace(
       std::piecewise_construct,
       std::forward_as_tuple(ftn),
-      std::forward_as_tuple(forwarder, session)
+      std::forward_as_tuple(std::move(forwarder), session, nextEpoch())
   );
   auto& rsub = emplaceIt->second;
   rsub.promise.setValue(folly::unit);
@@ -148,7 +153,7 @@ SubscriptionRegistry::PublishEntry SubscriptionRegistry::createFromPublish(
   rsub.publisher = std::move(publisher);
   rsub.isPublish = true;
 
-  auto [consumer, topNFilter, chainHead] = chainBuilder(forwarder);
+  auto [consumer, topNFilter, chainHead] = chainBuilder();
   rsub.topNFilter = topNFilter;
   rsub.chainHead = chainHead;
   topNFilter->setActivityTarget(&rsub.lastObjectTime);
@@ -160,10 +165,9 @@ bool SubscriptionRegistry::exists(const moxygen::FullTrackName& ftn) const {
   return subscriptions_.find(ftn) != subscriptions_.end();
 }
 
-std::shared_ptr<moxygen::MoQForwarder>
-SubscriptionRegistry::getForwarder(const moxygen::FullTrackName& ftn) const {
+ForwarderRef SubscriptionRegistry::getForwarderRef(const moxygen::FullTrackName& ftn) const {
   auto it = subscriptions_.find(ftn);
-  return it != subscriptions_.end() ? it->second.forwarder : nullptr;
+  return it != subscriptions_.end() ? it->second.forwarder : ForwarderRef{};
 }
 
 std::optional<SubscriptionRegistry::TopNView>
@@ -208,19 +212,21 @@ SubscriptionRegistry::getFetchView(const moxygen::FullTrackName& ftn) const {
   return FetchView{rsub.forwarder, rsub.publisher, rsub.requestID, rsub.promise.isFulfilled()};
 }
 
-std::shared_ptr<moxygen::MoQForwarder>
-SubscriptionRegistry::onPublisherTerminated(const moxygen::FullTrackName& ftn) {
+ForwarderRef SubscriptionRegistry::onPublisherTerminated(const moxygen::FullTrackName& ftn) {
   auto it = subscriptions_.find(ftn);
   if (it == subscriptions_.end()) {
-    return nullptr;
+    return {};
   }
   auto& rsub = it->second;
   rsub.handle.reset();
   rsub.upstream.reset();
   rsub.publisher.reset();
-  if (rsub.forwarder->empty()) {
+  // Non-LF only: the entry's ref is owned there, so reading inline is legal.
+  auto forwarder = rsub.forwarder.getIfOwned();
+  XCHECK(forwarder) << "onPublisherTerminated on a remote-owned entry: " << ftn;
+  if (forwarder->empty()) {
     subscriptions_.erase(it);
-    return nullptr;
+    return {};
   }
   return rsub.forwarder;
 }
@@ -229,9 +235,7 @@ void SubscriptionRegistry::remove(const moxygen::FullTrackName& ftn) {
   subscriptions_.erase(ftn);
 }
 
-void SubscriptionRegistry::removeIf(
-    folly::FunctionRef<bool(const moxygen::FullTrackName&, const EntryView&)> predicate
-) {
+void SubscriptionRegistry::removeIf(folly::FunctionRef<bool(const EntryView&)> predicate) {
   for (auto it = subscriptions_.begin(); it != subscriptions_.end();) {
     EntryView view{
         it->first,
@@ -240,7 +244,7 @@ void SubscriptionRegistry::removeIf(
         it->second.isPublish,
         it->second.lastObjectTime
     };
-    if (predicate(it->first, view)) {
+    if (predicate(view)) {
       it = subscriptions_.erase(it);
     } else {
       ++it;

--- a/src/SubscriptionRegistry.h
+++ b/src/SubscriptionRegistry.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "relay/ForwarderRef.h"
 #include "relay/TopNFilter.h"
 #include <folly/Function.h>
 #include <folly/container/F14Map.h>
@@ -21,6 +22,10 @@ namespace openmoq::moqx {
 
 class SubscriptionRegistry {
 public:
+  // Names one entry for as long as it sits in the map, so a caller that suspends
+  // can tell its own entry from one a reconnecting publisher put in its place.
+  enum class EntryEpoch : uint64_t {};
+
   struct FilterChainResult {
     std::shared_ptr<moxygen::TrackConsumer> consumer;
     std::shared_ptr<TopNFilter> topNFilter;
@@ -40,13 +45,12 @@ public:
     UpstreamSubscribePending(
         SubscriptionRegistry* registry,
         moxygen::FullTrackName ftn,
-        std::weak_ptr<moxygen::MoQForwarder> weakForwarder
+        EntryEpoch epoch
     )
-        : registry_(registry), ftn_(std::move(ftn)), weakForwarder_(std::move(weakForwarder)) {}
+        : registry_(registry), ftn_(std::move(ftn)), epoch_(epoch) {}
 
     UpstreamSubscribePending(UpstreamSubscribePending&& o) noexcept
-        : registry_(o.registry_), ftn_(std::move(o.ftn_)),
-          weakForwarder_(std::move(o.weakForwarder_)), active_(o.active_) {
+        : registry_(o.registry_), ftn_(std::move(o.ftn_)), epoch_(o.epoch_), active_(o.active_) {
       o.active_ = false;
     }
 
@@ -54,10 +58,10 @@ public:
     UpstreamSubscribePending(const UpstreamSubscribePending&) = delete;
     UpstreamSubscribePending& operator=(const UpstreamSubscribePending&) = delete;
 
-    // Identity-checked success path. Re-finds by ftn; checks forwarder identity
-    // to detect a reconnecting publisher that replaced the entry during the
-    // caller's co_await suspension. Sets handle, requestID, upstreamSession,
-    // publisher; fulfills promise. Returns false if entry is gone or replaced.
+    // Re-finds by ftn and checks the epoch, so a reconnecting publisher that
+    // replaced the entry during the caller's co_await suspension is not mistaken
+    // for it. Sets handle, requestID, upstreamSession, publisher; fulfills
+    // promise. Returns false if entry is gone or replaced.
     bool complete(
         std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
         moxygen::RequestID requestID,
@@ -70,34 +74,42 @@ public:
   private:
     SubscriptionRegistry* registry_;
     moxygen::FullTrackName ftn_;
-    std::weak_ptr<moxygen::MoQForwarder> weakForwarder_;
+    EntryEpoch epoch_;
     bool active_{true};
   };
 
   struct FirstSubscriber {
+    // The only strong handle the caller gets; the entry itself holds a ForwarderRef.
     std::shared_ptr<moxygen::MoQForwarder> forwarder;
     std::shared_ptr<moxygen::TrackConsumer> consumer;
     UpstreamSubscribePending pending;
   };
 
   struct SubsequentSubscriber {
-    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    ForwarderRef forwarder;
   };
+
+  // refMaker found no publisher to build a ref against; the map is untouched.
+  struct NoPublisher {};
 
   // Synchronous. First path: creates entry, calls chainBuilder, returns
   // FirstSubscriber immediately. Subsequent path: returns a Task that
   // co_awaits the promise then re-finds (throws on first-subscriber failure).
-  std::variant<FirstSubscriber, folly::coro::Task<SubsequentSubscriber>> getOrCreateFromSubscribe(
+  // refMaker runs only on the first path and owns the decision to proceed.
+  std::variant<FirstSubscriber, folly::coro::Task<SubsequentSubscriber>, NoPublisher>
+  getOrCreateFromSubscribe(
       const moxygen::FullTrackName& ftn,
       std::shared_ptr<moxygen::MoQForwarder::Callback> callback,
       folly::FunctionRef<FilterChainResult(std::shared_ptr<moxygen::MoQForwarder>)> chainBuilder,
+      folly::FunctionRef<std::optional<ForwarderRef>(const std::shared_ptr<moxygen::MoQForwarder>&)>
+          refMaker,
       std::optional<moxygen::AbsoluteLocation> largest = std::nullopt
   );
 
   // === Publish path ===
 
   struct Evicted {
-    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    ForwarderRef forwarder;
     std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle; // may be null
     folly::Executor* publisherExec{nullptr}; // old publisher's session exec, for handle teardown
   };
@@ -107,26 +119,27 @@ public:
     std::optional<Evicted> evicted;
   };
 
-  // Creates entry, pre-fulfills promise, wires activity tracking.
-  // Evicts any prior entry before emplacing — caller must call
-  // publishDone/unsubscribe on evicted data.
+  // Creates entry, pre-fulfills promise, wires activity tracking. `forwarder` is what the entry
+  // stores (remote in LF mode; owned otherwise). Evicts any prior entry before emplacing — caller
+  // must call publishDone/unsubscribe on evicted data.
   PublishEntry createFromPublish(
       const moxygen::FullTrackName& ftn,
-      std::shared_ptr<moxygen::MoQForwarder> forwarder,
+      ForwarderRef forwarder,
       std::shared_ptr<moxygen::MoQSession> session,
       std::shared_ptr<moxygen::Publisher> publisher,
       moxygen::RequestID requestID,
       std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
-      folly::FunctionRef<FilterChainResult(std::shared_ptr<moxygen::MoQForwarder>)> chainBuilder
+      folly::FunctionRef<FilterChainResult()> chainBuilder
   );
 
   // === Lookup ===
 
   bool exists(const moxygen::FullTrackName& ftn) const;
-  std::shared_ptr<moxygen::MoQForwarder> getForwarder(const moxygen::FullTrackName& ftn) const;
+  // Empty ref if there is no entry.
+  ForwarderRef getForwarderRef(const moxygen::FullTrackName& ftn) const;
 
   struct TopNView {
-    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    ForwarderRef forwarder;
     std::shared_ptr<TopNFilter> topNFilter; // may be null for subscribe-path tracks
     std::shared_ptr<moxygen::TrackConsumer> chainHead;
     std::chrono::steady_clock::time_point lastObjectTime;
@@ -135,7 +148,7 @@ public:
 
   // For onEmpty / forwardChanged / newGroupRequested / trackStatus
   struct UpstreamView {
-    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    ForwarderRef forwarder;
     std::shared_ptr<moxygen::Publisher> publisher;
     std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle;
     moxygen::RequestID requestID;
@@ -147,7 +160,7 @@ public:
 
   // For fetch()
   struct FetchView {
-    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    ForwarderRef forwarder;
     std::shared_ptr<moxygen::Publisher> publisher;
     moxygen::RequestID requestID;
     bool isReady;
@@ -156,9 +169,12 @@ public:
 
   // === Lifecycle transitions ===
 
-  // Clears handle + upstream. Erases if no subscribers remain (returns null).
+  // LF mode: replaces the entry's ref once ownership is anchored elsewhere (the
+  // publisher exec's LocalForwarderRegistry), so the relay exec holds no strong ref.
+
+  // Clears handle + upstream. Erases if no subscribers remain (returns empty).
   // If subscribers remain, entry persists; caller must call remove() from onEmpty.
-  std::shared_ptr<moxygen::MoQForwarder> onPublisherTerminated(const moxygen::FullTrackName& ftn);
+  ForwarderRef onPublisherTerminated(const moxygen::FullTrackName& ftn);
 
   // Called from onEmpty after handle->unsubscribe() (subscribe-mode), or after
   // a publisher-terminated entry's forwarder goes empty.
@@ -168,14 +184,13 @@ public:
 
   struct EntryView {
     const moxygen::FullTrackName& ftn;
-    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    const ForwarderRef& forwarder;
     std::shared_ptr<moxygen::MoQSession> upstream;
     bool isPublish;
     std::chrono::steady_clock::time_point lastObjectTime;
   };
 
-  void removeIf(folly::FunctionRef<bool(const moxygen::FullTrackName&, const EntryView&)> predicate
-  );
+  void removeIf(folly::FunctionRef<bool(const EntryView&)> predicate);
 
   void forEach(folly::FunctionRef<void(const EntryView&)> fn) const;
 
@@ -183,14 +198,12 @@ public:
 
 private:
   struct RelaySubscription {
-    RelaySubscription(
-        std::shared_ptr<moxygen::MoQForwarder> f,
-        std::shared_ptr<moxygen::MoQSession> u
-    )
-        : forwarder(std::move(f)), upstream(std::move(u)),
+    RelaySubscription(ForwarderRef f, std::shared_ptr<moxygen::MoQSession> u, EntryEpoch e)
+        : forwarder(std::move(f)), epoch(e), upstream(std::move(u)),
           lastObjectTime(std::chrono::steady_clock::now()) {}
 
-    std::shared_ptr<moxygen::MoQForwarder> forwarder;
+    ForwarderRef forwarder;
+    EntryEpoch epoch;
     std::shared_ptr<moxygen::MoQSession> upstream;
     std::shared_ptr<moxygen::Publisher> publisher;
     moxygen::RequestID requestID{0};
@@ -205,7 +218,7 @@ private:
   // Called by UpstreamSubscribePending::complete().
   bool completeSubscription(
       const moxygen::FullTrackName& ftn,
-      std::weak_ptr<moxygen::MoQForwarder> weakForwarder,
+      EntryEpoch epoch,
       std::shared_ptr<moxygen::Publisher::SubscriptionHandle> handle,
       moxygen::RequestID requestID,
       std::shared_ptr<moxygen::MoQSession> upstreamSession,
@@ -213,10 +226,7 @@ private:
   );
 
   // Called by UpstreamSubscribePending destructor on failure.
-  void failAndRemove(
-      const moxygen::FullTrackName& ftn,
-      std::weak_ptr<moxygen::MoQForwarder> weakForwarder
-  );
+  void failAndRemove(const moxygen::FullTrackName& ftn, EntryEpoch epoch);
 
   // Standalone coroutine for the subsequent-subscriber path. Parameters are
   // passed by value so they live in the heap-allocated coroutine frame rather
@@ -227,8 +237,12 @@ private:
       folly::coro::Future<folly::Unit> future
   );
 
+  EntryEpoch nextEpoch() { return static_cast<EntryEpoch>(++epochCounter_); }
+
   folly::F14NodeMap<moxygen::FullTrackName, RelaySubscription, moxygen::FullTrackName::hash>
       subscriptions_;
+  // Confined to the relay executor, so a plain counter.
+  uint64_t epochCounter_{0};
 };
 
 } // namespace openmoq::moqx

--- a/src/relay/ChannelSubscriber.h
+++ b/src/relay/ChannelSubscriber.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <moxygen/relay/MoQForwarder.h>
+
+#include <folly/Executor.h>
+#include <folly/logging/xlog.h>
+
+#include <memory>
+#include <thread>
+
+namespace openmoq::moqx {
+
+// A local forwarder's channel subscription on a publisher's forwarder.  Must be
+// constructed on the publisher's executor: the thread it captures there is the only
+// one detach() will run on, and the weak_ptr is reachable nowhere else.  Safe to
+// carry to other executors, since none of them can lock it.
+class ChannelSubscriber {
+public:
+  ChannelSubscriber() = default;
+
+  ChannelSubscriber(
+      std::weak_ptr<moxygen::MoQForwarder> publisherFwd,
+      folly::Executor* publisherExec
+  )
+      : publisherFwd_(std::move(publisherFwd)), publisherExec_(publisherExec),
+        publisherThread_(std::this_thread::get_id()) {}
+
+  folly::Executor* exec() const { return publisherExec_; }
+
+  // No-op once the publisher's forwarder is gone; it took the subscription with it.
+  void detach(folly::Executor* subscriberExec) const {
+    XCHECK_EQ(publisherThread_, std::this_thread::get_id())
+        << "channel subscriber detached off the publisher's thread";
+    if (auto publisher = publisherFwd_.lock()) {
+      publisher->removeChannelSubscriberByExec(subscriberExec);
+    }
+  }
+
+private:
+  std::weak_ptr<moxygen::MoQForwarder> publisherFwd_;
+  folly::Executor* publisherExec_{nullptr};
+  std::thread::id publisherThread_;
+};
+
+} // namespace openmoq::moqx

--- a/test/SubscriptionRegistryTest.cpp
+++ b/test/SubscriptionRegistryTest.cpp
@@ -6,6 +6,7 @@
 #include "relay/TopNFilter.h"
 
 #include <folly/coro/BlockingWait.h>
+#include <folly/executors/InlineExecutor.h>
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
@@ -25,10 +26,26 @@ SubscriptionRegistry::FilterChainResult subscribeChain(std::shared_ptr<MoQForwar
   return {std::static_pointer_cast<TrackConsumer>(f), nullptr};
 }
 
+// The relay exec owns the forwarder in every non-LF mode; these tests model that.
+std::optional<ForwarderRef> ownedRef(const std::shared_ptr<MoQForwarder>& f) {
+  return ForwarderRef::owned(f);
+}
+
+std::optional<ForwarderRef> noRef(const std::shared_ptr<MoQForwarder>&) {
+  return std::nullopt;
+}
+
+// LF mode: the entry holds only a weak ref, and the publisher exec's registry is what
+// keeps the forwarder alive. Nothing here plays that part, so the forwarder can die
+// while the entry is still present.
+std::optional<ForwarderRef> remoteRef(const std::shared_ptr<MoQForwarder>& f) {
+  return ForwarderRef::remote(f, folly::getKeepAliveToken(&folly::InlineExecutor::instance()));
+}
+
 // Chain for publish-path tests: createFromPublish dereferences topNFilter.
-SubscriptionRegistry::FilterChainResult publishChain(std::shared_ptr<MoQForwarder> f) {
+SubscriptionRegistry::FilterChainResult publishChain() {
   auto filter = std::make_shared<TopNFilter>(kFtn, nullptr);
-  return {std::static_pointer_cast<TrackConsumer>(f), filter};
+  return {nullptr, filter};
 }
 
 } // namespace
@@ -38,17 +55,25 @@ SubscriptionRegistry::FilterChainResult publishChain(std::shared_ptr<MoQForwarde
 TEST(SubscriptionRegistryTest, AwaitSubsequentSucceeds) {
   SubscriptionRegistry registry;
   auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
-      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, ownedRef)
   );
   auto task = std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
-      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, ownedRef)
   );
 
   EXPECT_TRUE(first.pending.complete(nullptr, RequestID(0), nullptr, nullptr));
 
   folly::EventBase evb;
   auto sub = folly::coro::blockingWait(std::move(task), &evb);
-  EXPECT_EQ(sub.forwarder, first.forwarder);
+  EXPECT_EQ(sub.forwarder.getIfOwned(), first.forwarder);
+}
+
+TEST(SubscriptionRegistryTest, DeclinedRefMakerCreatesNothing) {
+  SubscriptionRegistry registry;
+  auto result = registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, noRef);
+
+  EXPECT_TRUE(std::holds_alternative<SubscriptionRegistry::NoPublisher>(result));
+  EXPECT_FALSE(registry.exists(kFtn));
 }
 
 // === UpstreamSubscribePending ===
@@ -56,7 +81,7 @@ TEST(SubscriptionRegistryTest, AwaitSubsequentSucceeds) {
 TEST(SubscriptionRegistryTest, PendingDestructorRemovesEntry) {
   SubscriptionRegistry registry;
   {
-    auto result = registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain);
+    auto result = registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, ownedRef);
     ASSERT_TRUE(std::holds_alternative<SubscriptionRegistry::FirstSubscriber>(result));
     // drops result without calling complete() → destructor calls failAndRemove
   }
@@ -66,10 +91,10 @@ TEST(SubscriptionRegistryTest, PendingDestructorRemovesEntry) {
 TEST(SubscriptionRegistryTest, PendingDestructorFailsSubsequentSubscriber) {
   SubscriptionRegistry registry;
   auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
-      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, ownedRef)
   );
   auto task = std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
-      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, ownedRef)
   );
 
   // Move pending out and drop it — destructor fires failAndRemove, sets exception on promise.
@@ -84,7 +109,7 @@ TEST(SubscriptionRegistryTest, PendingDestructorFailsSubsequentSubscriber) {
 TEST(SubscriptionRegistryTest, PendingCompleteReturnsFalseWhenEntryGone) {
   SubscriptionRegistry registry;
   auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
-      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, ownedRef)
   );
 
   registry.remove(kFtn); // simulate publisher replacing the entry mid-subscribe
@@ -96,7 +121,7 @@ TEST(SubscriptionRegistryTest, PendingCompleteReturnsFalseWhenEntryGone) {
 TEST(SubscriptionRegistryTest, AwaitSubsequentHandlesErasedEntry) {
   SubscriptionRegistry registry;
 
-  auto token1 = registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain);
+  auto token1 = registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, ownedRef);
   ASSERT_TRUE(std::holds_alternative<SubscriptionRegistry::FirstSubscriber>(token1));
   auto& first = std::get<SubscriptionRegistry::FirstSubscriber>(token1);
 
@@ -105,7 +130,8 @@ TEST(SubscriptionRegistryTest, AwaitSubsequentHandlesErasedEntry) {
       /*callback=*/nullptr,
       [](std::shared_ptr<MoQForwarder>) -> SubscriptionRegistry::FilterChainResult {
         return {nullptr, nullptr};
-      }
+      },
+      ownedRef
   );
   ASSERT_TRUE(
       std::holds_alternative<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(token2)
@@ -128,7 +154,7 @@ TEST(SubscriptionRegistryTest, AwaitSubsequentHandlesErasedEntry) {
 TEST(SubscriptionRegistryTest, CreateFromPublishEvictsSubscribeEntry) {
   SubscriptionRegistry registry;
   auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
-      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain)
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, ownedRef)
   );
   auto originalForwarder = first.forwarder;
   first.pending.complete(nullptr, RequestID(0), nullptr, nullptr);
@@ -136,7 +162,7 @@ TEST(SubscriptionRegistryTest, CreateFromPublishEvictsSubscribeEntry) {
   auto newForwarder = std::make_shared<MoQForwarder>(kFtn, std::nullopt);
   auto entry = registry.createFromPublish(
       kFtn,
-      newForwarder,
+      ForwarderRef::owned(newForwarder),
       nullptr,
       nullptr,
       RequestID(1),
@@ -145,8 +171,36 @@ TEST(SubscriptionRegistryTest, CreateFromPublishEvictsSubscribeEntry) {
   );
 
   ASSERT_TRUE(entry.evicted.has_value());
-  EXPECT_EQ(entry.evicted->forwarder, originalForwarder);
-  EXPECT_EQ(registry.getForwarder(kFtn), newForwarder);
+  EXPECT_EQ(entry.evicted->forwarder.getIfOwned(), originalForwarder);
+  EXPECT_EQ(registry.getForwarderRef(kFtn).getIfOwned(), newForwarder);
+}
+
+// Cleanup keys off identity, not liveness. In LF mode the forwarder can already be gone
+// by the time the pending token resolves, and that is exactly when the entry most needs
+// erasing: leaving it behind strands an unfulfilled promise that every later subscriber
+// waits on forever.
+TEST(SubscriptionRegistryTest, PendingDestructorRemovesEntryAfterRemoteForwarderDies) {
+  SubscriptionRegistry registry;
+  auto first = std::get<SubscriptionRegistry::FirstSubscriber>(
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, remoteRef)
+  );
+  auto waiter = std::get<folly::coro::Task<SubscriptionRegistry::SubsequentSubscriber>>(
+      registry.getOrCreateFromSubscribe(kFtn, nullptr, subscribeChain, remoteRef)
+  );
+
+  std::weak_ptr<MoQForwarder> died = first.forwarder;
+  first.forwarder.reset();
+  first.consumer.reset();
+  ASSERT_TRUE(died.expired()) << "the entry holds only a weak ref";
+  ASSERT_TRUE(registry.exists(kFtn));
+
+  {
+    auto dropped = std::move(first.pending);
+  }
+
+  EXPECT_FALSE(registry.exists(kFtn)) << "erased even though its forwarder is gone";
+  folly::EventBase evb;
+  EXPECT_THROW(folly::coro::blockingWait(std::move(waiter), &evb), std::runtime_error);
 }
 
 // === onPublisherTerminated ===
@@ -154,10 +208,17 @@ TEST(SubscriptionRegistryTest, CreateFromPublishEvictsSubscribeEntry) {
 TEST(SubscriptionRegistryTest, OnPublisherTerminatedErasesEmptyEntry) {
   SubscriptionRegistry registry;
   auto forwarder = std::make_shared<MoQForwarder>(kFtn, std::nullopt);
-  registry
-      .createFromPublish(kFtn, forwarder, nullptr, nullptr, RequestID(0), nullptr, publishChain);
+  registry.createFromPublish(
+      kFtn,
+      ForwarderRef::owned(forwarder),
+      nullptr,
+      nullptr,
+      RequestID(0),
+      nullptr,
+      publishChain
+  );
 
   auto result = registry.onPublisherTerminated(kFtn);
-  EXPECT_EQ(result, nullptr);
+  EXPECT_FALSE(static_cast<bool>(result));
   EXPECT_FALSE(registry.exists(kFtn));
 }


### PR DESCRIPTION
In local-forwarder mode a SubscriptionRegistry entry held a shared_ptr to a forwarder that lives on the publisher's executor, so the relay executor could read its counters, run its destructor, or hand it to a subscriber thread that later found it displaced. Entries and every view over them now hold a ForwarderRef: a caller that owns the forwarder pins it inline, and everyone else posts to its executor. Entry cleanup keys off the entry's ForwarderId instead of locking a weak_ptr, which used to decline to erase an entry exactly when its forwarder was already gone, leaving an unfulfilled promise that every later subscriber to that track waited on forever. The local-forwarder fan-out now carries a track name and executor and resolves the publisher forwarder on that executor at the point of use, so a subscriber whose hop lands late fails with "publisher forwarder gone" rather than attaching to a forwarder nobody feeds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/577)
<!-- Reviewable:end -->
