### PR TITLE
build: durable sanitizer interlock + cheaper moxygen re-keys

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -151,6 +151,10 @@ Sanitizers must instrument the dependencies too, so `san --moxygen from-source`
 builds an instrumented moxygen as well; moqx lands in `build/san` (or
 `build/tsan`).
 
+The moxygen install prefix records its profile in `.moqx-moxygen-profile`
+(absent means `default`), and the moqx configure refuses a prefix whose profile
+doesn't match its own — that check holds for raw `cmake` invocations too.
+
 `prebuilt` and `prebuilt-with-fallback` are refused for these profiles, since
 neither can produce an instrumented moxygen. `MOQX_ALLOW_UNINSTRUMENTED_DEPS=1`
 overrides that to sanitize moqx's own TUs only — what the per-PR asan lane does.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,13 +107,6 @@ endif()
 # MOXYGEN_REV, OFF demands a prefix. See BUILD.md#how-dependencies-work.
 find_package(moxygen QUIET CONFIG)
 if(NOT moxygen_FOUND AND MOQX_MOXYGEN_PREBUILT)
-  if(MOQX_ENABLE_SANITIZERS OR MOQX_ENABLE_TSAN)
-    message(WARNING
-      "Sanitizers are enabled but moxygen resolves to the UNINSTRUMENTED "
-      "prebuilt — sanitizer coverage is limited to moqx's own TUs. For full "
-      "coverage build an instrumented moxygen: "
-      "scripts/configure.sh san|tsan --moxygen from-source (see BUILD.md).")
-  endif()
   include(cmake/FetchMoxygenPrebuilt.cmake)
   find_package(moxygen REQUIRED CONFIG)
 elseif(NOT moxygen_FOUND)
@@ -124,6 +117,55 @@ elseif(NOT moxygen_FOUND)
     "(or pass -DCMAKE_PREFIX_PATH=<moxygen install>; see BUILD.md).")
 endif()
 message(STATUS "moxygen: using install at ${moxygen_DIR}")
