### PR TITLE
scripts: bound apt fetches with timeouts and retries

### DIFF
--- a/scripts/install-system-deps.sh
+++ b/scripts/install-system-deps.sh
@@ -25,6 +25,13 @@ if [ "$(id -u)" -ne 0 ]; then
     fi
 fi
 
+# apt has no overall deadline: a stalled mirror connection can hang a fetch
+# indefinitely. Bound each transfer and retry so a bad mirror fails the run in
+# minutes instead of wedging it.
+apt_get() {
+    $SUDO apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@"
+}
+
 # reflect-cpp (a moqx dependency) needs CMake >= 3.23, newer than the 3.22 that
 # e.g. Ubuntu 22.04 ships. Install a current CMake from PyPI when the distro's is
 # too old, rather than requiring users to add a third-party apt repo.
@@ -39,7 +46,7 @@ ensure_recent_cmake() {
     # (folly/proxygen/…) source build still relies on.
     echo "CMake ${have:-not found} is older than $min; installing a current CMake 3.x from PyPI..."
     if ! command -v pip3 >/dev/null 2>&1; then
-        if command -v apt-get >/dev/null 2>&1; then $SUDO apt-get install -y python3-pip
+        if command -v apt-get >/dev/null 2>&1; then apt_get install -y python3-pip
         elif command -v dnf >/dev/null 2>&1; then $SUDO dnf install -y python3-pip; fi
     fi
     # --break-system-packages: PEP-668 distros refuse system-wide pip installs
@@ -52,8 +59,8 @@ ensure_recent_cmake() {
 
 install_ubuntu() {
     echo "Installing dependencies for Ubuntu/Debian..."
-    $SUDO apt-get update
-    $SUDO apt-get install -y \
+    apt_get update
+    apt_get install -y \
         build-essential cmake ninja-build git pkg-config ccache \
         libssl-dev libunwind-dev libgoogle-glog-dev libgflags-dev \
         libdouble-conversion-dev libevent-dev libsodium-dev libzstd-dev \

--- a/scripts/install-system-deps.sh
+++ b/scripts/install-system-deps.sh
@@ -25,11 +25,38 @@ if [ "$(id -u)" -ne 0 ]; then
     fi
 fi
 
-# apt has no overall deadline: a stalled mirror connection can hang a fetch
-# indefinitely. Bound each transfer and retry so a bad mirror fails the run in
-# minutes instead of wedging it.
+# apt can hang past its own transfer timeouts: a dribbling mirror defeats the
+# 30s read timeout, and a wedged https helper never fires it (the helper is
+# what enforces it). Progress watchdog: healthy apt prints continuously, so
+# kill the call after 2 minutes of output silence; hard-cap the whole call at
+# 15 minutes as a backstop against a mirror that trickles forever.
 apt_get() {
-    $SUDO apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@"
+    local log pid rc size prev=-1 idle=0
+    log=$(mktemp)
+    $SUDO timeout -k 30 900 apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 "$@" >"$log" 2>&1 &
+    pid=$!
+    tail -f --pid="$pid" "$log" &
+    while kill -0 "$pid" 2>/dev/null; do
+        sleep 5
+        size=$(stat -c %s "$log" 2>/dev/null || echo -1)
+        if [ "$size" = "$prev" ]; then
+            idle=$((idle + 5))
+            if [ "$idle" -ge 120 ]; then
+                echo "ERROR: apt-get made no progress for ${idle}s; aborting" >&2
+                $SUDO kill "$pid" 2>/dev/null || true
+                sleep 5
+                $SUDO kill -9 "$pid" 2>/dev/null || true
+                wait "$pid" 2>/dev/null || true
+                rm -f "$log"
+                return 124
+            fi
+        else
+            prev=$size; idle=0
+        fi
+    done
+    wait "$pid" && rc=0 || rc=$?
+    rm -f "$log"
+    return "$rc"
 }
 
 # reflect-cpp (a moqx dependency) needs CMake >= 3.23, newer than the 3.22 that
@@ -50,9 +77,10 @@ ensure_recent_cmake() {
         elif command -v dnf >/dev/null 2>&1; then $SUDO dnf install -y python3-pip; fi
     fi
     # --break-system-packages: PEP-668 distros refuse system-wide pip installs
-    # otherwise; older pips don't know the flag, hence the fallback.
-    $SUDO pip3 install --upgrade 'cmake<4' --break-system-packages 2>/dev/null \
-        || $SUDO pip3 install --upgrade 'cmake<4'
+    # otherwise; older pips don't know the flag, hence the fallback. timeout:
+    # PyPI is the other unbounded network fetch here (see apt_get).
+    $SUDO timeout 600 pip3 install --upgrade 'cmake<4' --break-system-packages 2>/dev/null \
+        || $SUDO timeout 600 pip3 install --upgrade 'cmake<4'
     hash -r
     echo "Using $(cmake --version | head -1)"
 }


### PR DESCRIPTION
## Why

During today's `azure.archive.ubuntu.com` outage (~15:30 UTC), 8+ hosted CI jobs from a rebased PR stack froze mid `apt-get update` — apt fell back to `archive.ubuntu.com` and stalled on a dead connection for 90+ minutes (apt has no overall fetch deadline). The hung jobs pinned hosted-runner slots against the account's 20-job concurrency cap, so every other job sat queued with no runner assigned until the runs were cancelled by hand.

Log signature (identical across the hung jobs):

    Ign:5 http://azure.archive.ubuntu.com/ubuntu jammy-security InRelease
    ...
    Get:5 https://archive.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
    <no further output for ~95 min>

## What

Route every `apt-get` call in `scripts/install-system-deps.sh` through a wrapper that adds `Acquire::Retries=3` and 30s http/https transfer timeouts. A wedged mirror now fails the run in a couple of minutes instead of hanging it (and CI retries are cheap next to a 90-minute account wedge).

Hardening, not a root-cause fix — the mirror outage was upstream infrastructure. Same failure class as the packages.microsoft.com flake previously seen in version-release.

Note: `timeout-minutes` is not supported on steps inside composite actions, so the guard lives in the script rather than `.github/actions/setup-build`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/608)
<!-- Reviewable:end -->
