### PR TITLE
admin: serialize /state through a chunked writer

### DIFF
--- a/src/admin/ChunkedJsonWriter.h
+++ b/src/admin/ChunkedJsonWriter.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Function.h>
+#include <folly/io/Cursor.h>
+#include <folly/io/IOBuf.h>
+#include <folly/io/IOBufQueue.h>
+
+#include <algorithm>
+#include <memory>
+
+#include "admin/JsonWriter.h"
+
+namespace openmoq::moqx::admin {
+
+// A JsonWriter that accumulates into its own queue and hands off a chunk once
+// that queue crosses a threshold, so a response goes out as it is produced.
+//
+// Handing off never blocks, which is what lets the relay-state walk -- a
+// synchronous FunctionRef traversal over maps that must not mutate underneath
+// it -- run start to finish without ever yielding its executor.
+//
+// Comma and nesting state live in the JsonWriter rather than the queue, so a
+// flush is invisible in the output: chunk boundaries can fall anywhere.
+class ChunkedJsonWriter {
+public:
+  // Returns false once the consumer is gone or has given up, after which the
+  // caller should stop walking.
+  using Sink = folly::Function<bool(std::unique_ptr<folly::IOBuf>)>;
+
+  static constexpr size_t kDefaultThreshold = 16 * 1024;
+
+  explicit ChunkedJsonWriter(Sink sink, size_t threshold = kDefaultThreshold)
+      : sink_(std::move(sink)), threshold_(threshold) {}
+
+  JsonWriter& json() { return w_; }
+
+  // For bytes outside the JSON value, i.e. the trailing newline; bypasses the
+  // writer's comma state.
+  void raw(std::string_view s) { app_.push(reinterpret_cast<const uint8_t*>(s.data()), s.size()); }
+
+  bool alive() const { return alive_; }
+
+  // Call at item boundaries during a walk.
+  bool maybeFlush() {
+    if (queue_.chainLength() >= threshold_) {
+      return flush();
+    }
+    return alive_;
+  }
+
+  bool flush() {
+    if (queue_.empty()) {
+      return alive_;
+    }
+    auto chunk = queue_.move();
+    app_.reset(&queue_, growthFor(threshold_));
+    // A walk that cannot be stopped mid-section keeps writing after the sink is
+    // gone; drop those bytes rather than accumulate them to no end.
+    if (alive_) {
+      alive_ = sink_(std::move(chunk));
+    }
+    return alive_;
+  }
+
+private:
+  // Roughly one allocation per chunk: the queue is emptied every time it
+  // crosses the threshold, so growing in smaller steps only buys proxygen a
+  // longer buffer chain to write.
+  static size_t growthFor(size_t threshold) {
+    return std::clamp(threshold, size_t{1024}, size_t{64 * 1024});
+  }
+
+  Sink sink_;
+  size_t threshold_;
+  folly::IOBufQueue queue_{folly::IOBufQueue::cacheChainLength()};
+  folly::io::QueueAppender app_{&queue_, growthFor(threshold_)};
+  JsonWriter w_{app_};
+  bool alive_{true};
+};
+
+} // namespace openmoq::moqx::admin

--- a/src/admin/JsonStateVisitors.h
+++ b/src/admin/JsonStateVisitors.h
@@ -7,27 +7,22 @@
 #pragma once
 
 #include <chrono>
-#include <memory>
 #include <string_view>
 #include <vector>
 
-#include <folly/io/Cursor.h>
-#include <folly/io/IOBuf.h>
-#include <folly/io/IOBufQueue.h>
-
 #include "MoqxRelayContext.h"
+#include "admin/ChunkedJsonWriter.h"
 #include "admin/JsonWriter.h"
 
 namespace openmoq::moqx::admin {
 
-// RelayStateVisitor that writes JSON directly via a shared JsonWriter.
-// Section begin/end callbacks map directly to JSON array/object open/close,
-// so no state tracking or deferred finalization is needed here.
+// RelayStateVisitor that writes JSON as the walk proceeds, handing off a chunk
+// whenever the writer crosses its threshold. Section begin/end callbacks map
+// directly to JSON array/object open/close, so no state tracking or deferred
+// finalization is needed here.
 class JsonRelayStateVisitor : public RelayStateVisitor {
-  JsonWriter& w_;
-
 public:
-  explicit JsonRelayStateVisitor(JsonWriter& w) : w_(w) {}
+  explicit JsonRelayStateVisitor(ChunkedJsonWriter& c) : c_(c), w_(c.json()) {}
 
   void onPeersBegin() override {
     w_.key("downstream_peers");
@@ -42,6 +37,7 @@ public:
       w_.field("relay_id", relayID);
     }
     w_.endObject();
+    c_.maybeFlush();
   }
   void onPeersEnd() override { w_.endArray(); }
 
@@ -73,6 +69,7 @@ public:
       w_.endObject();
     }
     w_.endObject();
