### PR TITLE
build: derive the moxygen release tag from the pin

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -130,6 +130,15 @@ jobs:
           fi
           echo "==> MOXYGEN_REV $MOX_PIN resolves to moxygen release $MOX_REF"
 
+          # Release branches must reference a permanent moxygen release:
+          # snapshots are pruned after 30 days, taking the release's moxygen
+          # reference and its reproducibility with them.
+          if [ "$BRANCH" != "main" ] && [[ "$MOX_REF" == snapshot-* ]]; then
+            echo "Error: $BRANCH resolves moxygen to the temporary snapshot $MOX_REF." >&2
+            echo "Set MOXYGEN_RELEASE_TAG in cmake/dependencies.cmake on $BRANCH to the moxygen v-tag for this release." >&2
+            exit 1
+          fi
+
           # Disagreement can only mean the operator meant to bump MOXYGEN_REV
           # first — the input cannot move the build off the pin.
           INPUT_REF="${{ inputs.moxygen_release }}"

--- a/cmake/FetchMoxygenPrebuilt.cmake
+++ b/cmake/FetchMoxygenPrebuilt.cmake
@@ -195,8 +195,11 @@ else()
     if(_http_code STREQUAL "404")
       message(FATAL_ERROR
         "moxygen: tag '${_rel_tag}' has no GitHub release, so it publishes no "
-        "prebuilt. Build from source:\n"
-        "  scripts/configure.sh --moxygen from-source && scripts/build.sh")
+        "prebuilt. The pinned rev's build failed, predates retained per-rev "
+        "snapshots, or its snapshot aged out (a v* release carrying the rev "
+        "still works: -DMOXYGEN_RELEASE_TAG=<tag>). Build from source:\n"
+        "  scripts/configure.sh --moxygen from-source && scripts/build.sh\n"
+        "or bump the pin in cmake/dependencies.cmake to a published rev.")
     elseif(_http_code STREQUAL "403" OR _http_code STREQUAL "429")
       message(FATAL_ERROR
         "moxygen: the GitHub API rate limit is exhausted for this IP (anonymous "

--- a/cmake/MoxygenRelease.cmake
+++ b/cmake/MoxygenRelease.cmake
@@ -59,8 +59,9 @@ function(moqx_moxygen_tags_at_pin OUT_VAR)
 endfunction()
 
 # Return the release tag whose assets belong to MOXYGEN_REV. GitHub keeps no
-# commit->release index, so this asks the remote which tags point at the pin, and
-# prefers an immutable v* release over a mutable snapshot-*.
+# commit->release index, so this asks the remote which tags point at the pin,
+# preferring immutable over mutable: a v* release, then the retained per-rev
+# snapshot-<sha12>, then a rolling snapshot-*latest.
 function(moqx_moxygen_release_tag OUT_VAR)
   # An explicit tag wins and needs no remote read; the fetch verifies the
   # release's commit against the pin either way.
@@ -70,23 +71,31 @@ function(moqx_moxygen_release_tag OUT_VAR)
   endif()
   moqx_moxygen_tags_at_pin(_matched)
   set(_tag "")
+  set(_pinned "")
+  set(_rolling "")
   foreach(_t IN LISTS _matched)
     if(NOT _t MATCHES "^snapshot")
       set(_tag "${_t}")
       break()
+    elseif(_t MATCHES "^snapshot-[0-9a-f]+$" AND _pinned STREQUAL "")
+      set(_pinned "${_t}")
+    elseif(_rolling STREQUAL "")
+      set(_rolling "${_t}")
     endif()
   endforeach()
-  if(_tag STREQUAL "" AND _matched)
-    list(GET _matched 0 _tag)
+  if(_tag STREQUAL "")
+    set(_tag "${_pinned}")
+  endif()
+  if(_tag STREQUAL "")
+    set(_tag "${_rolling}")
   endif()
   if(_tag STREQUAL "")
     message(FATAL_ERROR
       "moxygen: no tag on ${MOXYGEN_REPOSITORY} points at the pinned MOXYGEN_REV\n"
       "  ${MOXYGEN_REV}\n"
       "so no release publishes a prebuilt for it and there is nothing to fetch.\n"
-      "Expected when the rev's only tag was a rolling snapshot-* that has since\n"
-      "moved on. -DMOXYGEN_RELEASE_TAG cannot rescue it: that release's assets\n"
-      "moved with the tag.\n"
+      "Expected when the rev was never published: its build failed, or it\n"
+      "predates the retained per-rev snapshot-<sha> pre-releases.\n"
       "\n"
       "Build moxygen from source instead:\n"
       "  scripts/configure.sh --moxygen from-source && scripts/build.sh\n"

--- a/cmake/MoxygenRelease.cmake
+++ b/cmake/MoxygenRelease.cmake
@@ -19,14 +19,17 @@ if(NOT DEFINED MOXYGEN_RELEASE_TAG)
       CACHE STRING "moxygen release tag to fetch the prebuilt from (empty = derive from MOXYGEN_REV)")
 endif()
 
-# Return the release tag whose assets belong to MOXYGEN_REV.
+# Return the release tag whose assets belong to MOXYGEN_REV. Two modes:
 #
-# The tag is a pure function of the pin: moxygen publishes every build as a
+# Normal builds derive it from the pin: moxygen publishes every build as a
 # retained snapshot-<sha12> pre-release (openmoq/scripts/publish-artifacts.sh
 # in the fork), so no tag search is needed — the fetch verifies the release
-# exists and that its commit matches the pin. For a pin whose per-rev snapshot
-# has aged out but that a v* release still carries, set MOXYGEN_RELEASE_TAG to
-# that release.
+# exists and that its commit matches the pin.
+#
+# Release builds set MOXYGEN_RELEASE_TAG to the moxygen v* release, the
+# permanent artifact: snapshots are pruned after 30 days, so a release built
+# on one loses reproducibility. version-release enforces this for release
+# branches.
 function(moqx_moxygen_release_tag OUT_VAR)
   # An explicit tag wins; the fetch verifies the release's commit against the
   # pin either way.

--- a/cmake/MoxygenRelease.cmake
+++ b/cmake/MoxygenRelease.cmake
@@ -59,9 +59,14 @@ function(moqx_moxygen_tags_at_pin OUT_VAR)
 endfunction()
 
 # Return the release tag whose assets belong to MOXYGEN_REV. GitHub keeps no
-# commit->release index, so this asks the remote which tags point at the pin,
-# preferring immutable over mutable: a v* release, then the retained per-rev
-# snapshot-<sha12>, then a rolling snapshot-*latest.
+# commit->release index, so this asks the remote which tags point at the pin.
+#
+# Every matched tag names the same build, but not for the same length of time:
+# rolling aliases (moxygen's publish contract names them *-latest) are deleted
+# and recreated on every moxygen push, so an alias resolved here can dangle by
+# fetch time, and a recorded one (release branches pin the resolved tag for
+# reproducibility) goes stale on the next push. Prefer a tag whose meaning
+# outlives this resolve: a v* release, else a retained per-rev snapshot.
 function(moqx_moxygen_release_tag OUT_VAR)
   # An explicit tag wins and needs no remote read; the fetch verifies the
   # release's commit against the pin either way.
@@ -71,23 +76,25 @@ function(moqx_moxygen_release_tag OUT_VAR)
   endif()
   moqx_moxygen_tags_at_pin(_matched)
   set(_tag "")
-  set(_pinned "")
-  set(_rolling "")
+  set(_snapshot "")
+  set(_alias "")
   foreach(_t IN LISTS _matched)
-    if(NOT _t MATCHES "^snapshot")
+    if(_t MATCHES "-latest$")
+      if(_alias STREQUAL "")
+        set(_alias "${_t}")
+      endif()
+    elseif(NOT _t MATCHES "^snapshot")
       set(_tag "${_t}")
       break()
-    elseif(_t MATCHES "^snapshot-[0-9a-f]+$" AND _pinned STREQUAL "")
-      set(_pinned "${_t}")
-    elseif(_rolling STREQUAL "")
-      set(_rolling "${_t}")
+    elseif(_snapshot STREQUAL "")
+      set(_snapshot "${_t}")
     endif()
   endforeach()
   if(_tag STREQUAL "")
-    set(_tag "${_pinned}")
+    set(_tag "${_snapshot}")
   endif()
   if(_tag STREQUAL "")
-    set(_tag "${_rolling}")
+    set(_tag "${_alias}")
   endif()
   if(_tag STREQUAL "")
     message(FATAL_ERROR

--- a/cmake/MoxygenRelease.cmake
+++ b/cmake/MoxygenRelease.cmake
@@ -16,97 +16,26 @@
 # in cmake/dependencies.cmake is.
 if(NOT DEFINED MOXYGEN_RELEASE_TAG)
   set(MOXYGEN_RELEASE_TAG ""
-      CACHE STRING "moxygen release tag to fetch the prebuilt from (empty = auto-resolve from MOXYGEN_REV)")
+      CACHE STRING "moxygen release tag to fetch the prebuilt from (empty = derive from MOXYGEN_REV)")
 endif()
 
-# Run `git ls-remote --tags` and return the tag names pointing at MOXYGEN_REV
-# (annotated tags matched via their peeled ^{} line).
-function(moqx_moxygen_tags_at_pin OUT_VAR)
-  # Script mode has no find_package(Git) behind it, unlike the project build.
-  if(NOT DEFINED GIT_EXECUTABLE OR GIT_EXECUTABLE STREQUAL "")
-    find_package(Git QUIET)
-  endif()
-  if(NOT GIT_EXECUTABLE)
-    message(FATAL_ERROR
-      "moxygen: git is required to resolve the release for MOXYGEN_REV")
-  endif()
-  execute_process(
-    COMMAND "${GIT_EXECUTABLE}" ls-remote --tags "https://github.com/${MOXYGEN_REPOSITORY}"
-    OUTPUT_VARIABLE _ls_out RESULT_VARIABLE _ls_rc ERROR_VARIABLE _ls_err)
-  if(NOT _ls_rc EQUAL 0)
-    message(FATAL_ERROR
-      "moxygen: 'git ls-remote https://github.com/${MOXYGEN_REPOSITORY}' failed: ${_ls_err}")
-  endif()
-  string(REGEX REPLACE "\r?\n" ";" _ls_lines "${_ls_out}")
-  # Both sides lowercased: ls-remote prints lowercase, a hand-edited pin need not
-  # be, and a case mismatch here reports a published rev as having no release.
-  string(TOLOWER "${MOXYGEN_REV}" _pin_lc)
-  set(_matched "")
-  foreach(_line IN LISTS _ls_lines)
-    if(_line STREQUAL "")
-      continue()
-    endif()
-    string(REGEX MATCH "^[0-9a-fA-F]+" _sha "${_line}")
-    string(TOLOWER "${_sha}" _sha)
-    if(_sha STREQUAL "${_pin_lc}" AND _line MATCHES "refs/tags/(.+)$")
-      set(_t "${CMAKE_MATCH_1}")
-      string(REGEX REPLACE "\\^\\{\\}$" "" _t "${_t}")  # peel annotated-tag suffix
-      list(APPEND _matched "${_t}")
-    endif()
-  endforeach()
-  list(REMOVE_DUPLICATES _matched)
-  set(${OUT_VAR} "${_matched}" PARENT_SCOPE)
-endfunction()
-
-# Return the release tag whose assets belong to MOXYGEN_REV. GitHub keeps no
-# commit->release index, so this asks the remote which tags point at the pin.
+# Return the release tag whose assets belong to MOXYGEN_REV.
 #
-# Every matched tag names the same build, but not for the same length of time:
-# rolling aliases (moxygen's publish contract names them *-latest) are deleted
-# and recreated on every moxygen push, so an alias resolved here can dangle by
-# fetch time, and a recorded one (release branches pin the resolved tag for
-# reproducibility) goes stale on the next push. Prefer a tag whose meaning
-# outlives this resolve: a v* release, else a retained per-rev snapshot.
+# The tag is a pure function of the pin: moxygen publishes every build as a
+# retained snapshot-<sha12> pre-release (openmoq/scripts/publish-artifacts.sh
+# in the fork), so no tag search is needed — the fetch verifies the release
+# exists and that its commit matches the pin. For a pin whose per-rev snapshot
+# has aged out but that a v* release still carries, set MOXYGEN_RELEASE_TAG to
+# that release.
 function(moqx_moxygen_release_tag OUT_VAR)
-  # An explicit tag wins and needs no remote read; the fetch verifies the
-  # release's commit against the pin either way.
+  # An explicit tag wins; the fetch verifies the release's commit against the
+  # pin either way.
   if(NOT MOXYGEN_RELEASE_TAG STREQUAL "")
     set(${OUT_VAR} "${MOXYGEN_RELEASE_TAG}" PARENT_SCOPE)
     return()
   endif()
-  moqx_moxygen_tags_at_pin(_matched)
-  set(_tag "")
-  set(_snapshot "")
-  set(_alias "")
-  foreach(_t IN LISTS _matched)
-    if(_t MATCHES "-latest$")
-      if(_alias STREQUAL "")
-        set(_alias "${_t}")
-      endif()
-    elseif(NOT _t MATCHES "^snapshot")
-      set(_tag "${_t}")
-      break()
-    elseif(_snapshot STREQUAL "")
-      set(_snapshot "${_t}")
-    endif()
-  endforeach()
-  if(_tag STREQUAL "")
-    set(_tag "${_snapshot}")
-  endif()
-  if(_tag STREQUAL "")
-    set(_tag "${_alias}")
-  endif()
-  if(_tag STREQUAL "")
-    message(FATAL_ERROR
-      "moxygen: no tag on ${MOXYGEN_REPOSITORY} points at the pinned MOXYGEN_REV\n"
-      "  ${MOXYGEN_REV}\n"
-      "so no release publishes a prebuilt for it and there is nothing to fetch.\n"
-      "Expected when the rev was never published: its build failed, or it\n"
-      "predates the retained per-rev snapshot-<sha> pre-releases.\n"
-      "\n"
-      "Build moxygen from source instead:\n"
-      "  scripts/configure.sh --moxygen from-source && scripts/build.sh\n"
-      "or bump the pin in cmake/dependencies.cmake to a currently published rev.")
-  endif()
-  set(${OUT_VAR} "${_tag}" PARENT_SCOPE)
+  # Publisher tags with lowercase GITHUB_SHA; a hand-edited pin need not be.
+  string(TOLOWER "${MOXYGEN_REV}" _rev_lc)
+  string(SUBSTRING "${_rev_lc}" 0 12 _rev12)
+  set(${OUT_VAR} "snapshot-${_rev12}" PARENT_SCOPE)
 endfunction()

--- a/cmake/print-release-tag.cmake
+++ b/cmake/print-release-tag.cmake
@@ -3,8 +3,9 @@
 #
 #   cmake -P cmake/print-release-tag.cmake
 #
-# Hits the network (git ls-remote) unless MOXYGEN_RELEASE_TAG pins the answer;
-# no tag at the pin exits non-zero.
+# Pure derivation, no network: the tag is a function of the pin (or of
+# MOXYGEN_RELEASE_TAG when set). Whether the release exists is the fetch's
+# concern, not this script's.
 # message() writes to stderr in script mode; -E echo is the stdout channel.
 #
 # cmake_minimum_required matters here — a -P script without one runs under


### PR DESCRIPTION
## Why

The retention fix for the drift → from-source-fallback storms is openmoq/moxygen#371 (per-rev `snapshot-<sha12>` pre-releases, retained 30 days, instead of a rolling tag whose deletion orphans every older rev). This PR is the consumer side: resolve the pin **to that per-rev release directly**.

## What

`moqx_moxygen_release_tag()` no longer searches remote tags at all. The tag is a pure function of the pin — `snapshot-<first 12 of MOXYGEN_REV>` — and `FetchMoxygenPrebuilt` already verifies the resolved release's `target_commitish` against the pin before downloading, so a wrong or missing release fails loudly with guidance. Per review: no string-matching of another repo's tag names, no preference ordering, no `ls-remote` (and its git dependency is gone — `print-release-tag.cmake` is now a 0.1s no-network derivation, previously a network round-trip on every configure).

`MOXYGEN_RELEASE_TAG` keeps its role as the explicit override — release branches already pin it (docs/release.md), and it's the escape hatch for a rev whose per-rev snapshot aged out past the 30-day retention but that a durable `v*` release still carries. The 404 error message now explains all three causes (failed publish, pre-retention rev, aged-out snapshot) and both remedies.

## Testing

- Derivation unit-tested: mixed-case pin lowercases and truncates to `snapshot-<sha12>`; explicit `MOXYGEN_RELEASE_TAG` bypasses derivation.
- Live: `cmake -P cmake/print-release-tag.cmake` → `snapshot-1b32be12e4af` in 0.1s, no network.
- End-to-end fetch succeeds once #371 lands and a moxygen main push publishes the first per-rev release; until then the 404 path reports cleanly (equivalent to today's fallback behavior).

## Sequencing

Merge after (or with) openmoq/moxygen#371 — before #371's first published build, derivation points at a release that doesn't exist yet, so CI stays on the from-source fallback it's already on (e.g. right now: pin `1b32be1`, moxygen head `63062c2`, no tag on the pin).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/612)
<!-- Reviewable:end -->
