### PR TITLE
relay: drain cross-executor messages before destroying the servers

### DIFF
--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -16,6 +16,7 @@
 #include <folly/coro/Collect.h>
 #include <folly/coro/Task.h>
 #include <folly/executors/thread_factory/NamedThreadFactory.h>
+#include <folly/futures/Future.h>
 #include <folly/logging/xlog.h>
 
 using namespace moxygen;
@@ -159,6 +160,37 @@ void MoqxRelayContext::initUpstreams(folly::EventBase* workerEvb) {
 void MoqxRelayContext::stop() {
   for (auto& [name, entry] : services_) {
     entry.relay->stop();
+  }
+}
+
+namespace {
+// This should be sufficient to ensure all cross-exec messages run at teardown,
+// but can be increased if necessary.
+constexpr int kShutdownDrainRounds = 10;
+} // namespace
+
+void MoqxRelayContext::drainExecs(
+    const std::vector<folly::Executor::KeepAlive<folly::EventBase>>& ioEvbs
+) {
+  std::vector<folly::Executor*> execs;
+  execs.reserve(ioEvbs.size() + services_.size());
+  for (const auto& ka : ioEvbs) {
+    execs.push_back(ka.get());
+  }
+  for (auto& [name, entry] : services_) {
+    // Null in single-thread mode, where relay state runs on the io threads.
+    if (auto* relayExec = entry.relay->getRelayExec()) {
+      execs.push_back(relayExec);
+    }
+  }
+
+  for (int round = 0; round < kShutdownDrainRounds; ++round) {
+    std::vector<folly::SemiFuture<folly::Unit>> pending;
+    pending.reserve(execs.size());
+    for (auto* exec : execs) {
+      pending.push_back(folly::via(exec, [] {}).semi());
+    }
+    folly::collectAll(std::move(pending)).get();
   }
 }
 

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -91,6 +91,12 @@ public:
   // reconnect coroutines can exit before worker EVBs are drained.
   void stop();
 
+  // Runs a barrier across ioEvbs and every relay executor, waiting for each
+  // round to finish everywhere before posting the next.
+  // This is an expedient fixup to ensure the threads live long enough without holding
+  // KeepAlive tokens throughout.
+  void drainExecs(const std::vector<folly::Executor::KeepAlive<folly::EventBase>>& ioEvbs);
+
   // Force-evicts cached tracks unconditionally. Scoped by optional ftn or ns;
   // if both are empty all tracks are evicted. Optionally scoped to a single
   // service. Returns number of tracks evicted.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -264,6 +264,10 @@ int main(int argc, char* argv[]) {
   for (auto& server : servers) {
     server->stop();
   }
+  // Settle the cross-executor teardown cascade while every loop is still
+  // healthy; ~MoQServer frees the per-thread MoQExecutors and ioExecutor.reset()
+  // will terminate an IO thread when it reaches zero queued work without keepalives.
+  context->drainExecs(ioExecutor->getAllEventBases());
   servers.clear();
   ioExecutor.reset();
 


### PR DESCRIPTION
Shutdown teardown bounces between the io threads and the relay threads several times: a subscriber going away notifies the publisher's forwarder, which notifies the relay, which unsubscribes upstream. Those hops are fire-and-forget lambdas holding raw executor pointers, and ~MoQServer frees each thread's MoQExecutor, so a lambda still queued when the servers went away called add() on freed memory.

drainExecs runs a barrier across the io EVBs and every relay executor, waiting for each round to finish everywhere before posting the next, so each round lets the cascade advance one more hop. main calls it after stopping the servers and before destroying them. This is a stopgap until those executors are held with KeepAlive tokens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/587)
<!-- Reviewable:end -->