+    c_.maybeFlush();
   }
   void onSubscriptionsEnd() override { w_.endArray(); }
 
@@ -111,6 +108,7 @@ public:
   void endNamespaceNode() override {
     w_.endObject(); // children
     w_.endObject(); // node
+    c_.maybeFlush();
   }
   void onNamespaceTreeEnd() override {}
 
@@ -154,22 +152,24 @@ public:
       }
       w_.endArray();
       w_.endObject();
+      c_.maybeFlush();
     }
     w_.endArray();
     w_.endObject();
   }
+
+private:
+  ChunkedJsonWriter& c_;
+  JsonWriter& w_;
 };
 
-// RelayContextVisitor that builds the top-level JSON envelope.
-// A single JsonWriter is shared with JsonRelayStateVisitor so comma state
-// remains consistent across the two visitor layers.
+// Builds the top-level envelope around the per-service walks. Shares one
+// ChunkedJsonWriter with the relay visitor so comma state stays consistent
+// across the two layers and a chunk can be cut anywhere.
 class JsonRelayContextVisitor : public RelayContextVisitor {
-  folly::IOBufQueue queue_{folly::IOBufQueue::cacheChainLength()};
-  folly::io::QueueAppender app_{&queue_, 4096};
-  JsonWriter w_{app_};
-  JsonRelayStateVisitor relayVisitor_{w_};
-
 public:
+  explicit JsonRelayContextVisitor(ChunkedJsonWriter& c) : c_(c), w_(c.json()), relayVisitor_(c) {}
+
   void onRelayBegin(std::string_view relayID, int64_t activeSessions) override {
     w_.beginObject();
     w_.field("relay_id", relayID);
@@ -192,16 +192,21 @@ public:
     w_.endObject();
   }
 
-  void onServiceEnd() override { w_.endObject(); }
+  void onServiceEnd() override {
+    w_.endObject();
+    c_.maybeFlush();
+  }
 
   void onRelayEnd() override {
     w_.endObject(); // services
     w_.endObject(); // relay
-    static constexpr uint8_t kNewline = '\n';
-    app_.write(kNewline);
+    c_.raw("\n");
   }
 
-  std::unique_ptr<folly::IOBuf> move() { return queue_.move(); }
+private:
+  ChunkedJsonWriter& c_;
+  JsonWriter& w_;
+  JsonRelayStateVisitor relayVisitor_;
 };
 
 } // namespace openmoq::moqx::admin

--- a/src/admin/StateHandler.cpp
+++ b/src/admin/StateHandler.cpp
@@ -10,6 +10,7 @@
 #include <folly/coro/Task.h>
 #include <folly/coro/WithCancellation.h>
 #include <folly/io/IOBuf.h>
+#include <folly/io/IOBufQueue.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <folly/logging/xlog.h>
 #include <proxygen/httpserver/ResponseBuilder.h>
@@ -17,6 +18,7 @@
 
 #include "MoqxRelayContext.h"
 #include "admin/AdminServer.h"
+#include "admin/ChunkedJsonWriter.h"
 #include "admin/JsonStateVisitors.h"
 
 namespace openmoq::moqx::admin {
@@ -26,9 +28,19 @@ namespace {
 // Runs on the relay worker EVB. Dumps state and returns the serialized body.
 folly::coro::Task<std::unique_ptr<folly::IOBuf>>
 buildStateBody(std::shared_ptr<MoqxRelayContext> ctx) {
-  JsonRelayContextVisitor visitor;
-  ctx->dumpState(visitor);
-  co_return visitor.move();
+  folly::IOBufQueue body{folly::IOBufQueue::cacheChainLength()};
+  {
+    // Chunks are collected rather than sent: the response still goes out whole
+    // at EOM.
+    ChunkedJsonWriter writer([&body](std::unique_ptr<folly::IOBuf> chunk) {
+      body.append(std::move(chunk));
+      return true;
+    });
+    JsonRelayContextVisitor visitor(writer);
+    ctx->dumpState(visitor);
+    writer.flush();
+  }
+  co_return body.move();
 }
 
 } // namespace


### PR DESCRIPTION
The /state visitors held their own IOBufQueue and handed the finished body back at the end, so the whole document had to exist in memory before anything could be sent.

ChunkedJsonWriter owns the queue instead and hands a chunk to a sink once it crosses a threshold; the visitors call maybeFlush() at item boundaries:

```
  ChunkedJsonWriter writer([](auto chunk) { return send(std::move(chunk)); });
  JsonRelayContextVisitor visitor(writer);
```

Comma and nesting state stay in the JsonWriter, so a flush is invisible in the output and a chunk boundary can fall anywhere. StateHandler's sink still collects every chunk and sends the body whole at EOM, so /state is byte-identical -- verified against the previous commit, and again with the threshold forced to 1 so every item flushed separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/625)
<!-- Reviewable:end -->
