### PR TITLE
relay: fix reentrant wake-while-iterating in pending rendezvous tree

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -3165,18 +3165,24 @@ void MoqxRelay::erasePendingRendezvousFromNode(
   }
 }
 
-// Signals every waiter in this subtree (namespace-level publish/publishNamespace)
-// and clears it out, since all of it is now resolved.
-void MoqxRelay::wakePendingRendezvousSubtree(PendingRendezvousNode& node) {
+// Removes every waiter in this subtree from the tree (namespace-level
+// publish/publishNamespace) into `out`, since all of it is now resolved.
+// Does NOT signal: see collectPendingRendezvousSubtree's declaration comment.
+void MoqxRelay::collectPendingRendezvousSubtree(
+    PendingRendezvousNode& node,
+    PendingRendezvousNode::WaiterList& out
+) {
   for (auto& [_, trackWaiters] : node.waitersByTrack) {
-    for (auto& waiter : trackWaiters) {
-      waiter->signal();
-    }
-  }
-  for (auto& [_, child] : node.children) {
-    wakePendingRendezvousSubtree(*child);
+    out.insert(
+        out.end(),
+        std::make_move_iterator(trackWaiters.begin()),
+        std::make_move_iterator(trackWaiters.end())
+    );
   }
   node.waitersByTrack.clear();
+  for (auto& [_, child] : node.children) {
+    collectPendingRendezvousSubtree(*child, out);
+  }
   node.children.clear();
 }
 
@@ -3213,23 +3219,34 @@ void MoqxRelay::applyFnAtNamespaceNode(
 // Wakes only waiters for this exact track (a PUBLISH landed). Waiters for
 // other tracks under the same namespace node are left parked.
 void MoqxRelay::wakePendingRendezvousForTrack(const FullTrackName& ftn) {
-  applyFnAtNamespaceNode(ftn.trackNamespace, [&ftn](PendingRendezvousNode& node) {
+  PendingRendezvousNode::WaiterList toWake;
+  applyFnAtNamespaceNode(ftn.trackNamespace, [&](PendingRendezvousNode& node) {
     auto waitersIt = node.waitersByTrack.find(ftn.trackName);
     if (waitersIt != node.waitersByTrack.end()) {
-      for (auto& waiter : waitersIt->second) {
-        waiter->signal();
-      }
+      toWake = std::move(waitersIt->second);
       node.waitersByTrack.erase(waitersIt);
     }
   });
+  // Signal only once the tree walk/prune above is fully done: TimedBaton::signal()
+  // may resume the parked coroutine synchronously, re-entering erasePendingRendezvous()
+  // which must not observe (or corrupt) a container we were still iterating/mutating.
+  for (auto& waiter : toWake) {
+    waiter->signal();
+  }
 }
 
 // Wakes every waiter under this namespace (a PUBLISH_NAMESPACE landed) — any
 // track under it may now be resolvable.
 void MoqxRelay::wakePendingRendezvousUnderNamespace(const TrackNamespace& ns) {
-  applyFnAtNamespaceNode(ns, [](PendingRendezvousNode& node) {
-    wakePendingRendezvousSubtree(node);
+  PendingRendezvousNode::WaiterList toWake;
+  applyFnAtNamespaceNode(ns, [&](PendingRendezvousNode& node) {
+    collectPendingRendezvousSubtree(node, toWake);
   });
+  // See the comment in wakePendingRendezvousForTrack: signal strictly after
+  // all tree mutation completes.
+  for (auto& waiter : toWake) {
+    waiter->signal();
+  }
 }
 
 std::optional<std::chrono::milliseconds> MoqxRelay::takeRendezvousTimeout(

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -705,7 +705,15 @@ private:
       size_t namespaceIndex,
       const std::shared_ptr<moxygen::TimedBaton>& waiter
   );
-  static void wakePendingRendezvousSubtree(PendingRendezvousNode& node);
+  // Removes every waiter in this subtree from the tree and appends it to `out`.
+  // Callers must signal the collected waiters only after all tree mutation is
+  // complete: TimedBaton::signal() may resume the parked coroutine
+  // synchronously, which re-enters erasePendingRendezvous() and must not
+  // observe a container we are still iterating/mutating.
+  static void collectPendingRendezvousSubtree(
+      PendingRendezvousNode& node,
+      PendingRendezvousNode::WaiterList& out
+  );
   void applyFnAtNamespaceNode(
       const moxygen::TrackNamespace& ns,
       folly::FunctionRef<void(PendingRendezvousNode&)> onNode

--- a/test/MoqxRelayRendezvousTests.cpp
+++ b/test/MoqxRelayRendezvousTests.cpp
@@ -564,6 +564,88 @@ TEST_P(MoqxRelayRendezvousTest, SubscribeRoutesPastSubscribeNamespaceCreatedNode
   driveIfMultiThread();
 }
 
+// Regression test: two waiters parked on the *same* track must both be woken
+// by a single PUBLISH. wakePendingRendezvousForTrack signals every entry in
+// waitersByTrack[track] in one pass — a reentrant erase from a prior signal()
+// call corrupting that same vector mid-iteration would drop or crash on the
+// second waiter instead of resolving it.
+TEST_P(MoqxRelayRendezvousTest, MultipleWaitersOnSameTrackAllResolveOnPublish) {
+  auto subSessionA = createV18Session();
+  auto subSessionB = createV18Session();
+  auto consumerA = createMockConsumer();
+  auto consumerB = createMockConsumer();
+
+  auto futureA =
+      startSubscribe(subSessionA, makeRendezvousSubscribeRequest(kTestTrackName, 5000), consumerA);
+  auto futureB =
+      startSubscribe(subSessionB, makeRendezvousSubscribeRequest(kTestTrackName, 5000), consumerB);
+
+  exec_->driveFor(10);
+  ASSERT_FALSE(futureA.isReady()) << "first subscribe should be parked";
+  ASSERT_FALSE(futureB.isReady()) << "second subscribe should be parked on the same track";
+
+  auto pubSession = createMockSession();
+  doPublish(pubSession, kTestTrackName);
+
+  ASSERT_TRUE(driveUntil([&] { return futureA.isReady() && futureB.isReady(); }))
+      << "a single PUBLISH must wake every waiter parked on this track";
+
+  auto resultA = std::move(futureA).value();
+  auto resultB = std::move(futureB).value();
+  ASSERT_TRUE(resultA.hasValue()) << "first waiter should resolve, not be skipped/corrupted";
+  ASSERT_TRUE(resultB.hasValue()) << "second waiter should resolve, not be skipped/corrupted";
+
+  resultA.value()->unsubscribe();
+  resultB.value()->unsubscribe();
+  removeSession(pubSession);
+  removeSession(subSessionA);
+  removeSession(subSessionB);
+  driveIfMultiThread();
+}
+
+// Regression test: two waiters parked on *different* tracks under the same
+// namespace must both be woken by a single PUBLISH_NAMESPACE.
+// collectPendingRendezvousSubtree iterates the node's waitersByTrack map in
+// one pass — a reentrant erase corrupting that map mid-iteration would drop
+// or crash on the second track's waiter instead of resolving it.
+TEST_P(MoqxRelayRendezvousTest, MultipleWaitersUnderNamespaceAllResolveOnPublishNamespace) {
+  auto subSessionA = createV18Session();
+  auto subSessionB = createV18Session();
+  auto consumerA = createMockConsumer();
+  auto consumerB = createMockConsumer();
+
+  FullTrackName ftnA{kTestNamespace, "track1"};
+  FullTrackName ftnB{kTestNamespace, "track2"};
+
+  auto futureA = startSubscribe(subSessionA, makeRendezvousSubscribeRequest(ftnA, 5000), consumerA);
+  auto futureB = startSubscribe(subSessionB, makeRendezvousSubscribeRequest(ftnB, 5000), consumerB);
+
+  exec_->driveFor(10);
+  ASSERT_FALSE(futureA.isReady()) << "first subscribe should be parked";
+  ASSERT_FALSE(futureB.isReady()
+  ) << "second subscribe (different track, same namespace) should be parked";
+
+  auto pubSession = createMockSession();
+  bool sawUpstream = false;
+  expectUpstreamSubscribe(pubSession, sawUpstream);
+  doPublishNamespace(pubSession, kTestNamespace);
+
+  ASSERT_TRUE(driveUntil([&] { return futureA.isReady() && futureB.isReady(); }))
+      << "a single PUBLISH_NAMESPACE must wake every waiter parked under this namespace";
+
+  auto resultA = std::move(futureA).value();
+  auto resultB = std::move(futureB).value();
+  ASSERT_TRUE(resultA.hasValue()) << "first waiter should resolve, not be skipped/corrupted";
+  ASSERT_TRUE(resultB.hasValue()) << "second waiter should resolve, not be skipped/corrupted";
+
+  resultA.value()->unsubscribe();
+  resultB.value()->unsubscribe();
+  removeSession(pubSession);
+  removeSession(subSessionA);
+  removeSession(subSessionB);
+  driveIfMultiThread();
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AllModes,
     MoqxRelayRendezvousTest,


### PR DESCRIPTION
wakePendingRendezvousForTrack/wakePendingRendezvousSubtree called waiter->signal() while iterating waitersByTrack/children. TimedBaton:: signal() can resume the parked coroutine synchronously, re-entering erasePendingRendezvous() and mutating the same container the wake loop is still iterating over.

Split each wake path into two phases: walk/prune the tree and collect every waiter into a local vector (renaming wakePendingRendezvousSubtree to collectPendingRendezvousSubtree to reflect this), then signal the collected waiters only after all tree mutation is complete.

Add regression tests parking two waiters on the same track / on different tracks under the same namespace, asserting both resolve when woken by a single PUBLISH / PUBLISH_NAMESPACE.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/652)
<!-- Reviewable:end -->
