### PR TITLE
admin: stream /state as the walk produces it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ add_library(moqx_core STATIC
   src/admin/MetricsHandler.cpp
   src/admin/TrackMetricsHandler.cpp
   src/admin/StateHandler.cpp
+  src/admin/StateResponse.cpp
   src/stats/StatsRegistry.cpp
   src/stats/TrackStatsRegistry.cpp
   src/stats/MoQStatsCollector.cpp

--- a/docs/config.md
+++ b/docs/config.md
@@ -519,7 +519,7 @@ Prometheus a series set that reshuffles between scrapes.  See [docs/metrics.md] 
 | `GET` | `/info` | Returns `{"service":"moqx","version":"...","start_time":<epoch seconds>,"uptime_seconds":<n>}`. |
 | `GET` | `/metrics` | Prometheus-format metrics. See [docs/metrics.md](metrics.md) (pending PR #137). |
 | `GET` | `/metrics/track` | Per-track Prometheus metrics for live tracks. See [docs/metrics.md](metrics.md). |
-| `GET` | `/state` | Relay state: connected peers, active subscriptions, namespace tree, and cache stats. Per-subscription counters are ingress-side (`total_groups_received`, `total_objects_received`, `largest`), counted on the relay executor; for subscriber counts use `moqx_track_subscribers` from `/metrics/track`. Pending PR #146. |
+| `GET` | `/state` | Relay state: connected peers, active subscriptions, namespace tree, and cache stats. Always `Transfer-Encoding: chunked`, streamed as the walk produces it. Per-subscription counters are ingress-side (`total_groups_received`, `total_objects_received`, `largest`), counted on the relay executor; for subscriber counts use `moqx_track_subscribers` from `/metrics/track`. |
 
 ---
 

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -2967,6 +2967,9 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
     visitor.onPeer(sess->getPeerAddress().describe(), sess->getAuthority(), peer.relayID);
   }
   visitor.onPeersEnd();
+  if (!visitor.alive()) {
+    return;
+  }
 
   visitor.onSubscriptionsBegin();
   registry_.forEach([&](const SubscriptionRegistry::EntryView& e) {
@@ -2989,6 +2992,9 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
     visitor.onSubscription(info);
   });
   visitor.onSubscriptionsEnd();
+  if (!visitor.alive()) {
+    return;
+  }
 
   visitor.onNamespaceTreeBegin();
   namespaceTree_.walkTree(
@@ -3008,6 +3014,9 @@ void MoqxRelay::dumpState(RelayStateVisitor& visitor) const {
       [&]() { visitor.endNamespaceNode(); }
   );
   visitor.onNamespaceTreeEnd();
+  if (!visitor.alive()) {
+    return;
+  }
 
   if (cache_) {
     visitor.onCacheBegin(cache_->totalCachedBytes(), MoqxCache::SteadyClock::now());

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -96,6 +96,10 @@ public:
   // Return false to stop the cache walk. The view does not outlive the call.
   virtual bool onCacheTrack(const MoqxCache::TrackStatsView& track) = 0;
   virtual void onCacheEnd() = 0;
+
+  // False once the consumer is gone; the walk stops at the next section
+  // boundary rather than formatting the rest for nobody.
+  virtual bool alive() const = 0;
 };
 
 class MoqxRelay : public moxygen::Publisher,

--- a/src/MoqxRelayContext.cpp
+++ b/src/MoqxRelayContext.cpp
@@ -451,6 +451,9 @@ folly::coro::Task<void> MoqxRelayContext::dumpState(RelayContextVisitor& visitor
   }
 
   for (auto& service : services) {
+    if (!visitor.alive()) {
+      break;
+    }
     RelayStateVisitor& rv = visitor.onServiceBegin(service.name);
     // registry_ lives on the relay exec when there is one; without one, config
     // forces threads==1, so the worker EVB is that single io thread.

--- a/src/MoqxRelayContext.h
+++ b/src/MoqxRelayContext.h
@@ -44,6 +44,9 @@ public:
   virtual void onServiceUpstream(std::string_view url, std::string_view state) = 0;
   virtual void onServiceEnd() = 0;
   virtual void onRelayEnd() = 0;
+  // Checked between services so a consumer that has gone away stops the walk
+  // rather than paying for every remaining service.
+  virtual bool alive() const = 0;
 };
 
 // Holds relay state shared across all listener instances.

--- a/src/admin/EgressGate.h
+++ b/src/admin/EgressGate.h
@@ -54,6 +54,11 @@ public:
     baton_.signal(proxygen::coro::TimedBaton::Status::cancelled);
   }
 
+  // Lets a caller skip awaitDrainable, and its coroutine frame, on the common
+  // unpaused path. shutdown() clears paused_, so a caller that skips on this
+  // must still check its own cancellation before sending.
+  bool paused() const { return paused_; }
+
   // False means the request is going away, so stop rather than send.
   folly::coro::Task<bool> awaitDrainable() {
     XCHECK(baton_.getEventBase()->isInEventBaseThread()) << "EgressGate is admin EVB only";

--- a/src/admin/JsonStateVisitors.h
+++ b/src/admin/JsonStateVisitors.h
@@ -153,6 +153,8 @@ public:
     w_.endObject();
   }
 
+  bool alive() const override { return c_.alive(); }
+
 private:
   ChunkedJsonWriter& c_;
   JsonWriter& w_;
@@ -198,6 +200,8 @@ public:
     w_.endObject(); // relay
     c_.raw("\n");
   }
+
+  bool alive() const override { return c_.alive(); }
 
 private:
   ChunkedJsonWriter& c_;

--- a/src/admin/StateHandler.cpp
+++ b/src/admin/StateHandler.cpp
@@ -7,41 +7,58 @@
 #include "admin/StateHandler.h"
 
 #include <folly/CancellationToken.h>
