### PR TITLE
ci-pr: slim the PR lane set

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,10 +1,14 @@
 name: ci pr
 
-# PR verification: format + build/test matrix.
-# Main push uses ci-main.yml which adds publish/release/notify.
+# PR verification: format + build/test matrix + d16 conformance.
+# Main push uses ci-main.yml which runs the full conformance grid and
+# microbenchmarks, and adds publish/release/notify.
 
 on:
   pull_request:
+    # ready_for_review included so promoting a draft triggers the conformance
+    # jobs its draft gate skipped.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -120,22 +124,16 @@ jobs:
 
   conformance:
     needs: [check-format]
+    # Drafts skip conformance to keep stack pushes cheap; promotion to ready
+    # runs it (ready_for_review trigger above).
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # mvfst — both transports for d14 and d16. d14+WT was unblocked by
-          # facebookexperimental/moxygen#151 (Accept moq-00 in WT-Available-Protocols).
-          # pico — raw QUIC for d14 and d16. WT cells deferred until pico
-          # WT CONNECT (openmoq/moxygen#172 / PR #173) syncs in.
-          - name: mvfst d14 Q
-            versions: "14"
-            transport: "Q"
-            stack: "mvfst"
-          - name: mvfst d14 WT
-            versions: "14"
-            transport: ""
-            stack: "mvfst"
+          # d16 cells only; ci-main runs the full grid (d14 + d16) on every
+          # main push. pico WT cells deferred until pico WT CONNECT
+          # (openmoq/moxygen#172 / PR #173) syncs in.
           - name: mvfst d16 Q
             versions: "16"
             transport: "Q"
@@ -144,10 +142,6 @@ jobs:
             versions: "16"
             transport: ""
             stack: "mvfst"
-          - name: pico d14 Q
-            versions: "14"
-            transport: "Q"
-            stack: "pico"
           - name: pico d16 Q
             versions: "16"
             transport: "Q"
@@ -174,61 +168,3 @@ jobs:
 
       - name: Run conformance tests
         run: bash test/test_conformance.sh ./build/default/moqx ${{ matrix.versions }} ${{ matrix.transport }} ${{ matrix.stack }}
-
-  microbenchmark:
-    needs: [check-format]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: linux
-            runner: ubuntu-22.04
-          - name: macos
-            # Pinned to the moxygen publish runner: releases ship
-            # moxygen-macos-15-arm64.tar.gz and no macos-26 one, so macos-latest
-            # 404s. Keep in lockstep with the build job above.
-            runner: macos-15
-    name: microbenchmark (${{ matrix.name }})
-    runs-on: ${{ matrix.runner }}
-    # Ceiling for the from-source fallback; see the build job.
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/setup-build
-        with:
-          ccache-key: microbench
-
-      - name: Build microbenchmarks
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          scripts/configure.sh default --moxygen prebuilt-with-fallback \
-            -DMOQX_BUILD_BENCHMARKS=ON -DMOQX_BUILD_TESTS=OFF
-          scripts/build.sh default
-
-      - name: Run microbenchmarks
-        run: |
-          ./build/default/benchmark/moqx_benchmark \
-            --bm_json_verbose=microbench-results.json \
-            | tee microbench-output.txt
-
-      - name: Render summary
-        if: always()
-        run: |
-          {
-            echo "## Microbenchmark results — ${{ matrix.name }}"
-            echo ""
-            echo '```'
-            cat microbench-output.txt
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload microbenchmark artifacts
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: microbench-results-${{ matrix.name }}
-          path: |
-            microbench-results.json
-            microbench-output.txt


### PR DESCRIPTION
## Why

A "rebase stack" across N branches fires every PR lane on every branch simultaneously; with the account's hosted-runner caps (20 total, 5 macOS), a 6-branch stack demands ~66 hosted jobs and most of the burst sits queued (see the 2026-08-19 wedge, which a hung apt made worse — hardening in #608).

## What

- **Drop the microbenchmark job** (−2 hosted jobs, one of them macOS — the scarcest slot). ci-main runs the identical job on every main push, and microbench numbers from contended shared runners aren't decision-grade for PR review anyway.
- **Run only the d16 conformance cells on PRs** (3 cells instead of 6). ci-main keeps the full d14+d16 grid on every main push, so d14 regressions surface at merge time.
- **Skip conformance on draft PRs** (`if: !draft` + `ready_for_review` trigger), so pushing a stack as drafts costs only format + 3 builds per branch; promoting to ready runs the full set.

Per PR push: 11 hosted jobs → 6 (2 on drafts); macOS jobs 2 → 1 (0 on drafts).

Required checks (`check-format`, `linux`, `asan debug`) are untouched — the draft gate deliberately excludes `asan debug` both because it's required (a skipped job would satisfy the check) and because it's the highest-value PR signal.

Trade-off accepted: draft PRs show the conformance jobs as skipped/gray in the checks list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/609)
<!-- Reviewable:end -->
