### PR TITLE
fix: accept empty namespaces on draft-18+ for PUBLISH/SUBSCRIBE/FETCH/TRACK_STATUS

### DIFF
--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -182,14 +182,14 @@ public:
       moxygen::SubscribeRequest subReq,
       std::shared_ptr<moxygen::TrackConsumer> consumer
   ) override {
-    if (subReq.fullTrackName.trackNamespace.empty()) {
+    auto session = moxygen::MoQSession::getRequestSession();
+    if (subReq.fullTrackName.trackNamespace.empty() && !MoqxRelay::emptyNamespaceAllowed(session)) {
       co_return folly::makeUnexpected(moxygen::SubscribeError{
           subReq.requestID,
           moxygen::SubscribeErrorCode::DOES_NOT_EXIST,
           "namespace required"
       });
     }
-    auto session = moxygen::MoQSession::getRequestSession();
     auto* subscriberExec = session->getExecutor();
     // No executor hop: subscribeFromSubscriberExec starts on subscriberExec.
     co_return co_await relay_->subscribeFromSubscriberExec(
@@ -613,17 +613,28 @@ void MoqxRelay::onPublishDone(const FullTrackName& ftn) {
 }
 
 // Validates a publish namespace against allowedNamespacePrefix_ (UNINTERESTED)
-// and non-emptiness (INTERNAL_ERROR). Returns std::nullopt on success. Safe to
-// call on any thread (reads only immutable config).
-std::optional<PublishError>
-MoqxRelay::validatePublishNamespace(const FullTrackName& ftn, RequestID requestID) const {
+// and non-emptiness (INTERNAL_ERROR, unless the negotiated draft allows it).
+// Returns std::nullopt on success. Safe to call on any thread (reads only
+// immutable config plus the caller-supplied emptyNamespaceAllowed).
+std::optional<PublishError> MoqxRelay::validatePublishNamespace(
+    const FullTrackName& ftn,
+    RequestID requestID,
+    bool emptyNamespaceAllowed
+) const {
   if (!ftn.trackNamespace.startsWith(allowedNamespacePrefix_)) {
     return PublishError{requestID, PublishErrorCode::UNINTERESTED, "bad namespace"};
   }
-  if (ftn.trackNamespace.empty()) {
+  if (ftn.trackNamespace.empty() && !emptyNamespaceAllowed) {
     return PublishError{requestID, PublishErrorCode::INTERNAL_ERROR, "namespace required"};
   }
   return std::nullopt;
+}
+
+// Draft 18+ allows an empty track namespace (PUBLISH/SUBSCRIBE/FETCH/TRACK_STATUS).
+bool MoqxRelay::emptyNamespaceAllowed(const std::shared_ptr<MoQSession>& session) {
+  auto maybeNegotiatedVersion = session->getNegotiatedVersion();
+  XCHECK(maybeNegotiatedVersion.has_value());
+  return getDraftMajorVersion(*maybeNegotiatedVersion) >= 18;
 }
 
 // Chain and entry claim are one call: LocalForwarderCallback vacates the entry when the
@@ -655,7 +666,11 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
     std::shared_ptr<Publisher::SubscriptionHandle> handle,
     std::shared_ptr<MoQSession> session
 ) {
-  if (auto err = validatePublishNamespace(pub.fullTrackName, pub.requestID)) {
+  if (auto err = validatePublishNamespace(
+          pub.fullTrackName,
+          pub.requestID,
+          emptyNamespaceAllowed(session)
+      )) {
     return folly::makeUnexpected(std::move(*err));
   }
 
@@ -748,7 +763,11 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   // getRequestSession() stays valid on relayExec_: RequestContext propagates
   // across the filter's executor hop. Validate before touching state.
   auto session = MoQSession::getRequestSession();
-  if (auto err = validatePublishNamespace(pub.fullTrackName, pub.requestID)) {
+  if (auto err = validatePublishNamespace(
+          pub.fullTrackName,
+          pub.requestID,
+          emptyNamespaceAllowed(session)
+      )) {
     return folly::makeUnexpected(std::move(*err));
   }
   XCHECK(mode() != Mode::LocalForwarder) << "publish() bypassed by LocalPublishFilter in LF mode";
@@ -2399,7 +2418,7 @@ MoqxRelay::subscribeImpl(SubscribeRequest subReq, std::shared_ptr<TrackConsumer>
   maybeSetSessionExec(*session);
   const auto& ftn = subReq.fullTrackName;
 
-  if (ftn.trackNamespace.empty()) {
+  if (ftn.trackNamespace.empty() && !emptyNamespaceAllowed(session)) {
     co_return folly::makeUnexpected(
         SubscribeError({subReq.requestID, SubscribeErrorCode::DOES_NOT_EXIST, "namespace required"})
     );
@@ -2558,7 +2577,7 @@ folly::coro::Task<Publisher::FetchResult>
 MoqxRelay::fetchImpl(Fetch fetch, std::shared_ptr<FetchConsumer> consumer) {
   auto session = MoQSession::getRequestSession();
 
-  if (fetch.fullTrackName.trackNamespace.empty()) {
+  if (fetch.fullTrackName.trackNamespace.empty() && !emptyNamespaceAllowed(session)) {
     co_return folly::makeUnexpected(
         FetchError({fetch.requestID, FetchErrorCode::DOES_NOT_EXIST, "namespace required"})
     );
@@ -2644,7 +2663,7 @@ folly::coro::Task<Publisher::TrackStatusResult> MoqxRelay::trackStatusImpl(Track
 
   auto session = MoQSession::getRequestSession();
 
-  if (trackStatus.fullTrackName.trackNamespace.empty()) {
+  if (trackStatus.fullTrackName.trackNamespace.empty() && !emptyNamespaceAllowed(session)) {
     co_return folly::makeUnexpected(TrackStatusError(
         {trackStatus.requestID, TrackStatusErrorCode::DOES_NOT_EXIST, "namespace required"}
     ));

--- a/src/MoqxRelay.h
+++ b/src/MoqxRelay.h
@@ -413,8 +413,13 @@ private:
       InstallKind kind
   );
 
-  std::optional<moxygen::PublishError>
-  validatePublishNamespace(const moxygen::FullTrackName& ftn, moxygen::RequestID requestID) const;
+  std::optional<moxygen::PublishError> validatePublishNamespace(
+      const moxygen::FullTrackName& ftn,
+      moxygen::RequestID requestID,
+      bool emptyNamespaceAllowed
+  ) const;
+
+  static bool emptyNamespaceAllowed(const std::shared_ptr<moxygen::MoQSession>& session);
 
   folly::coro::Task<folly::Expected<moxygen::PublishOk, moxygen::PublishError>>
   registerPublishOnRelayExec(

--- a/test/MoqxRelayFetchTests.cpp
+++ b/test/MoqxRelayFetchTests.cpp
@@ -11,6 +11,54 @@
 
 namespace openmoq::moqx::test {
 
+// Test: FETCH with an empty namespace is rejected pre-draft-18.
+TEST_P(MoQRelayTest, FetchEmptyNamespaceRejectedPreV18) {
+  auto session = createMockSession();
+  // Default session negotiates kVersionDraftCurrent (draft-14, which is < 18)
+
+  Fetch fetch(
+      RequestID(0),
+      FullTrackName{TrackNamespace{{}}, "track1"},
+      AbsoluteLocation{0, 0},
+      AbsoluteLocation{1, 0}
+  );
+  auto fetchConsumer = std::make_shared<NiceMock<MockFetchConsumer>>();
+  withSessionContext(session, [&]() {
+    auto task = publisherInterface()->fetch(std::move(fetch), fetchConsumer);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    ASSERT_FALSE(res.hasValue());
+    EXPECT_EQ(res.error().errorCode, FetchErrorCode::DOES_NOT_EXIST);
+    EXPECT_EQ(res.error().reasonPhrase, "namespace required");
+  });
+
+  removeSession(session);
+}
+
+// Test: FETCH with an empty namespace is not rejected for its namespace on
+// draft-18+ — it falls through to the normal "no such upstream" resolution.
+TEST_P(MoQRelayTest, FetchEmptyNamespaceAllowedV18) {
+  auto session = createMockSession();
+  ON_CALL(*session, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft18)));
+
+  Fetch fetch(
+      RequestID(0),
+      FullTrackName{TrackNamespace{{}}, "track1"},
+      AbsoluteLocation{0, 0},
+      AbsoluteLocation{1, 0}
+  );
+  auto fetchConsumer = std::make_shared<NiceMock<MockFetchConsumer>>();
+  withSessionContext(session, [&]() {
+    auto task = publisherInterface()->fetch(std::move(fetch), fetchConsumer);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    ASSERT_FALSE(res.hasValue());
+    EXPECT_EQ(res.error().errorCode, FetchErrorCode::DOES_NOT_EXIST);
+    EXPECT_EQ(res.error().reasonPhrase, "no upstream for fetch");
+  });
+
+  removeSession(session);
+}
+
 // Test: fetch fallback to subscriptions_ after publisher termination must not
 // crash. When findPublishNamespaceSession returns null (no publishNamespace),
 // fetch falls back to subscriptions_. After onPublishDone, upstream is null

--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -39,6 +39,52 @@ TEST_P(MoQRelayTest, PublishSuccess) {
   removeSession(publisherSession);
 }
 
+// Test: PUBLISH with an empty namespace is rejected pre-draft-18.
+TEST_P(MoQRelayTest, PublishEmptyNamespaceRejectedPreV18) {
+  relay_->setAllowedNamespacePrefix(TrackNamespace{{}});
+  auto session = createMockSession();
+  // Default session negotiates kVersionDraftCurrent (draft-14, which is < 18)
+
+  PublishRequest pub;
+  pub.fullTrackName = FullTrackName{TrackNamespace{{}}, "track1"};
+  withSessionContext(session, [&]() {
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
+    if (res.hasValue()) {
+      // MT mode: the cross-exec filter acks synchronously; rejection surfaces
+      // in the reply task instead.
+      auto reply = folly::coro::blockingWait(std::move(res->reply), exec_.get());
+      ASSERT_FALSE(reply.hasValue()) << "Empty namespace should be rejected for pre-v18 sessions";
+      EXPECT_EQ(reply.error().errorCode, PublishErrorCode::INTERNAL_ERROR);
+    } else {
+      EXPECT_EQ(res.error().errorCode, PublishErrorCode::INTERNAL_ERROR);
+    }
+  });
+
+  removeSession(session);
+}
+
+// Test: PUBLISH with an empty namespace is accepted on draft-18+.
+TEST_P(MoQRelayTest, PublishEmptyNamespaceAllowedV18) {
+  relay_->setAllowedNamespacePrefix(TrackNamespace{{}});
+  auto session = createMockSession();
+  ON_CALL(*session, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft18)));
+
+  PublishRequest pub;
+  pub.fullTrackName = FullTrackName{TrackNamespace{{}}, "track1"};
+  withSessionContext(session, [&]() {
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
+    ASSERT_TRUE(res.hasValue()) << "Empty namespace should be allowed for v18+ sessions";
+    // MT mode: the cross-exec filter acks synchronously above; the real
+    // result resolves in the reply task.
+    auto reply = folly::coro::blockingWait(std::move(res->reply), exec_.get());
+    EXPECT_TRUE(reply.hasValue()) << "Empty namespace should be allowed for v18+ sessions";
+  });
+
+  exec_->drive();
+  removeSession(session);
+}
+
 // Namespace tree tests (Prune*, MixedContent*, ActiveChildCount, PublishKeepsNode)
 // are in NamespaceTreeTest.cpp.
 // MoQForwarder unit tests (draining, tombstoning, hard errors, etc.)

--- a/test/MoqxRelaySubscribeTests.cpp
+++ b/test/MoqxRelaySubscribeTests.cpp
@@ -14,6 +14,48 @@
 
 namespace openmoq::moqx::test {
 
+// Test: SUBSCRIBE with an empty namespace is rejected pre-draft-18.
+TEST_P(MoQRelayTest, SubscribeEmptyNamespaceRejectedPreV18) {
+  auto session = createMockSession();
+  // Default session negotiates kVersionDraftCurrent (draft-14, which is < 18)
+
+  auto consumer = createMockConsumer();
+  auto handle = subscribeToTrack(
+      session,
+      FullTrackName{TrackNamespace{{}}, "track1"},
+      consumer,
+      RequestID(0),
+      /*addToState=*/false,
+      SubscribeErrorCode::DOES_NOT_EXIST
+  );
+  EXPECT_EQ(handle, nullptr);
+
+  removeSession(session);
+}
+
+// Test: SUBSCRIBE with an empty namespace is accepted on draft-18+.
+TEST_P(MoQRelayTest, SubscribeEmptyNamespaceAllowedV18) {
+  relay_->setAllowedNamespacePrefix(TrackNamespace{{}});
+  FullTrackName emptyNsTrack{TrackNamespace{{}}, "track1"};
+
+  auto publisherSession = createMockSession();
+  ON_CALL(*publisherSession, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft18)));
+  doPublish(publisherSession, emptyNsTrack);
+
+  auto subSession = createMockSession();
+  ON_CALL(*subSession, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft18)));
+  auto consumer = createMockConsumer();
+  auto handle = subscribeToTrack(subSession, emptyNsTrack, consumer, RequestID(0));
+  ASSERT_NE(handle, nullptr);
+
+  handle->unsubscribe();
+  exec_->drive();
+  removeSession(publisherSession);
+  removeSession(subSession);
+}
+
 // Test: forwardChanged must not crash when called after the publisher has
 // terminated (onPublishDone clears handle/upstream). We trigger forwardChanged
 // via Subscriber::requestUpdate changing forward from true→false (1→0

--- a/test/MoqxRelayTrackStatusTests.cpp
+++ b/test/MoqxRelayTrackStatusTests.cpp
@@ -11,6 +11,48 @@
 
 namespace openmoq::moqx::test {
 
+// Test: TRACK_STATUS with an empty namespace is rejected pre-draft-18.
+TEST_P(MoQRelayTest, TrackStatusEmptyNamespaceRejectedPreV18) {
+  auto session = createMockSession();
+  // Default session negotiates kVersionDraftCurrent (draft-14, which is < 18)
+
+  TrackStatus trackStatus;
+  trackStatus.fullTrackName = FullTrackName{TrackNamespace{{}}, "track1"};
+  trackStatus.requestID = RequestID(1);
+
+  withSessionContext(session, [&]() {
+    auto task = publisherInterface()->trackStatus(trackStatus);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    ASSERT_FALSE(res.hasValue());
+    EXPECT_EQ(res.error().errorCode, TrackStatusErrorCode::DOES_NOT_EXIST);
+    EXPECT_EQ(res.error().reasonPhrase, "namespace required");
+  });
+
+  removeSession(session);
+}
+
+// Test: TRACK_STATUS with an empty namespace is not rejected for its
+// namespace on draft-18+ — it falls through to the normal not-found path.
+TEST_P(MoQRelayTest, TrackStatusEmptyNamespaceAllowedV18) {
+  auto session = createMockSession();
+  ON_CALL(*session, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(kVersionDraft18)));
+
+  TrackStatus trackStatus;
+  trackStatus.fullTrackName = FullTrackName{TrackNamespace{{}}, "track1"};
+  trackStatus.requestID = RequestID(1);
+
+  withSessionContext(session, [&]() {
+    auto task = publisherInterface()->trackStatus(trackStatus);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    ASSERT_FALSE(res.hasValue());
+    EXPECT_EQ(res.error().errorCode, TrackStatusErrorCode::DOES_NOT_EXIST);
+    EXPECT_EQ(res.error().reasonPhrase, "no such namespace or track");
+  });
+
+  removeSession(session);
+}
+
 // Test: TrackStatus on non-existent track
 TEST_P(MoQRelayTest, TrackStatusNonExistentTrack) {
   auto clientSession = createMockSession();


### PR DESCRIPTION
Port of moxygen 9c1092e7 ("draft-18: Accept empty namespaces"). All four request paths unconditionally rejected an empty track namespace with INTERNAL_ERROR/DOES_NOT_EXIST, even for sessions that negotiated draft 18+, which permits it. Adds emptyNamespaceAllowed(session), gated on getDraftMajorVersion() >= 18, and applies it at each of the five call sites: publish() and publishFromPublisherExec() via validatePublishNamespace()'s new emptyNamespaceAllowed parameter, plus subscribeImpl(), fetchImpl(), trackStatusImpl(), and the LF-mode LocalSubscribeFilter::subscribe() fast path.

trackStatusOnSubscriberExec()'s empty-namespace check is unchanged: it only decides whether the subscriber-exec fast path can answer locally, and always falls through to trackStatusImpl() for a real answer either way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/687)
<!-- Reviewable:end -->
