### PR TITLE
ci: cap asan-debug build parallelism to fit runner memory

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -62,8 +62,13 @@ jobs:
             preset: san
             build_dir: build-san
             runner: [self-hosted, linode]
+            # Sized by memory, not cores. See ci-pr.yml for the measurements.
+            build_jobs: 10
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    env:
+      # Empty falls through to build.sh's nproc default on the hosted runners.
+      MOQX_BUILD_JOBS: ${{ matrix.build_jobs || '' }}
     steps:
       - name: Generate app token
         id: app-token

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -47,8 +47,17 @@ jobs:
             preset: san
             build_dir: build-san
             runner: [self-hosted, linode]
+            # Sized by memory, not cores. The linode box is 16c/31GB with no
+            # swap; the heaviest test TUs peak near 2.3 GB of cc1plus RSS each
+            # under Debug+ASan. Worst-case concurrent footprint is 38 GB at
+            # -j16 and 34 GB at -j14, both of which OOM-kill the compiler.
+            # -j10 lands at ~25 GB, leaving headroom for the co-resident relay.
+            build_jobs: 10
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    env:
+      # Empty falls through to build.sh's nproc default on the hosted runners.
+      MOQX_BUILD_JOBS: ${{ matrix.build_jobs || '' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

The `asan debug` job has been failing intermittently on the linode runner with:

```
c++: fatal error: Killed signal terminated program cc1plus
```

This is the kernel OOM killer, not a compiler bug. It has hit PRs from several
people — #574, #576, #577, `mh/anonymous-claim`, `qlogs/admin-endpoint` — so it
reads as a flake rather than anything wrong with the changes under test.

## Cause

The job builds at `-j$(nproc)`. The runner has 16 cores but only **31 GB RAM and
no swap** (496 MB). Under the `san` profile (`CMAKE_BUILD_TYPE=Debug` +
`-fsanitize=address,undefined`) the heaviest TUs peak near 2.3 GB of cc1plus RSS
each — and roughly fifteen of them are the `MoqxRelay*Tests` files, which ninja
schedules as a block. That is where the build consistently dies.

Measured peak RSS per TU under the real `san` flags, worst-case concurrent
footprint being the sum of the N largest:

| jobs | worst case | result |
|------|-----------|--------|
| `-j16` | 38.4 GB | OOM (current) |
| `-j14` | 34.0 GB | OOM |
| `-j12` | 29.4 GB | ~0.8 GB headroom, too tight |
| `-j10` | 24.8 GB | ~5.4 GB headroom |

Top offenders: `UpstreamProviderTest.cpp` 3.45 GB, `MoqxCacheTest.cpp` 2.84 GB,
`MoqxRelayTestFixture.cpp` 2.37 GB, then a dozen more at ~2.30 GB.
`src/config/Loader.cpp` measures 2.42 GB, matching the 2.40 GB the kernel
recorded for the killed process.

Per-TU memory crossed the line with the moxygen dep-hash bump in 104a9c94 — the
first kill was that same afternoon, and there have been eight since, all on
Aug 11 and Aug 13.

## Fix

Cap the asan matrix entry at `MOQX_BUILD_JOBS: 10`. `scripts/build.sh` already
honors that variable ahead of `nproc` (added in #523), so no script change is
needed. Hosted runners get an empty value and keep the `nproc` default.

Set at job level so it covers the source-build path in `Setup dependencies` too,
which compiles folly and friends and has the same exposure.

## Notes

- `nproc - 2` (what moxygen's workflows use) would **not** have fixed this — 34 GB
  still exceeds 31 GB. The cap has to be sized by memory, not cores.
- A per-target ninja job pool was considered and rejected: the heavy TUs are
  spread across `moqx_config_loader`, `moqx_core`, and most of the test
  executables, so it would not have contained the problem.
- The co-resident relay and stats stack is **not** a factor — it is about 800 MB
  of 31 GB. Journal lines like `grafana invoked oom-killer` are misleading; those
  processes just allocated next after the wall was hit. Every actual victim is
  cc1plus.
- Worth doing separately: the box has no swap, so every spike is a hard kill
  rather than a slowdown. A few GB would turn these into slow builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/588)
<!-- Reviewable:end -->
