### PR TITLE
Cache only from hosted runners; bound and harden ccache

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -28,7 +28,12 @@ runs:
 
     # The moqx CMakeLists routes the compiler through ccache automatically when
     # it is installed (install-system-deps.sh installs it).
+    #
+    # Hosted runners only: the self-hosted box keeps ~/.cache between jobs, so
+    # the round trip buys nothing and its ccache is large enough to crowd every
+    # other lane out of the repo-wide 10 GB cache budget.
     - name: Cache ccache
+      if: runner.environment == 'github-hosted'
       uses: actions/cache@v5
       with:
         path: ~/.cache/ccache
@@ -52,7 +57,12 @@ runs:
 
     # One shared fetch cache for CPM sources and the prebuilt moxygen install,
     # ~680 MB of downloads per configure otherwise, content-keyed on the pins.
+    # Hosted runners only, for the reason above and one more: actions/cache stores
+    # paths relative to the workspace, and ~/.cache sits 3 levels above a hosted
+    # workspace but 4 above the self-hosted one. A cache saved there replays as
+    # ../../../../.cache on a hosted runner, lands on /home, and fails to extract.
     - name: Cache dependency downloads
+      if: runner.environment == 'github-hosted'
       uses: actions/cache@v5
       with:
         path: ~/.cache/moqx
@@ -87,6 +97,16 @@ runs:
         echo "MOQX_DEPS_CACHE=$HOME/.cache/moqx" >> "$GITHUB_ENV"
         # Pin ccache's dir to the cached path; its own default is platform-dependent.
         echo "CCACHE_DIR=$HOME/.cache/ccache" >> "$GITHUB_ENV"
+        # Hash compiler contents, not mtime: apt and Homebrew replace compilers
+        # under these runners, and a same-mtime swap would serve stale objects.
+        echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"
+        # Bound the cache. Hosted lanes share the repo's 10 GB budget; the
+        # self-hosted box keeps its cache on local disk and pays no such tax.
+        if [ "${{ runner.environment }}" = "github-hosted" ]; then
+          echo "CCACHE_MAXSIZE=1500M" >> "$GITHUB_ENV"
+        else
+          echo "CCACHE_MAXSIZE=20G" >> "$GITHUB_ENV"
+        fi
         # GITHUB_TOKEN stays off $GITHUB_ENV, which would hand it to every later
         # step in the job, ctest among them — and ctest runs the relay and the
         # shell integration tests. The configure step sets it for its one API read.


### PR DESCRIPTION
Closes the correctness half of #628.

The self-hosted box keeps `~/.cache` between jobs, so uploading its caches to
GitHub buys nothing. Its ccache alone was 14.4 GB of the repo's 10 GB budget,
which evicts `main`'s entries and leaves every PR lane starting cold.

It also fixes a restore failure that is costing time today. `actions/cache`
stores paths relative to the workspace, and `~/.cache` sits 3 levels above a
hosted workspace but 4 above the self-hosted one:

| runner | workspace |
|---|---|
| hosted | `/home/runner/work/moqx/moqx` |
| linode | `/home/github-runner/actions-runner/_work/moqx/moqx` |

Both derive the same dependency-cache key, so an archive saved on linode replays
as `../../../../.cache` on a hosted runner, lands on `/home`, and fails with
`Cannot mkdir: Permission denied` for every entry. Hosted lanes have been
re-cloning the CPM sources on every run. The ccache keys are unaffected — they
are lane-derived and each lane runs on exactly one runner family.

Also sets `CCACHE_MAXSIZE` so the cache cannot grow back into the budget
(1500M hosted, 20G on the box with its own disk), and `CCACHE_COMPILERCHECK=content`,
since apt and Homebrew replace compilers under these runners and the default
`mtime` check would serve stale objects after a same-mtime swap.

This is items 1-4 of the target posture in #628. Items 5-6 (save-on-main-only,
staying under budget) follow separately; moxygen's side is openmoq/moxygen#381.

## Verifying

Cache behaviour cannot be exercised locally. On this PR's run, check that the
hosted lanes still show `Cache restored from key: ccache-Linux-...` and that the
`asan debug` job shows the two cache steps skipped. Afterwards the repo's cache
usage should drop from ~25 GB to roughly 7 GB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/636)
<!-- Reviewable:end -->
