### PR TITLE
cache: fix FETCH_OK End Location for cache-answered fetches

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -443,6 +443,23 @@ MoqxCache::CacheTrack::updateLargest(AbsoluteLocation current, bool eot) {
   return folly::unit;
 }
 
+MoqxCache::FetchOkEnd
+MoqxCache::CacheTrack::fetchOkEnd(AbsoluteLocation start, AbsoluteLocation exclusiveEnd) const {
+  if (!largestGroupAndObject) {
+    return {exclusiveEnd, false};
+  }
+  auto trackEnd = largestGroupAndObject->next().value_or(kLocationMax);
+  if (exclusiveEnd < trackEnd) {
+    return {exclusiveEnd, false};
+  }
+  if (trackEnd <= start) {
+    // The whole range is past the track. An End Location below the fetch
+    // start is a session error at the receiver.
+    return {start, false};
+  }
+  return {trackEnd, endOfTrack};
+}
+
 MoqxCache::CacheGroup& MoqxCache::CacheTrack::getOrCreateGroup(uint64_t groupID) {
   auto it = groups.find(groupID);
   if (it == groups.end()) {
@@ -1421,24 +1438,16 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetch(
       (track->liveWritebackCount > 0 || last <= *track->largestGroupAndObject)) {
     // we can immediately return fetch OK
     XLOG(DBG1) << "Live track or known past data, return FetchOK";
-    AbsoluteLocation largestInFetch = standalone->end;
-    bool isEndOfTrack = false;
-    if (standalone->end > *track->largestGroupAndObject) {
-      standalone->end = *track->largestGroupAndObject;
-      auto next = standalone->end.next();
-      XCHECK(next) << "largestGroupAndObject.next() must be valid";
-      standalone->end = *next;
-      largestInFetch = standalone->end;
-      isEndOfTrack = track->endOfTrack;
-      // fetchImpl range exclusive of end
-    } else if (largestInFetch.object == 0) {
-      auto pg = largestInFetch.prevGroup();
-      XCHECK(pg) << "largestInFetch.group must be > 0 when object == 0";
-      largestInFetch = *pg;
-    }
-    auto fetchHandle = std::make_shared<FetchHandle>(
-        FetchOk{fetch.requestID, fetch.groupOrder, isEndOfTrack, largestInFetch, track->extensions}
-    );
+    auto okEnd = track->fetchOkEnd(standalone->start, standalone->end);
+    // fetchImpl's range end is exclusive too, so it can reuse End Location.
+    standalone->end = okEnd.endLocation;
+    auto fetchHandle = std::make_shared<FetchHandle>(FetchOk{
+        fetch.requestID,
+        fetch.groupOrder,
+        okEnd.endOfTrack,
+        okEnd.endLocation,
+        track->extensions
+    });
     co_withExecutor(
         co_await folly::coro::co_current_executor,
         folly::coro::co_withCancellation(
@@ -1622,9 +1631,9 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetchImpl(
       if (fetch.groupOrder != GroupOrder::NewestFirst) {
         co_return std::move(res.value());
       } else {
-        bool isEndOfTrack = track->endOfTrack && standalone->end >= *track->largestGroupAndObject;
+        auto okEnd = track->fetchOkEnd(standalone->start, standalone->end);
         fetchHandle = std::make_shared<FetchHandle>(
-            FetchOk{fetch.requestID, fetch.groupOrder, isEndOfTrack, standalone->end, {}}
+            FetchOk{fetch.requestID, fetch.groupOrder, okEnd.endOfTrack, okEnd.endLocation, {}}
         );
         fetchHandle->setUpstreamFetchHandle(res.value());
         co_return fetchHandle;
@@ -1639,25 +1648,10 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetchImpl(
   }
   if (!fetchHandle) {
     XLOG(DBG1) << "Fetch completed entirely from cache";
-    if (servedOneObject) {
-      if (standalone->end.object == 0) {
-        auto pg = standalone->end.prevGroup();
-        XCHECK(pg) << "standalone->end.group must be > 0 when object == 0";
-        standalone->end = *pg;
-      }
-      bool endOfTrack = false;
-      if (track->endOfTrack && standalone->end >= *track->largestGroupAndObject) {
-        endOfTrack = true;
-        standalone->end = *track->largestGroupAndObject;
-      }
-      co_return std::make_shared<FetchHandle>(
-          FetchOk{fetch.requestID, fetch.groupOrder, endOfTrack, standalone->end, {}}
-      );
-    } else {
-      co_return std::make_shared<FetchHandle>(
-          FetchOk{fetch.requestID, fetch.groupOrder, false, standalone->end, {}}
-      );
-    }
+    auto okEnd = track->fetchOkEnd(standalone->start, standalone->end);
+    co_return std::make_shared<FetchHandle>(
+        FetchOk{fetch.requestID, fetch.groupOrder, okEnd.endOfTrack, okEnd.endLocation, {}}
+    );
   }
   co_return nullptr;
 }

--- a/src/MoqxCache.h
+++ b/src/MoqxCache.h
@@ -262,6 +262,13 @@ private:
   };
   using FetchesInProgressMap = std::map<moxygen::AbsoluteLocation, FetchInProgressEntry>;
 
+  // FETCH_OK's End Location is exclusive: one past the last object in the
+  // response.
+  struct FetchOkEnd {
+    moxygen::AbsoluteLocation endLocation;
+    bool endOfTrack{false};
+  };
+
   struct CacheTrack {
     folly::F14FastMap<uint64_t, std::shared_ptr<CacheGroup>> groups;
     moxygen::LocationIntervalSet gaps;
@@ -286,6 +293,10 @@ private:
 
     folly::Expected<folly::Unit, moxygen::MoQPublishError>
     updateLargest(moxygen::AbsoluteLocation current, bool endOfTrack = false);
+    // The requested end, clamped to one past the largest object in the track
+    // but never below start.
+    FetchOkEnd
+    fetchOkEnd(moxygen::AbsoluteLocation start, moxygen::AbsoluteLocation exclusiveEnd) const;
     CacheGroup& getOrCreateGroup(uint64_t groupID);
     // Same as getOrCreateGroup but, when creating, evicts old groups to honor
     // the per-track group limit and inserts the new group into the LRU.

--- a/test/MoqxCacheTest.cpp
+++ b/test/MoqxCacheTest.cpp
@@ -561,7 +561,8 @@ CO_TEST_F(MoqxCacheTest, TestFetchAllHitEOG) {
   expectFetchObjects({0, 0}, {0, 11}, false, 10, 1, 1, true);
   auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 0}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res.hasValue());
-  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{0, 0}));
+  // The last object in the response is the end of group marker at {0,10}.
+  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{0, 11}));
 }
 
 CO_TEST_F(MoqxCacheTest, TestFetchMissUpstreamError) {
@@ -756,7 +757,54 @@ CO_TEST_F(MoqxCacheTest, TestFetchEndBeyondEndOfTrack) {
   auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 10}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res.hasValue());
   EXPECT_TRUE(res.value()->fetchOk().endOfTrack);
