### PR TITLE
build: lint and format the repo's Python with ruff

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install clang-format
         run: pip install clang-format==19.1.7
 
+      # format.sh pins the ruff version; uv is what fetches it.
+      - uses: astral-sh/setup-uv@v6
+
       - name: Check formatting
         run: bash scripts/dev/format.sh --check
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install clang-format
         run: pip install clang-format==19.1.7
 
+      # format.sh pins the ruff version; uv is what fetches it.
+      - uses: astral-sh/setup-uv@v6
+
       - name: Check formatting
         run: bash scripts/dev/format.sh --check
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ docker/grafana/provisioning/dashboards/archive/
 # Python bytecode from local tooling.
 __pycache__/
 *.pyc
+.ruff_cache/

--- a/BUILD.md
+++ b/BUILD.md
@@ -185,9 +185,11 @@ of its own, leaving the interceptors undefined at link.
   `cmake --preset` flow, with targets `relay` (default) and `interop-client`. Its
   `moxygen` stage resolves the prefix the same way `prebuilt-with-fallback` does,
   and is keyed on the pin rather than on `src/` so a source change reuses it.
-- **Format / lint** (CI requires clang-format-19) —
-  [`scripts/dev/format.sh`](/scripts/dev/format.sh) `[--check]`,
-  [`scripts/dev/lint.sh`](/scripts/dev/lint.sh) `build/default`.
+- **Format / lint** — [`scripts/dev/format.sh`](/scripts/dev/format.sh)
+  `[--check]` covers C++ (clang-format-19) and Python (ruff, configured in
+  [`ruff.toml`](/ruff.toml)). Both versions are pinned; `uv` fetches the ruff
+  pin. [`scripts/dev/lint.sh`](/scripts/dev/lint.sh) `build/default` is
+  clang-tidy.
 - **CLion** — point its CMake profile at `cmake --preset default`; for from-source,
   run `scripts/configure.sh --moxygen from-source` first, then add
   `-DMOQX_MOXYGEN_PREBUILT=OFF -DCMAKE_PREFIX_PATH=<prefix>` to the profile.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ PR description if preserving history on `main` is warranted.
 
 Before submitting:
 
-1. `clang-format-19 -i` changed C++ files.
+1. `scripts/dev/format.sh` — formats and lints C++ and Python. Needs
+   clang-format 19 and either `uv` or the pinned ruff on PATH.
 2. Build and run tests locally.
 3. Update [docs/config.md](docs/config.md) or [RUNNING.md](RUNNING.md)
    if you changed admin API or runtime config.

