### PR TITLE
build: add --sync-moxygen-dir to move the moxygen checkout to the pin

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -3,7 +3,8 @@
 #
 # Usage:
 #   configure.sh [PROFILE] --moxygen (prebuilt-with-fallback|prebuilt|from-source)
-#                [--moxygen-dir DIR] [--clean] [-j N] [-DVAR=VALUE]...
+#                [--moxygen-dir DIR] [--sync-moxygen-dir] [--clean] [-j N]
+#                [-DVAR=VALUE]...
 #   PROFILE:                       default | san | tsan, or any preset from
 #                                  CMakeUserPresets.json; inherit `default` so
 #                                  binaryDir stays build/<name>. Default: default.
@@ -16,6 +17,14 @@
 #   --moxygen-dir DIR:             with from-source, build the local checkout DIR
 #                                  (the cross-repo moxygen+moqx dev loop)
 #                                  Which to pick: BUILD.md#how-dependencies-work
+#   --sync-moxygen-dir:            first move --moxygen-dir's checkout to
+#                                  MOXYGEN_REV, via scripts/dev/sync-moxygen.sh.
+#                                  Refuses (never stashes or forces) when that tree
+#                                  is dirty, mid rebase/merge, or sits on a commit
+#                                  no ref but HEAD names. A branch is fine — it
+#                                  survives the detach. Without this the checkout
+#                                  is built exactly as it stands, which is the
+#                                  point of --moxygen-dir.
 #   --clean:                       also discard this profile's from-source moxygen
 #                                  build (build/<PROFILE> is rebuilt from scratch
 #                                  either way; no effect unless the source build runs)
@@ -58,12 +67,13 @@ usage() { awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "${BASH_S
 truthy() { case "$1" in [Oo][Nn]|[Tt][Rr][Uu][Ee]|1|[Yy][Ee][Ss]) return 0 ;; *) return 1 ;; esac; }
 . "$ROOT/scripts/lib/jobs.sh"
 
