### PR TITLE
release: pin MOXYGEN_REV to the moxygen v0.3.3 commit

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -15,7 +15,7 @@
 # on the next reconfigure of an existing build dir. A cached pin would silently
 # shadow the file's value.
 set(MOXYGEN_REPOSITORY "openmoq/moxygen")
-set(MOXYGEN_REV "d425d2f3f6fe4eabbd2737713b1bf410c5b7ccf8")
+set(MOXYGEN_REV "df2a78b6f1d2a7369fc01ff43cfe99e172ac2f6f")
 
 set(CATAPULT_REPOSITORY "Quicr/catapult")
 set(CATAPULT_REV "2bbf479fe2e65e425624316d335443a8c0fc0507")


### PR DESCRIPTION
One-line release-pin set so the v0.3.3 version-release dispatch can pass validate.

`validate` requires `MOXYGEN_REV` to resolve to the release named in the `moxygen_release` input — the guard that keeps a moqx tag honest about what it consumed. moxygen v0.3.3 tagged `df2a78b6` at 08:03; the daily sync then advanced the pin past it to tip `d425d2f3`, whose only release is a snapshot. Every v0.3.3 dispatch since fails validate identically — the valid window (pin sitting exactly on the release commit) never existed today because the sync jumped straight over it.

This sets the pin to the release commit deliberately. The next daily sync advances it to tip again as normal. `df2a78b6` is an ancestor of the current pin, so this consumes strictly released code — no untested combination.

After merge: dispatch `version release` with `moxygen_release: v0.3.3`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/690)
<!-- Reviewable:end -->
