### PR TITLE
test: fail integration tests when the relay exits non-zero

### DIFF
--- a/test/test_admin_cache_purge.sh
+++ b/test/test_admin_cache_purge.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 BINARY="${1:-$(dirname "$0")/../build/default/moqx}"
 # shellcheck source=test_ports.sh
 source "$(dirname "$0")/test_ports.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$(dirname "$0")/test_relay_lifecycle.sh"
 LISTEN_PORT=$TEST_CACHE_PURGE_LISTEN
 ADMIN_PORT=$TEST_CACHE_PURGE_ADMIN
 INFO_URL="http://localhost:${ADMIN_PORT}/info"
@@ -17,11 +19,13 @@ fi
 TMPDIR=$(mktemp -d)
 MOQX_PID=""
 cleanup() {
+  local relay_failed=0
   if [[ -n "${MOQX_PID:-}" ]]; then
     kill "$MOQX_PID" 2>/dev/null || true
-    wait "$MOQX_PID" 2>/dev/null || true
+    reap_relays "$MOQX_PID" || relay_failed=1
   fi
   rm -rf "$TMPDIR"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 

--- a/test/test_admin_cache_purge_race.sh
+++ b/test/test_admin_cache_purge_race.sh
@@ -30,6 +30,8 @@ resolve_moqbin "$BINARY"
 source "$REPO/test/test_ports.sh"
 # shellcheck source=test_versions.sh
 source "$REPO/test/test_versions.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$REPO/test/test_relay_lifecycle.sh"
 DATESERVER="$MOQBIN/moqdateserver"
 TEXTCLIENT="$MOQBIN/moqtextclient"
 
@@ -77,8 +79,11 @@ cleanup() {
     fi
     sleep 0.2
   done
-  wait "${PIDS[@]:-}" "${RELAY_PIDS[@]:-}" 2>/dev/null || true
+  reap_helpers "${PIDS[@]:-}"
+  local relay_failed=0
+  reap_relays "${RELAY_PIDS[@]:-}" || relay_failed=1
   rm -rf "$TMPDIR_SCRIPT"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 

--- a/test/test_admin_config.sh
+++ b/test/test_admin_config.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 BINARY="${1:-$(dirname "$0")/../build/default/moqx}"
 # shellcheck source=test_ports.sh
 source "$(dirname "$0")/test_ports.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$(dirname "$0")/test_relay_lifecycle.sh"
 LISTEN_PORT=$TEST_ADMIN_CONFIG_LISTEN
 ADMIN_PORT=$TEST_ADMIN_CONFIG_ADMIN
 ADMIN_URL="http://localhost:${ADMIN_PORT}/config"
@@ -16,8 +18,13 @@ fi
 TMPDIR=$(mktemp -d)
 MOQX_PID=""
 cleanup() {
-  [[ -n "$MOQX_PID" ]] && kill "$MOQX_PID" 2>/dev/null; wait "$MOQX_PID" 2>/dev/null || true
+  local relay_failed=0
+  if [[ -n "$MOQX_PID" ]]; then
+    kill "$MOQX_PID" 2>/dev/null || true
+    reap_relays "$MOQX_PID" || relay_failed=1
+  fi
   rm -rf "$TMPDIR"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 

--- a/test/test_admin_info.sh
+++ b/test/test_admin_info.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 BINARY="${1:-$(dirname "$0")/../build/default/moqx}"
 # shellcheck source=test_ports.sh
 source "$(dirname "$0")/test_ports.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$(dirname "$0")/test_relay_lifecycle.sh"
 LISTEN_PORT=$TEST_ADMIN_INFO_LISTEN
 ADMIN_PORT=$TEST_ADMIN_INFO_ADMIN
 ADMIN_URL="http://localhost:${ADMIN_PORT}/info"
@@ -16,8 +18,13 @@ fi
 TMPDIR=$(mktemp -d)
 MOQX_PID=""
 cleanup() {
-  [[ -n "$MOQX_PID" ]] && kill "$MOQX_PID" 2>/dev/null; wait "$MOQX_PID" 2>/dev/null || true
+  local relay_failed=0
+  if [[ -n "$MOQX_PID" ]]; then
+    kill "$MOQX_PID" 2>/dev/null || true
+    reap_relays "$MOQX_PID" || relay_failed=1
+  fi
   rm -rf "$TMPDIR"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 

--- a/test/test_admin_metrics.sh
+++ b/test/test_admin_metrics.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 BINARY="${1:-$(dirname "$0")/../build/default/moqx}"
 # shellcheck source=test_ports.sh
 source "$(dirname "$0")/test_ports.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$(dirname "$0")/test_relay_lifecycle.sh"
 LISTEN_PORT=$TEST_ADMIN_METRICS_LISTEN
 ADMIN_PORT=$TEST_ADMIN_METRICS_ADMIN
 METRICS_URL="http://localhost:${ADMIN_PORT}/metrics"
@@ -18,12 +20,14 @@ TMPDIR=$(mktemp -d)
 MOQX_PID=""
 # Cleanup function that ensures the process exits and port is released.
 cleanup() {
+  local relay_failed=0
   if [[ -n "${MOQX_PID:-}" ]]; then
     kill "$MOQX_PID" 2>/dev/null || true
     # Wait for process to exit and ensure port is released
-    wait "$MOQX_PID" 2>/dev/null || true
+    reap_relays "$MOQX_PID" || relay_failed=1
   fi
   rm -rf "$TMPDIR"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 

--- a/test/test_admin_tls.sh
+++ b/test/test_admin_tls.sh
@@ -5,6 +5,8 @@ BINARY="${1:-$(dirname "$0")/../build/default/moqx}"
 TESTDIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=test_ports.sh
 source "$(dirname "$0")/test_ports.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$(dirname "$0")/test_relay_lifecycle.sh"
 LISTEN_PORT=$TEST_ADMIN_TLS_LISTEN
 ADMIN_PORT=$TEST_ADMIN_TLS_ADMIN
 
@@ -19,8 +21,13 @@ KEY="${TESTDIR}/test_key.pem"
 TMPDIR=$(mktemp -d)
 MOQX_PID=""
 cleanup() {
-  [[ -n "$MOQX_PID" ]] && kill "$MOQX_PID" 2>/dev/null; wait "$MOQX_PID" 2>/dev/null || true
+  local relay_failed=0
+  if [[ -n "$MOQX_PID" ]]; then
+    kill "$MOQX_PID" 2>/dev/null || true
+    reap_relays "$MOQX_PID" || relay_failed=1
+  fi
   rm -rf "$TMPDIR"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 

--- a/test/test_admin_track_metrics.sh
+++ b/test/test_admin_track_metrics.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 BINARY="${1:-$(dirname "$0")/../build/default/moqx}"
 # shellcheck source=test_ports.sh
 source "$(dirname "$0")/test_ports.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$(dirname "$0")/test_relay_lifecycle.sh"
 LISTEN_PORT=$TEST_ADMIN_TRACK_METRICS_LISTEN
 ADMIN_PORT=$TEST_ADMIN_TRACK_METRICS_ADMIN
 TRACK_URL="http://localhost:${ADMIN_PORT}/metrics/track"
@@ -19,13 +21,19 @@ MOQX_PID=""
 DATESERVER_PIDS=()
 TEXTCLIENT_PIDS=()
 cleanup() {
-  for pid in "${TEXTCLIENT_PIDS[@]:-}" "${DATESERVER_PIDS[@]:-}" "${MOQX_PID:-}"; do
+  local relay_failed=0
+  for pid in "${TEXTCLIENT_PIDS[@]:-}" "${DATESERVER_PIDS[@]:-}"; do
     if [[ -n "$pid" ]]; then
       kill "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
+      reap_helpers "$pid"
     fi
   done
+  if [[ -n "${MOQX_PID:-}" ]]; then
+    kill "$MOQX_PID" 2>/dev/null || true
+    reap_relays "$MOQX_PID" || relay_failed=1
+  fi
   rm -rf "$TMPDIR"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 
@@ -238,7 +246,7 @@ if [[ -x "$DATESERVER" && -x "$TEXTCLIENT" ]]; then
   [[ "$HTTP_CODE" == "200" ]] || fail "expected HTTP 200 for limit=2 with 2 live tracks, got $HTTP_CODE"
 
   kill "${TEXTCLIENT_PIDS[@]}" "${DATESERVER_PIDS[@]}" 2>/dev/null || true
-  wait "${TEXTCLIENT_PIDS[@]}" "${DATESERVER_PIDS[@]}" 2>/dev/null || true
+  reap_helpers "${TEXTCLIENT_PIDS[@]}" "${DATESERVER_PIDS[@]}"
 else
   echo "SKIP: moqdateserver/moqtextclient not found in $MOQBIN; live-track checks skipped" >&2
 fi
@@ -246,7 +254,7 @@ fi
 # Disabled: the endpoint must say so rather than return an empty scrape that
 # reads as "no live tracks".
 kill "$MOQX_PID" 2>/dev/null || true
-wait "$MOQX_PID" 2>/dev/null || true
+reap_relays "$MOQX_PID" || fail "relay with track metrics enabled did not shut down cleanly"
 MOQX_PID=""
 
 python3 - "$TMPDIR/config.yaml" <<'PYEOF'

--- a/test/test_conformance.sh
+++ b/test/test_conformance.sh
@@ -33,6 +33,8 @@ BUILD_DIR="$(cd "$(dirname "$MOQX_BIN")" 2>/dev/null && pwd || true)"
 # shellcheck source=test_moqbin.sh
 source "$(dirname "${BASH_SOURCE[0]}")/test_moqbin.sh"
 resolve_moqbin "$MOQX_BIN"
+# shellcheck source=test_relay_lifecycle.sh
+source "$(dirname "${BASH_SOURCE[0]}")/test_relay_lifecycle.sh"
 
 # moxygen conformance script: MOXYGEN_SRC override, else the moxygen source this
 # build resolved — the cache records it wherever it lives, including a local
@@ -113,7 +115,26 @@ fi
 
 # Generate a temp config with our ports
 TMPCONFIG="$TMPDIR/config.yaml"
-trap 'rm -rf "$TMPDIR"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
+RELAY_PID=""
+SERVER_PID=""
+MOXYGEN_SHIM=""
+cleanup() {
+  local relay_failed=0
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    reap_helpers "$SERVER_PID"
+  fi
+  if [[ -n "$RELAY_PID" ]]; then
+    kill "$RELAY_PID" 2>/dev/null || true
+    reap_relays "$RELAY_PID" || relay_failed=1
+  fi
+  rm -rf "$TMPDIR"
+  if [[ -n "$MOXYGEN_SHIM" ]]; then
+    rm -rf "$MOXYGEN_SHIM"
+  fi
+  (( relay_failed == 0 )) || exit 1
+}
+trap cleanup EXIT
 
 cat > "$TMPCONFIG" <<EOF
 listeners:
@@ -187,7 +208,6 @@ MOXYGEN_SHIM=$(mktemp -d)
 mkdir -p "$MOXYGEN_SHIM/moxygen/moqtest"
 ln -s "$MOQBIN/moqtest_client" "$MOXYGEN_SHIM/moxygen/moqtest/moqtest_client"
 export MOXYGEN_DIR="$MOXYGEN_SHIM"
-trap 'rm -rf "$MOXYGEN_SHIM" "$TMPDIR"; kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null; wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null' EXIT
 
 set +e
 bash "$CONFORMANCE_SCRIPT" "$RELAY_URL" "${DOWNSTREAM_ARGS[@]+"${DOWNSTREAM_ARGS[@]}"}"
@@ -197,8 +217,9 @@ set -e
 echo "==> Conformance tests finished (exit code: $EXIT_CODE)"
 
 # Clean up before exiting so background process kills don't affect exit code
-kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null
-wait "$RELAY_PID" "$SERVER_PID" 2>/dev/null || true
+kill "$RELAY_PID" "$SERVER_PID" 2>/dev/null || true
+reap_helpers "$SERVER_PID"
+reap_relays "$RELAY_PID" || EXIT_CODE=1
 rm -rf "$MOXYGEN_SHIM" "$TMPDIR"
 
 # Disable the trap — we already cleaned up

--- a/test/test_qmux_relay.sh
+++ b/test/test_qmux_relay.sh
@@ -33,6 +33,8 @@ resolve_moqbin "$BINARY"
 source "$REPO/test/test_ports.sh"
 # shellcheck source=test_versions.sh
 source "$REPO/test/test_versions.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$REPO/test/test_relay_lifecycle.sh"
 
 # Resolve a qmux-capable sample binary ($1 = name). Prefer MOQBIN; if that is a
 # pre-qmux release, fall back to a from-source install under .scratch. Empty if
@@ -105,8 +107,11 @@ cleanup() {
   for pid in "${PIDS[@]:-}"; do
     kill -KILL "$pid" 2>/dev/null || true
   done
-  wait "${PIDS[@]:-}" "${RELAY_PIDS[@]:-}" 2>/dev/null || true
+  reap_helpers "${PIDS[@]:-}"
+  local relay_failed=0
+  reap_relays "${RELAY_PIDS[@]:-}" || relay_failed=1
   rm -rf "$TMPDIR_SCRIPT"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 

--- a/test/test_relay_chain.sh
+++ b/test/test_relay_chain.sh
@@ -24,6 +24,8 @@ resolve_moqbin "$BINARY"
 source "$REPO/test/test_ports.sh"
 # shellcheck source=test_versions.sh
 source "$REPO/test/test_versions.sh"
+# shellcheck source=test_relay_lifecycle.sh
+source "$REPO/test/test_relay_lifecycle.sh"
 
 # Parse --save-logs option (may appear anywhere in args)
 SAVE_LOGS=false
@@ -103,9 +105,11 @@ cleanup() {
       kill -KILL "$pid" 2>/dev/null || true
     fi
   done
-  # Relays: wait indefinitely — relay's hard shutdown watchdog handles any hang.
-  wait "${PIDS[@]:-}" "${RELAY_PIDS[@]:-}" 2>/dev/null || true
+  reap_helpers "${PIDS[@]:-}"
+  local relay_failed=0
+  reap_relays "${RELAY_PIDS[@]:-}" || relay_failed=1
   rm -rf "$TMPDIR_SCRIPT"
+  (( relay_failed == 0 )) || exit 1
 }
 trap cleanup EXIT
 

--- a/test/test_relay_lifecycle.sh
+++ b/test/test_relay_lifecycle.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Shared process-reaping helpers for the relay integration tests.
+# Source this file; it defines functions only.
+#
+# Callers pass "${ARRAY[@]:-}", which expands to a single empty string when the
+# array is empty, so both helpers tolerate an empty argument.
+
+# reap_helpers <pid>...
+# Reaps non-relay helpers (dateserver, text clients). Their exit status is not
+# meaningful: cleanup times them out and SIGKILLs the survivors.
+reap_helpers() {
+  wait "$@" 2>/dev/null || true
+}
+
+# reap_relays <pid>...
+# Waits for each relay and reports any that failed. Relays must shut down
+# cleanly: a non-zero exit means a crash, a hung teardown (watchdog _Exit(1)),
+# or a sanitizer-detected leak (ASan flips the exit code to 1).
+#
+# Returns 1 if any relay failed rather than exiting, so the caller can finish
+# its own cleanup first. Call it as `reap_relays ... || failed=1`; a bare call
+# under `set -e` would abort the trap.
+reap_relays() {
+  local pid failed=0
+  for pid in "$@"; do
+    [[ -n "$pid" ]] || continue
+    if ! wait "$pid"; then
+      echo "FAIL: relay (pid $pid) exited non-zero — crash, hang, or sanitizer leak" >&2
+      failed=1
+    fi
+  done
+  return "$failed"
+}


### PR DESCRIPTION
Cleanup killed the relay and ignored its exit status, so a sanitizer-detected leak (ASan exits 1) or a hung teardown (the shutdown watchdog's _Exit) passed silently. Every test script that starts a relay now waits on it and fails if it exits non-zero. The waiting lives in test_relay_lifecycle.sh so the scripts don't each repeat it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/590)
<!-- Reviewable:end -->
