### PR TITLE
relay: release FetchCrossExecFilter's downstream on its target executor

### DIFF
--- a/src/relay/CrossExecFilter.h
+++ b/src/relay/CrossExecFilter.h
@@ -268,6 +268,15 @@ public:
       : CrossExecLifetime<FetchCrossExecFilter>(targetExec, deepCopyPayload),
         downstream_(std::move(downstream)) {}
 
+  // downstream_ is a cache writeback whose dtor mutates cache state, so release
+  // it on targetExec_, not on whichever owner dropped last. targetExec_ must
+  // outlive the filter.
+  ~FetchCrossExecFilter() override {
+    if (downstream_) {
+      targetExec_->add([d = std::move(downstream_)]() {});
+    }
+  }
+
   folly::Expected<folly::Unit, moxygen::MoQPublishError> object(
       uint64_t groupID,
       uint64_t subgroupID,

--- a/test/CrossExecFilterTest.cpp
+++ b/test/CrossExecFilterTest.cpp
@@ -10,6 +10,7 @@
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
 #include <moxygen/test/Mocks.h>
+#include <thread>
 
 using namespace testing;
 using namespace moxygen;
@@ -494,6 +495,41 @@ TEST_F(FetchCrossExecFilterTest, NonTerminalObjectErrorUAFOnQueuedTerminalLambda
   // selfGuard_.reset() → freed. The second object lambda then accesses
   // this->downstream_ on freed memory.
   exec_.drain();
+}
+
+// ~FetchWriteback (MoqxCache.cpp:939) erases from fetchesInProgress, unpins the
+// group and touches the LRU, so it has to be released on the executor that owns
+// the cache. selfGuard_ does not give that: the filter has a second, independent
+// owner in the upstream session's fetch state (MoQSession.cpp:2334), dropped on
+// the session's io thread with no ordering against deactivate(). Whichever drop
+// is last runs ~FetchCrossExecFilter, and downstream_ is released there.
+TEST(FetchCrossExecFilterLifetimeTest, DownstreamReleasedOnTargetExecutor) {
+  folly::ManualExecutor relayExec;
+  std::thread::id releaseThread;
+
+  auto downstream = std::shared_ptr<NiceMock<MockFetchConsumer>>(
+      new NiceMock<MockFetchConsumer>(),
+      [&releaseThread](NiceMock<MockFetchConsumer>* p) {
+        releaseThread = std::this_thread::get_id();
+        delete p;
+      }
+  );
+
+  auto filter = FetchCrossExecFilter::create(&relayExec, downstream);
+  auto sessionRef = filter; // the ref MoQSession keeps in its fetch state
+  filter.reset();
+  downstream.reset(); // filter->downstream_ is now the only owner
+
+  // Terminal call: its lambda runs on relayExec and releases selfGuard_,
+  // leaving the session holding the last ref.
+  sessionRef->reset(ResetStreamErrorCode::CANCELLED);
+  relayExec.drain();
+
+  std::thread sessionThread([&sessionRef] { sessionRef.reset(); });
+  sessionThread.join();
+  relayExec.drain();
+
+  EXPECT_EQ(releaseThread, std::this_thread::get_id());
 }
 
 } // namespace

--- a/test/PublisherCrossExecFilterTest.cpp
+++ b/test/PublisherCrossExecFilterTest.cpp
@@ -144,6 +144,11 @@ TEST_F(PublisherCrossExecFilterTest, FetchErrorDoesNotCallEndOfFetch) {
 }
 
 TEST_F(PublisherCrossExecFilterTest, FetchReturnsSuccess) {
+  // Schedule on the EventBase so callerExec captured inside fetch() is the
+  // EventBase (not blockingWait's internal ManualExecutor, which dies on return).
+  // This keeps targetExec_ alive for the post-blockingWait endOfFetch drain.
+  // Declared first so it outlives capturedConsumer, whose dtor posts to it.
+  folly::EventBase evb;
   FetchOk ok;
   ok.requestID = RequestID(4);
   auto handle = std::make_shared<NiceMock<MockFetchHandle>>(ok);
@@ -157,10 +162,6 @@ TEST_F(PublisherCrossExecFilterTest, FetchReturnsSuccess) {
           }
       );
 
-  // Schedule on the EventBase so callerExec captured inside fetch() is the
-  // EventBase (not blockingWait's internal ManualExecutor, which dies on return).
-  // This keeps targetExec_ alive for the post-blockingWait endOfFetch drain.
-  folly::EventBase evb;
   auto fetchCallback = std::make_shared<NiceMock<MockFetchConsumer>>();
   EXPECT_CALL(*fetchCallback, endOfFetch()).WillOnce([]() {
     return folly::Expected<folly::Unit, MoQPublishError>(folly::unit);


### PR DESCRIPTION
selfGuard_ decides when the filter dies but not where: the upstream session holds a second ref and drops it on its io thread with no ordering against deactivate(). Whichever drop lands last destroys the filter, so downstream_ -- a cache writeback whose dtor erases from fetchesInProgress, unpins the group and touches the LRU -- could be released off the cache's executor.

Only downstream_ has that affinity, so the destructor posts just its release to targetExec_ rather than deferring the whole object, as CrossExecFetchHandle already does with inner_. That requires targetExec_ to outlive the filter, which FetchReturnsSuccess violated by declaring its EventBase after the consumer; the declarations are reordered.

Fixes: #650


Claude-Session: https://claude.ai/code/session_01SdGFiDXgY1jWNQrDe9rabi

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/653)
<!-- Reviewable:end -->
