### PR TITLE
relay: walk cached track stats in place

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -2412,23 +2412,30 @@ folly::Expected<folly::Unit, MoQPublishError> MoqxCache::cacheObjectAndUpdateByt
   return res;
 }
 
+void MoqxCache::forEachTrackStats(folly::FunctionRef<bool(const TrackStatsView&)> fn) const {
+  std::vector<GroupStats> groups; // reused across tracks; reserve only grows
+  for (const auto& [ftn, track] : cache_) {
+    groups.clear();
+    groups.reserve(track->groups.size());
+    for (const auto& [groupId, group] : track->groups) {
+      groups.push_back({groupId, group->objects.size()});
+    }
+    std::sort(groups.begin(), groups.end(), [](const GroupStats& a, const GroupStats& b) {
+      return a.groupId < b.groupId;
+    });
+    if (!fn(TrackStatsView{ftn, track->endOfTrack, track->lastWrite, groups})) {
+      return;
+    }
+  }
+}
+
 std::vector<MoqxCache::TrackStats> MoqxCache::getTrackStats() const {
   std::vector<TrackStats> result;
   result.reserve(cache_.size());
-  for (const auto& [ftn, track] : cache_) {
-    TrackStats ts;
-    ts.name = ftn;
-    ts.endOfTrack = track->endOfTrack;
-    ts.lastWrite = track->lastWrite;
-    ts.groups.reserve(track->groups.size());
-    for (const auto& [groupId, group] : track->groups) {
-      ts.groups.push_back({groupId, group->objects.size()});
-    }
-    std::sort(ts.groups.begin(), ts.groups.end(), [](const GroupStats& a, const GroupStats& b) {
-      return a.groupId < b.groupId;
-    });
-    result.push_back(std::move(ts));
-  }
+  forEachTrackStats([&](const TrackStatsView& t) {
+    result.push_back({t.name, t.endOfTrack, t.lastWrite, t.groups});
+    return true;
+  });
   return result;
 }
 

--- a/src/MoqxCache.h
+++ b/src/MoqxCache.h
@@ -168,6 +168,19 @@ public:
     std::vector<GroupStats> groups; // sorted by groupId ascending
   };
 
+  // One track's stats without owning any of them; valid for the call only.
+  struct TrackStatsView {
+    const moxygen::FullTrackName& name;
+    bool endOfTrack;
+    TimePoint lastWrite;
+    const std::vector<GroupStats>& groups; // sorted by groupId ascending
+  };
+
+  // Walks cached tracks in place. Return false to stop. Preferred over
+  // getTrackStats() on the relay executor: no track name is copied and one
+  // group vector is reused for the whole walk.
+  void forEachTrackStats(folly::FunctionRef<bool(const TrackStatsView&)> fn) const;
+
   // Returns a snapshot of all cached tracks and their group/object counts.
   // Groups within each track are returned in ascending groupId order.
   std::vector<TrackStats> getTrackStats() const;

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -2923,11 +2923,11 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
   visitor.onNamespaceTreeEnd();
 
   if (cache_) {
-    visitor.onCacheStats(
-        cache_->totalCachedBytes(),
-        cache_->getTrackStats(),
-        MoqxCache::SteadyClock::now()
-    );
+    visitor.onCacheBegin(cache_->totalCachedBytes(), MoqxCache::SteadyClock::now());
+    cache_->forEachTrackStats([&](const MoqxCache::TrackStatsView& track) {
+      return visitor.onCacheTrack(track);
+    });
+    visitor.onCacheEnd();
   }
 }
 

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -93,12 +93,11 @@ public:
   virtual void onNamespaceTreeEnd() = 0;
 
   // --- Cache section ---
-  // Called once with cache state; not called if cache is disabled.
-  virtual void onCacheStats(
-      size_t totalBytes,
-      const std::vector<MoqxCache::TrackStats>& tracks,
-      MoqxCache::TimePoint now
-  ) = 0;
+  // Not called at all if the cache is disabled.
+  virtual void onCacheBegin(size_t totalBytes, MoqxCache::TimePoint now) = 0;
+  // Return false to stop the cache walk. The view does not outlive the call.
+  virtual bool onCacheTrack(const MoqxCache::TrackStatsView& track) = 0;
+  virtual void onCacheEnd() = 0;
 };
 
 class MoqxRelay : public moxygen::Publisher,

