### PR TITLE
ci: prune superseded build caches, and report ccache statistics

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -97,6 +97,9 @@ runs:
         echo "MOQX_DEPS_CACHE=$HOME/.cache/moqx" >> "$GITHUB_ENV"
         # Pin ccache's dir to the cached path; its own default is platform-dependent.
         echo "CCACHE_DIR=$HOME/.cache/ccache" >> "$GITHUB_ENV"
+        # Zero the counters so the stats printed after each build describe this
+        # run rather than the accumulated history of the restored cache.
+        CCACHE_DIR="$HOME/.cache/ccache" ccache -z >/dev/null 2>&1 || true
         # Hash compiler contents, not mtime: apt and Homebrew replace compilers
         # under these runners, and a same-mtime swap would serve stale objects.
         echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -106,6 +106,11 @@ jobs:
 
       # test.sh, not raw ctest: it resolves the --parallel the suite needs (the
       # shell integration tests carry unique ports so they can share a run).
+      # Hit rate is the only way to tell a warm cache from a restored one.
+      - name: ccache stats
+        if: always()
+        run: ccache -s
+
       - name: Test
         env:
           ASAN_OPTIONS: ${{ matrix.leak_check && 'detect_leaks=1:abort_on_error=1' || '' }}
@@ -182,6 +187,11 @@ jobs:
         run: |
           scripts/configure.sh default --moxygen prebuilt-with-fallback -DMOQX_BUILD_TESTS=OFF
           scripts/build.sh default
