### PR TITLE
cache: forward the datagram lastInGroup flag to the downstream consumer

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -895,11 +895,10 @@ public:
   }
 
   folly::Expected<folly::Unit, MoQPublishError>
-  datagram(const ObjectHeader& header, Payload payload, bool /*lastInGroup*/ = false) override {
+  datagram(const ObjectHeader& header, Payload payload, bool lastInGroup = false) override {
     if (track_.shouldSkipCaching()) {
-      return consumer_->datagram(header, std::move(payload));
+      return consumer_->datagram(header, std::move(payload), lastInGroup);
     }
-    // TODO: Handle lastInGroup parameter when caching
     auto res = track_.updateLargest({header.group, header.id}, isEndOfTrack(header.status));
     if (!res) {
       return res;
@@ -920,7 +919,7 @@ public:
     if (cacheRes.hasError()) {
       return cacheRes;
     }
-    return consumer_->datagram(header, std::move(payload));
+    return consumer_->datagram(header, std::move(payload), lastInGroup);
   }
 
   folly::Expected<folly::Unit, MoQPublishError> publishDone(PublishDone pubDone) override {

--- a/test/MoqxCacheTest.cpp
+++ b/test/MoqxCacheTest.cpp
@@ -2110,6 +2110,27 @@ TEST_F(MoqxCacheTest, TestPriorGroupIdGapWithDatagram) {
   EXPECT_TRUE(result.hasValue());
 }
 
+TEST_F(MoqxCacheTest, TestDatagramForwardsLastInGroup) {
+  // Datagrams carry END_OF_GROUP out-of-band via lastInGroup; the cache
+  // writeback must not drop it on the way to the downstream consumer.
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+
+  EXPECT_CALL(*trackConsumer_, datagram(_, _, true)).WillOnce(Return(folly::unit));
+  auto result = writeback->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100), true);
+  EXPECT_TRUE(result.hasValue());
+}
+
+TEST_F(MoqxCacheTest, TestDatagramForwardsLastInGroupWhenCachingSkipped) {
+  // Same as above, but on the shouldSkipCaching() passthrough path.
+  cache_.setDefaultMaxCacheDuration(std::chrono::milliseconds(0));
+  cache_.setTrackExtensions(kTestTrackName, Extensions{});
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+
+  EXPECT_CALL(*trackConsumer_, datagram(_, _, true)).WillOnce(Return(folly::unit));
+  auto result = writeback->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100), true);
+  EXPECT_TRUE(result.hasValue());
+}
+
 TEST_F(MoqxCacheTest, TestPriorGroupIdGapSameValueMultipleObjects) {
   // Test that multiple objects in a group with the same Prior Group ID Gap
   // value succeeds (redundant but valid)


### PR DESCRIPTION
SubscribeWriteback::datagram() took lastInGroup but dropped it on both the skip-caching and the caching path, so the END_OF_GROUP marker never reached the downstream consumer for datagram objects.

Ported from moxygen commit 1074cb5b (the MoqxCache-equivalent hunk only — the MoQFramer/MoQTypes/MoQSession portions of that commit are already picked up via the vendored moxygen library, which is pinned past that commit). No upstream cache test exists for this one (its coverage lived in MoQFramerTest.cpp, not applicable here), so this adds regression coverage for both the caching and skip-caching paths.


Claude-Session: https://claude.ai/code/session_01MRY5gbyL3XEngVhotspy6h

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/681)
<!-- Reviewable:end -->