+
+# <prefix>/.moqx-moxygen-profile names the sanitizer profile the moxygen stack
+# was compiled with (written by the superbuild; absent — prebuilts, foreign
+# prefixes — reads as "default"). moqx and that stack must agree: uninstrumented
+# deps under a sanitized moqx silently stop coverage at moqx's own TUs, and any
+# other mismatch breaks at link (missing/clashing sanitizer runtimes) or skews
+# folly's kIsDebug across the ABI (the superbuild builds san/tsan as Debug).
+get_filename_component(_moqx_moxygen_prefix "${moxygen_DIR}/../../.." ABSOLUTE)
+set(_moqx_moxygen_stamp "default")
+if(EXISTS "${_moqx_moxygen_prefix}/.moqx-moxygen-profile")
+  file(READ "${_moqx_moxygen_prefix}/.moqx-moxygen-profile" _moqx_moxygen_stamp)
+  string(STRIP "${_moqx_moxygen_stamp}" _moqx_moxygen_stamp)
+endif()
+# Mirrors the flag conditions above: under Release the enable options apply no
+# instrumentation, so moqx needs the uninstrumented stack.
+set(_moqx_own_profile "default")
+if(MOQX_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(_moqx_own_profile "san")
+elseif(MOQX_ENABLE_TSAN AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(_moqx_own_profile "tsan")
+endif()
+if(NOT _moqx_moxygen_stamp STREQUAL _moqx_own_profile)
+  if(NOT _moqx_own_profile STREQUAL "default" AND _moqx_moxygen_stamp STREQUAL "default")
+    # The one opt-in-able degradation: knowingly sanitize moqx's TUs alone.
+    if(MOQX_ALLOW_ABI_SKEW)
+      message(WARNING
+        "Sanitizers are enabled but the moxygen at ${_moqx_moxygen_prefix} is "
+        "UNINSTRUMENTED — sanitizer coverage is limited to moqx's own TUs.")
+    else()
+      message(FATAL_ERROR
+        "moqx builds the '${_moqx_own_profile}' profile but the moxygen at\n"
+        "  ${_moqx_moxygen_prefix}\n"
+        "is uninstrumented; sanitizer coverage would silently stop at moqx's own "
+        "TUs. Build a matching stack:\n"
+        "  scripts/configure.sh ${_moqx_own_profile} --moxygen from-source\n"
+        "(or pass -DMOQX_ALLOW_ABI_SKEW=ON to knowingly link the uninstrumented one).")
+    endif()
+  else()
+    message(FATAL_ERROR
+      "the moxygen at\n"
+      "  ${_moqx_moxygen_prefix}\n"
+      "was built for the '${_moqx_moxygen_stamp}' profile but moqx builds "
+      "'${_moqx_own_profile}'; the link would fail or misbehave (sanitizer "
+      "runtime/interceptor mismatch, Debug-built deps skewing kIsDebug). No "
+      "opt-in covers this — build the matching stack:\n"
+      "  scripts/configure.sh ${_moqx_own_profile} --moxygen from-source\n"
+      "(or configure the '${_moqx_moxygen_stamp}' preset to match this install).")
+  endif()
+endif()
 
 # find_package caches moxygen_DIR and the folly/fizz/… tree with it, so a build
 # dir binds to the moxygen it first resolved and a pin bump cannot take effect in

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -100,7 +100,8 @@ done
 # -N resolves the preset's cache variables without configuring, so an unknown
 # name dies here with cmake's list of presets. Those variables also say which
 # moxygen is needed; MOQX_MOXYGEN_PROFILE overrides the derivation.
-preset_info="$(cmake --preset "$profile" -N)"
+# --log-level=VERBOSE: CMake >= 4.0 prints the variable summary only there.
+preset_info="$(cmake --preset "$profile" -N --log-level=VERBOSE)"
 # What the preset declares it needs...
 # The *_src labels name whatever settled each flag, so the errors below blame the
 # thing the reader has to change.

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -218,6 +218,24 @@ configure_from_source() {
   configure_moqx "${from_source[@]}"
 }
 
+# The fallback builds the pinned rev, but a superbuild dir bound to a local
+# --moxygen-dir checkout would be silently re-keyed to the pin — an implicit
+# code path discarding an explicit binding. Refuse and make the caller choose.
+# A recorded source under the CPM clone root is the pin (or an old pin), which
+# the superbuild re-keys on its own.
+guard_fallback_rekey() {
+  [[ -f "$sb/CMakeCache.txt" ]] || return 0
+  local recorded
+  recorded="$(sed -n 's/^MOQX_MOXYGEN_SOURCE_DIR:INTERNAL=//p' "$sb/CMakeCache.txt")"
+  [[ -n "$recorded" ]] || return 0
+  [[ "$recorded" == "${CPM_SOURCE_CACHE:-$MOQX_DEPS_CACHE/cpm}"/* ]] && return 0
+  die "no prebuilt for the pin, and $sb is bound to the local checkout
+  $recorded
+falling back would rebuild it against the pinned rev, dropping that binding —
+  keep the checkout:  configure.sh $profile --moxygen from-source --moxygen-dir $recorded
+  build the pin:      configure.sh $profile --moxygen from-source   (add --clean to rebuild from scratch)"
+}
+
 # Is a prebuilt published for the pin on this platform? Populates the dependency
 # cache when it is, so the configure that follows needs no network. Forwarding the
 # probe's own knobs keeps it answering for the platform moqx goes on to ask for.
@@ -250,6 +268,7 @@ case "$resolved" in
       configure_moqx -DMOQX_MOXYGEN_PREBUILT=ON
     else
       resolved="from-source"
+      guard_fallback_rekey
       echo "configure.sh: no moxygen prebuilt for the pin (see above) — building it from source, which is slow" >&2
       [[ -n "${GITHUB_ACTIONS:-}" ]] \
         && echo "::warning title=moxygen prebuilt unavailable::configure.sh fell back to the from-source superbuild"

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -67,6 +67,11 @@ endif()
 set(_moxygen_install "${CMAKE_BINARY_DIR}/moxygen-install")
 message(STATUS "moxygen will install to ${_moxygen_install}")
 
+# <prefix>/.moqx-moxygen-profile names the profile this stack was compiled with;
+# moqx's configure interlocks on it (no stamp reads as "default"). Written here,
+# copied into the prefix by the install step below.
+file(WRITE "${CMAKE_BINARY_DIR}/moxygen-profile-stamp" "${MOQX_MOXYGEN_PROFILE}\n")
+
 # moxygen compile/link flags: sanitizers, plus a macOS fmt workaround. Apple
 # Clang 21+ rejects fmt 10.2.1's consteval format-string check (fmtlib/fmt#4740);
 # applied on all macOS since project(NONE) leaves no compiler version to gate on.
@@ -142,6 +147,9 @@ ExternalProject_Add(moxygen
   # find_package and includes to pick up.
   INSTALL_COMMAND ${CMAKE_COMMAND} -E rm -rf <INSTALL_DIR>
           COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR> --config ${_build_type}
+          COMMAND ${CMAKE_COMMAND} -E copy
+                  ${CMAKE_BINARY_DIR}/moxygen-profile-stamp
+                  <INSTALL_DIR>/.moqx-moxygen-profile
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${_build_type}
     # INSTALL_DIR only fills the <INSTALL_DIR> placeholder; the prefix must be

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -28,13 +28,16 @@ CPMAddPackage(
 )
 
 # CPM gives every rev its own source directory, and CMake refuses a build dir
-# whose source moved ("does not match the source used to generate cache"). Drop
-# the inner build when the pin changes, so a bump reconfigures instead of dying.
+# whose source moved ("does not match the source used to generate cache"). That
+# binding lives only in the cache, so drop CMakeCache.txt + CMakeFiles/ and keep
+# the rest: _deps/ (the folly stack) has path-stable sources and command lines,
+# so its objects survive the reconfigure as ninja no-ops.
 set(_moxygen_build "${CMAKE_BINARY_DIR}/moxygen-build")
 if(EXISTS "${_moxygen_build}/CMakeCache.txt"
    AND NOT "${moxygen_SOURCE_DIR}" STREQUAL "${MOQX_MOXYGEN_SOURCE_DIR}")
-  message(STATUS "moxygen: source moved to ${moxygen_SOURCE_DIR} — discarding ${_moxygen_build}")
-  file(REMOVE_RECURSE "${_moxygen_build}")
+  message(STATUS "moxygen: source moved to ${moxygen_SOURCE_DIR} — resetting ${_moxygen_build}'s cache (keeping _deps/)")
+  file(REMOVE "${_moxygen_build}/CMakeCache.txt")
+  file(REMOVE_RECURSE "${_moxygen_build}/CMakeFiles")
 endif()
 set(MOQX_MOXYGEN_SOURCE_DIR "${moxygen_SOURCE_DIR}" CACHE INTERNAL
     "moxygen source the ExternalProject below last configured against")


### PR DESCRIPTION
Fixes from Alan's build-system feedback (P1 + items 1 and 2).

## The dead interlock (P1)

CMake 4.0 demoted `cmake --preset -N`'s variable summary to VERBOSE
([release notes](https://cmake.org/cmake/help/latest/release/4.0.html)); verified empty on 4.0.3/4.1.2/4.2.0/4.2.1, present on 3.31.6. On cmake ≥ 4 `configure.sh` derived `default` for every preset, so `san`/`tsan` builds got an uninstrumented stack with no error. Two layers:

- `--log-level=VERBOSE` on the probe restores the derivation (same output on 3.x and 4.x).
- Durable interlock in CMake itself: the superbuild writes the profile into `<prefix>/.moqx-moxygen-profile`; moqx's configure refuses a mismatched prefix. No stamp (prebuilts, foreign prefixes) reads as `default`. Uninstrumented deps under a sanitized build remain opt-in-able via `MOQX_ALLOW_ABI_SKEW`; any other mix has no opt-in.

**Behavior change:** raw-cmake `-DMOQX_ENABLE_SANITIZERS=ON` over the prebuilt was a WARNING, is now FATAL with the `MOQX_ALLOW_ABI_SKEW=ON` escape (per #579, the partial state was never intended). When instrumented prebuilts exist (openmoq/moxygen#353), their release job stamps the tarball and they pass the same check.

Related: #584 (macOS fallback superbuild under brew's CMake 4 — this PR fixes the interlock half; the superbuild-on-CMake-4 half remains open).

## Narrow the source-moved discard

A moxygen source-path change wiped the whole inner build dir including `_deps/` (the folly stack). The binding CMake refuses on lives only in `CMakeCache.txt`/`CMakeFiles/`, so only those are reset now. Measured on a re-key: fizz/wangle/mvfst/proxygen/fmt (~680 objects) untouched; folly's ~360 objects still recompile because moxygen's standalone embeds its source path in `FOLLY_XLOG_STRIP_PREFIXES` on folly's TUs (upstream; ccache absorbs most of it).

## Refuse the fallback re-key

`prebuilt-with-fallback` falling back on a superbuild bound to a local `--moxygen-dir` checkout silently rebuilt it against the pin. It now dies naming the recorded checkout and both ways out (`--moxygen-dir <path>` to keep it, `--moxygen from-source` for the pin). Clone-to-clone changes (pin bumps) still proceed; reusing the recorded path was rejected because the fallback has to match the prebuilt it stands in for.

## Verified

- Script interlock refuses `san --moxygen prebuilt` under cmake 3.31.6 and 4.2.1; unknown presets still die.
- Stamp matrix: san-over-prebuilt FATAL / warns with `MOQX_ALLOW_ABI_SKEW=ON`; default-over-san FATAL; san-over-san and default-over-default pass (full `san --moxygen from-source` end-to-end, stamp reads `san`).
- Re-key run shows the new "keeping _deps/" reset with dep objects preserved.
- Fallback guard dies on a local-bound tree, passes on a clone-bound one.
- Default profile: full build + 835 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDJdLKaVJKaDYa48VopGxb

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/605)
<!-- Reviewable:end -->
