### PR TITLE
relay: count ingest on the relay executor, drop bogus subscriber counts

### DIFF
--- a/docker/json-exporter/json-exporter.yml
+++ b/docker/json-exporter/json-exporter.yml
@@ -5,8 +5,8 @@
 # (see the moqx-state and moqx-info jobs in prometheus.yml).
 #
 # Per-track series come from the relay's own /metrics/track, not from here:
-# both emitted moqx_track_subscribers, and /state's entries are transient and
-# undercount under load.
+# /state no longer carries subscriber counts (they were per-thread forwarder
+# counts, meaningless in LocalForwarder mode).
 modules:
   moqx:
     metrics:

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -36,10 +36,10 @@ scrape_configs:
         labels:
           instance: moqx-host
 
-  # Per-track subscriber series, via json_exporter scraping the relay admin
-  # /state (the aggregate /metrics has no per-track labels). Probe pattern:
-  # Prometheus hits json-exporter:7979/probe with target=<relay /state>. 15s
-  # because per-track cardinality scales with the number of distinct tracks.
+  # Top-level relay scalars (active_sessions, relay_id) that neither /metrics
+  # nor /metrics/track carries, via json_exporter scraping the relay admin
+  # /state. Probe pattern: Prometheus hits json-exporter:7979/probe with
+  # target=<relay /state>. Per-track series come from /metrics/track instead.
   - job_name: moqx-state
     metrics_path: /probe
     scrape_interval: 15s

--- a/docs/config.md
+++ b/docs/config.md
@@ -519,7 +519,7 @@ Prometheus a series set that reshuffles between scrapes.  See [docs/metrics.md] 
 | `GET` | `/info` | Returns `{"service":"moqx","version":"...","start_time":<epoch seconds>,"uptime_seconds":<n>}`. |
 | `GET` | `/metrics` | Prometheus-format metrics. See [docs/metrics.md](metrics.md) (pending PR #137). |
 | `GET` | `/metrics/track` | Per-track Prometheus metrics for live tracks. See [docs/metrics.md](metrics.md). |
-| `GET` | `/state` | Relay state: connected peers, active subscriptions, namespace tree, and cache stats. Pending PR #146. |
+| `GET` | `/state` | Relay state: connected peers, active subscriptions, namespace tree, and cache stats. Per-subscription counters are ingress-side (`total_groups_received`, `total_objects_received`, `largest`), counted on the relay executor; for subscriber counts use `moqx_track_subscribers` from `/metrics/track`. Pending PR #146. |
 
 ---
 

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -1455,18 +1455,114 @@ private:
   TrackNamespace trackNamespacePrefix_;
 };
 