--- a/docker/prometheus/namespace-targets.py
+++ b/docker/prometheus/namespace-targets.py
@@ -10,6 +10,7 @@ Namespaces are written in the moq-transport safe form the endpoint expects:
 [A-Za-z0-9_] passes through, every other byte becomes .<hex>, and tuple
 elements are joined with '-'.
 """
+
 import json
 import os
 import sys
@@ -21,16 +22,14 @@ STATE_URL = os.environ.get("MOQX_STATE_URL", "http://moqx:8000/state")
 OUT_PATH = os.environ.get("MOQX_TARGETS_PATH", "/targets/namespaces.json")
 INTERVAL = float(os.environ.get("MOQX_TARGETS_INTERVAL", "30"))
 
-_PASS = set(
-    "abcdefghijklmnopqrstuvwxyz" "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "0123456789" "_"
-)
+_PASS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
 
 def safe_element(element):
     out = []
     for byte in element.encode():
         ch = chr(byte)
-        out.append(ch if ch in _PASS else ".%02x" % byte)
+        out.append(ch if ch in _PASS else f".{byte:02x}")
     return "".join(out)
 
 
@@ -67,9 +66,7 @@ def namespaces():
 
 
 def write(path, entries):
-    payload = [
-        {"targets": [safe_namespace(ns)]} for ns in entries
-    ]
+    payload = [{"targets": [safe_namespace(ns)]} for ns in entries]
     body = json.dumps(payload, indent=2) + "\n"
     if os.path.exists(path) and open(path).read() == body:
         return False
@@ -89,9 +86,11 @@ def main():
         try:
             entries = namespaces()
             if write(OUT_PATH, entries):
-                print("wrote %d namespace target(s)" % len(entries), flush=True)
+                print(f"wrote {len(entries)} namespace target(s)", flush=True)
         except Exception as exc:  # keep polling: the relay restarts
-            print("namespace target refresh failed: %s" % exc, file=sys.stderr, flush=True)
+            print(
+                f"namespace target refresh failed: {exc}", file=sys.stderr, flush=True
+            )
         time.sleep(INTERVAL)
 
 

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -135,7 +135,7 @@ Promotes `snapshot-latest` artifacts to a versioned `vX.Y.Z` release (no rebuild
 
 | Job | Runner | Purpose |
 |-----|--------|---------|
-| check-format | ubuntu-latest (trixie) | clang-format-19 check |
+| check-format | ubuntu-latest (trixie) | clang-format-19 check; ruff lint + format check (via uv) |
 | linux | ubuntu-22.04 | Build + test (prebuilt tarball, from-source fallback) |
 | asan debug | self-hosted (linode) | ASan/UBSan on moqx TUs, build + test |
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+# Lint and format for the repository's Python. scripts/dev/format.sh runs it
+# and pins the version.
+
+# The floor: the oldest interpreter a contributor already has is the macOS
+# Command Line Tools' 3.9.6.
+target-version = "py39"
+
+# Third-party trees that land in the checkout as symlinks.
+extend-exclude = ["deps", "gh-pages", "build", ".scratch"]
+
+[lint]
+# Spelled out rather than extended from ruff's default, which is large and
+# moves between releases. E4/E7/E9 + F is that default's core; I sorts imports,
+# B is bugbear, UP is pyupgrade held to target-version above.
+select = ["E4", "E7", "E9", "F", "I", "B", "UP"]

--- a/scripts/dev/format.sh
+++ b/scripts/dev/format.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
+# format.sh — format (or --check) the repository's C++ and Python.
+#
+# Both formatters are version-pinned: releases disagree, and an unpinned one
+# reformats the tree back and forth.
 set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 REQUIRED_CF_VERSION=19
+REQUIRED_RUFF_VERSION=0.16.4
 
 CF_BIN=${CF_BIN:-$(command -v clang-format-${REQUIRED_CF_VERSION} || command -v clang-format)}
 CF_VERSION=$(${CF_BIN} --version | sed -n 's/.*version \([0-9]*\)\..*/\1/p' | head -1)
@@ -15,6 +21,24 @@ if [[ "${CF_VERSION}" -ne "${REQUIRED_CF_VERSION}" ]]; then
   echo "  Debian/Ubuntu:  apt install clang-format-${REQUIRED_CF_VERSION}  (or https://apt.llvm.org)" >&2
   echo "  macOS:          brew install llvm@${REQUIRED_CF_VERSION}" >&2
   echo "  CentOS/RHEL:    yum install clang-tools-extra-${REQUIRED_CF_VERSION}.0  (EPEL/AppStream)" >&2
+  exit 1
+fi
+
+# uv fetches the pinned ruff on any platform, with no venv and no system
+# package. An exact-version ruff on PATH is taken as-is.
+if [[ -n "${RUFF_BIN:-}" ]]; then
+  RUFF=("${RUFF_BIN}")
+elif [[ "$(ruff --version 2>/dev/null | awk '{print $2}')" == "${REQUIRED_RUFF_VERSION}" ]]; then
+  RUFF=(ruff)
+elif command -v uv >/dev/null 2>&1; then
+  RUFF=(uv tool run "ruff@${REQUIRED_RUFF_VERSION}")
+else
+  echo "error: ruff ${REQUIRED_RUFF_VERSION} required, and no uv to fetch it" >&2
+  echo "Install uv (it then pins ruff itself):" >&2
+  echo "  any platform:   curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+  echo "  macOS:          brew install uv" >&2
+  echo "Or install ruff ${REQUIRED_RUFF_VERSION} directly and put it on PATH:" >&2
+  echo "  pipx install ruff==${REQUIRED_RUFF_VERSION}" >&2
   exit 1
 fi
 
@@ -45,10 +69,15 @@ if [[ "${1:-}" == "--check" ]]; then
   cf_exit=0
   ${CF_BIN} --dry-run -Werror ${FILES} || cf_exit=$?
 
+  echo "Checking Python formatting and lint..."
+  ruff_exit=0
+  "${RUFF[@]}" format --check . || ruff_exit=$?
+  "${RUFF[@]}" check . || ruff_exit=$?
+
   if [[ $header_errors -ne 0 ]]; then
     echo "error: files missing copyright headers (run scripts/dev/format.sh to fix)" >&2
   fi
-  if [[ $header_errors -ne 0 || $cf_exit -ne 0 ]]; then
+  if [[ $header_errors -ne 0 || $cf_exit -ne 0 || $ruff_exit -ne 0 ]]; then
     exit 1
   fi
 else
@@ -61,4 +90,9 @@ else
 
   echo "Formatting files..."
   ${CF_BIN} -i ${FILES}
+
+  # --fix is the safe fixes only; whatever is left exits non-zero for a human.
+  echo "Formatting and linting Python..."
+  "${RUFF[@]}" format .
+  "${RUFF[@]}" check --fix .
 fi

--- a/scripts/perf/perf-compare.py
+++ b/scripts/perf/perf-compare.py
@@ -16,7 +16,6 @@ import os
 import sys
 from pathlib import Path
 
-
 # Metrics to track with display configuration.
 # (key, display_name, unit, higher_is_better, threshold_pct)
 TRACKED_METRICS = [
@@ -99,7 +98,9 @@ def compute_baseline(historical: list[dict]) -> dict:
     return baseline
 
 
-def compare_results(current: dict, baseline: dict, threshold_override: float = None) -> list[dict]:
+def compare_results(
+    current: dict, baseline: dict, threshold_override: float = None
+) -> list[dict]:
     """Compare current results against baseline, flagging regressions."""
     comparisons = []
     results = current.get("results", {})
@@ -109,20 +110,24 @@ def compare_results(current: dict, baseline: dict, threshold_override: float = N
         baseline_val = baseline.get(key)
 
         if current_val is None or baseline_val is None or baseline_val == 0:
-            comparisons.append({
-                "key": key,
-                "name": display_name,
-                "unit": unit,
-                "current": current_val,
-                "baseline": baseline_val,
-                "delta_pct": None,
-                "status": "no-data",
-            })
+            comparisons.append(
+                {
+                    "key": key,
+                    "name": display_name,
+                    "unit": unit,
+                    "current": current_val,
+                    "baseline": baseline_val,
+                    "delta_pct": None,
+                    "status": "no-data",
+                }
+            )
             continue
 
         current_val = float(current_val)
         baseline_val = float(baseline_val)
-        threshold = threshold_override if threshold_override is not None else default_threshold
+        threshold = (
+            threshold_override if threshold_override is not None else default_threshold
+        )
 
         delta_pct = ((current_val - baseline_val) / baseline_val) * 100
 
@@ -134,15 +139,17 @@ def compare_results(current: dict, baseline: dict, threshold_override: float = N
 
         status = "regression" if is_regression else "ok"
 
-        comparisons.append({
-            "key": key,
-            "name": display_name,
-            "unit": unit,
-            "current": current_val,
-            "baseline": baseline_val,
-            "delta_pct": delta_pct,
-            "status": status,
-        })
+        comparisons.append(
+            {
+                "key": key,
+                "name": display_name,
+                "unit": unit,
+                "current": current_val,
+                "baseline": baseline_val,
+                "delta_pct": delta_pct,
+                "status": status,
+            }
+        )
 
     return comparisons
 
@@ -169,12 +176,13 @@ def format_delta(delta_pct, status: str) -> str:
     return f"{sign}{delta_pct:.1f}%{indicator}"
 
 
-def generate_markdown(current: dict, comparisons: list[dict], window: int, baseline_count: int) -> str:
+def generate_markdown(
+    current: dict, comparisons: list[dict], window: int, baseline_count: int
+) -> str:
     """Generate markdown summary for PR comment."""
     lines = []
 
     commit_short = current.get("commit_short", current.get("commit", "")[:7])
-    branch = current.get("branch", "unknown")
 
     has_regressions = any(c["status"] == "regression" for c in comparisons)
     has_baseline = baseline_count > 0
@@ -187,7 +195,9 @@ def generate_markdown(current: dict, comparisons: list[dict], window: int, basel
     lines.append("")
 
     if has_baseline:
-        lines.append(f"Comparing `{commit_short}` against rolling {baseline_count}-run average on `main`.")
+        lines.append(
+            f"Comparing `{commit_short}` against rolling {baseline_count}-run average on `main`."
+        )
     else:
         lines.append(f"Results for `{commit_short}` (no baseline data available yet).")
 
@@ -207,7 +217,9 @@ def generate_markdown(current: dict, comparisons: list[dict], window: int, basel
         if comp["baseline"] is not None and comp["unit"]:
             baseline_str += f" {comp['unit']}"
         delta_str = format_delta(comp["delta_pct"], comp["status"])
-        lines.append(f"| {comp['name']} | {current_str} | {baseline_str} | {delta_str} |")
+        lines.append(
+            f"| {comp['name']} | {current_str} | {baseline_str} | {delta_str} |"
+        )
 
     lines.append("")
 
@@ -217,7 +229,9 @@ def generate_markdown(current: dict, comparisons: list[dict], window: int, basel
     lines.append("<details><summary>Test parameters & full results</summary>")
     lines.append("")
     lines.append(f"- **Result:** {test_result}")
-    lines.append(f"- **Subscribers:** {params.get('subscriber_max', '?')} (ramp {params.get('ramp', '?')}/s)")
+    lines.append(
+        f"- **Subscribers:** {params.get('subscriber_max', '?')} (ramp {params.get('ramp', '?')}/s)"
+    )
     lines.append(f"- **Duration:** {params.get('duration', '?')}s")
     lines.append(f"- **IO threads:** {params.get('io_threads', '?')}")
     lines.append(f"- **Client threads:** {params.get('client_threads', '?')}")
@@ -229,20 +243,34 @@ def generate_markdown(current: dict, comparisons: list[dict], window: int, basel
 
     if has_regressions:
         regressed = [c["name"] for c in comparisons if c["status"] == "regression"]
-        lines.append(f":warning: **Potential regressions detected** in: {', '.join(regressed)}")
+        lines.append(
+            f":warning: **Potential regressions detected** in: {', '.join(regressed)}"
+        )
         lines.append("")
 
     return "\n".join(lines)
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Compare perf results against baseline")
+    parser = argparse.ArgumentParser(
+        description="Compare perf results against baseline"
+    )
     parser.add_argument("--current", required=True, help="Path to current results JSON")
-    parser.add_argument("--data-dir", required=True, help="Path to historical data directory")
-    parser.add_argument("--window", type=int, default=10, help="Rolling window size (default: 10)")
-    parser.add_argument("--threshold", type=float, default=None,
-                        help="Override regression threshold %% (default: per-metric)")
-    parser.add_argument("--output", default=None, help="Output markdown file (default: stdout)")
+    parser.add_argument(
+        "--data-dir", required=True, help="Path to historical data directory"
+    )
+    parser.add_argument(
+        "--window", type=int, default=10, help="Rolling window size (default: 10)"
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help="Override regression threshold %% (default: per-metric)",
+    )
+    parser.add_argument(
+        "--output", default=None, help="Output markdown file (default: stdout)"
+    )
     parser.add_argument("--output-json", default=None, help="Output comparison as JSON")
     args = parser.parse_args()
 

--- a/tools/moq_decode.py
+++ b/tools/moq_decode.py
@@ -428,7 +428,9 @@ def p_params(cursor, annot, draft, count, param_keys, setup=False):
                 f"Unknown parameter key {abs_key} in v{draft} (delta={raw_key})", s
             )
 
-        if not setup and abs_key == 9:  # LARGEST_OBJECT: length-prefixed AbsoluteLocation
+        if (
+            not setup and abs_key == 9
+        ):  # LARGEST_OBJECT: length-prefixed AbsoluteLocation
             vlen, vs = cursor.read_varint()
             annot.add(vs, cursor.pos, f"param[{i}].length", str(vlen))
             p_location(cursor, annot, f"param[{i}].largest_object")
@@ -461,8 +463,9 @@ def p_params(cursor, annot, draft, count, param_keys, setup=False):
             )
 
 
-def p_options(cursor, annot, payload_end, names, prefix="ext",
-              key_field="type", immutable=True):
+def p_options(
+    cursor, annot, payload_end, names, prefix="ext", key_field="type", immutable=True
+):
     """Delta-encoded key/value options that span the message length with NO
     count field. Draft-17+ SETUP options and object / Track-Property extensions
     share this exact grammar (MoQFramer.cpp writeSetup / parseExtensionKvPairs):
