### PR TITLE
metrics: omit_metadata query param drops HELP/TYPE lines

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -5,13 +5,25 @@ moqx exposes a Prometheus metrics endpoint on the admin HTTP server.
 ## Endpoint
 
 ```
-GET /metrics
+GET /metrics?omit_metadata=<bool>
 ```
 
 **Content-Type:** `text/plain; version=0.0.4; charset=utf-8`
 
 The response uses [Prometheus exposition format v0.0.4](https://prometheus.io/docs/instrumenting/exposition_formats/).
 All metric names are prefixed with `moqx_`.
+
+### Omitting metadata
+
+`omit_metadata` drops the `# HELP` and `# TYPE` lines while leaving every sample
+line unchanged; it applies to `/metrics` and `/metrics/track` alike. The metadata
+is static and repeats on every scrape, so a scraper that already knows the
+metric types can cut the response size substantially — most of a `/metrics/track`
+response is metadata when few tracks match.
+
+Accepted values are `1`, `true`, `0`, `false`, and a bare `?omit_metadata` with
+no value (true). Anything else is rejected with 400. Default is false, so
+scrapers that want the metadata need no change.
 
 ## Naming Conventions
 
@@ -186,7 +198,7 @@ Counters with per-code breakdowns:
 ## Per-Track Metrics
 
 ```
-GET /metrics/track?service=<name>&namespace=<a/b>&track=<name>&limit=<N>
+GET /metrics/track?service=<name>&namespace=<a/b>&track=<name>&limit=<N>&omit_metadata=<bool>
 ```
 
 Requires `admin.track_metrics_enabled` (default true); when it is false the
@@ -201,6 +213,7 @@ goes away, and start from zero if it comes back.
 | `service` | no | Restrict to one service. Default: all services, each labeled. |
 | `track` | no | Exact track name within the namespace. |
 | `limit` | no | Max tracks to report. Default `admin.track_metrics_endpoint_default_limit` (10); a value above `admin.track_metrics_endpoint_max_limit` (1000) is rejected with 400. |
+| `omit_metadata` | no | Drop the `# HELP` / `# TYPE` lines. See [Omitting metadata](#omitting-metadata). Default false. |
 
 Every parameter is optional, so `GET /metrics/track?limit=20` reports every live
 track when fewer than 20 match.

--- a/src/admin/AdminResponse.h
+++ b/src/admin/AdminResponse.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include <folly/io/IOBuf.h>
@@ -22,6 +23,23 @@ sendError(proxygen::ResponseHandler* downstream, int status, const std::string& 
       .header("Content-Type", "text/plain; charset=utf-8")
       .body(folly::IOBuf::copyBuffer(message))
       .sendWithEOM();
+}
+
+// Returns nullopt if the param is present with a value that isn't a boolean.
+// A bare `?flag` with no value reads as true, as flags conventionally do.
+inline std::optional<bool>
+boolQueryParam(const proxygen::HTTPMessage& req, const std::string& name, bool defaultValue) {
+  if (!req.hasQueryParam(name)) {
+    return defaultValue;
+  }
+  auto value = req.getDecodedQueryParam(name);
+  if (value.empty() || value == "1" || value == "true") {
+    return true;
+  }
+  if (value == "0" || value == "false") {
+    return false;
+  }
+  return std::nullopt;
 }
 
 } // namespace openmoq::moqx::admin

--- a/src/admin/MetricsHandler.cpp
+++ b/src/admin/MetricsHandler.cpp
@@ -15,6 +15,7 @@
 #include <proxygen/httpserver/ResponseBuilder.h>
 #include <proxygen/lib/http/HTTPMessage.h>
 
+#include "admin/AdminResponse.h"
 #include "admin/AdminServer.h"
 #include "stats/StatsRegistry.h"
 
@@ -28,37 +29,40 @@ void registerMetricsRoute(
       "GET",
       "/metrics",
       [registry = std::move(registry
-       )](auto /*req*/, auto /*body*/, auto* downstream, folly::CancellationToken cancelToken) {
+       )](auto req, auto /*body*/, auto* downstream, folly::CancellationToken cancelToken) {
         auto* evb = folly::EventBaseManager::get()->getEventBase();
+
+        auto omitMetadata = boolQueryParam(*req, "omit_metadata", false);
+        if (!omitMetadata) {
+          sendError(downstream, 400, "omit_metadata must be one of 1, 0, true, false\n");
+          return;
+        }
 
         folly::coro::co_withCancellation(
             cancelToken,
             folly::coro::co_withExecutor(
                 evb,
-                [](auto reg, auto* ds, auto token) -> folly::coro::Task<void> {
+                [](auto reg, auto* ds, auto token, bool omitMeta) -> folly::coro::Task<void> {
                   stats::StatsSnapshot snap;
                   try {
                     snap = co_await reg->aggregateAsync();
                   } catch (const std::exception& e) {
                     XLOG(ERR) << "MetricsHandler: aggregateAsync threw: " << e.what();
                     if (!token.isCancellationRequested()) {
-                      proxygen::ResponseBuilder(ds)
-                          .status(500, proxygen::HTTPMessage::getDefaultReason(500))
-                          .body(folly::IOBuf::copyBuffer("internal error\n"))
-                          .sendWithEOM();
+                      sendError(ds, 500, "internal error\n");
                     }
                     co_return;
                   }
                   if (token.isCancellationRequested()) {
                     co_return;
                   }
-                  auto body = stats::StatsSnapshot::formatPrometheus(snap);
+                  auto body = stats::StatsSnapshot::formatPrometheus(snap, omitMeta);
                   proxygen::ResponseBuilder(ds)
                       .status(200, proxygen::HTTPMessage::getDefaultReason(200))
                       .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
                       .body(std::move(body))
                       .sendWithEOM();
-                }(registry, downstream, cancelToken)
+                }(registry, downstream, cancelToken, *omitMetadata)
             )
         )
             .start();

--- a/src/admin/TrackMetricsHandler.cpp
+++ b/src/admin/TrackMetricsHandler.cpp
@@ -45,9 +45,9 @@ struct ClockAnchor {
 
 } // namespace
 
-std::unique_ptr<folly::IOBuf> formatTrackMetrics(const MoqxRelayContext::TrackMetricsResult& result
-) {
-  stats::PrometheusWriter out;
+std::unique_ptr<folly::IOBuf>
+formatTrackMetrics(const MoqxRelayContext::TrackMetricsResult& result, bool omitMetadata) {
+  stats::PrometheusWriter out{omitMetadata};
 
   struct Counter {
     std::string_view name;
@@ -227,6 +227,12 @@ void registerTrackMetricsRoute(
           limit = *parsed;
         }
 
+        auto omitMetadata = boolQueryParam(*req, "omit_metadata", false);
+        if (!omitMetadata) {
+          sendError(downstream, 400, "omit_metadata must be one of 1, 0, true, false\n");
+          return;
+        }
+
         std::string service = req->getDecodedQueryParam("service");
         std::optional<std::string> track;
         if (req->hasQueryParam("track")) {
@@ -247,7 +253,8 @@ void registerTrackMetricsRoute(
                    std::string service,
                    moxygen::TrackNamespace ns,
                    std::optional<std::string> track,
-                   size_t limit) -> folly::coro::Task<void> {
+                   size_t limit,
+                   bool omitMetadata) -> folly::coro::Task<void> {
                   if (token.isCancellationRequested()) {
                     co_return;
                   }
@@ -288,15 +295,16 @@ void registerTrackMetricsRoute(
                   proxygen::ResponseBuilder(ds)
                       .status(200, proxygen::HTTPMessage::getDefaultReason(200))
                       .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-                      .body(formatTrackMetrics(result))
+                      .body(formatTrackMetrics(result, omitMetadata))
                       .sendWithEOM();
                 }(context,
-                                 downstream,
-                                 cancelToken,
-                                 std::move(service),
-                                 std::move(nsPrefix),
-                                 std::move(track),
-                                 limit)
+                                      downstream,
+                                      cancelToken,
+                                      std::move(service),
+                                      std::move(nsPrefix),
+                                      std::move(track),
+                                      limit,
+                                      *omitMetadata)
             )
         )
             .start();

--- a/src/admin/TrackMetricsHandler.h
+++ b/src/admin/TrackMetricsHandler.h
@@ -24,8 +24,8 @@ struct TrackMetricsLimits {
   size_t maxLimit{1000};
 };
 
-std::unique_ptr<folly::IOBuf> formatTrackMetrics(const MoqxRelayContext::TrackMetricsResult& result
-);
+std::unique_ptr<folly::IOBuf>
+formatTrackMetrics(const MoqxRelayContext::TrackMetricsResult& result, bool omitMetadata = false);
 
 // Registers GET /metrics/track, which reports per-track counters in Prometheus
 // text format for tracks matching ?service=&namespace=&track=.

--- a/src/stats/PrometheusFormat.h
+++ b/src/stats/PrometheusFormat.h
@@ -44,6 +44,11 @@ inline std::string escapeLabelValue(std::string_view value) {
 //   https://prometheus.io/docs/instrumenting/exposition_formats/
 class PrometheusWriter {
 public:
+  PrometheusWriter() = default;
+  // omitMetadata drops the # HELP / # TYPE lines, which repeat unchanged on
+  // every scrape and dominate the response for small series counts.
+  explicit PrometheusWriter(bool omitMetadata) : omitMetadata_(omitMetadata) {}
+
   void append(std::string_view s) {
     appender_.push(reinterpret_cast<const uint8_t*>(s.data()), s.size());
   }
@@ -51,6 +56,9 @@ public:
   template <typename T> void num(T value) { append(folly::to<std::string>(value)); }
 
   void header(std::string_view name, std::string_view type, std::string_view help) {
+    if (omitMetadata_) {
+      return;
+    }
     append("# HELP ");
     append(name);
     append(" ");
@@ -65,6 +73,7 @@ public:
   std::unique_ptr<folly::IOBuf> move() { return queue_.move(); }
 
 private:
+  bool omitMetadata_{false};
   folly::IOBufQueue queue_{folly::IOBufQueue::cacheChainLength()};
   folly::io::QueueAppender appender_{&queue_, 8192};
 };

--- a/src/stats/StatsRegistry.cpp
+++ b/src/stats/StatsRegistry.cpp
@@ -62,7 +62,8 @@ StatsSnapshot& StatsSnapshot::operator+=(const StatsSnapshot& o) {
 // Histograms → _bucket{le=...}/_sum/_count, TYPE histogram
 
 /* static */
-std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapshot& snap) {
+std::unique_ptr<folly::IOBuf>
+StatsSnapshot::formatPrometheus(const StatsSnapshot& snap, bool omitMetadata) {
   folly::IOBufQueue queue{folly::IOBufQueue::cacheChainLength()};
   folly::io::QueueAppender appender{&queue, 8192};
 
@@ -70,12 +71,17 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
     appender.push(reinterpret_cast<const uint8_t*>(s.data()), s.size());
   };
   auto appNum = [&app](auto v) { app(folly::to<std::string>(v)); };
+  auto meta = [&app, omitMetadata](std::string_view s) {
+    if (!omitMetadata) {
+      app(s);
+    }
+  };
 
   // --- Counters ---
 #define EMIT_COUNTER(type, name)                                                                   \
-  app("# HELP moqx_" #name "_total\n"                                                              \
-      "# TYPE moqx_" #name "_total counter\n"                                                      \
-      "moqx_" #name "_total ");                                                                    \
+  meta("# HELP moqx_" #name "_total\n"                                                             \
+       "# TYPE moqx_" #name "_total counter\n");                                                   \
+  app("moqx_" #name "_total ");                                                                    \
   appNum(snap.name);                                                                               \
   app("\n\n");
   STATS_COUNTER_FIELDS(EMIT_COUNTER)
@@ -83,9 +89,9 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
 
   // --- Gauges ---
 #define EMIT_GAUGE(type, name)                                                                     \
-  app("# HELP moqx_" #name "\n"                                                                    \
-      "# TYPE moqx_" #name " gauge\n"                                                              \
-      "moqx_" #name " ");                                                                          \
+  meta("# HELP moqx_" #name "\n"                                                                   \
+       "# TYPE moqx_" #name " gauge\n");                                                           \
+  app("moqx_" #name " ");                                                                          \
   appNum(snap.name);                                                                               \
   app("\n\n");
   STATS_GAUGE_FIELDS(EMIT_GAUGE)
@@ -93,8 +99,8 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
 
   // --- Histograms ---
 #define EMIT_HISTOGRAM(name, bounds, unit)                                                         \
-  app("# HELP moqx_" #name "_" unit "\n"                                                           \
-      "# TYPE moqx_" #name "_" unit " histogram\n");                                               \
+  meta("# HELP moqx_" #name "_" unit "\n"                                                          \
+       "# TYPE moqx_" #name "_" unit " histogram\n");                                              \
   {                                                                                                \
     const auto& bvals = (bounds);                                                                  \
     const auto& bcounts = snap.name##Buckets;                                                      \
@@ -122,9 +128,9 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
   // Each field emits one labelled counter series:
   //   moqx_<name>_by_code_total{code="<label>"}
 #define EMIT_ERROR_COUNTER(name)                                                                   \
-  app("# HELP moqx_" #name "_by_code_total"                                                        \
-      " Error count broken down by RequestErrorCode\n"                                             \
-      "# TYPE moqx_" #name "_by_code_total counter\n");                                            \
+  meta("# HELP moqx_" #name "_by_code_total"                                                       \
+       " Error count broken down by RequestErrorCode\n"                                            \
+       "# TYPE moqx_" #name "_by_code_total counter\n");                                           \
   for (size_t i = 0; i < kRequestErrorCodeCount; ++i) {                                            \
     app("moqx_" #name "_by_code_total{code=\"");                                                   \
     app(kRequestErrorCodeLabels[i]);                                                               \
@@ -140,9 +146,9 @@ std::unique_ptr<folly::IOBuf> StatsSnapshot::formatPrometheus(const StatsSnapsho
   // Each field emits one labelled counter series:
   //   moqx_<name>_total{code="<label>"}
 #define EMIT_RESET_COUNTER(name)                                                                   \
-  app("# HELP moqx_" #name "_total"                                                                \
-      " Subgroup resets broken down by ResetStreamErrorCode\n"                                     \
-      "# TYPE moqx_" #name "_total counter\n");                                                    \
+  meta("# HELP moqx_" #name "_total"                                                               \
+       " Subgroup resets broken down by ResetStreamErrorCode\n"                                    \
+       "# TYPE moqx_" #name "_total counter\n");                                                   \
   for (size_t i = 0; i < kResetStreamErrorCodeCount; ++i) {                                        \
     app("moqx_" #name "_total{code=\"");                                                           \
     app(kResetStreamErrorCodeLabels[i]);                                                           \

--- a/src/stats/StatsRegistry.h
+++ b/src/stats/StatsRegistry.h
@@ -325,7 +325,9 @@ struct StatsSnapshot {
   StatsSnapshot& operator+=(const StatsSnapshot& o);
 
   // --- Prometheus text format ---
-  static std::unique_ptr<folly::IOBuf> formatPrometheus(const StatsSnapshot& snap);
+  // omitMetadata drops the # HELP / # TYPE lines from every series.
+  static std::unique_ptr<folly::IOBuf>
+  formatPrometheus(const StatsSnapshot& snap, bool omitMetadata = false);
 };
 
 class StatsCollectorBase {

--- a/test/admin/TrackMetricsFormatTest.cpp
+++ b/test/admin/TrackMetricsFormatTest.cpp
@@ -25,8 +25,8 @@ makeResult(stats::TrackCounters counters, std::string service) {
   return result;
 }
 
-std::string format(const MoqxRelayContext::TrackMetricsResult& result) {
-  auto body = formatTrackMetrics(result);
+std::string format(const MoqxRelayContext::TrackMetricsResult& result, bool omitMetadata = false) {
+  auto body = formatTrackMetrics(result, omitMetadata);
   return body->moveToFbString().toStdString();
 }
 
@@ -96,6 +96,22 @@ TEST(TrackMetricsFormatTest, OmitsUnsetTimestamps) {
   EXPECT_NE(out.find("# TYPE moqx_track_last_object_timestamp_seconds gauge"), std::string::npos);
   EXPECT_EQ(out.find("moqx_track_last_object_timestamp_seconds{"), std::string::npos);
   EXPECT_EQ(out.find("moqx_track_publish_start_timestamp_seconds{"), std::string::npos);
+}
+
+TEST(TrackMetricsFormatTest, OmitMetadataDropsHelpAndTypeButKeepsSamples) {
+  stats::TrackCounters counters;
+  counters.received.objects = 7;
+
+  auto out = format(makeResult(counters, "svc"), /*omitMetadata=*/true);
+
+  EXPECT_EQ(out.find("# HELP"), std::string::npos) << out;
+  EXPECT_EQ(out.find("# TYPE"), std::string::npos) << out;
+  EXPECT_NE(
+      out.find(
+          "moqx_track_objects_received_total{service=\"svc\",namespace=\"ns\",track=\"track\"} 7\n"
+      ),
+      std::string::npos
+  ) << out;
 }
 
 TEST(TrackMetricsFormatTest, EscapesServiceLabel) {

--- a/test/stats/MoQStatsCollectorTest.cpp
+++ b/test/stats/MoQStatsCollectorTest.cpp
@@ -14,8 +14,8 @@
 namespace openmoq::moqx::stats {
 
 namespace {
-std::string prometheusText(const StatsSnapshot& snap) {
-  auto out = StatsSnapshot::formatPrometheus(snap);
+std::string prometheusText(const StatsSnapshot& snap, bool omitMetadata = false) {
+  auto out = StatsSnapshot::formatPrometheus(snap, omitMetadata);
   out->coalesce();
   return std::string(reinterpret_cast<const char*>(out->data()), out->length());
 }
@@ -89,6 +89,23 @@ TEST_F(MoQStatsCollectorTest, PrometheusExportsResetAndAckLatency) {
   // Total is sum() over labels: an unhit reason still emits a zero series.
   EXPECT_NE(text.find("moqx_pubSubgroupReset_total{code=\"cancelled\"} 0"), std::string::npos);
   EXPECT_NE(text.find("moqx_moqObjectAckLatency_microseconds_count 1"), std::string::npos);
+}
+
+TEST_F(MoQStatsCollectorTest, PrometheusOmitMetadataDropsHelpAndType) {
+  auto pub = collector_->publisherCallback();
+  pub->onSubgroupReset(moxygen::ResetStreamErrorCode::DELIVERY_TIMEOUT);
+  pub->recordObjectAckLatency(300);
+
+  auto text = prometheusText(collector_->snapshot(), /*omitMetadata=*/true);
+
+  EXPECT_EQ(text.find("# HELP"), std::string::npos);
+  EXPECT_EQ(text.find("# TYPE"), std::string::npos);
+  EXPECT_NE(
+      text.find("moqx_pubSubgroupReset_total{code=\"delivery_timeout\"} 1"),
+      std::string::npos
+  );
+  EXPECT_NE(text.find("moqx_moqObjectAckLatency_microseconds_count 1"), std::string::npos);
+  EXPECT_NE(text.find("moqx_moqObjectAckLatency_microseconds_bucket{le="), std::string::npos);
 }
 
 } // namespace openmoq::moqx::stats

--- a/test/test_admin_track_metrics.sh
+++ b/test/test_admin_track_metrics.sh
@@ -105,6 +105,28 @@ for metric in \
   grep -q "^# TYPE ${metric} " < "$BODY_FILE" || fail "missing TYPE line for ${metric}"
 done
 
+# omit_metadata drops the schema lines from both metrics endpoints.
+for url in "${TRACK_URL}?namespace=test-ns&omit_metadata=1" \
+           "http://localhost:${ADMIN_PORT}/metrics?omit_metadata"; do
+  HTTP_CODE=$(curl -sw "%{http_code}" -o "$BODY_FILE" "$url" 2>/dev/null)
+  [[ "$HTTP_CODE" == "200" ]] || fail "expected HTTP 200 for omit_metadata, got $HTTP_CODE"
+  if grep -q '^# ' < "$BODY_FILE"; then
+    fail "omit_metadata should drop HELP/TYPE lines: $url"
+  fi
+done
+grep -q "^moqx_moqActiveSessions " < "$BODY_FILE" \
+  || fail "omit_metadata should keep sample lines"
+
+HTTP_CODE=$(curl -sw "%{http_code}" -o /dev/null \
+  "${TRACK_URL}?namespace=test-ns&omit_metadata=yes" 2>/dev/null)
+[[ "$HTTP_CODE" == "400" ]] || fail "expected HTTP 400 for non-boolean omit_metadata, got $HTTP_CODE"
+
+HTTP_CODE=$(curl -sw "%{http_code}" -o "$BODY_FILE" \
+  "${TRACK_URL}?namespace=test-ns&omit_metadata=false" 2>/dev/null)
+[[ "$HTTP_CODE" == "200" ]] || fail "expected HTTP 200 for omit_metadata=false, got $HTTP_CODE"
+grep -q "^# TYPE moqx_track_subscribers " < "$BODY_FILE" \
+  || fail "omit_metadata=false should keep TYPE lines"
+
 # Filters and limits are accepted.
 HTTP_CODE=$(curl -sw "%{http_code}" -o /dev/null \
   "${TRACK_URL}?namespace=test-ns&track=track1&service=default&limit=5" 2>/dev/null)


### PR DESCRIPTION
/metrics and /metrics/track accept omit_metadata (1|true|0|false, or bare; anything else is 400). Set, the response carries only sample lines, which are unchanged. PrometheusWriter and StatsSnapshot::formatPrometheus take the flag; boolQueryParam() in AdminResponse.h parses it for both handlers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/604)
<!-- Reviewable:end -->