-  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{0, 5}));
+  // One past the END_OF_TRACK object at {0,5}.
+  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{0, 6}));
+}
+
+// An end object of 0 asks for all of the end group, and End Location is an
+// exclusive range end, so it stays at the group boundary. Everything is
+// cached here, so FETCH_OK goes out before any object is served.
+CO_TEST_F(MoqxCacheTest, TestFetchWholeEndGroupInsideCachedRangeEndLocation) {
+  // Groups 0, 1 and 2, so a fetch for all of group 1 ends before the largest.
+  populateCacheRange({0, 0}, {3, 0}, 10, 1, 1, true);
+  expectFetchObjects({0, 0}, {2, 0}, false, 10, 1, 1, true);
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {1, 0}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasValue());
+  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{2, 0}));
+  EXPECT_FALSE(res.value()->fetchOk().endOfTrack);
+  co_await folly::coro::co_reschedule_on_current_executor;
+}
+
+// A fetch running past the end of track stops at the last object and says so,
+// rather than reporting the requested end.
+CO_TEST_F(MoqxCacheTest, TestFetchWholeEndGroupPastEndOfTrack) {
+  populateCacheRange({0, 0}, {0, 5});
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  writeback->datagram(ObjectHeader(0, 0, 5, 0, ObjectStatus::END_OF_TRACK), nullptr);
+  writeback.reset();
+
+  expectFetchObjects({0, 0}, {0, 5}, false);
+  EXPECT_CALL(*consumer_, endOfTrackAndGroup(0, 0, 5)).WillOnce(Return(folly::unit));
+  // All of group 0, which runs past the end of track at {0,5}.
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 0}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasValue());
+  EXPECT_TRUE(res.value()->fetchOk().endOfTrack);
+  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{0, 6}));
+}
+
+// An End Location below the fetch start is a PROTOCOL_VIOLATION at the
+// receiver, so clamping to the largest object cannot take it below the start.
+CO_TEST_F(MoqxCacheTest, TestFetchStartsPastLargestEndLocation) {
+  populateCacheRange({0, 0}, {0, 5});
+  // A live track answers from what it has rather than going upstream.
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+
+  EXPECT_CALL(*consumer_, endOfFetch()).WillOnce(Return(folly::unit));
+  auto res = co_await cache_.fetch(getFetch({5, 0}, {6, 0}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasValue());
+  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{5, 0}));
+  EXPECT_FALSE(res.value()->fetchOk().endOfTrack);
+  co_await folly::coro::co_reschedule_on_current_executor;
 }
 
 CO_TEST_F(MoqxCacheTest, TestFetchWaitsForFetchInProgress) {
@@ -982,7 +1030,8 @@ CO_TEST_F(MoqxCacheTest, TestFetchPopulatesNotExistObjectsAndGroups) {
   EXPECT_CALL(*consumer_, endOfGroup(0, 0, 1, true)).WillOnce(Return(folly::unit));
   auto res = co_await cache_.fetch(getFetch({0, 0}, {1, 0}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res.hasValue());
-  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{1, 0}));
+  // Group 1 does not exist, so the requested end is inside the track.
+  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{2, 0}));
 }
 
 TEST_F(MoqxCacheTest, TestInvalidCacheUpdateFails) {
@@ -1236,7 +1285,8 @@ CO_TEST_F(MoqxCacheTest, TestObjectPayloadMarksRemainingAsNonexistent) {
 
   auto res2 = co_await cache_.fetch(getFetch({0, 1}, {0, 2}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res2.hasValue());
-  EXPECT_EQ(res2.value()->fetchOk().endLocation, (AbsoluteLocation{0, 2}));
+  // Nothing was served, so the response ends where it started.
+  EXPECT_EQ(res2.value()->fetchOk().endLocation, (AbsoluteLocation{0, 1}));
 }
 
 CO_TEST_F(MoqxCacheTest, TestPopulateCacheWithBeginSubgroupAndFetch) {
@@ -1301,7 +1351,8 @@ CO_TEST_F(MoqxCacheTest, TestUpstreamReturnsNoObjectsTail) {
 
   auto res2 = co_await cache_.fetch(getFetch({1, 0}, {2, 5}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res2.hasValue());
-  EXPECT_EQ(res2.value()->fetchOk().endLocation, (AbsoluteLocation{2, 5}));
+  // Nothing was served, so the response ends where it started.
+  EXPECT_EQ(res2.value()->fetchOk().endLocation, (AbsoluteLocation{1, 0}));
 }
 
 CO_TEST_F(MoqxCacheTest, TestFullCacheMissNoObjectsUpstream) {
@@ -1323,6 +1374,8 @@ CO_TEST_F(MoqxCacheTest, TestFullCacheMissNoObjectsUpstream) {
 
   auto res2 = co_await cache_.fetch(getFetch({0, 0}, {0, 5}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res2.hasValue());
+  // The track has no largest object to clamp against, so End Location is the
+  // requested end even though the range turned out to be empty.
   EXPECT_EQ(res2.value()->fetchOk().endLocation, (AbsoluteLocation{0, 5}));
 }
 
@@ -1442,7 +1495,8 @@ CO_TEST_F(MoqxCacheTest, TestFetchAllHitEOGAcrossGroups) {
   expectFetchObjects({0, 0}, {2, 11}, false, 10, 1, 1, true);
   auto res = co_await cache_.fetch(getFetch({0, 0}, {2, 0}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res.hasValue());
-  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{2, 0}));
+  // The last object in the response is the end of group marker at {2,10}.
+  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{2, 11}));
 }
 
 CO_TEST_F(MoqxCacheTest, TestFetchWritebackAcrossGroups) {
@@ -1557,7 +1611,8 @@ CO_TEST_F(MoqxCacheTest, TestFetchRangeExactlyAtGroupBoundary) {
   expectFetchObjects({0, 0}, {2, 0}, false, 10, 1, 1, true);
   auto res = co_await cache_.fetch(getFetch({0, 0}, {1, 0}), trackingConsumer_, upstream_);
   EXPECT_TRUE(res.hasValue());
-  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{1, 0}));
+  // The last object in the response is the end of group marker at {1,10}.
+  EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{1, 11}));
 }
 
 CO_TEST_F(MoqxCacheTest, TestFetchAllMissAcrossGroupsDesc) {


### PR DESCRIPTION
An end object of 0 asks for all of the end group. When the cache answered a fetch itself, it folded that back to the start of the previous group and put that in FETCH_OK, but End Location is an exclusive range end, not a wire fetch end. The reply claimed a much shorter range than the response carried, and it hid the end of track too, since the End Of Track check ran on the already-shortened value.

End Location is now the requested end clamped to one past the largest object the track has, computed by CacheTrack::fetchOkEnd() the same way everywhere the cache builds a FETCH_OK. The clamp also stops at the fetch start, since a range that begins past everything the track has would otherwise report an End Location below the Start and earn a PROTOCOL_VIOLATION from the receiver.

Ported from moxygen commit ff81a8f5, including its test coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/678)
<!-- Reviewable:end -->
