### PR TITLE
fix: route SUBSCRIBE/FETCH past publisher-less namespace nodes

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -881,7 +881,6 @@ MoqxRelay::PublishSetupResult MoqxRelay::publishWithSession(
   auto tracksNode = tracksTree_.findNode(
       pub.fullTrackName.trackNamespace,
       /*createMissingNodes=*/false,
-      NamespaceTree::MatchType::Exact,
       &tracksSessions
   );
   if (tracksNode) {
@@ -1885,11 +1884,8 @@ folly::coro::Task<Publisher::SubscribeTracksResult> MoqxRelay::subscribeTracks(
 
   // Walk the existing publish tree and emit PUBLISH for each matching
   // already-published track (backfill for new subscriber).
-  auto pubNode = namespaceTree_.findNode(
-      subTracks.trackNamespacePrefix,
-      /*createMissingNodes=*/false,
-      NamespaceTree::MatchType::Exact
-  );
+  auto pubNode =
+      namespaceTree_.findNode(subTracks.trackNamespacePrefix, /*createMissingNodes=*/false);
   if (pubNode) {
     namespaceTree_.forEachNodeInSubtree(
         subTracks.trackNamespacePrefix,
@@ -1937,11 +1933,7 @@ void MoqxRelay::unsubscribeTracks(
 
 MoqxRelay::PublishState MoqxRelay::findPublishState(const FullTrackName& ftn) {
   PublishState state;
-  auto nodePtr = namespaceTree_.findNode(
-      ftn.trackNamespace,
-      /*createMissingNodes=*/false,
-      NamespaceTree::MatchType::Exact
-  );
+  auto nodePtr = namespaceTree_.findNode(ftn.trackNamespace, /*createMissingNodes=*/false);
 
   if (!nodePtr) {
     return state;

--- a/src/NamespaceTree.cpp
+++ b/src/NamespaceTree.cpp
@@ -77,8 +77,21 @@ void NamespaceTree::tryPruneSelf(NamespaceNode& node, bool hadContent, const Tra
 }
 
 std::shared_ptr<MoQSession> NamespaceTree::findPublisherSession(const TrackNamespace& ns) {
-  auto nodePtr = findNode(ns, /*createMissingNodes=*/false, MatchType::Prefix);
-  return nodePtr ? nodePtr->publisherSession_ : nullptr;
+  // publish()/subscribeNamespace() create nodes with no publisher; don't let
+  // those shadow a publishing ancestor further up the path.
+  std::shared_ptr<MoQSession> deepestPublisher = root_.publisherSession_;
+  const NamespaceNode* node = &root_;
+  for (size_t i = 0; i < ns.size(); i++) {
+    auto it = node->children_.find(ns[i]);
+    if (it == node->children_.end()) {
+      break;
+    }
+    node = it->second.get();
+    if (node->publisherSession_) {
+      deepestPublisher = node->publisherSession_;
+    }
+  }
+  return deepestPublisher;
 }
 
 NamespaceTree::SetPublisherResult NamespaceTree::setPublisher(
@@ -90,7 +103,7 @@ NamespaceTree::SetPublisherResult NamespaceTree::setPublisher(
     std::vector<uint64_t> relayHopPath
 ) {
   SetPublisherResult result;
-  auto node = findNode(ns, /*createMissingNodes=*/true, MatchType::Exact, &result.subscribers);
+  auto node = findNode(ns, /*createMissingNodes=*/true, &result.subscribers);
 
   if (node->publisherSession_) {
     result.replacedSession = node->publisherSession_;
@@ -136,7 +149,7 @@ NamespaceTree::unpublishNamespace(
   }
 
   UnpublishNamespaceResult result;
-  findNode(ns, /*createMissingNodes=*/false, MatchType::Exact, &result.subscribers);
+  findNode(ns, /*createMissingNodes=*/false, &result.subscribers);
   for (const auto& [sess, info] : node->subscribers_) {
     result.subscribers.emplace_back(sess, info);
   }
@@ -172,12 +185,7 @@ NamespaceTree::AddPublishResult NamespaceTree::addPublish(
     OnRankingFn onRanking
 ) {
   AddPublishResult result;
-  result.node = findNode(
-      ftn.trackNamespace,
-      /*createMissingNodes=*/true,
-      MatchType::Exact,
-      &result.subscribers
-  );
+  result.node = findNode(ftn.trackNamespace, /*createMissingNodes=*/true, &result.subscribers);
   for (const auto& [sess, info] : result.node->subscribers_) {
     result.subscribers.emplace_back(sess, info);
   }
@@ -277,7 +285,6 @@ bool NamespaceTree::hasOverlappingTracksSubscription(
 std::shared_ptr<NamespaceTree::NamespaceNode> NamespaceTree::findNode(
     const TrackNamespace& ns,
     bool createMissingNodes,
-    MatchType matchType,
     SessionSubscriberList* subscribers
 ) {
   std::shared_ptr<NamespaceNode> nodePtr(std::shared_ptr<void>(), &root_);
@@ -297,8 +304,6 @@ std::shared_ptr<NamespaceTree::NamespaceNode> NamespaceTree::findNode(
         node->trackNamespace = partialNs;
         nodePtr->children_.emplace(name, node);
         nodePtr = std::move(node);
-      } else if (matchType == MatchType::Prefix && nodePtr.get() != &root_) {
-        return nodePtr;
       } else {
         XLOG(DBG1) << "namespace node not found: " << ns;
         return nullptr;

--- a/src/NamespaceTree.h
+++ b/src/NamespaceTree.h
@@ -134,7 +134,6 @@ public:
 
   explicit NamespaceTree(Callback& cb) : cb_(cb), root_(*this) {}
 
-  enum class MatchType { Exact, Prefix };
   enum class Error { NodeNotFound, NotOwner, NotSubscribed };
 
   // Longest-prefix match for the publisher of ns; null if none found.
@@ -143,7 +142,6 @@ public:
   std::shared_ptr<NamespaceNode> findNode(
       const moxygen::TrackNamespace& ns,
       bool createMissingNodes = false,
-      MatchType matchType = MatchType::Exact,
       SessionSubscriberList* subscribers = nullptr
   );
 

--- a/test/NamespaceTreeTest.cpp
+++ b/test/NamespaceTreeTest.cpp
@@ -74,6 +74,23 @@ TEST_F(NamespaceTreeTest, PruneLeafKeepSiblings) {
   EXPECT_EQ(tree_.findPublisherSession(nsAD), publisherAD);
 }
 
+// Test: SUBSCRIBE routes past a publisher-less node
+// Scenario: test/A has a publisher. A subscriber to test/A/B creates a node
+// there with no publisher of its own. Looking up test/A/B/C must still find
+// test/A's publisher instead of stopping at the publisher-less B.
+TEST_F(NamespaceTreeTest, FindPublisherSessionSkipsPublisherlessNode) {
+  auto publisher = makeSession();
+
+  TrackNamespace nsA{{"test", "A"}};
+  TrackNamespace nsAB{{"test", "A", "B"}};
+  TrackNamespace nsABC{{"test", "A", "B", "C"}};
+
+  publish(nsA, publisher);
+  subscribe(nsAB, makeSession());
+
+  EXPECT_EQ(tree_.findPublisherSession(nsABC), publisher);
+}
+
 // Test: Tree pruning removes highest empty ancestor
 // Scenario: test/A/B/C only. Remove C should prune A (highest empty after test)
 TEST_F(NamespaceTreeTest, PruneHighestEmptyAncestor) {


### PR DESCRIPTION
Port of moxygen a682b57a ("Route SUBSCRIBE past publisher-less namespace nodes"). findPublisherSession() walked the namespace tree and read the publisher off whichever node the walk stopped at. PUBLISH and SUBSCRIBE_NAMESPACE also create nodes, and those carry no publisher, so a lookup that passed through one of them failed even when a broader namespace above it had a publisher. The lookup now keeps the deepest publisher it passes on the way down instead.

findNode()'s MatchType::Prefix mode existed only to support the old implementation and is now unused; dropped it along with the parameter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/684)
<!-- Reviewable:end -->
