### PR TITLE
admin: move the /state JSON visitors into their own header

### DIFF
--- a/src/admin/JsonStateVisitors.h
+++ b/src/admin/JsonStateVisitors.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include <folly/io/Cursor.h>
+#include <folly/io/IOBuf.h>
+#include <folly/io/IOBufQueue.h>
+
+#include "MoqxRelayContext.h"
+#include "admin/JsonWriter.h"
+
+namespace openmoq::moqx::admin {
+
+// RelayStateVisitor that writes JSON directly via a shared JsonWriter.
+// Section begin/end callbacks map directly to JSON array/object open/close,
+// so no state tracking or deferred finalization is needed here.
+class JsonRelayStateVisitor : public RelayStateVisitor {
+  JsonWriter& w_;
+
+public:
+  explicit JsonRelayStateVisitor(JsonWriter& w) : w_(w) {}
+
+  void onPeersBegin() override {
+    w_.key("downstream_peers");
+    w_.beginArray();
+  }
+  void
+  onPeer(std::string_view address, std::string_view authority, std::string_view relayID) override {
+    w_.beginObject();
+    w_.field("address", address);
+    w_.field("authority", authority);
+    if (!relayID.empty()) {
+      w_.field("relay_id", relayID);
+    }
+    w_.endObject();
+  }
+  void onPeersEnd() override { w_.endArray(); }
+
+  void onSubscriptionsBegin() override {
+    w_.key("subscriptions");
+    w_.beginArray();
+  }
+  void onSubscription(const SubscriptionInfo& info) override {
+    w_.beginObject();
+    w_.key("namespace");
+    w_.beginArray();
+    for (const auto& t : info.ftn.trackNamespace.trackNamespace) {
+      w_.strVal(t);
+    }
+    w_.endArray();
+    w_.field("track_name", info.ftn.trackName);
+    w_.field("is_publish", info.isPublish);
+    w_.key("subscribers");
+    w_.uintVal(static_cast<uint64_t>(info.subscribers));
+    w_.field("forwarding_subscribers", info.forwardingSubscribers);
+    w_.field("total_groups_received", info.totalGroupsReceived);
+    w_.field("total_objects_received", info.totalObjectsReceived);
+    w_.field("source_address", info.sourceAddress);
+    if (info.largest) {
+      w_.key("largest");
+      w_.beginObject();
+      w_.field("group", info.largest->group);
+      w_.field("object", info.largest->object);
+      w_.endObject();
+    }
+    w_.endObject();
+  }
+  void onSubscriptionsEnd() override { w_.endArray(); }
+
+  void onNamespaceTreeBegin() override {
+    w_.key("namespace_tree");
+    // The root beginNamespaceNode call immediately follows and opens the object.
+  }
+  void beginNamespaceNode(
+      std::string_view childKey,
+      const moxygen::TrackNamespace& ns,
+      size_t sessionCount,
+      std::string_view publisherAddress,
+      std::string_view peerID
+  ) override {
+    if (!childKey.empty()) {
+      w_.key(childKey);
+    }
+    w_.beginObject();
+    w_.key("full_namespace");
+    w_.beginArray();
+    for (const auto& t : ns.trackNamespace) {
+      w_.strVal(t);
+    }
+    w_.endArray();
+    w_.key("namespace_subscribers");
+    w_.uintVal(static_cast<uint64_t>(sessionCount));
+    if (!publisherAddress.empty()) {
+      w_.field("publisher", publisherAddress);
+    }
+    if (!peerID.empty()) {
+      w_.field("peer_id", peerID);
+    }
+    w_.key("children");
+    w_.beginObject();
+  }
+  void endNamespaceNode() override {
+    w_.endObject(); // children
+    w_.endObject(); // node
+  }
+  void onNamespaceTreeEnd() override {}
+
+  void onCacheStats(
+      size_t totalBytes,
+      const std::vector<MoqxCache::TrackStats>& tracks,
+      MoqxCache::TimePoint now
+  ) override {
+    w_.key("cache");
+    w_.beginObject();
+    w_.key("total_bytes");
+    w_.uintVal(static_cast<uint64_t>(totalBytes));
+    w_.key("tracks");
+    w_.beginArray();
+    for (const auto& t : tracks) {
+      w_.beginObject();
+      w_.key("namespace");
+      w_.beginArray();
+      for (const auto& s : t.name.trackNamespace.trackNamespace) {
+        w_.strVal(s);
+      }
+      w_.endArray();
+      w_.field("track_name", t.name.trackName);
+      w_.field("end_of_track", t.endOfTrack);
+      w_.key("last_write_ms_ago");
+      if (t.lastWrite == decltype(t.lastWrite)::min()) {
+        w_.nullVal();
+      } else {
+        auto msAgo =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - t.lastWrite).count();
+        w_.intVal(static_cast<int64_t>(msAgo));
+      }
+      w_.key("groups");
+      w_.beginArray();
+      for (const auto& g : t.groups) {
+        w_.beginObject();
+        w_.field("group_id", g.groupId);
+        w_.key("objects");
+        w_.uintVal(static_cast<uint64_t>(g.objects));
+        w_.endObject();
+      }
+      w_.endArray();
+      w_.endObject();
+    }
+    w_.endArray();
+    w_.endObject();
+  }
+};
+
+// RelayContextVisitor that builds the top-level JSON envelope.
+// A single JsonWriter is shared with JsonRelayStateVisitor so comma state
+// remains consistent across the two visitor layers.
+class JsonRelayContextVisitor : public RelayContextVisitor {
+  folly::IOBufQueue queue_{folly::IOBufQueue::cacheChainLength()};
+  folly::io::QueueAppender app_{&queue_, 4096};
+  JsonWriter w_{app_};
+  JsonRelayStateVisitor relayVisitor_{w_};
+
+public:
+  void onRelayBegin(std::string_view relayID, int64_t activeSessions) override {
+    w_.beginObject();
+    w_.field("relay_id", relayID);
+    w_.field("active_sessions", activeSessions);
+    w_.key("services");
+    w_.beginObject();
+  }
+
+  RelayStateVisitor& onServiceBegin(std::string_view name) override {
+    w_.key(name);
+    w_.beginObject();
+    return relayVisitor_;
+  }
+
+  void onServiceUpstream(std::string_view url, std::string_view state) override {
+    w_.key("upstream");
+    w_.beginObject();
+    w_.field("url", url);
+    w_.field("state", state);
+    w_.endObject();
+  }
+
+  void onServiceEnd() override { w_.endObject(); }
+
+  void onRelayEnd() override {
+    w_.endObject(); // services
+    w_.endObject(); // relay
+    static constexpr uint8_t kNewline = '\n';
+    app_.write(kNewline);
+  }
+
+  std::unique_ptr<folly::IOBuf> move() { return queue_.move(); }
+};
+
+} // namespace openmoq::moqx::admin

