### PR TITLE
fix: prefer exact-track upstream over namespace publisher for FETCH

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -2590,21 +2590,23 @@ MoqxRelay::fetchImpl(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
     }
   }
 
-  auto upstreamPublisher = findUpstreamPublisher(fetch.fullTrackName.trackNamespace);
-  if (!upstreamPublisher && upstream_) {
-    co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
+  // Prefer an exact-track upstream (from publish/subscribe) over a broader
+  // namespace-level publisher, matching subscribeImpl's resolution order.
+  auto fetchView = registry_.getFetchView(fetch.fullTrackName);
+  std::shared_ptr<Publisher> upstreamPublisher;
+  if (fetchView) {
+    upstreamPublisher = fetchView->publisher;
+  } else {
     upstreamPublisher = findUpstreamPublisher(fetch.fullTrackName.trackNamespace);
+    if (!upstreamPublisher && upstream_) {
+      co_await upstream_->waitForConnected(kUpstreamConnectWaitTimeout);
+      upstreamPublisher = findUpstreamPublisher(fetch.fullTrackName.trackNamespace);
+    }
   }
   if (!upstreamPublisher) {
-    // Attempt to find matching upstream subscription (from publish)
-    if (auto fetchView = registry_.getFetchView(fetch.fullTrackName)) {
-      upstreamPublisher = fetchView->publisher;
-    }
-    if (!upstreamPublisher) {
-      co_return folly::makeUnexpected(
-          FetchError({fetch.requestID, FetchErrorCode::DOES_NOT_EXIST, "no upstream for fetch"})
-      );
-    }
+    co_return folly::makeUnexpected(
+        FetchError({fetch.requestID, FetchErrorCode::DOES_NOT_EXIST, "no upstream for fetch"})
+    );
   }
   fetch.priority = kDefaultUpstreamPriority;
 

--- a/test/MoqxRelayFetchTests.cpp
+++ b/test/MoqxRelayFetchTests.cpp
@@ -66,6 +66,47 @@ TEST_P(MoQRelayTest, FetchAfterPublisherTermination) {
   removeSession(fetchSession);
 }
 
+// Test: FETCH must prefer an exact-track upstream over a broader
+// namespace-level publisher when both exist for the same track.
+TEST_P(MoQRelayTest, FetchPrefersExactTrackOverNamespace) {
+  auto namespacePublisher = createMockSession();
+  auto trackPublisher = createMockSession();
+  auto fetchSession = createMockSession();
+
+  // Broad, namespace-level publisher for kTestNamespace.
+  doPublishNamespace(namespacePublisher, kTestNamespace);
+
+  // A distinct, more specific publisher for the exact track, landing in the
+  // registry rather than the namespace tree.
+  doPublish(trackPublisher, kTestTrackName, /*addToState=*/true);
+
+  EXPECT_CALL(*namespacePublisher, fetch(_, _)).Times(0);
+  EXPECT_CALL(*trackPublisher, fetch(_, _))
+      .WillOnce([](Fetch, std::shared_ptr<FetchConsumer> consumer) {
+        // Terminate the fetch so the cross-exec consumer drops its
+        // self-anchor; a real upstream always ends the fetch.
+        consumer->endOfFetch();
+        return folly::coro::makeTask<Publisher::FetchResult>(std::make_shared<MockFetchHandle>(
+            FetchOk{RequestID(0), GroupOrder::OldestFirst, 0, AbsoluteLocation{0, 0}, {}}
+        ));
+      });
+
+  Fetch fetch(RequestID(0), kTestTrackName, AbsoluteLocation{0, 0}, AbsoluteLocation{1, 0});
+  auto fetchConsumer = std::make_shared<NiceMock<MockFetchConsumer>>();
+  EXPECT_CALL(*fetchConsumer, endOfFetch()).WillOnce([]() {
+    return folly::Expected<folly::Unit, MoQPublishError>(folly::unit);
+  });
+  withSessionContext(fetchSession, [&]() {
+    auto task = publisherInterface()->fetch(std::move(fetch), fetchConsumer);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    EXPECT_TRUE(res.hasValue());
+  });
+
+  removeSession(namespacePublisher);
+  removeSession(trackPublisher);
+  removeSession(fetchSession);
+}
+
 // Joining fetch referencing a PUBLISH: onPublishOk must store the PUBLISH_OK
 // request id so the fetch matches the fanned-out subscription and resolves.
 TEST_P(MoQRelayTest, JoiningFetchAgainstPublish) {


### PR DESCRIPTION
Port of moxygen 50f951ca ("Prefer exact track match over namespace for FETCH"). fetchImpl() resolved the namespace-level publisher first and only fell back to the registry's exact-track entry if that failed. When both existed for the same track, a FETCH was routed to the broader namespace publisher instead of the more specific upstream the relay already had on record for that exact track. Registry lookup now runs first, matching subscribeImpl's resolution order and trackStatusImpl's existing "registry first, namespace tree fallback" pattern.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/685)
<!-- Reviewable:end -->