-profile="default" moxygen="" moxygen_dir="" clean=0 jobs="" passthru=()
+profile="default" moxygen="" moxygen_dir="" sync_moxygen_dir=0 clean=0 jobs="" passthru=()
 if (($#)) && [[ "$1" != -* ]]; then profile="$1"; shift; fi
 while (($#)); do
   case "$1" in
     --moxygen)     (($# >= 2)) || die "--moxygen needs a value (prebuilt|prebuilt-with-fallback|from-source)"; moxygen="$2"; shift 2 ;;
     --moxygen-dir) (($# >= 2)) || die "--moxygen-dir needs a directory"; moxygen_dir="$(cd "$2" 2>/dev/null && pwd)" || die "--moxygen-dir: '$2' not found"; shift 2 ;;
+    --sync-moxygen-dir) sync_moxygen_dir=1; shift ;;
     --clean)       clean=1; shift ;;
     -j|--jobs)     (($# >= 2)) || die "$1 needs a job count"; jobs="$2"; shift 2 ;;
     -j*)           jobs="${1#-j}"; shift ;;
@@ -83,6 +93,8 @@ case "$moxygen" in
   *)  die "unknown --moxygen '$moxygen' (prebuilt-with-fallback|prebuilt|from-source)" ;;
 esac
 [[ -n "$moxygen_dir" && "$moxygen" != from-source ]] && die "--moxygen-dir requires --moxygen from-source"
+# Without --moxygen-dir the pin is what CPM fetches, so there is no checkout to move.
+((sync_moxygen_dir)) && [[ -z "$moxygen_dir" ]] && die "--sync-moxygen-dir requires --moxygen-dir"
 
 # Refusing beats last-wins: a stray -DMOQX_MOXYGEN_PREBUILT=ON would defeat the
 # from-source prefix and pull an uninstrumented moxygen under a sanitizer build,
@@ -230,6 +242,13 @@ fetch_prebuilt() {
   rm -f "$out"
   return "$rc"
 }
+
+# After the interlocks above: a configure that is going to die should not have moved
+# the checkout on its way out.
+if ((sync_moxygen_dir)); then
+  scripts/dev/sync-moxygen.sh --dir "$moxygen_dir" \
+    || die "--sync-moxygen-dir: refused to move $moxygen_dir (see above)"
+fi
 
 resolved="$moxygen"
 [[ "$moxygen" == prebuilt-with-fallback && "${MOQX_MOXYGEN_FALLBACK:-}" == off ]] && resolved="prebuilt"

--- a/scripts/dev/sync-moxygen.sh
+++ b/scripts/dev/sync-moxygen.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# sync-moxygen.sh — move the local moxygen checkout to MOXYGEN_REV.
+#
+# Usage: sync-moxygen.sh [--dir DIR]
+#
+#   --dir DIR   the moxygen checkout, else $MOQX_MOXYGEN_DIR. Required: which tree
+#               you develop moxygen in is a fact about your machine, so this script
+#               is told rather than guessing. Guessing from the build's own state
+#               (deps/moxygen, the CMake cache) can land on a CPM clone, which is
+#               CPM's to manage and must not be moved.
+#
+# The pin used to live in a git submodule, so a checkout moved moxygen with it. It is
+# a line of cmake/dependencies.cmake now and nothing tracks it, so anything wanting
+# that behaviour back — scripts/configure.sh --sync-moxygen-dir, or a VCS post-checkout
+# hook — calls this.
+#
+# It never stashes, resets, or checks out over local work: that tree is where moxygen
+# changes are made, and no pin is worth destroying it for. It refuses only what
+# detaching would actually cost you — uncommitted changes, an operation mid-flight, or
+# a commit no ref but HEAD names. Being on a branch is fine: the branch ref survives
+# the detach and the message below says how to return.
+#
+# A refusal is an error exit, so a caller that must stop just checks it. A caller
+# running on every checkout — a hook, where routine navigation lands on a dirty tree
+# all the time — writes `sync-moxygen.sh || true`.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+dir="${MOQX_MOXYGEN_DIR:-}"
+while (($#)); do
+  case "$1" in
+    --dir)    (($# >= 2)) || { echo "sync-moxygen.sh: --dir needs a directory" >&2; exit 1; }
+              dir="$2"; shift 2 ;;
+    -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *)        echo "sync-moxygen.sh: unknown option '$1' (see --help)" >&2; exit 1 ;;
+  esac
+done
+
+refuse() {
+  echo "sync-moxygen.sh: $*" >&2
+  exit 1
+}
+
+if [[ -z "$dir" ]]; then
+  refuse "no moxygen checkout given — pass --dir, or set MOQX_MOXYGEN_DIR"
+fi
+# Via a temp: assigning the failed cd's empty output back into dir would blank the
+# path out of the message below.
+abs_dir="$(cd "$dir" 2>/dev/null && pwd)" || refuse "moxygen checkout not found: $dir"
+dir="$abs_dir"
+
+# print-pin.cmake is the only supported reader; cmake/dependencies.cmake says so.
+pin="$(cmake -DPIN=MOXYGEN_REV -P cmake/print-pin.cmake)" \
+  || refuse "could not read MOXYGEN_REV via cmake/print-pin.cmake"
+[[ "$pin" =~ ^[0-9a-f]{40}$ ]] || refuse "MOXYGEN_REV is not a sha ('$pin')"
+
+head="$(git -C "$dir" rev-parse HEAD 2>/dev/null)" || refuse "$dir is not a git checkout"
+# Silent: on the hook path this is the common case on nearly every goto.
+if [[ "$head" == "$pin" ]]; then
+  exit 0
+fi
+
+# Captured separately: [[ -n "$(git status …)" ]] throws the exit code away, so a
+# corrupt index or a failing hook would yield empty output and read as "clean".
+status_out="$(git -C "$dir" status --porcelain --untracked-files=all)" \
+  || refuse "git status failed in $dir"
+if [[ -n "$status_out" ]]; then
+  refuse "$dir is dirty — commit, stash, or discard before it can move to $pin"
+fi
+
+git_dir="$(git -C "$dir" rev-parse --absolute-git-dir)"
+for marker in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG sequencer; do
+  if [[ -e "$git_dir/$marker" ]]; then
+    refuse "$marker in progress in $dir"
+  fi
+done
+
+# What detaching can actually destroy is a commit reachable only from HEAD: nothing
+# else names it afterwards and the reflog is the only way back. Any ref containing
+# HEAD — a branch, a tag, a remote — keeps it, and `git checkout` returns to it, so
+# being on a branch is not itself a reason to refuse.
+if [[ -z "$(git -C "$dir" for-each-ref --contains HEAD --count=1)" ]]; then
+  refuse "HEAD in $dir (${head:0:12}) is on no branch, tag, or remote — moving it would leave it reflog-only"
+fi
+
+# A pin can name a commit that is no branch tip (a merge parent, a force-pushed
+# rev), which a plain fetch will not bring down.
+git -C "$dir" rev-parse -q --verify "${pin}^{commit}" >/dev/null \
+  || git -C "$dir" fetch --quiet origin "$pin" \
+  || refuse "$pin is not fetchable in $dir"
+# Named before the checkout, and reported after: detaching off a branch is silent
+# otherwise, and this is the one line that says how to get back to it.
+was="$(git -C "$dir" symbolic-ref -q --short HEAD)" || was="${head:0:12}"
+git -C "$dir" checkout --quiet --detach "$pin" || refuse "could not check out $pin in $dir"
+echo "sync-moxygen.sh: moved $dir $was -> ${pin:0:12} (back with: git -C $dir checkout $was)"


### PR DESCRIPTION
moxygen was a git submodule until recently, so git submodule update moved the local checkout to the recorded revision. It is a CPM pin now, and there is no equivalent command. A --moxygen-dir build compiles the checkout as it stands, so after a pin bump the checkout has to be moved by hand.

scripts/dev/sync-moxygen.sh moves a named checkout to MOXYGEN_REV, and configure.sh --sync-moxygen-dir runs it before configuring. It refuses to move a tree that is dirty, has an operation in flight, or sits on a commit no ref but HEAD names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/603)
<!-- Reviewable:end -->
