### PR TITLE
Build the release container with the release version baked in

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -435,6 +435,96 @@ jobs:
   # succeeded. Tolerates portable-build being skipped (has_portable=false).
   # ════════════════════════════════════════════════════════════════════════════
 
+  # ════════════════════════════════════════════════════════════════════════════
+  # Release image: builds the container with MOQX_VERSION_STRING set to the
+  # release tag, so the binary and the OCI label report the version they ship
+  # under. The arg enters after the moxygen stage, so the dep layers come from
+  # the registry cache and only the moqx TUs recompile.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  release-image:
+    needs: [validate, create-release]
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    name: release image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    # The image's moxygen stage can fall back to compiling folly; see ci-main.
+    timeout-minutes: 180
+    steps:
+      # create-release tags snapshot_sha; the image is that commit.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.snapshot_sha }}
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - uses: docker/setup-buildx-action@v4
+
+      # Reads ci-main's buildcache. Writing it back with mode=max evicts the
+      # ccache and dependency caches sharing the repo's 10 GB budget.
+      - name: Build with the release version baked in
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}"
+          ARCH="${{ matrix.arch }}"
+          TAG="${{ needs.validate.outputs.tag }}"
+          docker buildx build -f docker/Dockerfile --target relay --load \
+            --secret id=github_token,env=GITHUB_TOKEN \
+            --build-arg MOQX_VERSION_STRING="$TAG" \
+            --cache-from "type=registry,ref=${IMAGE}/buildcache:${ARCH}" \
+            -t "${IMAGE}:${TAG}-${ARCH}" \
+            .
+
+      - name: Verify the stamped version and linkage
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}:${{ needs.validate.outputs.tag }}-${{ matrix.arch }}"
+          TAG="${{ needs.validate.outputs.tag }}"
+          if docker run --rm --entrypoint ldd "$IMAGE" /usr/local/bin/moqx 2>&1 | grep -q "not found"; then
+            echo "ERROR: missing shared libraries" >&2
+            docker run --rm --entrypoint ldd "$IMAGE" /usr/local/bin/moqx >&2
+            exit 1
+          fi
+          # The binary reports the tag it ships under.
+          REPORTED=$(docker run --rm --entrypoint /usr/local/bin/moqx "$IMAGE" --version 2>&1 || true)
+          echo "==> reported version: $REPORTED"
+          case "$REPORTED" in
+            *"$TAG"*) echo "==> version stamp OK" ;;
+            *) echo "ERROR: image does not report $TAG" >&2; exit 1 ;;
+          esac
+
+      - name: Push
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}"
+          docker push "${IMAGE}:${{ needs.validate.outputs.tag }}-${{ matrix.arch }}"
+
+  release-image-manifest:
+    needs: [validate, release-image]
+    permissions:
+      packages: write
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      # Release tags only; 'latest' and the rolling aliases track main.
+      - name: Create the multiplatform manifest
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}"
+          TAG="${{ needs.validate.outputs.tag }}"
+          docker buildx imagetools create -t "${IMAGE}:${TAG}" \
+            "${IMAGE}:${TAG}-amd64" "${IMAGE}:${TAG}-arm64"
+          docker buildx imagetools inspect "${IMAGE}:${TAG}"
+
   finalize:
     needs: [validate, create-release, portable-build, promote-snapshot]
     if: |


### PR DESCRIPTION
A versioned release ships four tarballs and a GitHub release but no container
image. `ghcr.io/openmoq/moqx:v0.3.0` 404s — the only images in GHCR come from
`ci-main`, tagged by commit sha and rolling label. Deploying a release means
translating the version to a sha by hand, which fails badly six weeks later when
`2d07646` means nothing to anyone.

## Why this is a build and not a re-tag

Re-tagging `ci-main`'s image looks like the cheap fix and is wrong. That image is
built on a push to `main`, before the version tag exists, and the version comes
from `git describe --tags --match 'v[0-9]*' --always`. Both publish jobs for the
v0.3.0 commit logged:

```
==> build version: v0.2.1-124-g2d076462
```

So a re-tag would give you an image named `v0.3.0` whose relay reports
`v0.2.1-124-g2d076462`, with nothing to flag the mismatch. The version is compiled
into the binary and emitted as an OCI label, so getting it right needs a build.

The rebuild is cheaper than it sounds: `ARG MOQX_VERSION_STRING` sits at
`docker/Dockerfile:50`, after the `moxygen` stage, so the dependency layers come
from the existing registry cache and only moqx's own TUs recompile.

The portable tarballs never had this problem — `portable-build` already passes
`-DMOQX_VERSION_STRING` explicitly. This brings the container in line.

## Details

- **Builds `snapshot_sha`, not the branch head.** `create-release` tags
  `snapshot_sha`, so the image has to be that commit. Worth noting
  `portable-build` uses a bare `actions/checkout` and therefore builds the
  dispatched branch head — if `main` moves between the last `ci-main` publish and
  the dispatch, the tarballs are not the commit the tag names. Not addressed here.
- **`cache-from` only, no `cache-to`.** `ci-main` owns the buildcache and its own
  comment notes that `mode=max` evicts the ccache and dependency caches it shares
  the 10 GB budget with.
- **`packages: write` is scoped to the two new jobs**, not raised to the workflow
  block, which is `contents: write` today.
- **Asserts the stamp before pushing.** The version check bypasses the entrypoint
  (`--entrypoint /usr/local/bin/moqx`) because the relay target's `ENTRYPOINT` is
  `entrypoint.sh`, which would otherwise swallow `--version`.
- **No `latest` or rolling alias.** Those track `main`, not a release.
- `finalize` deliberately does not depend on these jobs, so an image failure
  cannot make a complete release look unfinished.

## Not covered

`moqx-interop-client` is also published by `ci-main` and gets no release tag
either. Left out to keep this narrow.

## Verifying

Cannot be exercised locally — it needs a GHCR push. The next release is the test:
`release image (amd64)` and `(arm64)` should log `==> version stamp OK`, and
`ghcr.io/openmoq/moqx:vX.Y.Z` should then pull and report `vX.Y.Z`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/637)
<!-- Reviewable:end -->
