### PR TITLE
cache: record the upstream end of track

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -433,12 +433,15 @@ MoqxCache::CacheTrack::updateLargest(AbsoluteLocation current, bool eot) {
       endOfTrack = eot;
     }
     largestGroupAndObject = current;
-  } else if (eot && current != *largestGroupAndObject) {
-    // End of track is not the largest
-    XLOG(ERR) << "Malformed track, eot is not the largest object";
-    return folly::makeUnexpected(
-        MoQPublishError(MoQPublishError::MALFORMED_TRACK, "Malformed track")
-    );
+  } else if (eot) {
+    if (current != *largestGroupAndObject) {
+      // End of track is not the largest
+      XLOG(ERR) << "Malformed track, eot is not the largest object";
+      return folly::makeUnexpected(
+          MoQPublishError(MoQPublishError::MALFORMED_TRACK, "Malformed track")
+      );
+    }
+    endOfTrack = true;
   }
   return folly::unit;
 }
@@ -1420,11 +1423,13 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetch(
     // here: the request forwarded upstream has to keep the wire form.
     FetchRangeIterator
         fetchRangeIt(standalone->start, toExclusiveEnd(standalone->end), fetch.groupOrder, track);
-    co_return co_await upstream->fetch(
+    auto res = co_await upstream->fetch(
         fetch,
         std::make_shared<
             FetchWriteback>(true, std::move(consumer), fetchRangeIt, *this, fetch.fullTrackName)
     );
+    recordUpstreamEndOfTrack(*track, res);
+    co_return res;
   }
   // Nothing is forwarded verbatim from here on, so normalize in place and let
   // fetchUpstream put the wire form back when it talks to upstream.
@@ -1741,6 +1746,7 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetchUpstream(
 
   XLOG(DBG1) << "upstream success";
   track->extensions = res.value()->fetchOk().extensions;
+  recordUpstreamEndOfTrack(*track, res);
   if (lastObject) {
     if (!fetchHandle) {
       XLOG(DBG1) << "no fetchHandle and last object";
@@ -1772,6 +1778,28 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetchUpstream(
   }
   // completed successfully, ready for next object
   co_return nullptr;
+}
+
+void MoqxCache::recordUpstreamEndOfTrack(
+    CacheTrack& track,
+    const Publisher::FetchResult& upstreamResult
+) {
+  if (upstreamResult.hasError() || !upstreamResult.value()) {
+    return;
+  }
+  const auto& fetchOk = upstreamResult.value()->fetchOk();
+  if (!fetchOk.endOfTrack) {
+    return;
+  }
+  auto last = fetchOk.endLocation.prev();
+  if (!last) {
+    return;
+  }
+  auto res = track.updateLargest(*last, /*eot=*/true);
+  if (res.hasError()) {
+    XLOG(ERR) << "Upstream end of track at {" << last->group << "," << last->object
+              << "} conflicts with cached data";
+  }
 }
 
 folly::coro::Task<folly::Expected<folly::Unit, FetchError>>

--- a/src/MoqxCache.h
+++ b/src/MoqxCache.h
@@ -436,6 +436,13 @@ private:
   folly::coro::Task<folly::Expected<folly::Unit, moxygen::FetchError>>
   handleBlocked(std::shared_ptr<moxygen::FetchConsumer> consumer, const moxygen::Fetch& fetch);
 
+  // A FETCH response has no END_OF_TRACK object, so the FETCH_OK flag is the
+  // only way a fetch learns the track ended inside the range.
+  static void recordUpstreamEndOfTrack(
+      CacheTrack& track,
+      const moxygen::Publisher::FetchResult& upstreamResult
+  );
+
   void setMaxCacheDuration(const moxygen::FullTrackName& ftn, std::chrono::milliseconds duration);
   void clearMaxCacheDuration(const moxygen::FullTrackName& ftn);
 

--- a/test/MoqxCacheTest.cpp
+++ b/test/MoqxCacheTest.cpp
@@ -1181,6 +1181,26 @@ CO_TEST_F(MoqxCacheTest, TestUpstreamServesGroupWithGap) {
   EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{2, 0}));
 }
 
+// A FETCH response has no END_OF_TRACK object, so the FETCH_OK flag is the
+// only way the cache learns the track ended inside the range. The replay
+// below has to answer from cache and carry the flag forward.
+CO_TEST_F(MoqxCacheTest, TestUpstreamFetchOkEndOfTrackIsCached) {
+  expectUpstreamFetch({0, 0}, {0, 5}, /*endOfTrack=*/1, AbsoluteLocation{0, 5});
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 5}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasValue());
+  expectFetchObjects({0, 0}, {0, 5}, true);
+  serveCacheRangeFromUpstream({0, 0}, {0, 5});
+
+  co_await folly::coro::co_reschedule_on_current_executor;
+
+  // A range running past the end of track is answered entirely from cache.
+  expectFetchObjects({0, 0}, {0, 5}, false);
+  auto res2 = co_await cache_.fetch(getFetch({0, 0}, {0, 10}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res2.hasValue());
+  EXPECT_TRUE(res2.value()->fetchOk().endOfTrack);
+  EXPECT_EQ(res2.value()->fetchOk().endLocation, (AbsoluteLocation{0, 5}));
+}
+
 CO_TEST_F(MoqxCacheTest, TestUpstreamServesEndOfTrack) {
   // Test case for upstream serving END_OF_TRACK
 


### PR DESCRIPTION
A FETCH response has no END_OF_TRACK object, so the flag on the upstream FETCH_OK is the only place a fetch learns the track ends inside the range it asked for. The cache read that reply for its extensions and dropped the rest. Replaying the same track from cache then told the client End Of Track 0 and sent another pointless request upstream for the range past the last object.

The cache now folds the upstream end of track back into the track it is filling, on both the cold miss path and the tail fetch path. CacheTrack::updateLargest() also picks up the flag when the end of track is an object it already has.

Ported from moxygen commit 1c75b1c6, including its test coverage.


Claude-Session: https://claude.ai/code/session_01MRY5gbyL3XEngVhotspy6h

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/679)
<!-- Reviewable:end -->
