### PR TITLE
admin: write JSON strings a run at a time

### DIFF
--- a/src/admin/JsonWriter.h
+++ b/src/admin/JsonWriter.h
@@ -120,26 +120,47 @@ private:
     app_.push(reinterpret_cast<const uint8_t*>(s.data()), s.size());
   }
 
+  // Pushes unescaped runs whole. Track names and namespaces almost never need
+  // escaping, and this runs on the relay executor, so per-character appends are
+  // the wrong default.
   void writeString(std::string_view s) {
     append('"');
-    for (unsigned char c : s) {
-      if (c == '"') {
-        append("\\\"");
-      } else if (c == '\\') {
-        append("\\\\");
-      } else if (c == '\n') {
-        append("\\n");
-      } else if (c == '\r') {
-        append("\\r");
-      } else if (c == '\t') {
-        append("\\t");
-      } else if (c < 0x20) {
-        char buf[7];
-        std::snprintf(buf, sizeof(buf), "\\u%04x", c);
-        append(std::string_view(buf, 6));
-      } else {
-        append(static_cast<char>(c));
+    size_t runStart = 0;
+    for (size_t i = 0; i < s.size(); ++i) {
+      const auto c = static_cast<unsigned char>(s[i]);
+      char unicode[7];
+      std::string_view escape;
+      switch (c) {
+      case '"':
+        escape = "\\\"";
+        break;
+      case '\\':
+        escape = "\\\\";
+        break;
+      case '\n':
+        escape = "\\n";
+        break;
+      case '\r':
+        escape = "\\r";
+        break;
+      case '\t':
+        escape = "\\t";
+        break;
+      default:
+        if (c >= 0x20) {
+          continue;
+        }
+        std::snprintf(unicode, sizeof(unicode), "\\u%04x", c);
+        escape = std::string_view(unicode, 6);
       }
+      if (i > runStart) {
+        append(s.substr(runStart, i - runStart));
+      }
+      append(escape);
+      runStart = i + 1;
+    }
+    if (runStart < s.size()) {
+      append(s.substr(runStart));
     }
     append('"');
   }


### PR DESCRIPTION
JsonWriter::writeString appended one character at a time through the folly appender, even though track names and namespaces almost never contain a character that needs escaping. The walk runs on the relay executor, so that is the wrong default.

The scan now only breaks at characters that need escaping and pushes the unescaped run between them whole. Output is byte-identical -- checked differentially against the old loop over every single byte value and 200k random strings biased toward escapes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/621)
<!-- Reviewable:end -->