--- a/src/admin/StateHandler.cpp
+++ b/src/admin/StateHandler.cpp
@@ -6,12 +6,10 @@
 
 #include "admin/StateHandler.h"
 
-#include <chrono>
 #include <folly/CancellationToken.h>
 #include <folly/coro/Task.h>
 #include <folly/coro/WithCancellation.h>
 #include <folly/io/IOBuf.h>
-#include <folly/io/IOBufQueue.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <folly/logging/xlog.h>
 #include <proxygen/httpserver/ResponseBuilder.h>
@@ -19,195 +17,11 @@
 
 #include "MoqxRelayContext.h"
 #include "admin/AdminServer.h"
-#include "admin/JsonWriter.h"
+#include "admin/JsonStateVisitors.h"
 
 namespace openmoq::moqx::admin {
 
 namespace {
-
-// RelayStateVisitor that writes JSON directly via a shared JsonWriter.
-// Section begin/end callbacks map directly to JSON array/object open/close,
-// so no state tracking or deferred finalization is needed here.
-class JsonRelayStateVisitor : public RelayStateVisitor {
-  JsonWriter& w_;
-
-public:
-  explicit JsonRelayStateVisitor(JsonWriter& w) : w_(w) {}
-
-  void onPeersBegin() override {
-    w_.key("downstream_peers");
-    w_.beginArray();
-  }
-  void
-  onPeer(std::string_view address, std::string_view authority, std::string_view relayID) override {
-    w_.beginObject();
-    w_.field("address", address);
-    w_.field("authority", authority);
-    if (!relayID.empty()) {
-      w_.field("relay_id", relayID);
-    }
-    w_.endObject();
-  }
-  void onPeersEnd() override { w_.endArray(); }
-
-  void onSubscriptionsBegin() override {
-    w_.key("subscriptions");
-    w_.beginArray();
-  }
-  void onSubscription(const SubscriptionInfo& info) override {
-    w_.beginObject();
-    w_.key("namespace");
-    w_.beginArray();
-    for (const auto& t : info.ftn.trackNamespace.trackNamespace) {
-      w_.strVal(t);
-    }
-    w_.endArray();
-    w_.field("track_name", info.ftn.trackName);
-    w_.field("is_publish", info.isPublish);
-    w_.key("subscribers");
-    w_.uintVal(static_cast<uint64_t>(info.subscribers));
-    w_.field("forwarding_subscribers", info.forwardingSubscribers);
-    w_.field("total_groups_received", info.totalGroupsReceived);
-    w_.field("total_objects_received", info.totalObjectsReceived);
-    w_.field("source_address", info.sourceAddress);
-    if (info.largest) {
-      w_.key("largest");
-      w_.beginObject();
-      w_.field("group", info.largest->group);
-      w_.field("object", info.largest->object);
-      w_.endObject();
-    }
-    w_.endObject();
-  }
-  void onSubscriptionsEnd() override { w_.endArray(); }
-
-  void onNamespaceTreeBegin() override {
-    w_.key("namespace_tree");
-    // The root beginNamespaceNode call immediately follows and opens the object.
-  }
-  void beginNamespaceNode(
-      std::string_view childKey,
-      const moxygen::TrackNamespace& ns,
-      size_t sessionCount,
-      std::string_view publisherAddress,
-      std::string_view peerID
-  ) override {
-    if (!childKey.empty()) {
-      w_.key(childKey);
-    }
-    w_.beginObject();
-    w_.key("full_namespace");
-    w_.beginArray();
-    for (const auto& t : ns.trackNamespace) {
-      w_.strVal(t);
-    }
-    w_.endArray();
-    w_.key("namespace_subscribers");
-    w_.uintVal(static_cast<uint64_t>(sessionCount));
-    if (!publisherAddress.empty()) {
-      w_.field("publisher", publisherAddress);
-    }
-    if (!peerID.empty()) {
-      w_.field("peer_id", peerID);
-    }
-    w_.key("children");
-    w_.beginObject();
-  }
-  void endNamespaceNode() override {
-    w_.endObject(); // children
-    w_.endObject(); // node
-  }
-  void onNamespaceTreeEnd() override {}
-
-  void onCacheStats(
-      size_t totalBytes,
-      const std::vector<MoqxCache::TrackStats>& tracks,
-      MoqxCache::TimePoint now
-  ) override {
-    w_.key("cache");
-    w_.beginObject();
-    w_.key("total_bytes");
-    w_.uintVal(static_cast<uint64_t>(totalBytes));
-    w_.key("tracks");
-    w_.beginArray();
-    for (const auto& t : tracks) {
-      w_.beginObject();
-      w_.key("namespace");
-      w_.beginArray();
-      for (const auto& s : t.name.trackNamespace.trackNamespace) {
-        w_.strVal(s);
-      }
-      w_.endArray();
-      w_.field("track_name", t.name.trackName);
-      w_.field("end_of_track", t.endOfTrack);
-      w_.key("last_write_ms_ago");
-      if (t.lastWrite == decltype(t.lastWrite)::min()) {
-        w_.nullVal();
-      } else {
-        auto msAgo =
-            std::chrono::duration_cast<std::chrono::milliseconds>(now - t.lastWrite).count();
-        w_.intVal(static_cast<int64_t>(msAgo));
-      }
-      w_.key("groups");
-      w_.beginArray();
-      for (const auto& g : t.groups) {
-        w_.beginObject();
-        w_.field("group_id", g.groupId);
-        w_.key("objects");
-        w_.uintVal(static_cast<uint64_t>(g.objects));
-        w_.endObject();
-      }
-      w_.endArray();
-      w_.endObject();
-    }
-    w_.endArray();
-    w_.endObject();
-  }
-};
-
-// RelayContextVisitor that builds the top-level JSON envelope.
-// A single JsonWriter is shared with JsonRelayStateVisitor so comma state
-// remains consistent across the two visitor layers.
-class JsonRelayContextVisitor : public RelayContextVisitor {
-  folly::IOBufQueue queue_{folly::IOBufQueue::cacheChainLength()};
-  folly::io::QueueAppender app_{&queue_, 4096};
-  JsonWriter w_{app_};
-  JsonRelayStateVisitor relayVisitor_{w_};
-
-public:
-  void onRelayBegin(std::string_view relayID, int64_t activeSessions) override {
-    w_.beginObject();
-    w_.field("relay_id", relayID);
-    w_.field("active_sessions", activeSessions);
-    w_.key("services");
-    w_.beginObject();
-  }
-
-  RelayStateVisitor& onServiceBegin(std::string_view name) override {
-    w_.key(name);
-    w_.beginObject();
-    return relayVisitor_;
-  }
-
-  void onServiceUpstream(std::string_view url, std::string_view state) override {
-    w_.key("upstream");
-    w_.beginObject();
-    w_.field("url", url);
-    w_.field("state", state);
-    w_.endObject();
-  }
-
-  void onServiceEnd() override { w_.endObject(); }
-
-  void onRelayEnd() override {
-    w_.endObject(); // services
-    w_.endObject(); // relay
-    static constexpr uint8_t kNewline = '\n';
-    app_.write(kNewline);
-  }
-
-  std::unique_ptr<folly::IOBuf> move() { return queue_.move(); }
-};
 
 // Runs on the relay worker EVB. Dumps state and returns the serialized body.
 folly::coro::Task<std::unique_ptr<folly::IOBuf>>


### PR DESCRIPTION
The two visitors that serialize /state were anonymous-namespace classes inside StateHandler.cpp, so nothing could construct one -- a test that wanted to check the JSON had to go through the HTTP handler.

Code motion only: they move to admin/JsonStateVisitors.h verbatim, and StateHandler includes it. /state output is unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/624)
<!-- Reviewable:end -->
