### PR TITLE
relay: stop releasing an ending session on the relay executor

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -368,11 +368,22 @@ folly::coro::Task<void> MoqxRelay::onUpstreamConnectImpl(std::shared_ptr<MoQSess
 }
 
 void MoqxRelay::onSessionEnd(std::shared_ptr<MoQSession> session) {
-  runOnExec(relayExec_, [self = weak_from_this(), session = std::move(session)]() mutable {
-    if (auto relay = self.lock()) {
-      relay->legacyPublisherHopIDs_.erase(session.get());
-    }
-  });
+  // Raw key plus an owner compare: neither takes a strong ref, so the session is never
+  // released on relayExec_. lock() here would reintroduce that bug.
+  runOnExec(
+      relayExec_,
+      [self = weak_from_this(), key = session.get(), weak = std::weak_ptr<MoQSession>(session)]() {
+        auto relay = self.lock();
+        if (!relay) {
+          return;
+        }
+        auto it = relay->legacyPublisherHopIDs_.find(key);
+        if (it != relay->legacyPublisherHopIDs_.end() && !it->second.session.owner_before(weak) &&
+            !weak.owner_before(it->second.session)) {
+          relay->legacyPublisherHopIDs_.erase(it);
+        }
+      }
+  );
 }
 
 void MoqxRelay::onUpstreamDisconnect() {


### PR DESCRIPTION
onSessionEnd moved the shared_ptr<MoQSession> into the lambda it posted to relayExec_, so when that was the last reference the session was destroyed on the relay executor instead of its own. The lambda now captures the raw pointer it uses as the map key plus a weak_ptr, neither of which keeps the session alive. It erases the hop ID entry only when the stored weak_ptr and the ending session share an owner, so a new session that lands on a recycled address keeps its own entry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/677)
<!-- Reviewable:end -->
