### PR TITLE
admin: give route handlers an egress gate

### DIFF
--- a/src/admin/AdminServer.cpp
+++ b/src/admin/AdminServer.cpp
@@ -10,6 +10,7 @@
 
 #include <folly/CancellationToken.h>
 #include <folly/io/IOBufQueue.h>
+#include <folly/io/async/EventBaseManager.h>
 #include <folly/logging/xlog.h>
 #include <proxygen/httpserver/RequestHandler.h>
 #include <proxygen/httpserver/RequestHandlerFactory.h>
@@ -17,6 +18,8 @@
 #include <proxygen/httpserver/ScopedHTTPServer.h>
 #include <proxygen/lib/http/HTTPMessage.h>
 #include <wangle/ssl/SSLContextConfig.h>
+
+#include "admin/EgressGate.h"
 
 namespace openmoq::moqx::admin {
 
@@ -28,7 +31,9 @@ namespace openmoq::moqx::admin {
 // ---------------------------------------------------------------------------
 class AdminRequestHandler : public proxygen::RequestHandler {
 public:
-  explicit AdminRequestHandler(RouteHandler handler) : handler_(std::move(handler)) {}
+  explicit AdminRequestHandler(RouteHandler handler)
+      : handler_(std::move(handler)),
+        egress_(std::make_shared<EgressGate>(folly::EventBaseManager::get()->getEventBase())) {}
 
   void onRequest(std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override {
     req_ = std::move(headers);
@@ -39,20 +44,30 @@ public:
   }
 
   void onEOM() noexcept override {
-    handler_(std::move(req_), body_.move(), downstream_, cancellationSource_.getToken());
+    handler_(std::move(req_), body_.move(), downstream_, cancellationSource_.getToken(), egress_);
   }
 
   void onUpgrade(proxygen::UpgradeProtocol /*proto*/) noexcept override {}
 
-  void requestComplete() noexcept override { delete this; }
+  void onEgressPaused() noexcept override { egress_->onPaused(); }
 
-  void onError(proxygen::ProxygenError /*err*/) noexcept override {
+  void onEgressResumed() noexcept override { egress_->onResumed(); }
+
+  void requestComplete() noexcept override { finish(); }
+
+  void onError(proxygen::ProxygenError /*err*/) noexcept override { finish(); }
+
+private:
+  // Cancel before waking anything parked on the gate, so a coroutine that
+  // resumes sees the token already set and does not touch downstream_.
+  void finish() {
     cancellationSource_.requestCancellation();
+    egress_->shutdown();
     delete this;
   }
 
-private:
   RouteHandler handler_;
+  std::shared_ptr<EgressGate> egress_;
   std::unique_ptr<proxygen::HTTPMessage> req_;
   folly::IOBufQueue body_{folly::IOBufQueue::cacheChainLength()};
   folly::CancellationSource cancellationSource_;
@@ -80,14 +95,16 @@ public:
     }
 
     // Unknown route → 404
-    return new AdminRequestHandler(
-        [](auto /*req*/, auto /*body*/, auto* downstream, auto /*cancelToken*/) {
-          proxygen::ResponseBuilder(downstream)
-              .status(404, proxygen::HTTPMessage::getDefaultReason(404))
-              .body(folly::IOBuf::copyBuffer("Not Found\n"))
-              .sendWithEOM();
-        }
-    );
+    return new AdminRequestHandler([](auto /*req*/,
+                                      auto /*body*/,
+                                      auto* downstream,
+                                      auto /*cancelToken*/,
+                                      const auto& /*egress*/) {
+      proxygen::ResponseBuilder(downstream)
+          .status(404, proxygen::HTTPMessage::getDefaultReason(404))
+          .body(folly::IOBuf::copyBuffer("Not Found\n"))
+          .sendWithEOM();
+    });
   }
 
 private:

--- a/src/admin/AdminServer.h
+++ b/src/admin/AdminServer.h
@@ -25,15 +25,20 @@ class ResponseHandler;
 
 namespace openmoq::moqx::admin {
 
+class EgressGate;
+
 // Route handler: receives the complete request (headers + body) and owns the
 // response. May respond asynchronously — launch a coroutine and send via
-// downstream later. cancelToken is signalled if the client disconnects before
-// the response is produced (onError fired on the underlying RequestHandler).
+// downstream later. cancelToken is signalled once the request is over, whether
+// the client disconnected or the response completed, so a coroutine that
+// resumes with it set must not touch downstream.
+// egress is only of interest to handlers that stream a response in chunks.
 using RouteHandler = std::function<void(
     std::unique_ptr<proxygen::HTTPMessage> req,
     std::unique_ptr<folly::IOBuf> body,
     proxygen::ResponseHandler* downstream,
-    folly::CancellationToken cancelToken
+    folly::CancellationToken cancelToken,
+    const std::shared_ptr<EgressGate>& egress
 )>;
 
 struct Route {

--- a/src/admin/BuiltinRoutes.cpp
+++ b/src/admin/BuiltinRoutes.cpp
@@ -30,8 +30,13 @@ void registerBuiltinRoutes(AdminServer& server) {
   server.addRoute(
       "GET",
       "/info",
-      [startEpoch,
-       startSteady](auto /*req*/, auto /*body*/, auto* downstream, auto /*cancelToken*/) {
+      [startEpoch, startSteady](
+          auto /*req*/,
+          auto /*body*/,
+          auto* downstream,
+          auto /*cancelToken*/,
+          const auto& /*egress*/
+      ) {
         const auto uptime = std::chrono::duration_cast<std::chrono::seconds>(
                                 std::chrono::steady_clock::now() - startSteady
         )

--- a/src/admin/CachePurgeHandler.cpp
+++ b/src/admin/CachePurgeHandler.cpp
@@ -29,7 +29,8 @@ void registerCachePurgeRoute(AdminServer& adminServer, std::shared_ptr<MoqxRelay
        )](std::unique_ptr<proxygen::HTTPMessage> /*req*/,
           std::unique_ptr<folly::IOBuf> body,
           proxygen::ResponseHandler* downstream,
-          folly::CancellationToken cancelToken) {
+          folly::CancellationToken cancelToken,
+          const std::shared_ptr<EgressGate>& /*egress*/) {
         auto ctx = weak.lock();
         if (!ctx) {
           proxygen::ResponseBuilder(downstream)

--- a/src/admin/ConfigHandler.cpp
+++ b/src/admin/ConfigHandler.cpp
@@ -101,8 +101,12 @@ void registerConfigRoute(AdminServer& adminServer, std::shared_ptr<const config:
   adminServer.addRoute(
       "GET",
       "/config",
-      [config = std::move(config
-       )](auto /*req*/, auto /*body*/, auto* downstream, auto /*cancelToken*/
+      [config = std::move(config)](
+          auto /*req*/,
+          auto /*body*/,
+          auto* downstream,
+          auto /*cancelToken*/,
+          const auto& /*egress*/
       ) {
         proxygen::ResponseBuilder(downstream)
             .status(200, proxygen::HTTPMessage::getDefaultReason(200))

--- a/src/admin/ConnectionLogsHandler.cpp
+++ b/src/admin/ConnectionLogsHandler.cpp
@@ -183,7 +183,8 @@ void registerConnectionLogsRoutes(
           std::unique_ptr<proxygen::HTTPMessage> req,
           std::unique_ptr<folly::IOBuf> /*body*/,
           proxygen::ResponseHandler* downstream,
-          folly::CancellationToken cancelToken
+          folly::CancellationToken cancelToken,
+          const std::shared_ptr<EgressGate>& /*egress*/
       ) {
         // Resolve type → directory, file extension, Content-Type.
         const auto& typeStr = req->getQueryParam("type");

--- a/src/admin/EgressGate.h
+++ b/src/admin/EgressGate.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+
+#include <folly/coro/Task.h>
+#include <folly/io/async/EventBase.h>
+#include <folly/logging/xlog.h>
+#include <proxygen/lib/http/coro/util/TimedBaton.h>
+
+namespace openmoq::moqx::admin {
+
+// Makes proxygen's egress pause/resume callbacks awaitable, so a route that
+// streams a response can stop producing while the transaction cannot write --
+// otherwise pausing just relocates the bytes into proxygen's egress queue
+// instead of bounding them.
+//
+// Single-threaded, admin EVB only; the baton XCHECKs that, including in its
+// destructor. A handler that hops to another executor must not let the last
+// shared_ptr reference die there; keep one on the admin EVB frame.
+class EgressGate {
+public:
+  // No timeout of our own: proxygen's transaction timeout already bounds a
+  // stalled write, and a shorter deadline would abandon a merely slow client.
+  explicit EgressGate(folly::EventBase* evb) : baton_(evb, std::chrono::milliseconds(0)) {}
+
+  void onPaused() {
+    if (done_ || paused_) {
+      return;
+    }
+    paused_ = true;
+    // Signalled state is sticky until reset, so a resume that beats the waiter
+    // to the EVB is not a lost wakeup.
+    baton_.reset();
+  }
+
+  void onResumed() {
+    if (!paused_) {
+      return;
+    }
+    paused_ = false;
+    baton_.signal();
+  }
+
+  // The request is going away; wake any waiter and never park again.
+  void shutdown() {
+    done_ = true;
+    paused_ = false;
+    baton_.signal(proxygen::coro::TimedBaton::Status::cancelled);
+  }
+
+  // False means the request is going away, so stop rather than send.
+  folly::coro::Task<bool> awaitDrainable() {
+    XCHECK(baton_.getEventBase()->isInEventBaseThread()) << "EgressGate is admin EVB only";
+    // done_ dominates paused_, which shutdown() clears: a caller that suspended
+    // elsewhere and came back after the handler was deleted must not be told
+    // the transaction is drainable.
+    while (!done_ && paused_) {
+      const auto status = co_await baton_.wait();
+      if (status == proxygen::coro::TimedBaton::Status::cancelled ||
+          status == proxygen::coro::TimedBaton::Status::timedout) {
+        co_return false;
+      }
+      // Anything else means a pause re-armed the baton before this waiter got
+      // to run. paused_ is the truth; the status only says why we woke.
+    }
+    co_return !done_;
+  }
+
+private:
+  proxygen::coro::TimedBaton baton_;
+  bool paused_{false};
+  bool done_{false};
+};
+
+} // namespace openmoq::moqx::admin

--- a/src/admin/MetricsHandler.cpp
+++ b/src/admin/MetricsHandler.cpp
@@ -28,8 +28,13 @@ void registerMetricsRoute(
   adminServer.addRoute(
       "GET",
       "/metrics",
-      [registry = std::move(registry
-       )](auto req, auto /*body*/, auto* downstream, folly::CancellationToken cancelToken) {
+      [registry = std::move(registry)](
+          auto req,
+          auto /*body*/,
+          auto* downstream,
+          folly::CancellationToken cancelToken,
+          const std::shared_ptr<EgressGate>& /*egress*/
+      ) {
         auto* evb = folly::EventBaseManager::get()->getEventBase();
 
         auto omitMetadata = boolQueryParam(*req, "omit_metadata", false);

--- a/src/admin/StateHandler.cpp
+++ b/src/admin/StateHandler.cpp
@@ -50,7 +50,11 @@ void registerStateRoute(AdminServer& adminServer, std::shared_ptr<MoqxRelayConte
       "GET",
       "/state",
       [context = std::move(context
-       )](auto /*req*/, auto /*body*/, auto* downstream, folly::CancellationToken cancelToken) {
+       )](auto /*req*/,
+          auto /*body*/,
+          auto* downstream,
+          folly::CancellationToken cancelToken,
+          const std::shared_ptr<EgressGate>& /*egress*/) {
         auto* workerEvb = context->workerEvb();
         if (!workerEvb) {
           proxygen::ResponseBuilder(downstream)

--- a/src/admin/TrackMetricsHandler.cpp
+++ b/src/admin/TrackMetricsHandler.cpp
@@ -177,7 +177,8 @@ void registerTrackMetricsRoute(
           std::unique_ptr<proxygen::HTTPMessage> req,
           std::unique_ptr<folly::IOBuf> /*body*/,
           proxygen::ResponseHandler* downstream,
-          folly::CancellationToken cancelToken
+          folly::CancellationToken cancelToken,
+          const std::shared_ptr<EgressGate>& /*egress*/
       ) {
         // Without this the response is an empty scrape, which reads as "no
         // live tracks" rather than "counting is off".


### PR DESCRIPTION
A route that streams a response in chunks has no way to stop producing while the transaction cannot write, so pausing only relocates the bytes into proxygen's egress queue instead of bounding them.

EgressGate makes proxygen's onEgressPaused/onEgressResumed awaitable on the admin EVB. AdminRequestHandler owns one, feeds it those callbacks, cancels it on requestComplete/onError, and passes it to the route as a fifth argument:

```
  if (!co_await egress->awaitDrainable()) {
    co_return; // request is going away, stop rather than send
  }
```

Every existing handler ignores the new parameter; no behavior change yet.  This will be used in subsequent commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/622)
<!-- Reviewable:end -->