+#include <folly/coro/AsyncPipe.h>
 #include <folly/coro/Task.h>
 #include <folly/coro/WithCancellation.h>
 #include <folly/io/IOBuf.h>
-#include <folly/io/IOBufQueue.h>
 #include <folly/io/async/EventBaseManager.h>
-#include <folly/logging/xlog.h>
 #include <proxygen/httpserver/ResponseBuilder.h>
 #include <proxygen/lib/http/HTTPMessage.h>
 
 #include "MoqxRelayContext.h"
 #include "admin/AdminServer.h"
 #include "admin/ChunkedJsonWriter.h"
+#include "admin/EgressGate.h"
 #include "admin/JsonStateVisitors.h"
+#include "admin/StateResponse.h"
 
 namespace openmoq::moqx::admin {
 
 namespace {
 
-// Awaitable from the admin EVB: dumpState hops to each service's own executor
-// and back for itself.
-folly::coro::Task<std::unique_ptr<folly::IOBuf>>
-buildStateBody(std::shared_ptr<MoqxRelayContext> ctx) {
-  folly::IOBufQueue body{folly::IOBufQueue::cacheChainLength()};
+using ChunkPipe = folly::coro::AsyncPipe<std::unique_ptr<folly::IOBuf>>;
+
+// Runs the walk, hopping to each service's owning executor, and pushes chunks
+// into the pipe as they are produced. Never blocks on the consumer.
+folly::coro::Task<void> produceState(
+    std::shared_ptr<MoqxRelayContext> ctx,
+    ChunkPipe pipe,
+    std::shared_ptr<StreamBudget> budget
+) {
+  folly::exception_wrapper failure;
   {
-    // Chunks are collected rather than sent: the response still goes out whole
-    // at EOM.
-    ChunkedJsonWriter writer([&body](std::unique_ptr<folly::IOBuf> chunk) {
-      body.append(std::move(chunk));
-      return true;
+    ChunkedJsonWriter writer([&](std::unique_ptr<folly::IOBuf> chunk) {
+      if (!budget->tryAdd(chunk->computeChainDataLength())) {
+        failure = folly::make_exception_wrapper<std::runtime_error>(
+            "/state exceeded the buffered-response cap"
+        );
+        return false;
+      }
+      return pipe.write(std::move(chunk));
     });
     JsonRelayContextVisitor visitor(writer);
-    co_await ctx->dumpState(visitor);
-    writer.flush();
+    auto result = co_await folly::coro::co_awaitTry(ctx->dumpState(visitor));
+    if (result.hasException()) {
+      failure = std::move(result).exception();
+    } else {
+      writer.flush();
+    }
   }
-  co_return body.move();
+  if (failure) {
+    std::move(pipe).close(std::move(failure));
+  } else {
+    std::move(pipe).close();
+  }
 }
 
 } // namespace
@@ -55,7 +72,7 @@ void registerStateRoute(AdminServer& adminServer, std::shared_ptr<MoqxRelayConte
           auto /*body*/,
           auto* downstream,
           folly::CancellationToken cancelToken,
-          const std::shared_ptr<EgressGate>& /*egress*/) {
+          std::shared_ptr<EgressGate> egress) {
         if (!context->ready()) {
           proxygen::ResponseBuilder(downstream)
               .status(503, proxygen::HTTPMessage::getDefaultReason(503))
@@ -64,39 +81,23 @@ void registerStateRoute(AdminServer& adminServer, std::shared_ptr<MoqxRelayConte
           return;
         }
 
-        // The coroutine is pinned to the admin EVB so sendWithEOM is
-        // thread-safe; the walk's own executor hops happen inside the co_await
-        // and it resumes here.
+        auto* adminEvb = folly::EventBaseManager::get()->getEventBase();
+        auto budget = std::make_shared<StreamBudget>();
+        auto [gen, pipe] = ChunkPipe::create();
+
+        // Producer and consumer run concurrently: the producer migrates across
+        // relay executors while the consumer stays on the admin EVB, where
+        // sendBody is thread-safe. It re-checks the token before every send,
+        // which is safe because onError sets it before deleting the handler on
+        // this same single-threaded EVB.
+        folly::coro::co_withExecutor(adminEvb, produceState(context, std::move(pipe), budget))
+            .start();
+
         folly::coro::co_withCancellation(
             cancelToken,
             folly::coro::co_withExecutor(
-                folly::EventBaseManager::get()->getEventBase(),
-                [](auto ctx, auto* ds, auto token) -> folly::coro::Task<void> {
-                  if (token.isCancellationRequested()) {
-                    co_return;
-                  }
-                  std::unique_ptr<folly::IOBuf> body;
-                  try {
-                    body = co_await buildStateBody(ctx);
-                  } catch (const std::exception& e) {
-                    XLOG(ERR) << "StateHandler: dumpState threw: " << e.what();
-                    if (!token.isCancellationRequested()) {
-                      proxygen::ResponseBuilder(ds)
-                          .status(500, proxygen::HTTPMessage::getDefaultReason(500))
-                          .body(folly::IOBuf::copyBuffer("internal error\n"))
-                          .sendWithEOM();
-                    }
-                    co_return;
-                  }
-                  if (token.isCancellationRequested()) {
-                    co_return;
-                  }
-                  proxygen::ResponseBuilder(ds)
-                      .status(200, proxygen::HTTPMessage::getDefaultReason(200))
-                      .header("Content-Type", "application/json")
-                      .body(std::move(body))
-                      .sendWithEOM();
-                }(context, downstream, cancelToken)
+                adminEvb,
+                sendState(downstream, cancelToken, std::move(gen), budget, std::move(egress))
             )
         )
             .start();

--- a/src/admin/StateHandler.h
+++ b/src/admin/StateHandler.h
@@ -17,7 +17,8 @@ class AdminServer;
 
 // Registers GET /state on the given admin server.
 //
-// The handler walks each service on the executor that owns it.
+// The handler walks each service on the executor that owns it, writing JSON as
+// it goes and sending it chunked as it is produced.
 void registerStateRoute(AdminServer& adminServer, std::shared_ptr<MoqxRelayContext> context);
 
 } // namespace admin

--- a/src/admin/StateResponse.cpp
+++ b/src/admin/StateResponse.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "admin/StateResponse.h"
+
+#include <folly/logging/xlog.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <proxygen/lib/http/HTTPMessage.h>
+
+namespace openmoq::moqx::admin {
+
+folly::coro::Task<void> sendState(
+    proxygen::ResponseHandler* ds,
+    folly::CancellationToken token,
+    folly::coro::AsyncGenerator<std::unique_ptr<folly::IOBuf>&&> gen,
+    std::shared_ptr<StreamBudget> budget,
+    std::shared_ptr<EgressGate> egress
+) {
+  bool headersSent = false;
+
+  // Headers ride the first chunk, so a failure before any output is still a
+  // status rather than an aborted 200.
+  auto begin = [&](proxygen::ResponseBuilder& builder) {
+    if (!headersSent) {
+      builder.status(200, proxygen::HTTPMessage::getDefaultReason(200))
+          .header("Content-Type", "application/json");
+      headersSent = true;
+    }
+  };
+
+  auto sendChunk = [&](std::unique_ptr<folly::IOBuf> chunk) {
+    budget->release(chunk->computeChainDataLength());
+    proxygen::ResponseBuilder builder(ds);
+    begin(builder);
+    builder.body(std::move(chunk)).send();
+  };
+
+  auto finish = [&] {
+    proxygen::ResponseBuilder builder(ds);
+    begin(builder);
+    builder.sendWithEOM();
+  };
+
+  // Ends a response that cannot be finished normally. Only safe with the token
+  // clear: onError sets it before deleting the handler that owns ds.
+  auto fail = [&] {
+    if (headersSent) {
+      // Already committed to 200; a truncated body is the only signal left.
+      ds->sendAbort();
+    } else {
+      proxygen::ResponseBuilder(ds)
+          .status(500, proxygen::HTTPMessage::getDefaultReason(500))
+          .body(folly::IOBuf::copyBuffer("internal error\n"))
+          .sendWithEOM();
+    }
+  };
+
+  try {
+    while (true) {
+      // Not pulling while proxygen is not draining is what makes the cap bound
+      // real memory rather than relocate it into the egress queue. The common
+      // case never parks, so it never pays for a coroutine frame either.
+      if (egress->paused() && !co_await egress->awaitDrainable()) {
+        // The gate gives up on cancellation, which the token check covers, and
+        // on egress timing out, which does not: leaving that response
+        // unterminated would hang the client until proxygen gave up too.
+        if (!token.isCancellationRequested()) {
+          fail();
+        }
+        co_return;
+      }
+      if (token.isCancellationRequested()) {
+        co_return;
+      }
+      auto chunk = co_await gen.next();
+      if (!chunk) {
+        break;
+      }
+      if (token.isCancellationRequested()) {
+        co_return;
+      }
+      sendChunk(std::move(*chunk));
+    }
+  } catch (const std::exception& e) {
+    XLOG(ERR) << "/state: walk threw: " << e.what();
+    if (!token.isCancellationRequested()) {
+      fail();
+    }
+    co_return;
+  }
+
+  if (token.isCancellationRequested()) {
+    co_return;
+  }
+  finish();
+}
+
+} // namespace openmoq::moqx::admin

--- a/src/admin/StateResponse.h
+++ b/src/admin/StateResponse.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+#include <folly/CancellationToken.h>
+#include <folly/coro/AsyncGenerator.h>
+#include <folly/coro/Task.h>
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseHandler.h>
+
+#include "admin/EgressGate.h"
+
+namespace openmoq::moqx::admin {
+
+// The /state walk cannot be slowed down -- it is synchronous and never yields
+// its executor -- so a consumer that stops draining cannot push back. This
+// bounds what that can cost instead: past the cap the response is abandoned.
+// Only our own queue counts against it; bytes handed to proxygen are released.
+inline constexpr size_t kMaxBufferedStateBytes = 4 * 1024 * 1024;
+
+// Bytes handed to the pipe but not yet handed to proxygen.
+class StreamBudget {
+public:
+  explicit StreamBudget(size_t cap = kMaxBufferedStateBytes) : cap_(cap) {}
+
+  bool tryAdd(size_t n) { return outstanding_.fetch_add(n, std::memory_order_relaxed) + n <= cap_; }
+  void release(size_t n) { outstanding_.fetch_sub(n, std::memory_order_relaxed); }
+
+private:
+  std::atomic<size_t> outstanding_{0};
+  size_t cap_;
+};
+
+// Drains a chunk stream into a chunked response on the admin EVB. Headers wait
+// for the first chunk, so a walk that fails before producing any output -- the
+// usual case, since a small /state does not flush until the end -- can still be
+// reported as a 500 rather than an aborted 200.
+folly::coro::Task<void> sendState(
+    proxygen::ResponseHandler* ds,
+    folly::CancellationToken token,
+    folly::coro::AsyncGenerator<std::unique_ptr<folly::IOBuf>&&> gen,
+    std::shared_ptr<StreamBudget> budget,
+    std::shared_ptr<EgressGate> egress
+);
+
+} // namespace openmoq::moqx::admin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,6 +124,26 @@ target_include_directories(moqx_track_metrics_format_test PRIVATE
   ${PROJECT_SOURCE_DIR}/src
 )
 
+moqx_add_gtest(moqx_state_stream_test
+  SRCS admin/StateStreamTest.cpp
+  LIBS moqx_core GTest::gtest_main GTest::gmock
+)
+target_include_directories(moqx_state_stream_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/src
+)
+
+moqx_add_gtest(moqx_state_response_test
+  SRCS admin/StateResponseTest.cpp
+  LIBS
+    moqx_core
+    GTest::gtest_main
+    GTest::gmock
+    Folly::folly_executors_manual_executor
+)
+target_include_directories(moqx_state_response_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/src
+)
+
 moqx_add_gtest(moqx_track_stats_registry_test
   SRCS stats/TrackStatsRegistryTest.cpp
   LIBS moqx_core GTest::gtest_main GTest::gmock

--- a/test/admin/StateResponseTest.cpp
+++ b/test/admin/StateResponseTest.cpp
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <folly/coro/AsyncPipe.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/WithCancellation.h>
+#include <folly/executors/ManualExecutor.h>
+#include <folly/io/async/EventBase.h>
+#include <proxygen/httpserver/RequestHandler.h>
+
+#include "admin/StateResponse.h"
+
+namespace openmoq::moqx::admin {
+
+namespace {
+
+using ChunkPipe = folly::coro::AsyncPipe<std::unique_ptr<folly::IOBuf>>;
+
+class NoopRequestHandler : public proxygen::RequestHandler {
+public:
+  void onRequest(std::unique_ptr<proxygen::HTTPMessage>) noexcept override {}
+  void onBody(std::unique_ptr<folly::IOBuf>) noexcept override {}
+  void onUpgrade(proxygen::UpgradeProtocol) noexcept override {}
+  void onEOM() noexcept override {}
+  void requestComplete() noexcept override {}
+  void onError(proxygen::ProxygenError) noexcept override {}
+};
+
+// Records what proxygen would have put on the wire.
+class FakeResponseHandler : public proxygen::ResponseHandler {
+public:
+  FakeResponseHandler() : proxygen::ResponseHandler(&upstream_) {}
+
+  void sendHeaders(proxygen::HTTPMessage& msg) noexcept override {
+    status = msg.getStatusCode();
+    chunked = msg.getIsChunked();
+    contentLength = msg.getHeaders().getSingleOrEmpty(proxygen::HTTP_HEADER_CONTENT_LENGTH);
+    ++headerSends;
+  }
+  void sendChunkHeader(size_t) noexcept override { ++chunkHeaders; }
+  void sendBody(std::unique_ptr<folly::IOBuf> b) noexcept override {
+    if (b) {
+      body += b->moveToFbString().toStdString();
+    }
+    ++bodySends;
+  }
+  void sendChunkTerminator() noexcept override {}
+  void sendEOM() noexcept override { ++eoms; }
+  void sendAbort(folly::Optional<proxygen::ErrorCode>) noexcept override { ++aborts; }
+  void refreshTimeout() noexcept override {}
+  void pauseIngress() noexcept override {}
+  void resumeIngress() noexcept override {}
+  folly::Expected<ResponseHandler*, proxygen::ProxygenError>
+  newPushedResponse(proxygen::PushHandler*) noexcept override {
+    return folly::makeUnexpected(proxygen::kErrorUnknown);
+  }
+  const wangle::TransportInfo& getSetupTransportInfo() const noexcept override { return info_; }
+  void getCurrentTransportInfo(wangle::TransportInfo*) const override {}
+
+  uint16_t status{0};
+  bool chunked{false};
+  std::string contentLength;
+  std::string body;
+  int headerSends{0};
+  int bodySends{0};
+  int chunkHeaders{0};
+  int eoms{0};
+  int aborts{0};
+
+private:
+  NoopRequestHandler upstream_;
+  wangle::TransportInfo info_;
+};
+
+std::unique_ptr<folly::IOBuf> buf(const std::string& s) {
+  return folly::IOBuf::copyBuffer(s);
+}
+
+// Loads `chunks` into a closed pipe, optionally failing the stream at the end.
+folly::coro::AsyncGenerator<std::unique_ptr<folly::IOBuf>&&>
+load(const std::vector<std::string>& chunks, StreamBudget& budget, bool failAtEnd = false) {
+  auto [gen, pipe] = ChunkPipe::create();
+  for (auto& c : chunks) {
+    budget.tryAdd(c.size());
+    pipe.write(buf(c));
+  }
+  if (failAtEnd) {
+    std::move(pipe).close(folly::make_exception_wrapper<std::runtime_error>("walk blew up"));
+  } else {
+    std::move(pipe).close();
+  }
+  return std::move(gen);
+}
+
+class StateResponseTest : public ::testing::Test {
+protected:
+  // Feeds `chunks` through sendState with egress never paused.
+  void
+  run(std::vector<std::string> chunks,
+      bool failAtEnd = false,
+      folly::CancellationToken token = folly::CancellationToken()) {
+    auto budget = std::make_shared<StreamBudget>();
+    auto gen = load(chunks, *budget, failAtEnd);
+    folly::coro::blockingWait(sendState(&ds, std::move(token), std::move(gen), budget, gate));
+  }
+
+  // The gate XCHECKs that it is on its own EVB, and folly counts a never-looped
+  // EventBase as every thread's, so one satisfies that check from blockingWait
+  // or a ManualExecutor alike. Declared first: a coroutine frame left in exec
+  // holds a gate reference, and ~TimedBaton reads the EVB.
+  folly::EventBase evb;
+  folly::ManualExecutor exec;
+  FakeResponseHandler ds;
+  std::shared_ptr<EgressGate> gate{std::make_shared<EgressGate>(&evb)};
+};
+
+} // namespace
+
+TEST_F(StateResponseTest, SingleChunkGoesOutChunked) {
+  run({R"({"relay_id":"x"})"});
+
+  EXPECT_EQ(ds.status, 200);
+  EXPECT_TRUE(ds.chunked);
+  EXPECT_TRUE(ds.contentLength.empty()) << ds.contentLength;
+  EXPECT_EQ(ds.body, R"({"relay_id":"x"})");
+  EXPECT_EQ(ds.headerSends, 1);
+  EXPECT_EQ(ds.chunkHeaders, 1);
+  EXPECT_EQ(ds.eoms, 1);
+  EXPECT_EQ(ds.aborts, 0);
+}
+
+TEST_F(StateResponseTest, MultipleChunksGoOutChunked) {
+  run({"{", R"("a":1,)", R"("b":2})"});
+
+  EXPECT_EQ(ds.status, 200);
+  EXPECT_TRUE(ds.chunked);
+  EXPECT_TRUE(ds.contentLength.empty()) << ds.contentLength;
+  EXPECT_EQ(ds.body, R"({"a":1,"b":2})");
+  EXPECT_EQ(ds.headerSends, 1) << "headers go out once, on the first flush";
+  EXPECT_EQ(ds.chunkHeaders, 3);
+  EXPECT_EQ(ds.eoms, 1);
+  EXPECT_EQ(ds.aborts, 0);
+}
+
+// Deferring the headers is what buys this: nothing was committed yet, so a
+// failure can still be reported as a status rather than a truncated body.
+TEST_F(StateResponseTest, FailureBeforeHeadersIsAClean500) {
+  run({}, /*failAtEnd=*/true);
+
+  EXPECT_EQ(ds.status, 500);
+  EXPECT_EQ(ds.body, "internal error\n");
+  EXPECT_EQ(ds.aborts, 0);
+  EXPECT_EQ(ds.eoms, 1);
+}
+
+TEST_F(StateResponseTest, FailureAfterHeadersAborts) {
+  // The first chunk commits the headers; the rest never arrives because the
+  // stream fails, leaving abort as the only signal.
+  run({"{"}, /*failAtEnd=*/true);
+
+  EXPECT_EQ(ds.status, 200);
+  EXPECT_EQ(ds.aborts, 1);
+  EXPECT_EQ(ds.eoms, 0) << "an aborted response must not also be completed";
+}
+
+TEST_F(StateResponseTest, CancelledRequestSendsNothing) {
+  folly::CancellationSource source;
+  source.requestCancellation();
+  run({R"({"relay_id":"x"})"}, /*failAtEnd=*/false, source.getToken());
+
+  EXPECT_EQ(ds.headerSends, 0);
+  EXPECT_EQ(ds.bodySends, 0);
+  EXPECT_EQ(ds.eoms, 0);
+  EXPECT_EQ(ds.aborts, 0);
+}
+
+// An empty stream still has to complete the response rather than hang.
+TEST_F(StateResponseTest, EmptyStreamStillCompletes) {
+  run({});
+
+  EXPECT_EQ(ds.status, 200);
+  EXPECT_EQ(ds.eoms, 1);
+  EXPECT_EQ(ds.body, "");
+}
+
+// The gate is what makes the buffered-bytes cap mean anything: while proxygen
+// cannot write, nothing is pulled from the producer at all.
+TEST_F(StateResponseTest, PausedEgressStopsPullingUntilResumed) {
+  auto budget = std::make_shared<StreamBudget>();
+  auto gen = load({"{", R"("a":1,)", R"("b":2})"}, *budget);
+
+  gate->onPaused();
+  auto fut = folly::coro::co_withExecutor(
+                 &exec,
+                 sendState(&ds, folly::CancellationToken(), std::move(gen), budget, gate)
+  )
+                 .start();
+  exec.drain();
+
+  EXPECT_FALSE(fut.isReady()) << "parked on the gate";
+  EXPECT_EQ(ds.headerSends, 0);
+  EXPECT_EQ(ds.bodySends, 0);
+
+  gate->onResumed();
+  exec.drain();
+
+  EXPECT_TRUE(fut.isReady());
+  EXPECT_EQ(ds.body, R"({"a":1,"b":2})");
+  EXPECT_EQ(ds.eoms, 1);
+}
+
+// What onError does: cancel, then shut the gate, then delete the handler. A
+// coroutine parked on the gate has to unpark and leave downstream alone.
+TEST_F(StateResponseTest, ShutdownWhileParkedSendsNothing) {
+  auto budget = std::make_shared<StreamBudget>();
+  auto gen = load({R"({"relay_id":"x"})"}, *budget);
+  folly::CancellationSource source;
+
+  gate->onPaused();
+  auto fut = folly::coro::co_withExecutor(
+                 &exec,
+                 sendState(&ds, source.getToken(), std::move(gen), budget, gate)
+  )
+                 .start();
+  exec.drain();
+  ASSERT_FALSE(fut.isReady());
+
+  source.requestCancellation();
+  gate->shutdown();
+  exec.drain();
+
+  EXPECT_TRUE(fut.isReady());
+  EXPECT_EQ(ds.headerSends, 0);
+  EXPECT_EQ(ds.bodySends, 0);
+  EXPECT_EQ(ds.eoms, 0);
+  EXPECT_EQ(ds.aborts, 0);
+}
+
+// A gate that gives up on a request nobody cancelled must still terminate the
+// response; abandoning it would hang the client until proxygen timed out.
+TEST_F(StateResponseTest, GateGivingUpOnALiveRequestStillTerminates) {
+  auto budget = std::make_shared<StreamBudget>();
+  auto gen = load({R"({"relay_id":"x"})"}, *budget);
+
+  gate->onPaused();
+  auto fut = folly::coro::co_withExecutor(
+                 &exec,
+                 sendState(&ds, folly::CancellationToken(), std::move(gen), budget, gate)
+  )
+                 .start();
+  exec.drain();
+  ASSERT_FALSE(fut.isReady());
+
+  gate->shutdown();
+  exec.drain();
+
+  EXPECT_TRUE(fut.isReady());
+  EXPECT_EQ(ds.status, 500);
+  EXPECT_EQ(ds.eoms, 1);
+}
+
+// Resume posts the baton, but folly defers the waiter; a pause landing in that
+// window re-arms the baton, so the waiter wakes to a status of notReady. That
+// must read as "keep waiting", not as "the request is gone".
+TEST_F(StateResponseTest, RepauseBeforeTheWaiterRunsDoesNotAbandonTheResponse) {
+  auto budget = std::make_shared<StreamBudget>();
+  auto gen = load({R"({"relay_id":"x"})"}, *budget);
+
+  gate->onPaused();
+  auto fut = folly::coro::co_withExecutor(
+                 &exec,
+                 sendState(&ds, folly::CancellationToken(), std::move(gen), budget, gate)
+  )
+                 .start();
+  exec.drain();
+  ASSERT_FALSE(fut.isReady());
+
+  gate->onResumed();
+  gate->onPaused();
+  exec.drain();
+
+  EXPECT_FALSE(fut.isReady()) << "still parked, not abandoned";
+  EXPECT_EQ(ds.eoms, 0);
+  EXPECT_EQ(ds.aborts, 0);
+  EXPECT_EQ(ds.status, 0) << "no 500 either";
+
+  gate->onResumed();
+  exec.drain();
+
+  EXPECT_TRUE(fut.isReady());
+  EXPECT_EQ(ds.body, R"({"relay_id":"x"})");
+  EXPECT_EQ(ds.eoms, 1);
+}
+
+TEST_F(StateResponseTest, CancellationWhileParkedSendsNothing) {
+  auto budget = std::make_shared<StreamBudget>();
+  auto gen = load({R"({"relay_id":"x"})"}, *budget);
+  folly::CancellationSource source;
+
+  gate->onPaused();
+  auto fut = folly::coro::co_withExecutor(
+                 &exec,
+                 folly::coro::co_withCancellation(
+                     source.getToken(),
+                     sendState(&ds, source.getToken(), std::move(gen), budget, gate)
+                 )
+  )
+                 .start();
+  exec.drain();
+  ASSERT_FALSE(fut.isReady());
+
+  source.requestCancellation();
+  exec.drain();
+
+  EXPECT_TRUE(fut.isReady());
+  EXPECT_EQ(ds.headerSends, 0);
+  EXPECT_EQ(ds.eoms, 0);
+}
+
+TEST_F(StateResponseTest, BudgetRejectsPastTheCap) {
+  StreamBudget budget(/*cap=*/10);
+  EXPECT_TRUE(budget.tryAdd(6));
+  EXPECT_TRUE(budget.tryAdd(4));
+  EXPECT_FALSE(budget.tryAdd(1)) << "11 > 10";
+  budget.release(10);
+  EXPECT_TRUE(budget.tryAdd(9)) << "releasing what was sent makes room again";
+}
+
+} // namespace openmoq::moqx::admin

--- a/test/admin/StateStreamTest.cpp
+++ b/test/admin/StateStreamTest.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <folly/json.h>
+
+#include "admin/JsonStateVisitors.h"
+
+namespace openmoq::moqx::admin {
+
+namespace {
+
+// Collects every chunk so a test can assert on the whole body and on how it was
+// cut up.
+struct Collected {
+  std::vector<std::string> chunks;
+
+  std::string body() const {
+    std::string out;
+    for (const auto& c : chunks) {
+      out += c;
+    }
+    return out;
+  }
+};
+
+ChunkedJsonWriter::Sink sinkInto(Collected& out) {
+  return [&out](std::unique_ptr<folly::IOBuf> chunk) {
+    out.chunks.push_back(chunk->moveToFbString().toStdString());
+    return true;
+  };
+}
+
+moxygen::FullTrackName ftn(std::vector<std::string> ns, std::string name) {
+  return moxygen::FullTrackName{moxygen::TrackNamespace{std::move(ns)}, std::move(name)};
+}
+
+// One walk, exercising every section and both nesting levels of the tree.
+void walk(RelayContextVisitor& v) {
+  v.onRelayBegin("relay-1", 3);
+  RelayStateVisitor& rv = v.onServiceBegin("default");
+
+  rv.onPeersBegin();
+  rv.onPeer("10.0.0.1:1", "peer.example", "peer-a");
+  rv.onPeer("10.0.0.2:2", "other.example", "");
+  rv.onPeersEnd();
+
+  rv.onSubscriptionsBegin();
+  auto first = ftn({"ns", "sub"}, "track");
+  RelayStateVisitor::SubscriptionInfo a{
+      .ftn = first,
+      .isPublish = true,
+      .largest = moxygen::AbsoluteLocation{7, 2},
+      .totalGroupsReceived = 4,
+      .totalObjectsReceived = 9,
+      .sourceAddress = "1.2.3.4:5",
+  };
+  rv.onSubscription(a);
+  auto second = ftn({"ns"}, "quiet");
+  RelayStateVisitor::SubscriptionInfo b{.ftn = second, .isPublish = false};
+  rv.onSubscription(b);
+  rv.onSubscriptionsEnd();
+
+  rv.onNamespaceTreeBegin();
+  rv.beginNamespaceNode("", moxygen::TrackNamespace{}, 0, "", "");
+  rv.beginNamespaceNode("test", moxygen::TrackNamespace{{"test"}}, 2, "10.0.0.1:1", "peer-a");
+  rv.beginNamespaceNode("inner", moxygen::TrackNamespace{{"test", "inner"}}, 1, "", "");
+  rv.endNamespaceNode();
+  rv.endNamespaceNode();
+  rv.endNamespaceNode();
+  rv.onNamespaceTreeEnd();
+
+  auto now = MoqxCache::TimePoint{} + std::chrono::seconds(100);
+  auto writtenName = ftn({"ns"}, "t");
+  auto unwrittenName = ftn({"ns"}, "u");
+  std::vector<MoqxCache::GroupStats> groups{{3, 8}};
+  std::vector<MoqxCache::GroupStats> noGroups;
+  rv.onCacheBegin(42, now);
+  rv.onCacheTrack({writtenName, false, now - std::chrono::milliseconds(250), groups});
+  rv.onCacheTrack({unwrittenName, true, MoqxCache::TimePoint::min(), noGroups});
+  rv.onCacheEnd();
+
+  v.onServiceUpstream("moqt://up/rel", "connected");
+  v.onServiceEnd();
+  v.onRelayEnd();
+}
+
+std::string bodyAtThreshold(size_t threshold, Collected& out) {
+  ChunkedJsonWriter w(sinkInto(out), threshold);
+  JsonRelayContextVisitor visitor(w);
+  walk(visitor);
+  w.flush();
+  return out.body();
+}
+
+std::string bodyAtThreshold(size_t threshold) {
+  Collected out;
+  return bodyAtThreshold(threshold, out);
+}
+
+} // namespace
+
+// The load-bearing property: comma and nesting state live in the JsonWriter,
+// and the QueueAppender is reset after each move, so a flush can land anywhere
+// without disturbing the bytes.
+// Round-trips every escape the writer knows about, at thresholds that cut the
+// string apart mid-escape.
+TEST(StateStreamTest, StringsSurviveEscapingAndChunking) {
+  const std::string tricky =
+      "a long unescaped run \"quoted\" back\\slash new\nline tab\there \x01 ctrl \x1f end";
+  for (size_t threshold : {size_t(1), size_t(3), size_t(16), size_t(4096)}) {
+    Collected out;
+    ChunkedJsonWriter w(sinkInto(out), threshold);
+    w.json().beginObject();
+    w.json().key("s");
+    w.json().strVal(tricky);
+    w.json().endObject();
+    w.flush();
+
+    auto parsed = folly::parseJson(out.body());
+    EXPECT_EQ(parsed["s"].asString(), tricky) << "threshold " << threshold;
+  }
+}
+
+TEST(StateStreamTest, ChunkBoundariesAreInvisible) {
+  const auto reference = bodyAtThreshold(ChunkedJsonWriter::kDefaultThreshold);
+
+  for (size_t threshold : {size_t(1), size_t(7), size_t(64), size_t(512), size_t(4096)}) {
+    Collected out;
+    EXPECT_EQ(bodyAtThreshold(threshold, out), reference) << "threshold=" << threshold;
+  }
+}
+
+TEST(StateStreamTest, SmallThresholdActuallySplits) {
+  Collected out;
+  bodyAtThreshold(1, out);
+  EXPECT_GT(out.chunks.size(), 1u);
+
+  Collected single;
+  bodyAtThreshold(ChunkedJsonWriter::kDefaultThreshold, single);
+  EXPECT_EQ(single.chunks.size(), 1u) << "a small /state should stay one chunk";
+}
+
+TEST(StateStreamTest, BodyIsValidJsonWithTrailingNewline) {
+  auto body = bodyAtThreshold(1);
+  ASSERT_FALSE(body.empty());
+  EXPECT_EQ(body.back(), '\n');
+
+  auto parsed = folly::parseJson(body);
+  EXPECT_EQ(parsed["relay_id"].asString(), "relay-1");
+  EXPECT_EQ(parsed["active_sessions"].asInt(), 3);
+  ASSERT_TRUE(parsed["services"].count("default"));
+}
+
+TEST(StateStreamTest, PeersCarryAddressAndOmitEmptyRelayId) {
+  auto parsed = folly::parseJson(bodyAtThreshold(1))["services"]["default"];
+  const auto& peers = parsed["downstream_peers"];
+  ASSERT_EQ(peers.size(), 2);
+  EXPECT_EQ(peers[0]["address"].asString(), "10.0.0.1:1");
+  EXPECT_EQ(peers[0]["relay_id"].asString(), "peer-a");
+  EXPECT_EQ(peers[1].count("relay_id"), 0) << "an empty relay_id is omitted, not emitted as \"\"";
+}
+
+TEST(StateStreamTest, SubscriptionCarriesIngestCountersAndOmitsSubscriberCounts) {
+  auto body = bodyAtThreshold(1);
+  auto sub = folly::parseJson(body)["services"]["default"]["subscriptions"][0];
+
+  EXPECT_EQ(folly::toJson(sub["namespace"]), R"(["ns","sub"])");
+  EXPECT_EQ(sub["track_name"].asString(), "track");
+  EXPECT_TRUE(sub["is_publish"].asBool());
+  EXPECT_EQ(sub["total_groups_received"].asInt(), 4);
+  EXPECT_EQ(sub["total_objects_received"].asInt(), 9);
+  EXPECT_EQ(sub["largest"]["group"].asInt(), 7);
+  EXPECT_EQ(sub["largest"]["object"].asInt(), 2);
+
+  // Dropped outright: in LocalForwarder mode these counted io threads, not
+  // subscribers. /metrics/track carries the real numbers.
+  EXPECT_EQ(body.find("forwarding_subscribers"), std::string::npos) << body;
+  EXPECT_EQ(body.find(R"("subscribers")"), std::string::npos) << body;
+}
+
+TEST(StateStreamTest, OmitsLargestWhenUnset) {
+  auto sub = folly::parseJson(bodyAtThreshold(1))["services"]["default"]["subscriptions"][1];
+  EXPECT_EQ(sub.count("largest"), 0);
+  EXPECT_EQ(sub["total_objects_received"].asInt(), 0);
+}
+
+TEST(StateStreamTest, NestsNamespaceChildrenByKey) {
+  auto tree = folly::parseJson(bodyAtThreshold(1))["services"]["default"]["namespace_tree"];
+  const auto& test = tree["children"]["test"];
+  EXPECT_EQ(folly::toJson(test["full_namespace"]), R"(["test"])");
+  EXPECT_EQ(test["namespace_subscribers"].asInt(), 2);
+  EXPECT_EQ(test["publisher"].asString(), "10.0.0.1:1");
+  EXPECT_EQ(test["peer_id"].asString(), "peer-a");
+
+  const auto& inner = test["children"]["inner"];
+  EXPECT_EQ(folly::toJson(inner["full_namespace"]), R"(["test","inner"])");
+  // A node with no publisher or peer omits both rather than emitting "".
+  EXPECT_EQ(inner.count("publisher"), 0);
+  EXPECT_EQ(inner.count("peer_id"), 0);
+}
+
+TEST(StateStreamTest, CacheAgeIsRelativeToTheCapturedInstant) {
+  auto cache = folly::parseJson(bodyAtThreshold(1))["services"]["default"]["cache"];
+  EXPECT_EQ(cache["total_bytes"].asInt(), 42);
+  EXPECT_EQ(cache["tracks"][0]["last_write_ms_ago"].asInt(), 250);
+  // Field-wise, not toJson: dynamic objects are hash maps, so their key order
+  // is not stable enough to compare serialized.
+  const auto& groups = cache["tracks"][0]["groups"];
+  ASSERT_EQ(groups.size(), 1);
+  EXPECT_EQ(groups[0]["group_id"].asInt(), 3);
+  EXPECT_EQ(groups[0]["objects"].asInt(), 8);
+  // An unwritten track reports null rather than an absurd age.
+  EXPECT_TRUE(cache["tracks"][1]["last_write_ms_ago"].isNull());
+}
+
+// onServiceUpstream runs after the relay walk, so upstream trails cache. Any
+// consumer diffing raw /state sees that order, so it is pinned positionally --
+// parsing cannot express key order.
+TEST(StateStreamTest, UpstreamFollowsCache) {
+  auto body = bodyAtThreshold(1);
+  auto cachePos = body.find(R"("cache")");
+  auto upstreamPos = body.find(R"("upstream")");
+  ASSERT_NE(cachePos, std::string::npos) << body;
+  ASSERT_NE(upstreamPos, std::string::npos) << body;
+  EXPECT_LT(cachePos, upstreamPos) << body;
+
+  auto upstream = folly::parseJson(body)["services"]["default"]["upstream"];
+  EXPECT_EQ(upstream["url"].asString(), "moqt://up/rel");
+  EXPECT_EQ(upstream["state"].asString(), "connected");
+}
+
+// A sink that has given up stops the walk rather than letting it run to the end
+// writing bytes nobody will read.
+TEST(StateStreamTest, DeadSinkStopsReportingAlive) {
+  ChunkedJsonWriter w([](std::unique_ptr<folly::IOBuf>) { return false; }, /*threshold=*/1);
+  JsonRelayContextVisitor visitor(w);
+  EXPECT_TRUE(visitor.alive());
+  walk(visitor);
+  EXPECT_FALSE(visitor.alive());
+}
+
+} // namespace openmoq::moqx::admin

--- a/test/test_admin_state.sh
+++ b/test/test_admin_state.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Exercises GET /state against a real relay: the route wiring and the walk
-# across service executors, neither of which the unit tests reach.
+# Exercises GET /state against a real relay: the route wiring, the walk across
+# service executors, the producer and consumer coroutines, and the chunked
+# framing, none of which the unit tests reach.
 set -euo pipefail
 
 BINARY="${1:-$(dirname "$0")/../build/default/moqx}"
@@ -50,13 +51,24 @@ curl -sf -D "$TMPDIR/headers.txt" -o "$TMPDIR/body.json" "$ADMIN_URL"
 echo "Headers:"; cat "$TMPDIR/headers.txt"
 echo "Body: $(cat "$TMPDIR/body.json")"
 
+if ! grep -qi '^Transfer-Encoding: chunked' "$TMPDIR/headers.txt"; then
+  echo "FAIL: /state is not chunked" >&2
+  exit 1
+fi
+
+if grep -qi '^Content-Length:' "$TMPDIR/headers.txt"; then
+  echo "FAIL: chunked response must not carry Content-Length" >&2
+  exit 1
+fi
+
 if ! grep -qi '^Content-Type: application/json' "$TMPDIR/headers.txt"; then
   echo "FAIL: missing JSON content type" >&2
   exit 1
 fi
 
-# The body has to parse: every service's fragment is written by a different
-# executor into one shared writer.
+# Reassembled chunks have to parse: every service's fragment is written by a
+# different executor into one shared writer, and a flush that corrupted comma or
+# nesting state would land here too.
 python3 -c "
 import json, sys
 state = json.load(open('$TMPDIR/body.json'))


### PR DESCRIPTION
/state serialized the whole document before sending a byte, so a relay with a large namespace tree or cache held the entire response in memory, and the client waited for the last service to be walked before seeing the first.

The walk now writes into an AsyncPipe that the admin EVB drains into a chunked response. Producer and consumer run concurrently: the producer migrates across relay executors, while the consumer stays on the admin EVB where sendBody is thread-safe and parks on the EgressGate whenever the transaction cannot write. A slow client therefore leaves the unsent bytes in the pipe rather than relocating them into proxygen's egress queue, where nothing would account for them. The walk itself never stalls: it is synchronous and never yields its executor, so the consumer cannot push back on it. StreamBudget bounds what that can cost instead, capping what may pile up in the pipe and failing the response past it. Headers wait for the first chunk, so a walk that throws before producing output is still reported as a 500 rather than an aborted 200.

Both visitors gain alive(), checked at section boundaries, so a client that hangs up stops the walk rather than formatting the rest for nobody.

StateStreamTest covers the visitors and chunk boundaries, StateResponseTest the consumer, budget and gate, and test_admin_state.sh the framing end to end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/633)
<!-- Reviewable:end -->