@@ -498,8 +501,13 @@ def p_options(cursor, annot, payload_end, names, prefix="ext",
                 f"╭─ immutable block start  ({vlen} bytes, [{block_start:04x}..{block_end:04x}))",
             )
             p_options(
-                cursor, annot, block_end, names,
-                f"{prefix}[{i}].imm", key_field, immutable=False,
+                cursor,
+                annot,
+                block_end,
+                names,
+                f"{prefix}[{i}].imm",
+                key_field,
+                immutable=False,
             )
             annot.add(
                 block_end, block_end, f"{prefix}[{i}].imm", "╰─ immutable block end"
@@ -1070,7 +1078,7 @@ def main():
         if parser:
             parser(cursor, annot, draft, payload_end)
         else:
-            raw = cursor.read_bytes(frame_len)
+            cursor.read_bytes(frame_len)
             annot.add(
                 payload_start,
                 cursor.pos,


### PR DESCRIPTION
Nothing formats or lints the Python in tools/, scripts/perf/ and docker/ — check-format covers C++ only. ruff.toml configures it, with target-version py39 so pyupgrade holds to the oldest interpreter contributors already have, and an explicit rule list so a ruff upgrade cannot switch on rules nobody chose.

scripts/dev/format.sh now runs ruff beside clang-format and pins its version the same way; uv fetches the pin, and check-format installs uv. Reformats the three existing scripts and fixes what the lint found: two unused locals, three percent-format strings and an unsorted import block.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/655)
<!-- Reviewable:end -->
