### PR TITLE
ci: require a published snapshot before bumping the moxygen pin

### DIFF
--- a/.github/workflows/moxygen-sync.yml
+++ b/.github/workflows/moxygen-sync.yml
@@ -122,11 +122,36 @@ jobs:
           CURRENT_SHA=$(cmake -DPIN=MOXYGEN_REV -P cmake/print-pin.cmake)
           echo "current_sha=${CURRENT_SHA}" >> "$GITHUB_OUTPUT"
 
+          # A rev is consumable once ci-main publishes its snapshot. gh prints
+          # its 404 body on stdout, so the exit code is the answer.
+          has_assets() {
+            local n
+            n=$(gh api "repos/openmoq/moxygen/releases/tags/snapshot-${1:0:12}" \
+                  --jq '.assets | length' 2>/dev/null) || return 1
+            [ "${n:-0}" -gt 0 ]
+          }
+
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
             TARGET_SHA="$CLIENT_PAYLOAD_SHA"
+            # The publish raises this event, so a miss means it reported a
+            # success it did not deliver.
+            if [ -n "$TARGET_SHA" ] && ! has_assets "$TARGET_SHA"; then
+              echo "::error::moxygen ${TARGET_SHA:0:12} dispatched an update but publishes no snapshot assets"
+              exit 1
+            fi
           else
-            # Manual/scheduled trigger: latest openmoq/moxygen main
-            TARGET_SHA=$(gh api repos/openmoq/moxygen/commits/main --jq '.sha')
+            # Newest openmoq/moxygen main whose snapshot has published.
+            TARGET_SHA=""
+            for sha in $(gh api "repos/openmoq/moxygen/commits?sha=main&per_page=20" --jq '.[].sha'); do
+              has_assets "$sha" && { TARGET_SHA="$sha"; break; }
+              echo "skipping ${sha:0:12} — snapshot not published yet"
+            done
+            # Nothing publishable: hand the current rev to the up-to-date path
+            # below rather than failing, since a publish backlog is transient.
+            if [ -z "$TARGET_SHA" ]; then
+              echo "::warning::No moxygen main commit in the last 20 has published snapshot assets"
+              TARGET_SHA="$CURRENT_SHA"
+            fi
           fi
 
           # Guard: TARGET_SHA is spliced into cmake/dependencies.cmake by sed


### PR DESCRIPTION
The sync pins the newest moxygen main commit whether or not its snapshot exists
yet. moxygen `ci-main` takes ~80 minutes to build and publish, so a sync landing
inside that window pins a rev nothing can consume, and every moqx lane compiles
the Meta stack from source instead.

## Observed

2026-08-28, moxygen `68465b9`:

```
16:15  moxygen ci-main starts building 68465b9
16:21  moqx sync PR opens, pinned to 68465b9      <- 69 min early
17:30  moxygen publishes snapshot-68465b9ffa19
```

Every lane in that PR fell back to source: linux 49 min, conformance 45/45/37,
macOS 39, asan 34 — roughly four hours of runner time for a one-line pin bump.
Build-step times in the conformance lanes were 2062s, 2590s and 2620s against
286s, 212s and 280s on a normal pin bump.

## Change

Scheduled and manual runs walk back from main until they find a rev whose
`snapshot-<sha12>` release has assets, rather than taking the newest rev
unconditionally.

- **Nothing found in 20 commits** — skip with a warning and no PR. A publish
  backlog is transient; a red sync every hour is not useful.
- **`repository_dispatch`** keeps its payload rev but errors if the assets are
  missing. The publish is what raises that event, so a miss means it reported a
  success it did not deliver.

The cron cascade already tries to sequence this by spacing moxygen's sync at 04:23
against moqx's at 08:23. That only holds when schedules fire on time, and they
have been arriving hours late; the case above was a manual dispatch, which lands
wherever it lands. This makes the ordering a property of the data rather than of
the clock.

## Verifying

`gh api` prints its 404 body on stdout, so the predicate takes the exit code as
the answer and only compares a value that is actually a count — the obvious
`|| echo 0` form appends to the error JSON and fails the comparison with
`integer expression expected`, once per skipped commit.

Checked against live data: the predicate returns true for the current main rev
(14 assets) and false, silently, for a nonexistent one. Selection is a no-op today
because the newest rev already has assets, which is the intended behaviour — it
only diverges inside a publish window.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/668)
<!-- Reviewable:end -->
