### PR TITLE
relay: defer CrossExecFilter destruction to its target executor

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -658,7 +658,7 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
   // crossExecFilter is a channel subscriber for the relay exec
   // registerPublishOnRelayExec completes wiring the chain (topNFilter → terminationFilter →
   // cache).
-  auto crossExecFilter = std::make_shared<CrossExecFilter>(relayExec_, nullptr);
+  auto crossExecFilter = CrossExecFilter::create(relayExec_, nullptr);
   // forward=true + passive=true: internal relay chain observes all objects but
   // does not count as a real forwarding subscriber.
   localPubFwd
@@ -1298,7 +1298,7 @@ folly::coro::Task<void> MoqxRelay::addSubscriberAndPublishViaLocalForwarder(
   localFwd->setCallback(pendingCb);
   // deepCopyPayload=true (default): each subscriber thread owns its IOBuf chain,
   // avoiding cross-thread contention on the shared atomic refcount.
-  auto crossExecFilter = std::make_shared<CrossExecFilter>(subscriberExec, localFwd);
+  auto crossExecFilter = CrossExecFilter::create(subscriberExec, localFwd);
   bool hasForwardingSub = (localFwd->numForwardingSubscribers() > 0);
 
   // Wire localFwd in as a channel subscriber on the publisher's exec
@@ -2120,7 +2120,7 @@ folly::coro::Task<MoqxRelay::PublisherAttachment> MoqxRelay::attachNewLocalForwa
           // Passive relay chain (top-N/termination/cache): forward=true so it observes every
           // object, passive=true so it doesn't count as a forwarding subscriber or in the
           // onEmpty quorum (the publisher's onEmpty still fires when the last real sub leaves).
-          relayChainFilter = std::make_shared<CrossExecFilter>(relayExec_, nullptr);
+          relayChainFilter = CrossExecFilter::create(relayExec_, nullptr);
           publisherFwd->addChannelSubscriber(
               relayExec_,
               /*forward=*/true,
@@ -2314,7 +2314,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoqxRelay::subscribeFromSubscriber
 
   // deepCopyPayload=true (default): each subscriber thread owns its IOBuf chain,
   // avoiding cross-thread contention on the shared atomic refcount.
-  auto crossExecFilter = std::make_shared<CrossExecFilter>(subscriberExec, localFwd);
+  auto crossExecFilter = CrossExecFilter::create(subscriberExec, localFwd);
 
   // addSubscriber before the relay hop: numForwardingSubscribers() must be correct
   // when addChannelSubscriber runs on publisherExec, so forward flag is right from the start.

--- a/src/relay/CrossExecFilter.cpp
+++ b/src/relay/CrossExecFilter.cpp
@@ -202,6 +202,17 @@ CrossExecSubgroupFilter::awaitReadyToConsume() {
 
 // ---- CrossExecFilter ----
 
+std::shared_ptr<CrossExecFilter> CrossExecFilter::create(
+    folly::Executor* targetExec,
+    std::shared_ptr<moxygen::TrackConsumer> inner,
+    bool deepCopyPayload
+) {
+  return std::shared_ptr<CrossExecFilter>(
+      new CrossExecFilter(PrivateTag{}, targetExec, std::move(inner), deepCopyPayload),
+      [](CrossExecFilter* self) { self->targetExec_->add([self]() { delete self; }); }
+  );
+}
+
 folly::Expected<folly::Unit, moxygen::MoQPublishError>
 CrossExecFilter::setTrackAlias(moxygen::TrackAlias alias) {
   if (auto err = loadDeferredError()) {

--- a/src/relay/CrossExecFilter.h
+++ b/src/relay/CrossExecFilter.h
@@ -185,14 +185,27 @@ private:
 // For deferred use (e.g. publish()): construct with inner=nullptr, then call
 // setDownstream() on targetExec_ before any data methods are enqueued. FIFO
 // ordering guarantees setDownstream() runs before those lambdas execute.
+//
+// Lifetime: the last ref may drop on any executor, so create() installs a
+// deleter that posts the delete to targetExec_, behind the [this] lambdas
+// already queued.
 class CrossExecFilter final : public moxygen::TrackConsumerFilter,
                               public std::enable_shared_from_this<CrossExecFilter>,
                               public CrossExecBase {
+  struct PrivateTag {};
+
 public:
-  CrossExecFilter(
+  static std::shared_ptr<CrossExecFilter> create(
       folly::Executor* targetExec,
       std::shared_ptr<moxygen::TrackConsumer> inner,
       bool deepCopyPayload = true
+  );
+
+  CrossExecFilter(
+      PrivateTag,
+      folly::Executor* targetExec,
+      std::shared_ptr<moxygen::TrackConsumer> inner,
+      bool deepCopyPayload
   )
       : moxygen::TrackConsumerFilter(std::move(inner)), CrossExecBase(targetExec, deepCopyPayload) {
   }

--- a/src/relay/PublisherCrossExecFilter.cpp
+++ b/src/relay/PublisherCrossExecFilter.cpp
@@ -232,7 +232,7 @@ folly::coro::Task<moxygen::Publisher::SubscribeResult> PublisherCrossExecFilter:
 ) {
   auto callerExec = co_await folly::coro::co_current_executor;
   auto wrappedConsumer =
-      std::make_shared<CrossExecFilter>(callerExec, std::move(callback), /*deepCopyPayload=*/false);
+      CrossExecFilter::create(callerExec, std::move(callback), /*deepCopyPayload=*/false);
   auto result = co_await folly::coro::co_withExecutor(
       folly::getKeepAliveToken(targetExec_),
       inner_->subscribe(std::move(sub), std::move(wrappedConsumer))

--- a/src/relay/RelayExecUtil.h
+++ b/src/relay/RelayExecUtil.h
@@ -21,7 +21,7 @@ maybeCrossExec(folly::Executor* exec, std::shared_ptr<moxygen::TrackConsumer> c)
   if (!exec) {
     return c;
   }
-  return std::make_shared<CrossExecFilter>(exec, std::move(c), /*deepCopyPayload=*/false);
+  return CrossExecFilter::create(exec, std::move(c), /*deepCopyPayload=*/false);
 }
 
 // Wraps c in a FetchCrossExecFilter targeting exec, or returns c if exec is null.

--- a/src/relay/SubscriberCrossExecFilter.cpp
+++ b/src/relay/SubscriberCrossExecFilter.cpp
@@ -98,7 +98,7 @@ moxygen::Subscriber::PublishResult SubscriberCrossExecFilter::publish(
     moxygen::PublishRequest pub,
     std::shared_ptr<moxygen::SubscriptionHandle> handle
 ) {
-  auto filter = std::make_shared<CrossExecFilter>(targetExec_, nullptr);
+  auto filter = CrossExecFilter::create(targetExec_, nullptr);
   // co_invoke captures exec and inner by value here (while `this` is live),
   // so the task's coroutine frame owns them and doesn't need `this` to survive.
   auto reply = folly::coro::co_invoke(

--- a/test/CrossExecFilterTest.cpp
+++ b/test/CrossExecFilterTest.cpp
@@ -9,6 +9,7 @@
 #include <folly/executors/ManualExecutor.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
+#include <moxygen/relay/MoQForwarder.h>
 #include <moxygen/test/Mocks.h>
 #include <thread>
 
@@ -57,7 +58,7 @@ protected:
     ON_CALL(*innerSubgroup_, endOfSubgroup())
         .WillByDefault(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
 
-    filter_ = std::make_shared<CrossExecFilter>(&exec_, innerTrack_);
+    filter_ = CrossExecFilter::create(&exec_, innerTrack_);
   }
 
   folly::ManualExecutor exec_;
@@ -530,6 +531,67 @@ TEST(FetchCrossExecFilterLifetimeTest, DownstreamReleasedOnTargetExecutor) {
   relayExec.drain();
 
   EXPECT_EQ(releaseThread, std::this_thread::get_id());
+}
+
+// ---- CrossExecFilter lifetime ----
+
+// UAF regression tests: unlike its siblings, CrossExecFilter has no selfGuard_,
+// so the owner's ref is all that keeps it alive — and the owner may drop it from
+// an executor other than targetExec_, which the FIFO deferred-release protocol
+// does not cover. MoQForwarder::removeSubscriberOnError() does exactly that to
+// the relay-chain filter (MoqxRelay.cpp:2034) while a beginSubgroup lambda is
+// still queued, leaving CrossExecFilter.cpp:239 reading freed memory.
+// Times(1) states the contract a fix must keep: a call accepted before the last
+// ref dropped still reaches the inner consumer. Run under ASan to catch the UAF.
+TEST_F(CrossExecFilterTest, FilterDestroyedWithQueuedBeginSubgroupUAF) {
+  auto r = filter_->beginSubgroup(1, 0, 128, {});
+  ASSERT_TRUE(r.hasValue());
+  auto subFilter = std::move(r.value()); // move out so r holds null — no extra ref
+
+  // The owner drops its ref from another executor; nothing defers the
+  // destruction to exec_, so the queued lambda is left with a dangling `this`.
+  filter_.reset();
+
+  EXPECT_CALL(*innerTrack_, beginSubgroup(1, 0, 128, _)).Times(1);
+  subFilter->reset(ResetStreamErrorCode::CANCELLED); // required terminal call
+  exec_.drain();
+}
+
+TEST_F(CrossExecFilterTest, FilterDestroyedWithQueuedObjectStreamUAF) {
+  auto hdr = makeHeader(2, 0, 5);
+  auto result = filter_->objectStream(hdr, nullptr, false);
+  EXPECT_TRUE(result.hasValue());
+
+  filter_.reset();
+
+  EXPECT_CALL(*innerTrack_, objectStream(hdr, _, false)).Times(1);
+  exec_.drain();
+}
+
+// The same defect driven entirely through the real MoQForwarder API, no manual
+// reset(): removeChannelSubscriberByExec defaults pubDone to std::nullopt, so
+// removeSubscriberIt skips the publishDone that would have anchored the filter
+// via shared_from_this() and erases the subscriber map entry — dropping the
+// forwarder's only ref inline, on the publisher's executor, while the
+// beginSubgroup lambda is still queued on the filter's target executor.
+TEST(CrossExecFilterForwarderTest, ChannelSubscriberRemovedWithQueuedBeginSubgroupUAF) {
+  folly::ManualExecutor exec;
+  auto inner = std::make_shared<NiceMock<MockTrackConsumer>>();
+  auto innerSubgroup = std::make_shared<NiceMock<MockSubgroupConsumer>>();
+  ON_CALL(*inner, beginSubgroup(_, _, _, _))
+      .WillByDefault(Return(
+          folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(innerSubgroup)
+      ));
+
+  auto fwd = std::make_shared<MoQForwarder>(FullTrackName{TrackNamespace{{"ns"}}, "track"});
+  fwd->addChannelSubscriber(&exec, /*forward=*/true, CrossExecFilter::create(&exec, inner));
+
+  auto sub = fwd->beginSubgroup(1, 0, 128, {});
+  ASSERT_TRUE(sub.hasValue());
+
+  fwd->removeChannelSubscriberByExec(&exec);
+
+  exec.drain();
 }
 
 } // namespace

--- a/test/MoqxRelaySubscribeTests.cpp
+++ b/test/MoqxRelaySubscribeTests.cpp
@@ -413,9 +413,9 @@ TEST_P(MoQRelayTest, UpstreamSubscribeThrowDoesNotStrandGate) {
     GTEST_SKIP() << "only LF has a per-thread registry to strand";
   }
 
-  folly::ScopedEventBaseThread pubThread("pub-iothread");
-  auto* pubEvb = pubThread.getEventBase();
-  auto pubExec = std::make_shared<MoQFollyExecutorImpl>(pubEvb);
+  auto& pubAux = makeAuxExec("pub-iothread");
+  auto* pubEvb = pubAux.evb;
+  auto pubExec = pubAux.exec;
 
   auto makeSessionOnPubThread = [&] {
     auto session = std::make_shared<NiceMock<MockMoQSession>>(pubExec);
@@ -513,8 +513,8 @@ TEST_P(MoQRelayTest, CrossThreadSubsequentSubscriberSeedingRace) {
   auto subSession1 = createMockSession();      // first subscriber on exec_
 
   // Second subscriber on a dedicated OS thread => distinct thread-local tlForwarders_.
-  folly::ScopedEventBaseThread subThread("sub2-thread");
-  auto subExec = std::make_shared<MoQFollyExecutorImpl>(subThread.getEventBase());
+  auto& subAux = makeAuxExec("sub2-thread");
+  auto subExec = subAux.exec;
   auto subSession2 = std::make_shared<NiceMock<MockMoQSession>>(subExec);
   ON_CALL(*subSession2, getNegotiatedVersion())
       .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));
@@ -548,7 +548,7 @@ TEST_P(MoQRelayTest, CrossThreadSubsequentSubscriberSeedingRace) {
   auto pumpExec = [&](auto pred) {
     for (int i = 0; i < 2000 && !pred(); ++i) {
       exec_->drive();
-      subThread.getEventBase()->runInEventBaseThreadAndWait([] {});
+      subAux.evb->runInEventBaseThreadAndWait([] {});
     }
     return pred();
   };
@@ -616,7 +616,7 @@ TEST_P(MoQRelayTest, CrossThreadSubsequentSubscriberSeedingRace) {
   removeSession(subSession1);
   removeSession(subSession2);
   driveIfMultiThread();
-  subThread.getEventBase()->runInEventBaseThreadAndWait([] {});
+  subAux.evb->runInEventBaseThreadAndWait([] {});
 }
 
 // Regression: a PUBLISH that fans out to a thread where a SUBSCRIBE for the same track is
@@ -631,9 +631,9 @@ TEST_P(MoQRelayTest, PublishFanoutDuringParkedSubscribeSetup) {
 
   // Publisher on its own iothread, so its installPublisherForwarder lands in that thread's
   // registry and leaves the subscriber thread's entry Pending for the fanout to find.
-  folly::ScopedEventBaseThread pubThread("pub-iothread");
-  auto* pubEvb = pubThread.getEventBase();
-  auto pubExec = std::make_shared<MoQFollyExecutorImpl>(pubEvb);
+  auto& pubAux = makeAuxExec("pub-iothread");
+  auto* pubEvb = pubAux.evb;
+  auto pubExec = pubAux.exec;
   auto publisherSession = std::make_shared<NiceMock<MockMoQSession>>(pubExec);
   ON_CALL(*publisherSession, getNegotiatedVersion())
       .WillByDefault(Return(std::optional<uint64_t>(kVersionDraftCurrent)));

--- a/test/MoqxRelayTestFixture.cpp
+++ b/test/MoqxRelayTestFixture.cpp
@@ -81,18 +81,42 @@ void MoQRelayTest::resetRelay(
   }
 }
 
-void MoQRelayTest::TearDown() {
-  // Drain any pending relay exec tasks (e.g., async publishNamespaceDone dispatches
-  // from cleanup) before destroying relay state to avoid use-after-free on NamespaceTree.
-  if (relayEvb_) {
-    relayEvb_->runInEventBaseThreadAndWait([]() {});
-    relayEvb_->runInEventBaseThreadAndWait([]() {});
+MoQRelayTest::AuxExec& MoQRelayTest::makeAuxExec(const std::string& threadName) {
+  auto aux = std::make_unique<AuxExec>();
+  aux->thread = std::make_unique<folly::ScopedEventBaseThread>(threadName);
+  aux->evb = aux->thread->getEventBase();
+  aux->exec = std::make_shared<moxygen::MoQFollyExecutorImpl>(aux->evb);
+  auxExecs_.push_back(std::move(aux));
+  return *auxExecs_.back();
+}
+
+void MoQRelayTest::drainExecs(int rounds) {
+  for (int i = 0; i < rounds; ++i) {
+    for (auto& aux : auxExecs_) {
+      aux->evb->runInEventBaseThreadAndWait([]() {});
+    }
+    if (relayEvb_) {
+      relayEvb_->runInEventBaseThreadAndWait([]() {});
+    }
+    if (exec_) {
+      exec_->drive();
+    }
   }
+}
+
+void MoQRelayTest::TearDown() {
+  // CrossExecFilter posts `delete this` to targetExec_, so an exec must outlive
+  // the filters aimed at it. Drain before freeing relay state, and again after
+  // the last release; ~fixture frees auxExecs_ then exec_ after that.
+  drainExecs();
+  mockSessions_.clear(); // declared before exec_, so ~fixture frees it too late
   exec_->setRelayEvb(nullptr);
   publisherInterface_.reset();
   subscriberInterface_.reset();
   relay_.reset();
   relayThread_.reset();
+  relayEvb_ = nullptr;
+  drainExecs();
 }
 
 std::shared_ptr<MockMoQSession> MoQRelayTest::createMockSession() {

--- a/test/MoqxRelayTestFixture.h
+++ b/test/MoqxRelayTestFixture.h
@@ -203,6 +203,22 @@ protected:
   void
   resetRelay(config::CacheConfig cache, const std::string& relayID = "", uint64_t relayHopID = 0);
 
+  // An extra OS thread plus the MoQExecutor wrapping it, for a session off exec_.
+  struct AuxExec {
+    std::unique_ptr<folly::ScopedEventBaseThread> thread;
+    std::shared_ptr<moxygen::MoQFollyExecutorImpl> exec;
+    folly::EventBase* evb{nullptr};
+  };
+
+  // Fixture-owned, never a test-body local: CrossExecFilter posts `delete this`
+  // to its target exec, and those filters are released by relayThread_'s
+  // teardown in TearDown(), long after a test body's locals are gone.
+  AuxExec& makeAuxExec(const std::string& threadName);
+
+  // Barrier across exec_, relayEvb_ and the aux execs; mirrors
+  // MoqxRelayContext::drainExecs.
+  void drainExecs(int rounds = 2);
+
   // In MT mode: cross-exec filter wrappers that route test calls through relayExec_.
   // In ST mode: null — accessors fall back to relay_ directly.
   std::shared_ptr<moxygen::Publisher> publisherInterface_;
@@ -219,6 +235,7 @@ protected:
   std::shared_ptr<MoqxRelay> relay_;
   std::unique_ptr<folly::ScopedEventBaseThread> relayThread_;
   folly::EventBase* relayEvb_{nullptr};
+  std::vector<std::unique_ptr<AuxExec>> auxExecs_;
 };
 
 } // namespace openmoq::moqx::test

--- a/test/PublisherCrossExecFilterTest.cpp
+++ b/test/PublisherCrossExecFilterTest.cpp
@@ -13,6 +13,7 @@
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
+#include <folly/synchronization/Baton.h>
 #include <moxygen/test/Mocks.h>
 
 using namespace testing;
@@ -27,6 +28,17 @@ protected:
     targetExec_ = std::make_shared<folly::CPUThreadPoolExecutor>(1);
     inner_ = std::make_shared<NiceMock<MockPublisher>>();
     filter_ = std::make_shared<PublisherCrossExecFilter>(targetExec_.get(), inner_);
+  }
+
+  // See SubscriberCrossExecFilterTest.
+  void TearDown() override {
+    filter_.reset();
+    for (int i = 0; i < 2; ++i) {
+      folly::Baton<> flushed;
+      targetExec_->add([&flushed]() { flushed.post(); });
+      flushed.wait();
+    }
+    targetExec_->join();
   }
 
   std::shared_ptr<folly::CPUThreadPoolExecutor> targetExec_;

--- a/test/SubscriberCrossExecFilterTest.cpp
+++ b/test/SubscriberCrossExecFilterTest.cpp
@@ -11,6 +11,7 @@
 #include <folly/executors/ManualExecutor.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
+#include <folly/synchronization/Baton.h>
 #include <future>
 #include <moxygen/test/Mocks.h>
 
@@ -31,6 +32,19 @@ protected:
     targetExec_ = std::make_shared<folly::CPUThreadPoolExecutor>(1);
     inner_ = std::make_shared<NiceMock<MockSubscriberWithGoaway>>();
     filter_ = std::make_shared<SubscriberCrossExecFilter>(targetExec_.get(), inner_);
+  }
+
+  // CrossExecFilter posts `delete this` to targetExec_, but ~CPUThreadPoolExecutor
+  // abandons the queue and join() only drains what was queued before it. Barrier
+  // until those deletes are posted (one hop of chain, plus slack), then join.
+  void TearDown() override {
+    filter_.reset();
+    for (int i = 0; i < 2; ++i) {
+      folly::Baton<> flushed;
+      targetExec_->add([&flushed]() { flushed.post(); });
+      flushed.wait();
+    }
+    targetExec_->join();
   }
 
   std::shared_ptr<folly::CPUThreadPoolExecutor> targetExec_;


### PR DESCRIPTION
CrossExecFilter's methods enqueue [this]-capturing lambdas on targetExec_, but nothing keeps the filter alive until they run — owners release it from whatever executor they happen to be on. It can be freed with calls still queued, and the lambda then reads downstream_ off freed memory, seen as a SIGSEGV in beginSubgroup on a v0.3.1 relay.

The sibling filters anchor themselves with selfGuard_, but that needs a terminal call and a TrackConsumer has none that is guaranteed. Destruction is guaranteed, so create() installs a deleter that posts the delete to targetExec_ behind every lambda already queued, and PrivateTag makes create() the only way to build one.

```
  auto filter = CrossExecFilter::create(targetExec, downstream);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/654)
<!-- Reviewable:end -->
