### PR TITLE
test: fix spurious SIGPIPE failure in cache-purge race check 5

### DIFF
--- a/test/test_admin_cache_purge_race.sh
+++ b/test/test_admin_cache_purge_race.sh
@@ -276,7 +276,8 @@ echo "PASS [4]: Phase 2 purge returned valid response: evicted=$EVICTED"
 
 # 5. /metrics still readable (event loop not wedged).
 METRICS=$(curl -sf "$METRICS_URL" 2>/dev/null || echo "")
-if ! echo "$METRICS" | grep -q "moqx_moqActiveSessions"; then
+# herestring, not a pipe: grep -q exiting early would SIGPIPE echo under pipefail
+if ! grep -q "moqx_moqActiveSessions" <<< "$METRICS"; then
   echo "FAIL [5]: /metrics unresponsive after test (event loop wedged?)" >&2; exit 1
 fi
 echo "PASS [5]: /metrics readable after both phases"


### PR DESCRIPTION
Main CI went red on macos after #600 merged: `admin_cache_purge_concurrency_test` reported `FAIL [5]: /metrics unresponsive after test` — but the relay was healthy.

**Root cause** — a latent shell bug in the check itself. Under `set -o pipefail`:

```bash
if ! echo "$METRICS" | grep -q "moqx_moqActiveSessions"; then
```

`grep -q` exits as soon as it matches. When `$METRICS` exceeds the pipe buffer, `echo` is still writing, takes SIGPIPE (exit 141), and `pipefail` propagates 141 as the pipeline status — so a *successful* match trips the FAIL branch. The job log shows the smoking gun immediately before the FAIL line:

```
test_admin_cache_purge_race.sh: line 279: echo: write error: Broken pipe
FAIL [5]: /metrics unresponsive after test (event loop wedged?)
```

The moxygen `c8cff3a` bump likely grew the /metrics body past the buffer threshold, exposing the race on the macOS runner (BSD grep buffering differs from GNU).

**Fix**: feed grep via herestring instead of a pipe — no pipe, no SIGPIPE, same semantics. The other `grep -q` pipes in the script consume small single-line bodies and are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/602)
<!-- Reviewable:end -->
