### PR TITLE
Fix the benchmark build and give it PR coverage

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -42,6 +42,9 @@ jobs:
           - name: linux
             key: linux
             preset: default
+            # Compile coverage for benchmark/: the microbenchmark job is main-only,
+            # so nothing else builds those TUs before merge.
+            extra_cmake: -DMOQX_BUILD_BENCHMARKS=ON
             runner: ubuntu-22.04
           # arm64 is validated by the publish-side docker build (ci-main publish
           # arm64 entry); skipped here to avoid the ubuntu-runner ↔ bookworm-tarball

--- a/benchmark/MoQFramer.cpp
+++ b/benchmark/MoQFramer.cpp
@@ -127,7 +127,8 @@ BENCHMARK(BM_WriteSubgroupHeader, iters) {
   susp.dismiss();
   for (unsigned i = 0; i < iters; ++i) {
     buf.reset();
-    auto res = writer.writeSubgroupHeader(buf, TrackAlias(1), header);
+    auto res =
+        writer.writeSubgroupHeader(buf, TrackAlias(1), header, SubgroupOptions{});
     folly::doNotOptimizeAway(res);
   }
 }

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -151,6 +151,10 @@ ExternalProject_Add(moxygen
     -DINSTALL_DEPS=ON
     -DBUILD_TESTS=ON
     -DBUILD_SAMPLES=ON
+    -DBUILD_MOQTEST=ON
+    # Discover tests at ctest startup instead of POST_BUILD: parallel POST_BUILD
+    # discovery races on a shared JSON file under cmake 4.4.0.
+    -DCMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST
     -DBUILD_SHARED_LIBS=OFF
     -DBoost_USE_STATIC_LIBS=${BOOST_USE_STATIC_LIBS}
     # Never let moxygen's find_package probes satisfy themselves from a


### PR DESCRIPTION
`main` is red: both microbenchmark jobs fail to compile. The only change between
the last green run (26ebaa77) and the failure (cb15cbcf) is the moxygen pin bump
to 02eaa88, which added a `SubgroupOptions` argument to `writeSubgroupHeader`.
Every field of that struct is default-initialized, so `SubgroupOptions{}` keeps
the previous wire output — it is the form moxygen's own tests use.

The sync PR could not have caught this. `MOQX_BUILD_BENCHMARKS` is turned on in
exactly one place, `ci-main.yml`, and the microbenchmark job exists only there,
so no PR on any platform compiles `benchmark/`. This adds
`-DMOQX_BUILD_BENCHMARKS=ON` to the linux PR lane for compile coverage; the
break was platform-independent, so one lane is enough.

Two superbuild flags while here:

- `-DBUILD_MOQTEST=ON` stated rather than inherited from the standalone default,
  matching how the other flags are passed and afrind's guidance on the right
  flags for today.
- `-DCMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE=PRE_TEST`, which serializes test
  discovery at ctest startup. Parallel POST_BUILD discovery races on a shared
  JSON file under cmake 4.4.0 and intermittently fails macOS from-source builds.
  The equivalent guard already exists for moqx's own tests but could not reach
  the moxygen sub-build, which is a separate cmake invocation.

Verified by compiling all eight `benchmark/*.cpp` against the 02eaa88 prebuilt
headers — one error before, none after.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/635)
<!-- Reviewable:end -->
