### PR TITLE
relay: hop peer subscription calls to the forwarder's executor

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -11,6 +11,7 @@
 #include "relay/ChannelSubscriber.h"
 #include "relay/CrossExecFilter.h"
 #include "relay/CrossExecForwarderCallback.h"
+#include "relay/CrossExecSubscriptionHandle.h"
 #include "relay/InitialTrackState.h"
 #include "relay/LocalForwarderCallback.h"
 #include "relay/NullConsumers.h"
@@ -963,12 +964,18 @@ std::optional<MoqxRelay::PreparedPublish> MoqxRelay::startPublish(
     return std::nullopt;
   }
   subscriber->pinned = pinned;
+  // relayExec_ owns the forwarder, but the session calls unsubscribe() on its own io
+  // thread, so the handle has to hop before it reaches subscribers_.
+  std::shared_ptr<Publisher::SubscriptionHandle> peerHandle = subscriber;
+  if (mode() == Mode::RelayExec) {
+    peerHandle = std::make_shared<CrossExecSubscriptionHandle>(subscriber, relayExec_);
+  }
   Subscriber::PublishResult pub;
   if (subscriberExec) {
     SubscriberCrossExecFilter wrapped(subscriberExec, session);
-    pub = wrapped.publish(subscriber->getPublishRequest(), subscriber);
+    pub = wrapped.publish(subscriber->getPublishRequest(), std::move(peerHandle));
   } else {
-    pub = session->publish(subscriber->getPublishRequest(), subscriber);
+    pub = session->publish(subscriber->getPublishRequest(), std::move(peerHandle));
   }
   if (pub.hasError()) {
     XLOG(ERR) << "startPublish: publish failed: " << pub.error().reasonPhrase;

--- a/src/relay/CrossExecSubscriptionHandle.h
+++ b/src/relay/CrossExecSubscriptionHandle.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+#include <folly/coro/Task.h>
+#include <memory>
+#include <moxygen/MoQConsumers.h>
+#include <moxygen/Publisher.h>
+
+namespace openmoq::moqx {
+
+// Dispatches unsubscribe() and requestUpdate() to the executor that owns the wrapped
+// handle: a session handle held by the relay, or a forwarder Subscriber held by a session.
+class CrossExecSubscriptionHandle : public moxygen::SubscriptionHandle {
+public:
+  CrossExecSubscriptionHandle(
+      std::shared_ptr<moxygen::SubscriptionHandle> inner,
+      folly::Executor* exec
+  )
+      : inner_(std::move(inner)), exec_(exec) {
+    // hasSubscribeOk() is non-virtual and reads the base's own field, so it
+    // answers for the wrapper, not for inner_. Copy it or callers stop seeing one.
+    if (inner_->hasSubscribeOk()) {
+      setSubscribeOk(inner_->subscribeOk());
+    }
+  }
+
+  ~CrossExecSubscriptionHandle() override {
+    // Inner dtor may touch owner state; destroy it on exec_, not the dropping thread.
+    if (inner_) {
+      exec_->add([inner = std::move(inner_)]() mutable {});
+    }
+  }
+
+  const moxygen::SubscribeOk& subscribeOk() const override { return inner_->subscribeOk(); }
+
+  void unsubscribe() override {
+    exec_->add([inner = inner_]() mutable { inner->unsubscribe(); });
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate update) override {
+    co_return co_await folly::coro::co_withExecutor(
+        folly::getKeepAliveToken(exec_),
+        inner_->requestUpdate(std::move(update))
+    );
+  }
+
+private:
+  std::shared_ptr<moxygen::SubscriptionHandle> inner_;
+  folly::Executor* exec_;
+};
+
+} // namespace openmoq::moqx

--- a/src/relay/PublisherCrossExecFilter.cpp
+++ b/src/relay/PublisherCrossExecFilter.cpp
@@ -6,46 +6,11 @@
 
 #include "relay/PublisherCrossExecFilter.h"
 #include "relay/CrossExecFilter.h"
+#include "relay/CrossExecSubscriptionHandle.h"
 
 namespace openmoq::moqx {
 
 namespace {
-
-// Dispatches unsubscribe() and requestUpdate() to the subscriber session's
-// executor (targetExec), which owns the session state.  Held by the relay
-// on relay exec and called back from there.
-class CrossExecSubscriptionHandle : public moxygen::SubscriptionHandle {
-public:
-  CrossExecSubscriptionHandle(
-      std::shared_ptr<moxygen::SubscriptionHandle> inner,
-      folly::Executor* exec
-  )
-      : inner_(std::move(inner)), exec_(exec) {}
-
-  ~CrossExecSubscriptionHandle() override {
-    // Inner dtor may touch session state; destroy it on exec_, not the dropping thread.
-    if (inner_) {
-      exec_->add([inner = std::move(inner_)]() mutable {});
-    }
-  }
-
-  const moxygen::SubscribeOk& subscribeOk() const override { return inner_->subscribeOk(); }
-
-  void unsubscribe() override {
-    exec_->add([inner = inner_]() mutable { inner->unsubscribe(); });
-  }
-
-  folly::coro::Task<RequestUpdateResult> requestUpdate(moxygen::RequestUpdate update) override {
-    co_return co_await folly::coro::co_withExecutor(
-        folly::getKeepAliveToken(exec_),
-        inner_->requestUpdate(std::move(update))
-    );
-  }
-
-private:
-  std::shared_ptr<moxygen::SubscriptionHandle> inner_;
-  folly::Executor* exec_;
-};
 
 class CrossExecFetchHandle : public moxygen::Publisher::FetchHandle {
 public:

--- a/test/MoqxRelaySubscribeTests.cpp
+++ b/test/MoqxRelaySubscribeTests.cpp
@@ -9,6 +9,9 @@
 
 #include "MoqxRelayTestFixture.h"
 
+#include <atomic>
+#include <folly/synchronization/Baton.h>
+
 namespace openmoq::moqx::test {
 
 // Test: forwardChanged must not crash when called after the publisher has
@@ -756,5 +759,65 @@ TEST_P(MoQRelayTest, PublishFanoutDuringParkedSubscribeSetup) {
     driveIfMultiThread();
     pubEvb->runInEventBaseThreadAndWait([] {});
   }
+}
+
+// A peer UNSUBSCRIBE reaches the forwarder on the session's io thread: MoQSession
+// keeps the handle the relay published with and calls unsubscribe() on it directly,
+// with no relay-exec hop. If onEmpty then runs the relay callback inline, registry_
+// is erased off relayExec_ while the relay thread erases the same track, corrupting
+// the F14 table (folly SafeAssert "clearTag: tags_[index] != 0"). Parking relayEvb_
+// across the trigger keeps the assertion from being a race of its own.
+TEST_P(MoQRelayTest, PeerUnsubscribeDefersOnEmptyToRelayExec) {
+  if (relayMode() != RelayMode::MultiThread) {
+    GTEST_SKIP() << "chain-forwarder callback wiring is RelayExec-only";
+  }
+
+  auto publisherSession = createMockSession();
+  auto subSession = createMockSession();
+  setupPublishSucceeds(subSession);
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+  doSubscribeNamespace(subSession, kTestNamespace);
+  auto publishHandle = makePublishHandle();
+  ASSERT_NE(doPublishWithHandle(publisherSession, kTestTrackName, publishHandle), nullptr);
+  driveIfMultiThread();
+  ASSERT_NE(peerHandle(subSession), nullptr) << "relay should have published to the subscriber";
+  // hasSubscribeOk() is non-virtual, so a wrapper that does not copy it silently
+  // stops MoQSession seeding largest_ from the forwarder.
+  EXPECT_TRUE(peerHandle(subSession)->hasSubscribeOk());
+
+  std::atomic<bool> upstreamTornDown{false};
+  EXPECT_CALL(*publishHandle, unsubscribe()).WillRepeatedly([&upstreamTornDown] {
+    upstreamTornDown = true;
+  });
+  EXPECT_CALL(*publishHandle, requestUpdateCalled(_))
+      .WillRepeatedly([&upstreamTornDown](RequestUpdate update) {
+        if (update.forward && !*update.forward) {
+          upstreamTornDown = true;
+        }
+      });
+
+  // Shared, not stack: on a park timeout the test body returns while the lambda
+  // is still queued, and it would wait on a destroyed baton.
+  auto parked = std::make_shared<folly::Baton<>>();
+  auto release = std::make_shared<folly::Baton<>>();
+  relayEvb_->add([parked, release] {
+    parked->post();
+    release->wait();
+  });
+  ASSERT_TRUE(parked->try_wait_for(std::chrono::seconds(5)));
+
+  peerUnsubscribe(subSession);
+  exec_->driveSessionExecOnly();
+
+  EXPECT_FALSE(upstreamTornDown.load())
+      << "onEmpty reached MoqxRelay on the session executor instead of relayExec_";
+
+  release->post();
+  EXPECT_TRUE(driveUntil([&upstreamTornDown] { return upstreamTornDown.load(); }));
+
+  removeSession(publisherSession);
+  removeSession(subSession);
+  driveIfMultiThread();
 }
 } // namespace openmoq::moqx::test

--- a/test/MoqxRelayTestFixture.cpp
+++ b/test/MoqxRelayTestFixture.cpp
@@ -30,6 +30,12 @@ void TestMoQExecutor::drive() {
     evb->loopOnce();
   }
 }
+void TestMoQExecutor::driveSessionExecOnly() {
+  if (auto* evb = getBackingEventBase()) {
+    evb->loopOnce();
+  }
+}
+
 void TestMoQExecutor::driveFor(int n) {
   for (int i = 0; i < n; i++) {
     drive();
@@ -110,6 +116,8 @@ void MoQRelayTest::TearDown() {
   // the last release; ~fixture frees auxExecs_ then exec_ after that.
   drainExecs();
   mockSessions_.clear(); // declared before exec_, so ~fixture frees it too late
+  peerHandles_.clear();  // same, and their release hops to relayExec_
+  drainExecs();
   exec_->setRelayEvb(nullptr);
   publisherInterface_.reset();
   subscriberInterface_.reset();
@@ -368,21 +376,39 @@ std::shared_ptr<Publisher::SubscribeNamespaceHandle> MoQRelayTest::doSubscribeNa
 
 void MoQRelayTest::setupPublishSucceeds(std::shared_ptr<MockMoQSession> session) {
   ON_CALL(*session, publish(_, _))
-      .WillByDefault(Invoke([this](PublishRequest pub, auto) -> Subscriber::PublishResult {
-        PublishOk ok{
-            pub.requestID,
-            /*forward=*/pub.forward,
-            /*priority=*/128,
-            GroupOrder::Default,
-            LocationType::LargestObject,
-            /*start=*/std::nullopt,
-            /*endGroup=*/std::make_optional(uint64_t(0))
-        };
-        return Subscriber::PublishConsumerAndReplyTask{
-            createMockConsumer(),
-            folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(std::move(ok))
-        };
-      }));
+      .WillByDefault(Invoke(
+          [this, key = session.get()](
+              PublishRequest pub,
+              std::shared_ptr<Publisher::SubscriptionHandle> handle
+          ) -> Subscriber::PublishResult {
+            peerHandles_[key] = std::move(handle);
+            PublishOk ok{
+                pub.requestID,
+                /*forward=*/pub.forward,
+                /*priority=*/128,
+                GroupOrder::Default,
+                LocationType::LargestObject,
+                /*start=*/std::nullopt,
+                /*endGroup=*/std::make_optional(uint64_t(0))
+            };
+            return Subscriber::PublishConsumerAndReplyTask{
+                createMockConsumer(),
+                folly::coro::makeTask<folly::Expected<PublishOk, PublishError>>(std::move(ok))
+            };
+          }
+      ));
+}
+
+std::shared_ptr<Publisher::SubscriptionHandle>
+MoQRelayTest::peerHandle(const std::shared_ptr<MockMoQSession>& session) {
+  auto it = peerHandles_.find(session.get());
+  return it == peerHandles_.end() ? nullptr : it->second;
+}
+
+void MoQRelayTest::peerUnsubscribe(const std::shared_ptr<MockMoQSession>& session) {
+  auto handle = peerHandle(session);
+  ASSERT_NE(handle, nullptr) << "session was never published to";
+  handle->unsubscribe();
 }
 
 std::shared_ptr<NiceMock<MockSubscriptionHandle>> MoQRelayTest::makePublishHandle() {

--- a/test/MoqxRelayTestFixture.h
+++ b/test/MoqxRelayTestFixture.h
@@ -72,6 +72,10 @@ public:
   void drive() override;
   void driveFor(int n);
 
+  // drive() without the relayEvb_ rendezvous, so a test can flush only what the
+  // session executor already holds.
+  void driveSessionExecOnly();
+
   void setRelayEvb(folly::EventBase* evb) { relayEvb_ = evb; }
 
 private:
@@ -157,6 +161,7 @@ protected:
   };
 
   std::map<MoQSession*, std::shared_ptr<MockSessionState>> mockSessions_;
+  std::map<MoQSession*, std::shared_ptr<moxygen::Publisher::SubscriptionHandle>> peerHandles_;
 
   std::shared_ptr<MockSessionState> getOrCreateMockState(std::shared_ptr<MoQSession> session);
   void cleanupMockSession(std::shared_ptr<MoQSession> session);
@@ -195,6 +200,15 @@ protected:
   );
 
   void setupPublishSucceeds(std::shared_ptr<MockMoQSession> session);
+
+  // The handle the relay publishes with. MoQSession keeps it in TrackPublisherImpl
+  // and calls unsubscribe() on it, on its own io thread, when the peer sends
+  // UNSUBSCRIBE — no relay-exec hop, unlike the handle subscribe() hands back.
+  std::shared_ptr<moxygen::Publisher::SubscriptionHandle>
+  peerHandle(const std::shared_ptr<MockMoQSession>& session);
+
+  // Deliver a peer UNSUBSCRIBE on the calling thread, as MoQSession::onUnsubscribe does.
+  void peerUnsubscribe(const std::shared_ptr<MockMoQSession>& session);
 
   std::shared_ptr<NiceMock<MockSubscriptionHandle>> makePublishHandle();
 


### PR DESCRIPTION
In RelayExec mode relayExec_ owns the forwarder, but startPublish handed the session a MoQForwarder::Subscriber unwrapped, so unsubscribe() and requestUpdate() reached forwarder state and registry_ on the session's io thread while the relay thread was touching the same track. Concurrent erase corrupts the F14 table. The handle is now wrapped so both calls hop first, the way the subscribe direction already wraps the handles it returns:

  peerHandle = std::make_shared<CrossExecSubscriptionHandle>(subscriber, relayExec_);

The wrapper copies inner's SubscribeOk because hasSubscribeOk() is non-virtual, and MoQSession seeds a track's largest from it. TrackPublisherImpl::unsubscribe now resets its subgroups before the forwarder drops the subscriber; the forwarder reaches the same streams through CrossExecFilter, which already deferred them, so the second reset was redundant either way. The fixture gains peerUnsubscribe(), which delivers a peer UNSUBSCRIBE the way MoQSession::onUnsubscribe does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/683)
<!-- Reviewable:end -->