--- a/src/admin/JsonStateVisitors.h
+++ b/src/admin/JsonStateVisitors.h
@@ -8,7 +8,6 @@
 
 #include <chrono>
 #include <string_view>
-#include <vector>
 
 #include "MoqxRelayContext.h"
 #include "admin/ChunkedJsonWriter.h"
@@ -112,48 +111,47 @@ public:
   }
   void onNamespaceTreeEnd() override {}
 
-  void onCacheStats(
-      size_t totalBytes,
-      const std::vector<MoqxCache::TrackStats>& tracks,
-      MoqxCache::TimePoint now
-  ) override {
+  void onCacheBegin(size_t totalBytes, MoqxCache::TimePoint now) override {
+    now_ = now;
     w_.key("cache");
     w_.beginObject();
     w_.key("total_bytes");
     w_.uintVal(static_cast<uint64_t>(totalBytes));
     w_.key("tracks");
     w_.beginArray();
-    for (const auto& t : tracks) {
-      w_.beginObject();
-      w_.key("namespace");
-      w_.beginArray();
-      for (const auto& s : t.name.trackNamespace.trackNamespace) {
-        w_.strVal(s);
-      }
-      w_.endArray();
-      w_.field("track_name", t.name.trackName);
-      w_.field("end_of_track", t.endOfTrack);
-      w_.key("last_write_ms_ago");
-      if (t.lastWrite == decltype(t.lastWrite)::min()) {
-        w_.nullVal();
-      } else {
-        auto msAgo =
-            std::chrono::duration_cast<std::chrono::milliseconds>(now - t.lastWrite).count();
-        w_.intVal(static_cast<int64_t>(msAgo));
-      }
-      w_.key("groups");
-      w_.beginArray();
-      for (const auto& g : t.groups) {
-        w_.beginObject();
-        w_.field("group_id", g.groupId);
-        w_.key("objects");
-        w_.uintVal(static_cast<uint64_t>(g.objects));
-        w_.endObject();
-      }
-      w_.endArray();
-      w_.endObject();
-      c_.maybeFlush();
+  }
+  bool onCacheTrack(const MoqxCache::TrackStatsView& t) override {
+    w_.beginObject();
+    w_.key("namespace");
+    w_.beginArray();
+    for (const auto& s : t.name.trackNamespace.trackNamespace) {
+      w_.strVal(s);
     }
+    w_.endArray();
+    w_.field("track_name", t.name.trackName);
+    w_.field("end_of_track", t.endOfTrack);
+    w_.key("last_write_ms_ago");
+    if (t.lastWrite == MoqxCache::TimePoint::min()) {
+      w_.nullVal();
+    } else {
+      auto msAgo =
+          std::chrono::duration_cast<std::chrono::milliseconds>(now_ - t.lastWrite).count();
+      w_.intVal(static_cast<int64_t>(msAgo));
+    }
+    w_.key("groups");
+    w_.beginArray();
+    for (const auto& g : t.groups) {
+      w_.beginObject();
+      w_.field("group_id", g.groupId);
+      w_.key("objects");
+      w_.uintVal(static_cast<uint64_t>(g.objects));
+      w_.endObject();
+    }
+    w_.endArray();
+    w_.endObject();
+    return c_.maybeFlush();
+  }
+  void onCacheEnd() override {
     w_.endArray();
     w_.endObject();
   }
@@ -161,6 +159,7 @@ public:
 private:
   ChunkedJsonWriter& c_;
   JsonWriter& w_;
+  MoqxCache::TimePoint now_{};
 };
 
 // Builds the top-level envelope around the per-service walks. Shares one


### PR DESCRIPTION
/state's cache section went through MoqxCache::getTrackStats(), which copies every track name and allocates a group vector per track, so the walk could serialize the snapshot and then drop it.

forEachTrackStats hands the visitor a TrackStatsView borrowing the cache's own data, reusing one group vector across tracks; returning false stops the walk. The visitor's cache callback splits to match:

```
  visitor.onCacheBegin(bytes, now);
  cache_->forEachTrackStats([&](const auto& t) { return visitor.onCacheTrack(t); });
  visitor.onCacheEnd();
```

getTrackStats() stays for callers that want a snapshot, now implemented on top of the walk -- so MoqxCacheTest covers both. Tracks are visited in the same order, so the JSON is unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/627)
<!-- Reviewable:end -->