+
+      # Hit rate is the only way to tell a warm cache from a restored one.
+      - name: ccache stats
+        if: always()
+        run: ccache -s
 
       - name: Run conformance tests
         run: bash test/test_conformance.sh ./build/default/moqx ${{ matrix.versions }} ${{ matrix.transport }} ${{ matrix.stack }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -7,7 +7,8 @@ name: ci main
 #
 #   check-format ──────────────────────────────────────────────────────────────────┐
 #   build (linux, asan debug) ── publish (docker+smoke) ── release ────────────────┼── notify
-#   microbenchmark (linux, macos) ────────────────────────────────────────────────-┘
+#   microbenchmark (linux, macos) ────────────────────────────────────────────────-┤
+#                                                                                  └── prune-caches
 
 on:
   push:
@@ -632,6 +633,63 @@ jobs:
           STATS_PASSWORD: ${{ secrets.STATS_PASSWORD }}
           GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
         run: bash docker/relay-deploy.sh
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Prune build caches: keep the newest generation of each cache family.
+  #
+  # Every key carries github.sha, so each run mints an entry rather than
+  # replacing one. Nothing removed the superseded generations, and the repo
+  # reached 27 GB against a 10 GB budget — six live generations per lane, which
+  # GitHub then evicts by age, taking usable caches with them. Port of
+  # openmoq/moxygen#383.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  prune-caches:
+    needs: [build, conformance, publish]
+    if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: write
+    steps:
+      # Runs after the cache-writing jobs so this run's entries are already
+      # saved and are the generation kept.
+      - name: Delete superseded generations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          cat > family.jq <<'JQ'
+          # Family = the key without its trailing hex suffix: ccache keys end in
+          # -<sha>, dependency keys in -<content hash>. Anything else (setup-uv
+          # and friends) is left alone.
+          def family:
+            if (.key | test("-[0-9a-f]{32,}$")) then
+              (.key | capture("^(?<p>.*)-[0-9a-f]{32,}$").p)
+            else null end;
+          map(select(family != null))
+          | group_by(family)
+          | map(sort_by(.createdAt) | reverse | .[1:])
+          | flatten
+          | .[] | "\(.id)\t\(.sizeInBytes)\t\(.key)"
+          JQ
+
+          gh cache list --ref "$GITHUB_REF" --limit 100 \
+            --json id,key,sizeInBytes,createdAt > caches.json
+          jq -r -f family.jq caches.json > stale.tsv
+
+          if [ ! -s stale.tsv ]; then
+            echo "==> nothing superseded"
+            exit 0
+          fi
+
+          FREED=0
+          while IFS=$'\t' read -r id size key; do
+            echo "  deleting $key ($((size / 1048576)) MB)"
+            if gh cache delete "$id"; then
+              FREED=$((FREED + size))
+            fi
+          done < stale.tsv
+          echo "==> freed $((FREED / 1048576)) MB"
 
   # ════════════════════════════════════════════════════════════════════════════
   # Notify: aggregate status (runs after everything)

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -102,6 +102,11 @@ jobs:
 
       # test.sh, not raw ctest: it resolves the --parallel the suite needs (the
       # shell integration tests carry unique ports so they can share a run).
+      # Hit rate is the only way to tell a warm cache from a restored one.
+      - name: ccache stats
+        if: always()
+        run: ccache -s
+
       - name: Test
         env:
           ASAN_OPTIONS: ${{ matrix.leak_check && 'detect_leaks=1:abort_on_error=1' || '' }}
@@ -171,6 +176,11 @@ jobs:
         run: |
           scripts/configure.sh default --moxygen prebuilt-with-fallback -DMOQX_BUILD_TESTS=OFF
           scripts/build.sh default
+
+      # Hit rate is the only way to tell a warm cache from a restored one.
+      - name: ccache stats
+        if: always()
+        run: ccache -s
 
       - name: Run conformance tests
         run: bash test/test_conformance.sh ./build/default/moqx ${{ matrix.versions }} ${{ matrix.transport }} ${{ matrix.stack }}


### PR DESCRIPTION
moqx sits at **24.87 GB of active cache against GitHub's 10 GB budget**. Past the budget GitHub evicts by age, which is indiscriminate — it can drop a lane's newest generation while keeping older ones, so a run restores nothing and recompiles from scratch.

Two changes. Neither reduces cache capacity.

## 1. Prune superseded generations

Every key carries `github.sha`, so each run mints an entry rather than replacing one — that's forced by cache immutability, and it's how commit-to-commit reuse works via the `restore-keys` prefix. What was missing is removing the generations that reuse has moved past. Currently six live generations each of `ccache-Linux-linux`, `ccache-Linux-conformance`, `ccache-macOS-macos`.

Port of openmoq/moxygen#383, family rule adapted — moxygen's keys end in a timestamp or `-deps-<hash>`, moqx's in a trailing hex sha. Dry-run against the live cache list:

```
17 entries, 19.8 GB freed  →  24.87 GB drops to ~5 GB
```

This replaces age-based eviction with something deterministic: the newest generation of each family is always the one kept, which is the one `restore-keys` resolves to.

## 2. Report statistics

`ccache -z` at setup so each run is attributable, `ccache -s` after every build in `ci-pr` and `ci-main`, both build and conformance lanes.

Without this there is no hit-rate signal at all. Run 33779223966 is a good main run — every lane restored `ccache-*-10a7c2de`, linux configure+build in ~75s, the whole pipeline in 13 minutes — and the only way to see that was reading cache restore/save timestamps out of the log.

## Dropped from this PR: the 1500M → 700M resize

It was here, and the measurements that motivated it argue against it:

```
linux   1.33 / 1.50 GB (88.35%)   10 cleanups
macOS   1.50 / 1.50 GB (100.5%)   46 cleanups
```

The cache is already full and already evicting at 1500M. Halving it makes that worse. Its justification was budget pressure — "hosted lanes share the repo's 10 GB budget" — and pruning removes that pressure directly, so the reason evaporates while the risk remains.

It also runs against the evidence from openmoq/moxygen#402, where raising 500M → 2G took cleanups from 50 (linux) and 308 (macOS) to zero. Sizing should follow the numbers the stats step above will produce, not precede them.

## Retracted earlier

This PR first reverted `CCACHE_COMPILERCHECK=content` on a 97s vs 636s comparison. That comparison was wrong — the runs were different workloads, not different configs: one recompiled nothing, the other was a pin bump that invalidates every moqx TU through changed moxygen headers, as `CMakeLists.txt:235` documents. Pin-bump runs across the #636 boundary show no step change (BEFORE 692s avg, AFTER 659s excluding a 1953s from-source outlier). The revert is gone; the rest of #636 stays.

## Still open

**Pin in the cache key.** A lane's cache is shared across every PR and every moxygen pin through the `restore-keys` prefix, so it accumulates ~170 objects per distinct pin, most dead. `ccache-<os>-<lane>-<pin12>-<sha>` would give each pin a clean cache. Left out because CPM deps like catapult and reflectcpp don't depend on moxygen headers and hit today — they'd go cold on every bump.

**The dominant cost is not ccache.** From-source fallbacks were 43% of main runs on 08-20 to 08-22, near zero since. Those runs are 2000-3000s against 650s. #668 closes the remaining window; keeping the prebuilt always available is worth more than any cache tuning.

Branch name is stale; it predates the rewrite.

Refs #628

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/658)
<!-- Reviewable:end -->
