### PR TITLE
relay: hoist TrackStatsFilter's recent-group window into RecentGroupWindow

### DIFF
--- a/src/relay/RecentGroupWindow.h
+++ b/src/relay/RecentGroupWindow.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace openmoq::moqx {
+
+// A most-recently-used window of group IDs, so counting distinct groups
+// tolerates the subgroups of several groups arriving interleaved. Bounds how
+// deep an interleave can be before a group is counted twice.
+//
+// LRU rather than insertion order: a group that keeps receiving subgroups stays
+// in the window however many other groups open alongside it.
+class RecentGroupWindow {
+public:
+  static constexpr size_t kSize = 3;
+
+  // True the first time a group is seen, or the first time since it aged out.
+  [[nodiscard]] bool admit(uint64_t groupID) {
+    for (size_t i = 0; i < count_; ++i) {
+      if (groups_[i] == groupID) {
+        std::rotate(groups_.begin(), groups_.begin() + i, groups_.begin() + i + 1);
+        return false;
+      }
+    }
+    count_ = std::min(count_ + 1, kSize);
+    std::rotate(groups_.begin(), groups_.end() - 1, groups_.end());
+    groups_[0] = groupID;
+    return true;
+  }
+
+private:
+  // Lookup and the LRU update are both linear scans on the data path, so this
+  // stays an array rather than a map only while the window is tiny.
+  static_assert(kSize <= 8, "widening past this wants folly::findFixed (or a map), not a scan");
+
+  std::array<uint64_t, kSize> groups_{};
+  size_t count_{0};
+};
+
+} // namespace openmoq::moqx

--- a/src/relay/TrackStatsFilter.cpp
+++ b/src/relay/TrackStatsFilter.cpp
@@ -6,8 +6,6 @@
 
 #include "relay/TrackStatsFilter.h"
 
-#include <algorithm>
-
 namespace openmoq::moqx {
 
 using moxygen::MoQPublishError;
@@ -154,19 +152,10 @@ TrackStatsFilter::datagram(const ObjectHeader& header, Payload payload, bool las
   return moxygen::TrackConsumerFilter::datagram(header, std::move(payload), lastInGroup);
 }
 
-// LRU rather than insertion order: a group that keeps receiving subgroups stays
-// in the window however many other groups open alongside it.
 void TrackStatsFilter::countGroupIfNew(uint64_t groupID) {
-  for (size_t i = 0; i < recentCount_; ++i) {
-    if (recentGroups_[i] == groupID) {
-      std::rotate(recentGroups_.begin(), recentGroups_.begin() + i, recentGroups_.begin() + i + 1);
-      return;
-    }
+  if (recentGroups_.admit(groupID)) {
+    ++stats_->counters().forDirection(direction_).groups;
   }
-  recentCount_ = std::min(recentCount_ + 1, kRecentGroups);
-  std::rotate(recentGroups_.begin(), recentGroups_.end() - 1, recentGroups_.end());
-  recentGroups_[0] = groupID;
-  ++stats_->counters().forDirection(direction_).groups;
 }
 
 void TrackStatsFilter::countSubgroup() {

--- a/src/relay/TrackStatsFilter.h
+++ b/src/relay/TrackStatsFilter.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 #include <memory>
 
 #include <moxygen/MoQFilters.h>
 
+#include "relay/RecentGroupWindow.h"
 #include "stats/TrackStatsRegistry.h"
 
 namespace openmoq::moqx {
@@ -53,16 +53,7 @@ public:
   datagram(const moxygen::ObjectHeader& header, moxygen::Payload payload, bool lastInGroup = false)
       override;
 
-  // Bounds how deep an interleave can be before a group is counted twice:
-  // subgroups of the N most recent groups can arrive in any order.
-  static constexpr size_t kRecentGroups = 3;
-
-  // Lookup and LRU update are both linear scans on the data path, so this stays
-  // an array rather than a map only while the window is tiny.
-  static_assert(
-      kRecentGroups <= 8,
-      "widening past this wants folly::findFixed (or a map), not a longer scan"
-  );
+  static constexpr size_t kRecentGroups = RecentGroupWindow::kSize;
 
 private:
   friend class TrackStatsSubgroupFilter;
@@ -75,9 +66,7 @@ private:
 
   std::shared_ptr<stats::TrackStats> stats_;
   Direction direction_;
-  // Most-recently-seen first.
-  std::array<uint64_t, kRecentGroups> recentGroups_{};
-  size_t recentCount_{0};
+  RecentGroupWindow recentGroups_;
 };
 
 // Returns downstream unwrapped when no collector is bound on this thread, so


### PR DESCRIPTION
The 3-group MRU window that lets countGroupIfNew tolerate interleaved subgroups was inlined in TrackStatsFilter as a raw array plus a count, so any other counter that needs the same tolerance would have to copy it.

It moves to relay/RecentGroupWindow.h as RecentGroupWindow, which owns the array, the LRU rotate and the size static_assert:

```
  if (recentGroups_.admit(groupID)) {
    ++counters.groups; // first sight of this group, or first since it aged out
  }
```

Same window size and same LRU behavior; TrackStatsFilter::kRecentGroups now aliases RecentGroupWindow::kSize.

Plan is to re-use in a future commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/623)
<!-- Reviewable:end -->
