### PR TITLE
github: CODEOWNERS guard on the moxygen pin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Pin-bump protection. MOXYGEN_REV (and the other dependency pins in
+# dependencies.cmake) change through moxygen-sync PRs as the primary path
+# (bot-created, auto-approved by a code owner via PAT); any other PR touching
+# them needs explicit code-owner approval. Enforced by "require review from
+# Code Owners" on the main branch protection.
+/cmake/dependencies.cmake @gmarzot @michalhosna
+
+# The guard guards itself.
+/.github/CODEOWNERS @gmarzot @michalhosna

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # (bot-created, auto-approved by a code owner via PAT); any other PR touching
 # them needs explicit code-owner approval. Enforced by "require review from
 # Code Owners" on the main branch protection.
-/cmake/dependencies.cmake @gmarzot @michalhosna
+/cmake/dependencies.cmake @gmarzot @michalhosna @afrind
 
 # The guard guards itself.
-/.github/CODEOWNERS @gmarzot @michalhosna
+/.github/CODEOWNERS @gmarzot @michalhosna @afrind


### PR DESCRIPTION
Companion to the moxygen CODEOWNERS PR: adds `.github/CODEOWNERS` covering `cmake/dependencies.cmake` — which holds `MOXYGEN_REV` and the other dependency pins — plus the CODEOWNERS file itself, with @gmarzot and @michalhosna as owners.

Sync-bot pin bumps keep flowing untouched: sync PRs are auto-approved by the PAT identity (gmarzot, a code owner). Any other PR touching the pin file will need explicit code-owner approval once `require_code_owner_reviews` is flipped on main branch protection (after this merges). Non-pin PRs see no change — the repo already requires 1 approving review.

Note the guard covers all of `dependencies.cmake`, so CPM dependency version changes also get code-owner review — arguably the right scope; if it proves too broad, `MOXYGEN_REV` can be extracted to its own file later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/613)
<!-- Reviewable:end -->
