### PR TITLE
cache: convert remaining glog CHECK to folly XCHECK

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -1402,7 +1402,7 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetch(
     std::shared_ptr<Publisher> upstream
 ) {
   auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
-  CHECK(standalone);
+  XCHECK(standalone);
   auto emplaceResult = cache_.emplace(fetch.fullTrackName, std::make_shared<CacheTrack>());
   auto trackIt = emplaceResult.first;
   auto track = trackIt->second;
@@ -1489,7 +1489,7 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetchImpl(
   auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
   XLOG(DBG1) << "fetchImpl for {" << standalone->start.group << "," << standalone->start.object
              << "}, {" << standalone->end.group << "," << standalone->end.object << "}";
-  CHECK(standalone);
+  XCHECK(standalone);
   auto token = co_await folly::coro::co_current_cancellation_token;
   std::optional<AbsoluteLocation> fetchStart;
   bool servedOneObject = false;


### PR DESCRIPTION
Mechanical conversion of the last two glog macros in MoqxCache.cpp; the rest of the file already uses XLOG/XCHECK. No semantic change.

Ported from moxygen commit e7409c9c (the MoqxCache-equivalent hunk only; the rest of that mechanical conversion applies to files moqx doesn't fork).


Claude-Session: https://claude.ai/code/session_01MRY5gbyL3XEngVhotspy6h

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/682)
<!-- Reviewable:end -->