-// Filter TrackConsumer that intercepts publishDone to clean up relay state.
-// Holds a weak_ptr to avoid a reference cycle: relay owns RelaySubscription
-// which owns the filter chain (TopNFilter→TerminationFilter), so a strong
-// relay ref here would prevent the relay from ever being destroyed.
-class MoqxRelay::TerminationFilter : public TrackConsumerFilter {
+namespace {
+
+// Records ingested objects for one subgroup; the group ID is fixed at
+// beginSubgroup, so only the object ID varies per call.
+class RelayIngestSubgroupFilter : public moxygen::SubgroupConsumerFilter {
 public:
-  TerminationFilter(
+  RelayIngestSubgroupFilter(
+      std::shared_ptr<IngestCounters> ingest,
+      uint64_t groupID,
+      std::shared_ptr<SubgroupConsumer> downstream
+  )
+      : moxygen::SubgroupConsumerFilter(std::move(downstream)), ingest_(std::move(ingest)),
+        groupID_(groupID) {}
+
+  folly::Expected<folly::Unit, MoQPublishError> object(
+      uint64_t objectID,
+      Payload payload,
+      moxygen::Extensions extensions = moxygen::noExtensions(),
+      bool finSubgroup = false
+  ) override {
+    ingest_->record(groupID_, objectID);
+    return moxygen::SubgroupConsumerFilter::object(
+        objectID,
+        std::move(payload),
+        std::move(extensions),
+        finSubgroup
+    );
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError> beginObject(
+      uint64_t objectID,
+      uint64_t length,
+      Payload initialPayload,
+      moxygen::Extensions extensions = moxygen::noExtensions()
+  ) override {
+    ingest_->record(groupID_, objectID);
+    return moxygen::SubgroupConsumerFilter::beginObject(
+        objectID,
+        length,
+        std::move(initialPayload),
+        std::move(extensions)
+    );
+  }
+
+  // endOfGroup/endOfTrackAndGroup deliver a real status object, so they count.
+  folly::Expected<folly::Unit, MoQPublishError> endOfGroup(uint64_t endOfGroupObjectID) override {
+    ingest_->record(groupID_, endOfGroupObjectID);
+    return moxygen::SubgroupConsumerFilter::endOfGroup(endOfGroupObjectID);
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError> endOfTrackAndGroup(uint64_t endOfTrackObjectID
+  ) override {
+    ingest_->record(groupID_, endOfTrackObjectID);
+    return moxygen::SubgroupConsumerFilter::endOfTrackAndGroup(endOfTrackObjectID);
+  }
+
+private:
+  std::shared_ptr<IngestCounters> ingest_;
+  uint64_t groupID_;
+};
+
+} // namespace
+
+// The relay executor's per-object observation point on the ingest path: counts
+// what arrives for /state, and intercepts publishDone to clean up relay state.
+// Both buildFilterChain branches install one, so these counters are the only
+// source /state needs -- in LocalForwarder mode the forwarder itself is owned
+// by another executor and cannot be read during the walk.
+//
+// Holds a weak_ptr to avoid a reference cycle: relay owns RelaySubscription
+// which owns the filter chain (TopNFilter→RelayIngestFilter), so a strong
+// relay ref here would prevent the relay from ever being destroyed.
+class MoqxRelay::RelayIngestFilter : public TrackConsumerFilter {
+public:
+  RelayIngestFilter(
       std::weak_ptr<MoqxRelay> relay,
       FullTrackName ftn,
+      std::shared_ptr<IngestCounters> ingest,
       std::shared_ptr<TrackConsumer> downstream
   )
-      : TrackConsumerFilter(std::move(downstream)), relay_(std::move(relay)), ftn_(std::move(ftn)) {
+      : TrackConsumerFilter(std::move(downstream)), relay_(std::move(relay)), ftn_(std::move(ftn)),
+        ingest_(std::move(ingest)) {}
+
+  folly::Expected<std::shared_ptr<SubgroupConsumer>, MoQPublishError> beginSubgroup(
+      uint64_t groupID,
+      uint64_t subgroupID,
+      moxygen::Priority priority,
+      moxygen::BeginSubgroupOptions options = {}
+  ) override {
+    auto res = TrackConsumerFilter::beginSubgroup(groupID, subgroupID, priority, options);
+    if (!res) {
+      return res;
+    }
+    return std::static_pointer_cast<SubgroupConsumer>(
+        std::make_shared<RelayIngestSubgroupFilter>(ingest_, groupID, std::move(res.value()))
+    );
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError>
+  objectStream(const ObjectHeader& header, Payload payload, bool lastInGroup = false) override {
+    ingest_->record(header.group, header.id);
+    return TrackConsumerFilter::objectStream(header, std::move(payload), lastInGroup);
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError>
+  datagram(const ObjectHeader& header, Payload payload, bool lastInGroup = false) override {
+    ingest_->record(header.group, header.id);
+    return TrackConsumerFilter::datagram(header, std::move(payload), lastInGroup);
   }
 
   folly::Expected<folly::Unit, MoQPublishError> publishDone(PublishDone pubDone) override {
@@ -1483,18 +1579,8 @@ public:
 private:
   std::weak_ptr<MoqxRelay> relay_;
   FullTrackName ftn_;
+  std::shared_ptr<IngestCounters> ingest_;
 };
-
-std::shared_ptr<TrackConsumer> MoqxRelay::getSubscribeWriteback(
-    const FullTrackName& ftn,
-    std::shared_ptr<TrackConsumer> consumer
-) {
-  auto baseConsumer =
-      cache_ ? cache_->getSubscribeWriteback(ftn, std::move(consumer)) : std::move(consumer);
-  auto termFilter =
-      std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(baseConsumer));
-  return std::static_pointer_cast<TrackConsumer>(termFilter);
-}
 
 SubscriptionRegistry::FilterChainResult
 MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForwarder> forwarder) {
@@ -1504,12 +1590,11 @@ MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForward
     // topNFilter/termination/cache.
     std::shared_ptr<TrackConsumer> chainEnd =
         cache_ ? cache_->makePassiveConsumer(ftn) : std::make_shared<moxygen::NullTrackConsumer>();
-    auto terminationFilter =
-        std::make_shared<TerminationFilter>(shared_from_this(), ftn, std::move(chainEnd));
-    auto topNFilter = std::make_shared<TopNFilter>(
-        ftn,
-        std::static_pointer_cast<TrackConsumer>(terminationFilter)
-    );
+    auto ingest = std::make_shared<IngestCounters>();
+    auto ingestFilter =
+        std::make_shared<RelayIngestFilter>(shared_from_this(), ftn, ingest, std::move(chainEnd));
+    auto topNFilter =
+        std::make_shared<TopNFilter>(ftn, std::static_pointer_cast<TrackConsumer>(ingestFilter));
     topNFilter->setActivityThreshold(activityThreshold_);
     return SubscriptionRegistry::FilterChainResult{
         .consumer = std::static_pointer_cast<TrackConsumer>(forwarder),
@@ -1519,7 +1604,8 @@ MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForward
             ftn,
             std::static_pointer_cast<TrackConsumer>(topNFilter),
             stats::TrackDirection::Ingest
-        )
+        ),
+        .ingest = std::move(ingest)
     };
   }
 
@@ -1533,13 +1619,15 @@ MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForward
         /*passive=*/true
     );
   }
-  auto terminationFilter = std::make_shared<TerminationFilter>(
+  auto ingest = std::make_shared<IngestCounters>();
+  auto ingestFilter = std::make_shared<RelayIngestFilter>(
       shared_from_this(),
       ftn,
+      ingest,
       std::static_pointer_cast<TrackConsumer>(forwarder)
   );
   auto topNFilter =
-      std::make_shared<TopNFilter>(ftn, std::static_pointer_cast<TrackConsumer>(terminationFilter));
+      std::make_shared<TopNFilter>(ftn, std::static_pointer_cast<TrackConsumer>(ingestFilter));
   topNFilter->setActivityThreshold(activityThreshold_);
   auto chainHead = wrapWithTrackStats(
       trackStats_,
@@ -1550,7 +1638,8 @@ MoqxRelay::buildFilterChain(const FullTrackName& ftn, std::shared_ptr<MoQForward
   return SubscriptionRegistry::FilterChainResult{
       .consumer = chainHead,
       .topNFilter = topNFilter,
-      .chainHead = chainHead
+      .chainHead = chainHead,
+      .ingest = std::move(ingest)
   };
 }
 
@@ -2885,20 +2974,18 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
     if (e.upstream) {
       sourceAddr = e.upstream->getPeerAddress().describe();
     }
+    // Counted by RelayIngestFilter on this executor rather than read off the
+    // forwarder, which in LocalForwarder mode is owned by another one. There
+    // the counts are what the relay chain saw, downstream of the cross-exec
+    // hop, so they can trail the forwarder's own by whatever is in flight.
     RelayStateVisitor::SubscriptionInfo info{
         .ftn = e.ftn,
         .isPublish = e.isPublish,
+        .largest = e.ingest.largest,
+        .totalGroupsReceived = e.ingest.groups,
+        .totalObjectsReceived = e.ingest.objects,
         .sourceAddress = sourceAddr,
     };
-    if (auto forwarder = e.forwarder.getIfOwned()) {
-      info.subscribers = forwarder->subscriberCount();
-      info.forwardingSubscribers = forwarder->numForwardingSubscribers();
-      info.largest = forwarder->largest();
-      info.totalGroupsReceived = forwarder->totalGroupsReceived();
-      info.totalObjectsReceived = forwarder->totalObjectsReceived();
-    }
-    // else LF mode: forwarder is on the publisher exec, not accessible here.
-    // TODO: add LF mode stats to the visitor via a cross-exec callback.
     visitor.onSubscription(info);
   });
   visitor.onSubscriptionsEnd();

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -68,8 +68,6 @@ public:
   struct SubscriptionInfo {
     const moxygen::FullTrackName& ftn;
     bool isPublish;
-    size_t subscribers{0};
-    uint64_t forwardingSubscribers{0};
     std::optional<moxygen::AbsoluteLocation> largest;
     uint64_t totalGroupsReceived{0};
     uint64_t totalObjectsReceived{0};
@@ -289,7 +287,7 @@ public:
 private:
   class NamespaceSubscription;
   class TracksSubscription;
-  class TerminationFilter;
+  class RelayIngestFilter;
   class LocalSubscribeFilter;
   class LocalPublishFilter;
 
@@ -422,7 +420,7 @@ private:
 
   // TRACK_FILTER support
 
-  // Build the filter chain for a track subscription: TopNFilter → TerminationFilter → (cache) →
+  // Build the filter chain for a track subscription: TopNFilter → RelayIngestFilter → (cache) →
   // forwarder. Used by both publish() and subscribe() paths to ensure consistent filter chain.
   SubscriptionRegistry::FilterChainResult buildFilterChain(
       const moxygen::FullTrackName& ftn,
@@ -475,11 +473,6 @@ private:
   };
   folly::F14FastMap<const moxygen::MoQSession*, LegacyPublisherHopID> legacyPublisherHopIDs_;
   SubscriptionRegistry registry_;
-
-  std::shared_ptr<moxygen::TrackConsumer> getSubscribeWriteback(
-      const moxygen::FullTrackName& ftn,
-      std::shared_ptr<moxygen::TrackConsumer> consumer
-  );
 
   std::optional<std::vector<uint64_t>> ingestRelayHopPath(
       const moxygen::PublishNamespace& pubNs,

--- a/src/SubscriptionRegistry.cpp
+++ b/src/SubscriptionRegistry.cpp
@@ -56,7 +56,7 @@ SubscriptionRegistry::getOrCreateFromSubscribe(
     }
     const EntryEpoch epoch = nextEpoch();
     forwarder->setCallback(std::move(callback));
-    auto [consumer, topNFilter, chainHead] = chainBuilder(forwarder);
+    auto [consumer, topNFilter, chainHead, ingest] = chainBuilder(forwarder);
     auto [emplaceIt, inserted] = subscriptions_.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(ftn),
@@ -64,6 +64,7 @@ SubscriptionRegistry::getOrCreateFromSubscribe(
     );
     emplaceIt->second.topNFilter = topNFilter;
     emplaceIt->second.chainHead = chainHead;
+    emplaceIt->second.ingest = ingest;
     return FirstSubscriber{
         forwarder,
         std::move(consumer),
@@ -153,9 +154,10 @@ SubscriptionRegistry::PublishEntry SubscriptionRegistry::createFromPublish(
   rsub.publisher = std::move(publisher);
   rsub.isPublish = true;
 
-  auto [consumer, topNFilter, chainHead] = chainBuilder();
+  auto [consumer, topNFilter, chainHead, ingest] = chainBuilder();
   rsub.topNFilter = topNFilter;
   rsub.chainHead = chainHead;
+  rsub.ingest = ingest;
   topNFilter->setActivityTarget(&rsub.lastObjectTime);
 
   return PublishEntry{std::move(consumer), std::move(evicted)};
@@ -235,6 +237,15 @@ void SubscriptionRegistry::remove(const moxygen::FullTrackName& ftn) {
   subscriptions_.erase(ftn);
 }
 
+namespace {
+// An entry whose chain predates ingest counting reports zeros rather than
+// forcing every caller to null-check.
+const IngestCounters& ingestOr(const std::shared_ptr<IngestCounters>& p) {
+  static const IngestCounters kNone;
+  return p ? *p : kNone;
+}
+} // namespace
+
 void SubscriptionRegistry::removeIf(folly::FunctionRef<bool(const EntryView&)> predicate) {
   for (auto it = subscriptions_.begin(); it != subscriptions_.end();) {
     EntryView view{
@@ -242,7 +253,8 @@ void SubscriptionRegistry::removeIf(folly::FunctionRef<bool(const EntryView&)> p
         it->second.forwarder,
         it->second.upstream,
         it->second.isPublish,
-        it->second.lastObjectTime
+        it->second.lastObjectTime,
+        ingestOr(it->second.ingest)
     };
     if (predicate(view)) {
       it = subscriptions_.erase(it);
@@ -261,7 +273,14 @@ void SubscriptionRegistry::forEachName(folly::FunctionRef<void(const moxygen::Fu
 
 void SubscriptionRegistry::forEach(folly::FunctionRef<void(const EntryView&)> fn) const {
   for (const auto& [ftn, rsub] : subscriptions_) {
-    fn(EntryView{ftn, rsub.forwarder, rsub.upstream, rsub.isPublish, rsub.lastObjectTime});
+    fn(EntryView{
+        ftn,
+        rsub.forwarder,
+        rsub.upstream,
+        rsub.isPublish,
+        rsub.lastObjectTime,
+        ingestOr(rsub.ingest)
+    });
   }
 }
 

--- a/src/SubscriptionRegistry.h
+++ b/src/SubscriptionRegistry.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "relay/ForwarderRef.h"
+#include "relay/RecentGroupWindow.h"
 #include "relay/TopNFilter.h"
 #include <folly/Function.h>
 #include <folly/container/F14Map.h>
@@ -20,6 +21,33 @@
 
 namespace openmoq::moqx {
 
+// Ingest counters for one track, maintained on the relay executor by
+// MoqxRelay::RelayIngestFilter. /state reads these instead of the forwarder's
+// own: in LocalForwarder mode the forwarder lives on another executor.
+//
+// shared_ptr, not a pointer into the entry: the filter chain can outlive its
+// registry entry while a publisher drains.
+struct IngestCounters {
+  std::optional<moxygen::AbsoluteLocation> largest;
+  uint64_t groups{0};
+  uint64_t objects{0};
+
+  // Once per incoming object, whatever the delivery mode.
+  void record(uint64_t group, uint64_t object) {
+    ++objects;
+    if (recentGroups_.admit(group)) {
+      ++groups;
+    }
+    moxygen::AbsoluteLocation loc{group, object};
+    if (!largest || *largest < loc) {
+      largest = loc;
+    }
+  }
+
+private:
+  RecentGroupWindow recentGroups_;
+};
+
 class SubscriptionRegistry {
 public:
   // Names one entry for as long as it sits in the map, so a caller that suspends
@@ -32,6 +60,7 @@ public:
     // Differs from consumer in LocalForwarder mode, where the relay chain
     // hangs off a channel subscriber rather than the publisher's writes.
     std::shared_ptr<moxygen::TrackConsumer> chainHead;
+    std::shared_ptr<IngestCounters> ingest;
   };
 
   // === Subscribe path ===
@@ -188,6 +217,7 @@ public:
     std::shared_ptr<moxygen::MoQSession> upstream;
     bool isPublish;
     std::chrono::steady_clock::time_point lastObjectTime;
+    const IngestCounters& ingest;
   };
 
   void removeIf(folly::FunctionRef<bool(const EntryView&)> predicate);
@@ -213,6 +243,7 @@ private:
     std::shared_ptr<TopNFilter> topNFilter;
     std::shared_ptr<moxygen::TrackConsumer> chainHead;
     std::chrono::steady_clock::time_point lastObjectTime;
+    std::shared_ptr<IngestCounters> ingest;
   };
 
   // Called by UpstreamSubscribePending::complete().

--- a/src/admin/JsonStateVisitors.h
+++ b/src/admin/JsonStateVisitors.h
@@ -54,9 +54,6 @@ public:
     w_.endArray();
     w_.field("track_name", info.ftn.trackName);
     w_.field("is_publish", info.isPublish);
-    w_.key("subscribers");
-    w_.uintVal(static_cast<uint64_t>(info.subscribers));
-    w_.field("forwarding_subscribers", info.forwardingSubscribers);
     w_.field("total_groups_received", info.totalGroupsReceived);
     w_.field("total_objects_received", info.totalObjectsReceived);
     w_.field("source_address", info.sourceAddress);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ moqx_add_gtest(moqx_relay_test
     MoqxRelayPeerTests.cpp
     MoqxRelayTracksTests.cpp
     MoqxRelayTrackStatsTests.cpp
+    MoqxRelayStateTests.cpp
     MoqxRelayTestModes.cpp
   LIBS moqx_test_fixture moqx_test_main
 )

--- a/test/MoqxRelayStateTests.cpp
+++ b/test/MoqxRelayStateTests.cpp
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MoqxRelayTestFixture.h"
+
+#include <folly/json.h>
+
+#include "admin/JsonStateVisitors.h"
+
+namespace openmoq::moqx::test {
+
+namespace {
+
+// Mirrors what the /state handler does for one service, minus the HTTP layer:
+// the walk runs on the executor that owns relay state and writes JSON as it
+// goes. Threshold of 1 so every item is flushed separately -- if a chunk
+// boundary could corrupt the output, these tests would see it too.
+class StateWalk {
+public:
+  explicit StateWalk(size_t threshold = 1)
+      : writer_(
+            [this](std::unique_ptr<folly::IOBuf> chunk) {
+              body_ += chunk->moveToFbString().toStdString();
+              return true;
+            },
+            threshold
+        ),
+        visitor_(writer_) {
+    // dumpState emits a relay fragment, not a document; brace it so the result
+    // can be parsed.
+    writer_.json().beginObject();
+  }
+
+  admin::JsonRelayStateVisitor& visitor() { return visitor_; }
+
+  folly::dynamic finish() {
+    writer_.json().endObject();
+    writer_.flush();
+    return folly::parseJson(body_);
+  }
+
+private:
+  std::string body_;
+  admin::ChunkedJsonWriter writer_;
+  admin::JsonRelayStateVisitor visitor_;
+};
+
+const folly::dynamic* findSubscription(const folly::dynamic& state, const std::string& trackName) {
+  for (const auto& sub : state["subscriptions"]) {
+    if (sub["track_name"].asString() == trackName) {
+      return &sub;
+    }
+  }
+  return nullptr;
+}
+
+} // namespace
+
+class MoQRelayStateTest : public MoQRelayTest {
+protected:
+  // dumpState is synchronous and must run where relay state lives, which is
+  // exactly what verifyOnRelayExec provides in every mode.
+  folly::dynamic dumpState() {
+    StateWalk walk;
+    verifyOnRelayExec([&] { relay_->dumpState(walk.visitor()); });
+    return walk.finish();
+  }
+};
+
+TEST_P(MoQRelayStateTest, EmptyRelayHasRootTreeAndNoSubscriptions) {
+  auto state = dumpState();
+
+  EXPECT_EQ(state["subscriptions"].size(), 0);
+  // The walk always emits a root node, even with nothing published.
+  ASSERT_TRUE(state.count("namespace_tree"));
+  EXPECT_EQ(state["namespace_tree"]["children"].size(), 0);
+  // maxCachedTracks = 0 in the fixture, so the cache section is absent.
+  EXPECT_EQ(state.count("cache"), 0);
+}
+
+TEST_P(MoQRelayStateTest, PublishedTracksAppearInEveryMode) {
+  auto publisherSession = createMockSession();
+  const FullTrackName second{kTestNamespace, "track2"};
+  doPublish(publisherSession, kTestTrackName);
+  doPublish(publisherSession, second);
+  driveIfMultiThread();
+
+  auto state = dumpState();
+
+  EXPECT_EQ(state["subscriptions"].size(), 2);
+  const auto* first = findSubscription(state, "track1");
+  ASSERT_NE(first, nullptr) << folly::toJson(state);
+  EXPECT_TRUE((*first)["is_publish"].asBool());
+  EXPECT_NE(findSubscription(state, "track2"), nullptr) << folly::toJson(state);
+
+  removeSession(publisherSession);
+  exec_->drive();
+}
+
+// The bug this whole change exists for: in LocalForwarder mode the registry's
+// forwarder is owned by another executor, so reading these counters off it
+// reported zeros. They are now counted by RelayIngestFilter on the relay
+// executor, which sees every object in every mode.
+TEST_P(MoQRelayStateTest, IngestCountersAreReportedInEveryMode) {
+  auto publisherSession = createMockSession();
+  auto subscriber = createMockSession();
+  auto mockConsumer = createMockConsumer();
+  auto mockSg = createMockSubgroupConsumer();
+
+  EXPECT_CALL(*mockConsumer, beginSubgroup(0, 0, _, _))
+      .WillRepeatedly([&](uint64_t, uint64_t, uint8_t, moxygen::BeginSubgroupOptions) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(mockSg);
+      });
+  EXPECT_CALL(*mockSg, object(_, _, _, _))
+      .WillRepeatedly(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  subscribeToTrack(subscriber, kTestTrackName, mockConsumer, RequestID(1));
+
+  auto sg = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(sg.hasValue()) << sg.error().describe();
+  EXPECT_TRUE(sg.value()->object(0, folly::IOBuf::copyBuffer("abc")).hasValue());
+  EXPECT_TRUE(sg.value()->object(1, folly::IOBuf::copyBuffer("de")).hasValue());
+  EXPECT_TRUE(sg.value()->endOfSubgroup().hasValue());
+  driveIfMultiThread();
+
+  auto state = dumpState();
+
+  const auto* sub = findSubscription(state, "track1");
+  ASSERT_NE(sub, nullptr) << folly::toJson(state);
+  EXPECT_EQ((*sub)["total_groups_received"].asInt(), 1);
+  EXPECT_EQ((*sub)["total_objects_received"].asInt(), 2);
+  ASSERT_TRUE(sub->count("largest")) << folly::toJson(*sub);
+  EXPECT_EQ((*sub)["largest"]["group"].asInt(), 0);
+  EXPECT_EQ((*sub)["largest"]["object"].asInt(), 1);
+
+  removeSession(publisherSession);
+  removeSession(subscriber);
+  exec_->drive();
+}
+
+// Subgroups of different groups interleave on the wire, so a one-deep "did the
+// group change" check counts every switch as a new group. The MRU window
+// shared with TrackStatsFilter is what keeps this at 2.
+TEST_P(MoQRelayStateTest, InterleavedGroupsAreCountedOnce) {
+  auto publisherSession = createMockSession();
+  auto subscriber = createMockSession();
+  auto mockConsumer = createMockConsumer();
+  auto mockSg = createMockSubgroupConsumer();
+
+  EXPECT_CALL(*mockConsumer, beginSubgroup(_, _, _, _))
+      .WillRepeatedly([&](uint64_t, uint64_t, uint8_t, moxygen::BeginSubgroupOptions) {
+        return folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(mockSg);
+      });
+  EXPECT_CALL(*mockSg, object(_, _, _, _))
+      .WillRepeatedly(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  subscribeToTrack(subscriber, kTestTrackName, mockConsumer, RequestID(1));
+
+  auto first = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(first.hasValue()) << first.error().describe();
+  auto second = publishConsumer->beginSubgroup(1, 0, 0);
+  ASSERT_TRUE(second.hasValue()) << second.error().describe();
+  EXPECT_TRUE(first.value()->object(0, folly::IOBuf::copyBuffer("a")).hasValue());
+  EXPECT_TRUE(second.value()->object(0, folly::IOBuf::copyBuffer("b")).hasValue());
+  EXPECT_TRUE(first.value()->object(1, folly::IOBuf::copyBuffer("c")).hasValue());
+  EXPECT_TRUE(second.value()->object(1, folly::IOBuf::copyBuffer("d")).hasValue());
+  EXPECT_TRUE(first.value()->endOfSubgroup().hasValue());
+  EXPECT_TRUE(second.value()->endOfSubgroup().hasValue());
+  driveIfMultiThread();
+
+  auto state = dumpState();
+
+  const auto* sub = findSubscription(state, "track1");
+  ASSERT_NE(sub, nullptr) << folly::toJson(state);
+  EXPECT_EQ((*sub)["total_groups_received"].asInt(), 2) << "two groups, four switches";
+  EXPECT_EQ((*sub)["total_objects_received"].asInt(), 4);
+  EXPECT_EQ((*sub)["largest"]["group"].asInt(), 1);
+  EXPECT_EQ((*sub)["largest"]["object"].asInt(), 1);
+
+  removeSession(publisherSession);
+  removeSession(subscriber);
+  exec_->drive();
+}
+
+TEST_P(MoQRelayStateTest, AnnouncedNamespaceAppearsInTree) {
+  auto publisherSession = createMockSession();
+  doPublishNamespace(publisherSession, kTestNamespace);
+  driveIfMultiThread();
+
+  auto state = dumpState();
+
+  // kTestNamespace is {"test","namespace"} and kAllowedPrefix is {"test"}, so
+  // the tree nests one level per tuple below the root.
+  const auto& root = state["namespace_tree"];
+  ASSERT_EQ(root["children"].size(), 1) << folly::toJson(state);
+  const auto& test = root["children"]["test"];
+  ASSERT_EQ(test["children"].size(), 1) << folly::toJson(test);
+  const auto& inner = test["children"]["namespace"];
+  EXPECT_EQ(folly::toJson(inner["full_namespace"]), R"(["test","namespace"])");
+
+  removeSession(publisherSession);
+  exec_->drive();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllModes,
+    MoQRelayStateTest,
+    ::testing::Values(RelayMode::SingleThread, RelayMode::MultiThread, RelayMode::LocalForwarderMT),
+    [](const ::testing::TestParamInfo<RelayMode>& info) {
+      std::ostringstream os;
+      PrintTo(info.param, &os);
+      return os.str();
+    }
+);
+
+} // namespace openmoq::moqx::test


### PR DESCRIPTION
/state read each subscription's counters off the forwarder, which in LocalForwarder mode belongs to another executor -- so the walk skipped it and reported zeros for every track. The two subscriber counts it reported were per-forwarder besides: "subscribers on this thread's forwarder", not on the relay.

TerminationFilter, already installed on both chain branches, becomes RelayIngestFilter and counts objects as they pass, into an IngestCounters the registry entry holds:

```
  void record(uint64_t group, uint64_t object); // objects, groups, largest
```

Distinct groups go through the same RecentGroupWindow TrackStatsFilter uses, so interleaved subgroups are not counted twice. /state reads those, so total_groups_received, total_objects_received and largest are right in every mode; subscribers and forwarding_subscribers are gone, and with them the json_exporter module that built per-track series out of /state -- moqx_track_subscribers from /metrics/track is the real number. Also drops getSubscribeWriteback, dead since the chain builder took over.

MoqxRelayStateTests walks /state in all three relay modes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/630)
<!-- Reviewable:end -->
