### PR TITLE
cache: port upstream's fetch range validation into MoqxCache

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -21,6 +21,21 @@ using namespace moxygen;
 // Cap on prior-gap validation scans to avoid O(n) work for huge gaps.
 constexpr uint64_t kMaxGapValidation = 100;
 
+// On the wire an end object of 0 asks for all of the end group; every other
+// value is already one past the last object.  Everything inside the cache
+// works in the plain exclusive form this returns.
+AbsoluteLocation toExclusiveEnd(AbsoluteLocation wireEnd) {
+  if (wireEnd.object != 0) {
+    return wireEnd;
+  }
+  auto nextGroup = wireEnd.nextGroup();
+  if (!nextGroup) {
+    XLOG(ERR) << "Fetch end group=" << wireEnd.group
+              << " at max, using kLocationMax as exclusive end";
+  }
+  return nextGroup.value_or(kLocationMax);
+}
+
 // Compute the next iterator position after a gap when iterating descending
 // (NewestFirst). Groups iterate high-to-low, but objects within a group go
 // low-to-high. Returns std::nullopt if the gap extends past the iteration
@@ -920,28 +935,25 @@ MoqxCache::FetchWriteback* MoqxCache::CacheTrack::findFetchInProgress(AbsoluteLo
 class MoqxCache::FetchWriteback : public FetchConsumer {
 public:
   FetchWriteback(
-      AbsoluteLocation start,
-      AbsoluteLocation end,
       bool proxyFin,
       std::shared_ptr<FetchConsumer> consumer,
       FetchRangeIterator fetchRangeIt,
       MoqxCache& cache,
       const FullTrackName& ftn
   )
-      : start_(start), end_(end), proxyFin_(proxyFin), consumer_(std::move(consumer)),
-        fetchRangeIt_(std::move(fetchRangeIt)), cache_(cache), ftn_(ftn) {
+      : proxyFin_(proxyFin), consumer_(std::move(consumer)), fetchRangeIt_(std::move(fetchRangeIt)),
+        cache_(cache), ftn_(ftn) {
     // Track becomes non-evictable (remove from LRU)
     cache_.removeTrackFromLRU(*fetchRangeIt_.track);
 
-    emplaceAndPinGroup(start, FetchInProgressEntry{end, start, this});
+    auto start = fetchRangeIt_.minLocation;
+    emplaceAndPinGroup(start, FetchInProgressEntry{fetchRangeIt_.maxLocation, start, this});
   }
 
   ~FetchWriteback() override {
     XLOG(DBG1) << "FetchWriteback destructing";
     inProgress_.post();
-    if (fetchInProgressIt_ != fetchRangeIt_.track->fetchesInProgress.end()) {
-      eraseAndMakeGroupEvictable();
-    }
+    eraseAndMakeGroupEvictable();
     cancelSource_.requestCancellation();
 
     // Track may become evictable (add back to LRU if still in cache)
@@ -994,6 +1006,9 @@ public:
       bool fin,
       bool forwardingPreferenceIsDatagram = false
   ) override {
+    if (auto res = checkInRange({gID, objID}); !res) {
+      return res;
+    }
     if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->object(
           gID,
@@ -1042,6 +1057,11 @@ public:
       Payload initPayload,
       Extensions ext
   ) override {
+    auto inRange = checkInRange({gID, objID});
+    beginObjectAccepted_ = inRange.hasValue();
+    if (!inRange) {
+      return inRange;
+    }
     if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->beginObject(gID, sgID, objID, len, std::move(initPayload), std::move(ext));
     }
@@ -1062,12 +1082,29 @@ public:
 
   folly::Expected<ObjectPublishStatus, MoQPublishError>
   objectPayload(Payload payload, bool finFetch) override {
+    // beginObject can be rejected (out of range), and the payload for the
+    // object it refused belongs nowhere, cached or forwarded.
+    if (!beginObjectAccepted_) {
+      XLOG(ERR) << "objectPayload without beginObject";
+      return folly::makeUnexpected(
+          MoQPublishError(MoQPublishError::MALFORMED_TRACK, "Payload without beginObject")
+      );
+    }
     if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->objectPayload(std::move(payload), finFetch && proxyFin_);
     }
     auto& group =
         fetchRangeIt_.track->getOrCreateGroupWithEviction(fetchRangeIt_->group, cache_, ftn_);
-    auto& object = group.objects[fetchRangeIt_->object];
+    // Only the fetch's first group is pinned, so a later one can be evicted
+    // out from under an object in progress.
+    auto objectIt = group.objects.find(fetchRangeIt_->object);
+    if (objectIt == group.objects.end() || !objectIt->second) {
+      XLOG(ERR) << "objectPayload with no object in progress at " << *fetchRangeIt_;
+      return folly::makeUnexpected(
+          MoQPublishError(MoQPublishError::MALFORMED_TRACK, "Payload without beginObject")
+      );
+    }
+    auto& object = objectIt->second;
     size_t addedBytes = payload->computeChainDataLength();
     if (object->payload) {
       object->payload->appendChain(payload->clone());
@@ -1097,6 +1134,9 @@ public:
 
   folly::Expected<folly::Unit, MoQPublishError>
   endOfGroup(uint64_t gID, uint64_t sgID, uint64_t objID, bool fin) override {
+    if (auto res = checkInRange({gID, objID}); !res) {
+      return res;
+    }
     if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->endOfGroup(gID, sgID, objID, fin && proxyFin_);
     }
@@ -1111,6 +1151,9 @@ public:
 
   folly::Expected<folly::Unit, MoQPublishError>
   endOfTrackAndGroup(uint64_t gID, uint64_t sgID, uint64_t objID) override {
+    if (auto res = checkInRange({gID, objID}); !res) {
+      return res;
+    }
     if (fetchRangeIt_.track->shouldSkipCaching()) {
       return consumer_->endOfTrackAndGroup(gID, sgID, objID);
     }
@@ -1140,7 +1183,6 @@ public:
     consumer_->reset(error);
     wasReset_ = true;
     complete_.post();
-    start_ = end_; // nothing else is coming
     fetchRangeIt_.invalidate();
     updateInProgress();
   }
@@ -1178,6 +1220,21 @@ public:
   bool wasReset() const { return wasReset_; }
 
 private:
+  // Upstream may only send what it was asked for, markers included: a marker
+  // takes an object ID like any object.  Anything else would be cached and
+  // forwarded to a consumer that never requested it, and the gap marking would
+  // run against positions this fetch does not own.
+  folly::Expected<folly::Unit, MoQPublishError> checkInRange(AbsoluteLocation loc) const {
+    if (loc < fetchRangeIt_.minLocation || loc >= fetchRangeIt_.maxLocation) {
+      XLOG(ERR) << "Upstream sent " << loc << " outside fetch range [" << fetchRangeIt_.minLocation
+                << ", " << fetchRangeIt_.maxLocation << ")";
+      return folly::makeUnexpected(
+          MoQPublishError(MoQPublishError::MALFORMED_TRACK, "Object outside fetch range")
+      );
+    }
+    return folly::unit;
+  }
+
   void emplaceAndPinGroup(AbsoluteLocation loc, FetchInProgressEntry entry) {
     auto [it, inserted] = fetchRangeIt_.track->fetchesInProgress.emplace(loc, entry);
     XCHECK(inserted);
@@ -1197,6 +1254,11 @@ private:
   }
 
   void eraseAndMakeGroupEvictable() {
+    // Idempotent: a reset, a cancellation or an upstream error retires the
+    // entry through updateInProgress(), then the destructor calls this again.
+    if (fetchInProgressIt_ == fetchRangeIt_.track->fetchesInProgress.end()) {
+      return;
+    }
     auto groupID = fetchInProgressIt_->first.group;
     fetchRangeIt_.track->fetchesInProgress.erase(fetchInProgressIt_);
     fetchInProgressIt_ = fetchRangeIt_.track->fetchesInProgress.end();
@@ -1206,8 +1268,6 @@ private:
     }
   }
 
-  AbsoluteLocation start_;
-  AbsoluteLocation end_;
   FetchesInProgressMap::iterator fetchInProgressIt_;
   std::shared_ptr<CacheGroup> pinnedGroup_;
   bool proxyFin_{false};
@@ -1215,6 +1275,7 @@ private:
   folly::coro::Baton inProgress_;
   folly::coro::Baton complete_;
   uint64_t currentLength_{0};
+  bool beginObjectAccepted_{false};
   bool wasReset_{false};
   folly::CancellationSource cancelSource_;
   FetchRangeIterator fetchRangeIt_;
@@ -1338,35 +1399,24 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetch(
 
     // track is new (not cached), forward upstream, with writeback
     XLOG(DBG1) << "Cache miss, upstream fetch";
-    FetchRangeIterator fetchRangeIt(standalone->start, standalone->end, fetch.groupOrder, track);
+    // standalone aliases fetch.args, so the end can't be normalized in place
+    // here: the request forwarded upstream has to keep the wire form.
+    FetchRangeIterator
+        fetchRangeIt(standalone->start, toExclusiveEnd(standalone->end), fetch.groupOrder, track);
     co_return co_await upstream->fetch(
         fetch,
-        std::make_shared<FetchWriteback>(
-            standalone->start,
-            standalone->end,
-            true,
-            std::move(consumer),
-            fetchRangeIt,
-            *this,
-            fetch.fullTrackName
-        )
+        std::make_shared<
+            FetchWriteback>(true, std::move(consumer), fetchRangeIt, *this, fetch.fullTrackName)
     );
   }
-  AbsoluteLocation last = standalone->end;
-  if (last.object > 0) {
-    last.object--;
-  } else {
-    // {N, 0} means "all of group N" — inclusive last is {N, MAX}
-    last.object = kLocationMax.object;
-    auto nextGrp = standalone->end.nextGroup();
-    if (!nextGrp) {
-      XLOG(ERR) << "Fetch end group=" << standalone->end.group
-                << " at max, using kLocationMax as exclusive end";
-    }
-    standalone->end = nextGrp.value_or(kLocationMax);
-    // TODO: handle case where track.largestGroupAndObject is an END_OF_GROUP
-    // or END_OF_TRACK
-  }
+  // Nothing is forwarded verbatim from here on, so normalize in place and let
+  // fetchUpstream put the wire form back when it talks to upstream.
+  // TODO: handle case where track.largestGroupAndObject is an END_OF_GROUP
+  // or END_OF_TRACK
+  standalone->end = toExclusiveEnd(standalone->end);
+  auto lastMaybe = standalone->end.prev();
+  XCHECK(lastMaybe) << "exclusive end must be > {0, 0}";
+  AbsoluteLocation last = *lastMaybe;
   if (track->largestGroupAndObject &&
       (track->liveWritebackCount > 0 || last <= *track->largestGroupAndObject)) {
     // we can immediately return fetch OK
@@ -1664,6 +1714,8 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetchUpstream(
 ) {
   XLOG(DBG1) << "Fetching upstream for {" << fetchStart.group << "," << fetchStart.object << "}, {"
              << fetchEnd.group << "," << fetchEnd.object << "}";
+  // Put the wire form back for the request itself: an exclusive end sitting on
+  // a group boundary is "all of the previous group" to the peer.
   auto adjFetchEnd = fetchEnd;
   if (adjFetchEnd.object == 0) {
     auto pg = adjFetchEnd.prevGroup();
@@ -1675,8 +1727,6 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetchUpstream(
   // a smaller upstream end leaves stale fetchInProgress range that
   // makes concurrent lookups wait until endOfFetch.
   auto writeback = std::make_shared<FetchWriteback>(
-      fetchStart,
-      adjFetchEnd,
       lastObject,
       consumer,
       fetchRangeIt,

--- a/test/MoqxCacheTest.cpp
+++ b/test/MoqxCacheTest.cpp
@@ -590,6 +590,46 @@ CO_TEST_F(MoqxCacheTest, TestFetchMissNoTrackUpstreamCompleteHit) {
   serveCacheRangeFromUpstream({0, 0}, {0, 10});
 }
 
+// An end object of 0 asks for all of the end group.  The cached path folds
+// that in, and the miss path has to agree or its range iterator runs out a
+// group early and the writeback keeps retiring an already-retired entry.
+CO_TEST_F(MoqxCacheTest, TestFetchMissWholeEndGroup) {
+  expectUpstreamFetch({0, 0}, {2, 0}, 0, AbsoluteLocation{2, 10});
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {2, 0}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasValue());
+  // Groups 0, 1 and 2 in full -- group 2 is inside the range, not past it.
+  expectFetchObjects({0, 0}, {3, 0}, true);
+  serveCacheRangeFromUpstream({0, 0}, {3, 0});
+}
+
+// A publisher that sends past the range it was given is misbehaving.  Reject
+// the overrun rather than caching it, forwarding it to a consumer that never
+// asked for it, or walking the writeback's bookkeeping off the end of the
+// range.
+CO_TEST_F(MoqxCacheTest, TestFetchMissUpstreamOverrunsRange) {
+  expectUpstreamFetch({0, 0}, {1, 0}, 0, AbsoluteLocation{1, 10});
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {1, 0}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasValue());
+
+  // {1, 0} on the wire asks for all of group 1, so groups 0 and 1 are in
+  // range.  Hold back the endOfFetch so the overrun lands on a live fetch.
+  expectFetchObjects({0, 0}, {2, 0}, false);
+  serveCacheRangeFromUpstream({0, 0}, {2, 0}, 10, 1, 1, /*endOfGroup=*/false, /*endOfFetch=*/false);
+
+  // consumer_ is a StrictMock with no expectation for a group 2 object, so
+  // this also asserts the overrun is not forwarded downstream.
+  auto overrun = upstreamFetchConsumer_->object(2, 0, 0, makeBuf(100));
+  EXPECT_TRUE(overrun.hasError());
+  if (overrun.hasError()) {
+    EXPECT_EQ(overrun.error().code, MoQPublishError::MALFORMED_TRACK);
+  }
+  EXPECT_FALSE(cache_.hasCachedObject(kTestTrackName, AbsoluteLocation{2, 0}));
+
+  // A session tears the fetch stream down on that error.
+  EXPECT_CALL(*consumer_, reset(_));
+  upstreamFetchConsumer_->reset(ResetStreamErrorCode::MALFORMED_TRACK);
+}
+
 CO_TEST_F(MoqxCacheTest, TestFetchMissUpstreamCompleteHit) {
   // Test case for fetch when track is present, but no overlap
   populateCacheRange({0, 0}, {0, 1});
@@ -1143,8 +1183,9 @@ CO_TEST_F(MoqxCacheTest, TestPopulateObjectUsingBeginObjectAndObjectPayload) {
 CO_TEST_F(MoqxCacheTest, TestUpstreamFetchUsingBeginObjectAndObjectPayload) {
   // Test case for upstream fetch using beginObject and objectPayload
 
-  // Expect upstream fetch to be called with the specified range
-  expectUpstreamFetch({0, 0}, {0, 1}, 0, AbsoluteLocation{0, 0})
+  // Expect upstream fetch to be called with the specified range.  Two objects
+  // are served below, so the range has to cover both.
+  expectUpstreamFetch({0, 0}, {0, 2}, 0, AbsoluteLocation{0, 0})
       .via(co_await folly::coro::co_current_executor)
       .thenTry([this](auto) {
         // Begin an object with a specific size
@@ -1162,7 +1203,7 @@ CO_TEST_F(MoqxCacheTest, TestUpstreamFetchUsingBeginObjectAndObjectPayload) {
   EXPECT_CALL(*consumer_, beginObject(0, 0, 1, 100, _, _)).WillOnce(Return(folly::unit));
   EXPECT_CALL(*consumer_, objectPayload(_, true)).WillOnce(Return(ObjectPublishStatus::DONE));
   // Perform the fetch
-  auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 1}), trackingConsumer_, upstream_);
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 2}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res.hasValue());
   EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{0, 0}));
 }
@@ -1422,9 +1463,11 @@ CO_TEST_F(MoqxCacheTest, TestFetchWritebackAcrossGroups) {
 CO_TEST_F(MoqxCacheTest, FetchWritebackUpdateInProgressBoundaryCollision) {
   // Regression test for XCHECK(inserted) crash in FetchWriteback::updateInProgress.
   //
-  // Two concurrent ascending fetches share an adjacent boundary:
+  // Two concurrent ascending fetches share an adjacent boundary. An end object
+  // of 0 asks for all of the end group, so A's wire end of {9,0} is the
+  // exclusive end {10,0} that B starts on:
   //   A = [0,0; 10,0)  -- new track, takes fast path, FetchWriteback A key={0,0}
-  //   B = [10,0; 20,0) -- fetchImpl sees all-miss; fetchUpstream creates
+  //   B = [10,0; 21,0) -- fetchImpl sees all-miss; fetchUpstream creates
   //                        FetchWriteback B with key={10,0}
   //
   // findFetchInProgress({10,0}) returns nullptr for A because the in-range
@@ -1443,7 +1486,7 @@ CO_TEST_F(MoqxCacheTest, FetchWritebackUpdateInProgressBoundaryCollision) {
   {
     InSequence seq;
     // First upstream call: fetch A (new-track fast path), mock stores the writeback.
-    expectUpstreamFetch({0, 0}, {10, 0}, 0, AbsoluteLocation{20, 0});
+    expectUpstreamFetch({0, 0}, {9, 0}, 0, AbsoluteLocation{20, 0});
 
     // Second upstream call: fetch B's fetchUpstream — FetchWriteback B is already
     // inserted at key {10,0} before this lambda runs. Drive A's endOfFetch here
@@ -1467,7 +1510,7 @@ CO_TEST_F(MoqxCacheTest, FetchWritebackUpdateInProgressBoundaryCollision) {
   }
 
   auto [resA, resB] = co_await folly::coro::collectAll(
-      cache_.fetch(getFetch({0, 0}, {10, 0}), trackingConsumer_, upstream_),
+      cache_.fetch(getFetch({0, 0}, {9, 0}), trackingConsumer_, upstream_),
       cache_.fetch(getFetch({10, 0}, {20, 0}), trackingConsumer2, upstream_)
   );
 
@@ -4477,5 +4520,32 @@ CO_TEST_F(MoqxCacheTest, FetchWritebackObjectPayloadSkipsCacheAfterEviction) {
   // which exceeds 200 and wrongly evicts track2.
   cache_.setMaxCachedBytes(200);
   EXPECT_TRUE(cache_.hasTrack(track2));
+}
+
+// Test: a refused beginObject leaves nothing for the payload that follows to
+// attach to. An evicted track forwards straight downstream instead of caching,
+// so it needs the same guard as the caching path.
+CO_TEST_F(MoqxCacheTest, FetchWritebackObjectPayloadAfterRefusedBeginObject) {
+  expectUpstreamFetch({0, 0}, {0, 1}, false, AbsoluteLocation{0, 1});
+
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 1}), consumer_, upstream_);
+  EXPECT_TRUE(res.hasValue());
+
+  cache_.clear();
+
+  // Only {0, 0} was asked for, so object 5 overruns the range.  consumer_ is a
+  // StrictMock with no beginObject or objectPayload expectation, so this also
+  // asserts neither call reaches the downstream consumer.
+  auto begin = upstreamFetchConsumer_->beginObject(0, 0, 5, 300, makeBuf(50));
+  EXPECT_TRUE(begin.hasError());
+  if (begin.hasError()) {
+    EXPECT_EQ(begin.error().code, MoQPublishError::MALFORMED_TRACK);
+  }
+
+  auto payload = upstreamFetchConsumer_->objectPayload(makeBuf(100), false);
+  EXPECT_TRUE(payload.hasError());
+  if (payload.hasError()) {
+    EXPECT_EQ(payload.error().code, MoQPublishError::MALFORMED_TRACK);
+  }
 }
 } // namespace openmoq::moqx::test


### PR DESCRIPTION
Draft, for discussion. This is our reading of Alan's note: *"We have forked the cache, we can revert all OpenMOQ changes there. But that change needs to make it to moqxcache or the new conformance tests will fail."*

This is the moqxcache half. The companion PR is openmoq/moxygen#396, which reverts moxygen's copy of the cache to upstream.

## Why

moxygen #394 reworked upstream's `MoQCache` and shipped new conformance tests with it. The relay serves fetches from `MoqxCache`, our fork, which didn't get the change.

moqx PR #661 bumps the moxygen pin across that commit, and all three conformance jobs fail — they ran 3h before being cancelled. The previous pin bump, #660, passed all three in about 7 minutes each. Same jobs, only the pin differs.

From the #661 log:

```
[Test 61] FETCH range B-C, C cached
  Request: fetch
  FETCH {1,0}..{1,0}
  ... (no further output, cancelled after 3h)
```

`{1,0}` on the wire asks for all of group 1. The cached path already folded that into the exclusive `{2,0}`; the miss path did not, so its range iterator was constructed with `{1,0}` as both start and end — an empty range that never completes. Test 42 also crashes with exit 139.

## What this ports

| From upstream #394 | Effect |
|---|---|
| `toExclusiveEnd()` | folds the wire form once, used by the miss path and the cached path alike; `fetchUpstream` puts the wire form back for the outgoing request |
| `checkInRange()` | rejects anything upstream sends outside the range it was given, on `object`, `beginObject`, `endOfGroup`, `endOfTrackAndGroup` |
| `beginObjectAccepted_` | a payload following a refused `beginObject` is dropped instead of attaching to whatever `group.objects[...]` default-constructs |
| `FetchWriteback` range source | takes `minLocation`/`maxLocation` from the iterator instead of separate `start`/`end` arguments — the old call passed the *wire* form into `fetchesInProgress` |
| idempotent `eraseAndMakeGroupEvictable()` | the destructor can call it unconditionally |

Kept moqx-local: `shouldSkipCaching()` in place of upstream's `evicted` check, and the formatting.

## Tests

Ported upstream's three new tests and their range fix:

- `TestFetchMissWholeEndGroup` — the miss path agrees with the cached path on `{N,0}`
- `TestFetchMissUpstreamOverrunsRange` — an overrun is rejected, not cached or forwarded
- `FetchWritebackObjectPayloadAfterRefusedBeginObject` — the payload guard
- `TestUpstreamFetchUsingBeginObjectAndObjectPayload` — range widened to `{0,2}`, since it serves two objects

**One judgment call worth a look.** `FetchWritebackUpdateInProgressBoundaryCollision` is moqx-local, not upstream's. It pairs two fetches meant to abut at group 10, written when the miss path left `{10,0}` un-normalized. With the fix, A's wire end of `{10,0}` means *all of* group 10, so A and B overlap instead of abutting and the test hangs. I changed A's wire end to `{9,0}`, which is the exclusive `{10,0}` B starts on, preserving the adjacency the test was written for. If the original numbers were deliberate, this needs a different fix.

## Validation

`moqx_cache_test`: 156/156 pass locally, including the four above.

Conformance is **not** validated here. This branch is on the current pin (`37fed63`), which predates the new tests, so CI will run the old conformance suite and prove nothing. Per our convention pins move only through sync PRs, so this doesn't bump it. To actually validate, either land this and re-run #661, or move this commit onto `sync-moxygen/71ed936`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/662)
<!-- Reviewable:end -->
