### PR TITLE
Build-system fixup. 

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -151,6 +151,11 @@ Sanitizers must instrument the dependencies too, so `san --moxygen from-source`
 builds an instrumented moxygen as well; moqx lands in `build/san` (or
 `build/tsan`).
 
+The moqx configure measures the prefix's actual instrumentation (an `nm` probe
+for `__asan_init`/`__tsan_init` in an installed moxygen archive) and refuses a
+mismatch — for raw `cmake` invocations, downloaded prebuilts, and hand-built
+prefixes alike.
+
 `prebuilt` and `prebuilt-with-fallback` are refused for these profiles, since
 neither can produce an instrumented moxygen. `MOQX_ALLOW_UNINSTRUMENTED_DEPS=1`
 overrides that to sanitize moqx's own TUs only — what the per-PR asan lane does.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,12 +50,20 @@ option(MOQX_ENABLE_BPF_STEERING
 
 include(cmake/SanitizerFlags.cmake)
 
+# The sanitizer profile this build carries — the enable options are inert
+# under Release. Derived once, so profile-keyed checks cannot drift from the
+# flags actually applied.
+set(_moqx_own_profile "default")
 if(MOQX_ENABLE_SANITIZERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
-  add_compile_options(${MOQX_ASAN_FLAGS})
-  add_link_options(${MOQX_ASAN_FLAGS})
+  set(_moqx_own_profile "san")
+elseif(MOQX_ENABLE_TSAN AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(_moqx_own_profile "tsan")
 endif()
 
-if(MOQX_ENABLE_TSAN AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+if(_moqx_own_profile STREQUAL "san")
+  add_compile_options(${MOQX_ASAN_FLAGS})
+  add_link_options(${MOQX_ASAN_FLAGS})
+elseif(_moqx_own_profile STREQUAL "tsan")
   add_compile_options(${MOQX_TSAN_FLAGS})
   add_link_options(${MOQX_TSAN_FLAGS})
 endif()
@@ -107,12 +115,14 @@ endif()
 # MOXYGEN_REV, OFF demands a prefix. See BUILD.md#how-dependencies-work.
 find_package(moxygen QUIET CONFIG)
 if(NOT moxygen_FOUND AND MOQX_MOXYGEN_PREBUILT)
-  if(MOQX_ENABLE_SANITIZERS OR MOQX_ENABLE_TSAN)
-    message(WARNING
-      "Sanitizers are enabled but moxygen resolves to the UNINSTRUMENTED "
-      "prebuilt — sanitizer coverage is limited to moqx's own TUs. For full "
-      "coverage build an instrumented moxygen: "
-      "scripts/configure.sh san|tsan --moxygen from-source (see BUILD.md).")
+  # The published prebuilts are uninstrumented; refuse before the
+  # multi-hundred-MB download, not at the probe after it.
+  if(NOT _moqx_own_profile STREQUAL "default" AND NOT MOQX_ALLOW_ABI_SKEW)
+    message(FATAL_ERROR
+      "moqx builds the '${_moqx_own_profile}' profile but MOQX_MOXYGEN_PREBUILT=ON "
+      "resolves to the uninstrumented prebuilt. Build a matching stack:\n"
+      "  scripts/configure.sh ${_moqx_own_profile} --moxygen from-source\n"
+      "(or pass -DMOQX_ALLOW_ABI_SKEW=ON to knowingly link the uninstrumented one).")
   endif()
   include(cmake/FetchMoxygenPrebuilt.cmake)
   find_package(moxygen REQUIRED CONFIG)
@@ -124,6 +134,88 @@ elseif(NOT moxygen_FOUND)
     "(or pass -DCMAKE_PREFIX_PATH=<moxygen install>; see BUILD.md).")
 endif()
 message(STATUS "moxygen: using install at ${moxygen_DIR}")
+
+# The sanitizer profile the moxygen stack carries, measured: every TU compiled
+# with -fsanitize references __asan_init/__tsan_init, so one nm probe of an
+# installed archive answers for any prefix, downloads included.
+get_filename_component(_moqx_moxygen_prefix "${moxygen_DIR}/../../.." ABSOLUTE)
+if(NOT CMAKE_NM)
+  find_program(CMAKE_NM nm)
+endif()
+# Smallest archive wins: the probe reads the whole file, and every moxygen
+# archive carries at least one instrumented TU.
+file(GLOB _moqx_probe_candidates "${_moqx_moxygen_prefix}/lib/libmoxygen*.a"
+     "${_moqx_moxygen_prefix}/lib64/libmoxygen*.a")
+set(_moqx_probe_lib "")
+foreach(_lib IN LISTS _moqx_probe_candidates)
+  file(SIZE "${_lib}" _sz)
+  if(_moqx_probe_lib STREQUAL "" OR _sz LESS _moqx_probe_size)
+    set(_moqx_probe_lib "${_lib}")
+    set(_moqx_probe_size "${_sz}")
+  endif()
+endforeach()
+set(_moqx_moxygen_profile "")
+if(CMAKE_NM AND NOT _moqx_probe_lib STREQUAL "")
+  execute_process(
+    COMMAND "${CMAKE_NM}" -u "${_moqx_probe_lib}"
+    COMMAND grep -m1 -oE "__(a|t)san_init"
+    RESULTS_VARIABLE _moqx_probe_rcs
+    OUTPUT_VARIABLE _moqx_probe_sym
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  list(GET _moqx_probe_rcs 0 _moqx_nm_rc)
+  list(GET _moqx_probe_rcs 1 _moqx_grep_rc)
+  if(_moqx_nm_rc EQUAL 0)
+    if(_moqx_probe_sym STREQUAL "__asan_init")
+      set(_moqx_moxygen_profile "san")
+    elseif(_moqx_probe_sym STREQUAL "__tsan_init")
+      set(_moqx_moxygen_profile "tsan")
+    elseif(_moqx_grep_rc EQUAL 1)
+      set(_moqx_moxygen_profile "default")
+    endif()
+  endif()
+endif()
+if(_moqx_moxygen_profile STREQUAL "")
+  if(MOQX_ALLOW_ABI_SKEW)
+    message(WARNING
+      "could not verify the sanitizer instrumentation of the moxygen at "
+      "${_moqx_moxygen_prefix} (nm or a libmoxygen*.a archive missing) — "
+      "linking it unverified (MOQX_ALLOW_ABI_SKEW).")
+  else()
+    message(FATAL_ERROR
+      "could not verify the sanitizer instrumentation of the moxygen at\n"
+      "  ${_moqx_moxygen_prefix}\n"
+      "(nm or a libmoxygen*.a archive missing). Pass -DMOQX_ALLOW_ABI_SKEW=ON "
+      "to link it unverified.")
+  endif()
+elseif(NOT _moqx_moxygen_profile STREQUAL _moqx_own_profile)
+  if(NOT _moqx_own_profile STREQUAL "default" AND _moqx_moxygen_profile STREQUAL "default")
+    # The one opt-in-able degradation: knowingly sanitize moqx's TUs alone.
+    if(MOQX_ALLOW_ABI_SKEW)
+      message(WARNING
+        "Sanitizers are enabled but the moxygen at ${_moqx_moxygen_prefix} "
+        "carries no sanitizer instrumentation — coverage is limited to moqx's "
+        "own TUs.")
+    else()
+      message(FATAL_ERROR
+        "moqx builds the '${_moqx_own_profile}' profile but the moxygen at\n"
+        "  ${_moqx_moxygen_prefix}\n"
+        "carries no sanitizer instrumentation; coverage would silently stop at "
+        "moqx's own TUs. Build a matching stack:\n"
+        "  scripts/configure.sh ${_moqx_own_profile} --moxygen from-source\n"
+        "(or pass -DMOQX_ALLOW_ABI_SKEW=ON to knowingly link the uninstrumented one).")
+    endif()
+  else()
+    message(FATAL_ERROR
+      "the moxygen at\n"
+      "  ${_moqx_moxygen_prefix}\n"
+      "is ${_moqx_moxygen_profile}-instrumented but moqx builds "
+      "'${_moqx_own_profile}'; the link would fail or misbehave (sanitizer "
+      "runtime/interceptor mismatch, Debug-built deps skewing kIsDebug). No "
+      "opt-in covers this — build the matching stack:\n"
+      "  scripts/configure.sh ${_moqx_own_profile} --moxygen from-source\n"
+      "(or configure the '${_moqx_moxygen_profile}' preset to match this install).")
+  endif()
+endif()
 
 # find_package caches moxygen_DIR and the folly/fizz/… tree with it, so a build
 # dir binds to the moxygen it first resolved and a pin bump cannot take effect in
@@ -163,8 +255,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT MOQX_ALLOW_ABI_SKEW
 endif()
 
 # moxygen's sample binaries (moqclient/…) live in <prefix>/bin, which integration
-# tests reach through MOQBIN. moxygen_DIR is <prefix>/lib/cmake/moxygen.
-get_filename_component(MOXYGEN_BIN_DIR "${moxygen_DIR}/../../../bin" ABSOLUTE)
+# tests reach through MOQBIN.
+set(MOXYGEN_BIN_DIR "${_moqx_moxygen_prefix}/bin")
 
 # Test and perf scripts run outside ctest source this instead of re-deriving
 # MOQBIN from CMakeCache.txt. Regenerated on every configure.

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -126,7 +126,7 @@ elif ((tsan)); then
 else
   # Nothing on: whichever -D turned one off is the reason, else the preset.
   needs_profile="default" needs_src="$san_src"
-  if [[ "$needs_src" == preset\'* && "$tsan_src" != preset\'* ]]; then
+  if [[ "$needs_src" == "preset '"* && "$tsan_src" != "preset '"* ]]; then
     needs_src="$tsan_src"
   fi
 fi

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -130,6 +130,19 @@ else
     needs_src="$tsan_src"
   fi
 fi
+# Sanitizer flags are inert under Release (CMakeLists applies them non-Release
+# only). Refusing the contradiction here beats a superbuild-length detour to
+# the same refusal.
+build_type="$(sed -n 's/.*CMAKE_BUILD_TYPE="\(.*\)"/\1/p' <<<"$preset_info" | tail -1)"
+for arg in ${passthru[@]+"${passthru[@]}"}; do
+  case "$arg" in -DCMAKE_BUILD_TYPE[:=]*) build_type="${arg#*=}" ;; esac
+done
+if [[ "$needs_profile" != default && "$build_type" == Release ]]; then
+  die "$needs_src enables sanitizers ($needs_profile), but CMAKE_BUILD_TYPE=Release makes the
+  sanitizer flags inert, so moqx would carry none and refuse the instrumented moxygen —
+  drop -DCMAKE_BUILD_TYPE=Release, or drop the sanitizer profile"
+fi
+
 # ...versus the moxygen actually built/downloaded. A fallback build has to match
 # the prebuilt it stands in for, or losing the prebuilt would quietly change what
 # the lane tests.

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -100,7 +100,8 @@ done
 # -N resolves the preset's cache variables without configuring, so an unknown
 # name dies here with cmake's list of presets. Those variables also say which
 # moxygen is needed; MOQX_MOXYGEN_PROFILE overrides the derivation.
-preset_info="$(cmake --preset "$profile" -N)"
+# --log-level=VERBOSE: CMake >= 4.0 prints the variable summary only there.
+preset_info="$(cmake --preset "$profile" -N --log-level=VERBOSE)"
 # What the preset declares it needs...
 # The *_src labels name whatever settled each flag, so the errors below blame the
 # thing the reader has to change.

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -28,13 +28,14 @@ CPMAddPackage(
 )
 
 # CPM gives every rev its own source directory, and CMake refuses a build dir
-# whose source moved ("does not match the source used to generate cache"). Drop
-# the inner build when the pin changes, so a bump reconfigures instead of dying.
+# whose source moved. That binding lives only in CMakeCache.txt + CMakeFiles/;
+# dropping just those keeps _deps/ (the folly stack) as ninja no-ops.
 set(_moxygen_build "${CMAKE_BINARY_DIR}/moxygen-build")
 if(EXISTS "${_moxygen_build}/CMakeCache.txt"
    AND NOT "${moxygen_SOURCE_DIR}" STREQUAL "${MOQX_MOXYGEN_SOURCE_DIR}")
-  message(STATUS "moxygen: source moved to ${moxygen_SOURCE_DIR} — discarding ${_moxygen_build}")
-  file(REMOVE_RECURSE "${_moxygen_build}")
+  message(STATUS "moxygen: source moved to ${moxygen_SOURCE_DIR} — resetting ${_moxygen_build}'s cache (keeping _deps/)")
+  file(REMOVE "${_moxygen_build}/CMakeCache.txt")
+  file(REMOVE_RECURSE "${_moxygen_build}/CMakeFiles")
 endif()
 set(MOQX_MOXYGEN_SOURCE_DIR "${moxygen_SOURCE_DIR}" CACHE INTERNAL
     "moxygen source the ExternalProject below last configured against")


### PR DESCRIPTION
Fixes from @afrind  build-system feedback

### Dead sanitizer interlock (P1).

CMake 4.0 demoted `cmake --preset -N`'s variable summary to VERBOSE ([release notes](https://cmake.org/cmake/help/latest/release/4.0.html)), so on cmake ≥ 4 `configure.sh` derived `default` for every preset and san/tsan builds got an uninstrumented stack with no error. 

2 fixes:
  - `--log-level=VERBOSE` on the probe restores the derivation (same output on 3.x and 4.x).
- durable check in CMake: moqx's configure measures the prefix's actual instrumentation (an `nm` probe for `__asan_init`/`__tsan_init` in an installed moxygen archive) and refuses a mismatch

`MOQX_ALLOW_ABI_SKEW=ON` still opts into uninstrumented deps;

### Cheaper moxygen re-keys.

A source-path change (pin bump, `--moxygen-dir` switch) now resets only the inner `CMakeCache.txt`/`CMakeFiles/` instead of wiping the whole build: fizz/wangle/mvfst/proxygen survive as ninja no-ops. folly still recompiles (moxygen's
  standalone embeds its source path in `FOLLY_XLOG_STRIP_PREFIXES` on folly's TUs)

### Behaviour change: a raw-cmake sanitized configure over the uninstrumented prebuilt raised from WARN to FATAL 

Setting `MOQX_ALLOW_ABI_SKEW=ON` restores the old behaviour, warn and link it anyway. The same applies to a prefix whose instrumentation cannot be measured (no `nm`, no static moxygen archive): refused by default, linked unverified with the opt-in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/607)
<!-- Reviewable:end -->
