### PR TITLE
version-release: require a permanent moxygen release on release branches

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -130,6 +130,15 @@ jobs:
           fi
           echo "==> MOXYGEN_REV $MOX_PIN resolves to moxygen release $MOX_REF"
 
+          # Release branches must reference a permanent moxygen release:
+          # snapshot pre-releases are pruned after 30 days, taking the
+          # release's moxygen reference and its reproducibility with them.
+          if [ "$BRANCH" != "main" ] && [[ "$MOX_REF" == snapshot-* ]]; then
+            echo "Error: $BRANCH resolves moxygen to the temporary snapshot $MOX_REF." >&2
+            echo "Set MOXYGEN_RELEASE_TAG in cmake/dependencies.cmake on $BRANCH to the moxygen v-tag for this release." >&2
+            exit 1
+          fi
+
           # Disagreement can only mean the operator meant to bump MOXYGEN_REV
           # first — the input cannot move the build off the pin.
           INPUT_REF="${{ inputs.moxygen_release }}"


### PR DESCRIPTION
Small, release-scoped guard extracted from the #612 discussion (which is being parked — see there).

Snapshot pre-releases are pruned after 30 days (openmoq/moxygen#371). If a release branch's `MOXYGEN_REV` resolves to a snapshot — i.e. nobody set `MOXYGEN_RELEASE_TAG` on the branch — the release builds fine today and loses its moxygen reference, and its reproducibility, a month later. Nothing fails loudly at any point.

This adds one check to `validate`: a non-main dispatch whose resolved moxygen ref is `snapshot-*` fails immediately with the fix in the message (set `MOXYGEN_RELEASE_TAG` in `cmake/dependencies.cmake` on the branch to the moxygen v-tag). Main-branch dispatches are unchanged: they build on the current snapshot and skip portable tarballs, exactly as today.

No resolver changes — this works with the tag resolution on main as-is.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/617)
<!-- Reviewable:end -->
