### PR TITLE
ci: drive the moxygen release from moqx and publish atomically

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -23,15 +23,17 @@ name: version release
 #   finalize (--draft=false)
 #
 # Inputs:
-#   version          required. semver, e.g. 1.2.3
-#   moxygen_release  optional cross-check, not a selector. The moxygen consumed
-#                    is always the one MOXYGEN_REV pins — pass the tag you expect
-#                    that pin to resolve to and the run fails early if it doesn't.
+#   version  required. semver, e.g. 1.2.3
 #
-# Behavior matrix, on the moxygen release MOXYGEN_REV resolves to:
-#   tagged v* release (carries portable assets)  → portable matrix runs
-#   rolling snapshot-* release (does not)        → portable skipped (no failure)
-#   no tag at the pin                            → validate fails, nothing tagged
+# The moxygen consumed is always the one MOXYGEN_REV pins. On the release
+# MOXYGEN_REV resolves to:
+#   tagged v* release            → used as-is; portable matrix runs
+#   snapshot-* only / no v* tag  → this run mints moxygen v<version> at
+#                                  exactly the pinned commit (dispatches
+#                                  moxygen version-release with rev=pin) and
+#                                  waits for it to publish, then proceeds.
+#                                  One dispatch releases both repos, tags
+#                                  agreeing by construction.
 #
 # Snapshot source — derived from dispatched ref:
 #   dispatched on main         → consume snapshot-latest
@@ -48,10 +50,6 @@ on:
       version:
         description: 'moqx version (e.g. 1.2.3)'
         required: true
-        type: string
-      moxygen_release:
-        description: 'Expected moxygen release tag (optional, e.g. v1.2.3) — checked against what MOXYGEN_REV resolves to.'
-        required: false
         type: string
 
 # Serialize per-version dispatches: prevents two runs with the same
@@ -72,6 +70,8 @@ jobs:
 
   validate:
     runs-on: ubuntu-22.04
+    # Bounds the wait on a moxygen release this run dispatches.
+    timeout-minutes: 90
     outputs:
       version: ${{ steps.v.outputs.version }}
       tag: ${{ steps.v.outputs.tag }}
@@ -84,10 +84,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Only needed when this run must mint the moxygen release itself.
+      # continue-on-error so a token-permission problem cannot break the
+      # common path where the moxygen release already exists.
+      - name: Generate moxygen dispatch token
+        id: mox-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OMOQ_APP_ID }}
+          private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
+          owner: openmoq
+          repositories: moxygen
+          permission-actions: write
+
       - name: Validate inputs and resolve refs
         id: v
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MOX_REPO: openmoq/moxygen
+          MOX_DISPATCH_TOKEN: ${{ steps.mox-token.outputs.token }}
         run: |
           VERSION="${{ inputs.version }}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
@@ -118,31 +134,60 @@ jobs:
             exit 1
           fi
 
-          # Resolve the moxygen tag exactly the way the build will. Anything else
+          # Resolve the moxygen tag exactly the way the build will (git tags
+          # at the pin; immutable v* preferred over snapshot-*). Anything else
           # (moxygen's newest release, say) disagrees with MOXYGEN_REV, fails
           # both matrix legs at configure, and strands the release as a draft.
           MOX_PIN=$(cmake -DPIN=MOXYGEN_REV -P cmake/print-pin.cmake)
-          if ! MOX_REF=$(cmake -P cmake/print-release-tag.cmake); then
-            echo "Error: no published moxygen release points at the pinned MOXYGEN_REV" >&2
-            echo "  $MOX_PIN" >&2
-            echo "Bump the pin on $BRANCH to a published rev before cutting a release." >&2
-            exit 1
-          fi
-          echo "==> MOXYGEN_REV $MOX_PIN resolves to moxygen release $MOX_REF"
-
-          # Disagreement can only mean the operator meant to bump MOXYGEN_REV
-          # first — the input cannot move the build off the pin.
-          INPUT_REF="${{ inputs.moxygen_release }}"
-          if [ -n "$INPUT_REF" ]; then
-            # Accept bare semver (0.1.4) or v-prefixed (v0.1.4); normalize.
-            if [[ "$INPUT_REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-              INPUT_REF="v$INPUT_REF"
-            fi
-            if [ "$INPUT_REF" != "$MOX_REF" ]; then
-              echo "Error: moxygen_release '$INPUT_REF' is not the release MOXYGEN_REV resolves to ('$MOX_REF')." >&2
-              echo "Bump MOXYGEN_REV on $BRANCH instead — the build verifies the tag against the pin." >&2
+          if MOX_REF=$(cmake -P cmake/print-release-tag.cmake 2>/dev/null) \
+              && [[ "$MOX_REF" != snapshot* ]]; then
+            echo "==> MOXYGEN_REV $MOX_PIN resolves to moxygen release $MOX_REF"
+          else
+            # No named moxygen release at the pin: mint one, same version, at
+            # exactly the pinned commit. moxygen publishes atomically (draft
+            # until finalize), and a draft holds no tag ref — so once its run
+            # succeeds the resolver sees a complete release.
+            MOX_TAG="v${VERSION}"
+            if gh release view "$MOX_TAG" --repo "$MOX_REPO" >/dev/null 2>&1; then
+              echo "Error: moxygen $MOX_TAG exists but does not point at MOXYGEN_REV ($MOX_PIN)." >&2
+              echo "Pick a different moqx version, or bump the pin to that release's commit." >&2
               exit 1
             fi
+            if [ -z "$MOX_DISPATCH_TOKEN" ]; then
+              echo "Error: no named moxygen release at $MOX_PIN and the dispatch token is unavailable" >&2
+              echo "(omoq-sync-bot needs actions:write on openmoq/moxygen to mint one from here)." >&2
+              exit 1
+            fi
+            echo "==> no named moxygen release at ${MOX_PIN:0:12} — dispatching moxygen version-release $MOX_TAG there"
+            SINCE=$(date -u -d '-1 minute' +%Y-%m-%dT%H:%M:%S+00:00)
+            GH_TOKEN="$MOX_DISPATCH_TOKEN" gh workflow run omoq-version-release.yml \
+              --repo "$MOX_REPO" --ref main -f "version=$VERSION" -f "rev=$MOX_PIN"
+
+            # gh workflow run returns no run id; the run appears a few seconds later.
+            RUN_ID=""
+            for _ in $(seq 1 12); do
+              sleep 5
+              RUN_ID=$(GH_TOKEN="$MOX_DISPATCH_TOKEN" gh run list --repo "$MOX_REPO" \
+                --workflow omoq-version-release.yml --event workflow_dispatch --branch main \
+                --created ">=$SINCE" --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+              [ -n "$RUN_ID" ] && break
+            done
+            if [ -z "$RUN_ID" ]; then
+              echo "Error: moxygen did not start a version-release run for $MOX_TAG" >&2
+              exit 1
+            fi
+            echo "==> watching moxygen run ${{ github.server_url }}/$MOX_REPO/actions/runs/$RUN_ID"
+            if ! GH_TOKEN="$MOX_DISPATCH_TOKEN" gh run watch "$RUN_ID" --repo "$MOX_REPO" \
+                --exit-status --interval 60; then
+              echo "Error: moxygen version-release $MOX_TAG failed — fix it and re-dispatch this workflow (it takes the common path once moxygen $MOX_TAG exists)." >&2
+              exit 1
+            fi
+            if ! MOX_REF=$(cmake -P cmake/print-release-tag.cmake 2>/dev/null) \
+                || [[ "$MOX_REF" == snapshot* ]]; then
+              echo "Error: moxygen run $RUN_ID succeeded but $MOX_TAG does not resolve at ${MOX_PIN:0:12}" >&2
+              exit 1
+            fi
+            echo "==> moxygen published $MOX_REF"
           fi
 
           # Verify moxygen reference exists; on failure, list recent releases.

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -258,14 +258,28 @@ jobs:
             PORTABLE_NOTE="_Portable Linux tarballs not produced for this release: moxygen \`${MOX_REF}\` does not include the required portable assets._"
           fi
 
+          # A failed prior run leaves an invisible draft; a second create with
+          # the same tag_name would not collide (drafts hold no tag ref) and
+          # uploads-by-tag would then be ambiguous. Remove it first. Paginate:
+          # snapshot publishes push an old draft past the first page within hours.
+          gh api --paginate "repos/{owner}/{repo}/releases" \
+            --jq ".[] | select(.tag_name == \"$TAG\" and .draft) | .id" | \
+            while read -r id; do
+              echo "Deleting stale draft release id $id for $TAG"
+              gh api -X DELETE "repos/{owner}/{repo}/releases/$id"
+            done
+
           # Mark prereleases (1.2.3-rc1) as such so GitHub's "latest"
           # algorithm correctly excludes them.
           PRERELEASE_FLAG=()
           if [[ "$VERSION" == *-* ]]; then
             PRERELEASE_FLAG=(--prerelease)
           fi
-
+          # --draft: invisible to consumers (and to by-tag lookups) until
+          # finalize flips it, so a release either exists complete or not at
+          # all — never public with assets still uploading.
           gh release create "$TAG" \
+            --draft \
             --target "$SNAPSHOT_SHA" \
             --title "moqx $VERSION" \
             "${PRERELEASE_FLAG[@]}" \
@@ -318,7 +332,12 @@ jobs:
           app-id: ${{ secrets.OMOQ_APP_ID }}
           private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
 
+      # Build the resolved commit, not the branch tip — the tip can move
+      # between dispatch and here, and the promoted assets are the resolved
+      # commit's.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.snapshot_sha }}
 
       - name: Install system dependencies
         run: |
@@ -476,11 +495,6 @@ jobs:
             xargs -0 -n1 -P 6 -I{} gh release upload "$TAG" --repo "$REPO" {} --clobber
 
   # ════════════════════════════════════════════════════════════════════════════
-  # Finalize: confirm the release is fully published once all uploads
-  # succeeded. Tolerates portable-build being skipped (has_portable=false).
-  # ════════════════════════════════════════════════════════════════════════════
-
-  # ════════════════════════════════════════════════════════════════════════════
   # Release image: builds the container with MOQX_VERSION_STRING set to the
   # release tag, so the binary and the OCI label report the version they ship
   # under. The arg enters after the moxygen stage, so the dep layers come from
@@ -570,6 +584,12 @@ jobs:
             "${IMAGE}:${TAG}-amd64" "${IMAGE}:${TAG}-arm64"
           docker buildx imagetools inspect "${IMAGE}:${TAG}"
 
+  # ════════════════════════════════════════════════════════════════════════════
+  # Finalize: publish the draft once all uploads succeeded, so consumers never
+  # see a partial release. Tolerates portable-build being skipped
+  # (has_portable=false).
+  # ════════════════════════════════════════════════════════════════════════════
+
   finalize:
     needs: [validate, create-release, portable-build, promote-snapshot]
     if: |
@@ -588,16 +608,20 @@ jobs:
           app-id: ${{ secrets.OMOQ_APP_ID }}
           private-key: ${{ secrets.OMOQ_APP_PRIV_KEY }}
 
-      - name: Confirm release published
+      - name: Publish release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
+          # Flip the draft: the release (and its tag) becomes visible only
+          # now, with every asset already attached.
+          #
           # No --latest flag here. Let GitHub's auto-latest algorithm
           # pick the highest non-prerelease semver tag. Forcing --latest
           # would mark a hotfix patch from a release/vM.m branch as
           # latest even when a newer vM.(m+1) line exists.
+          gh release edit "$TAG" --repo "$REPO" --draft=false
           echo "Released: $TAG"
           # isLatest is not a --json field on `gh release view` (only on
           # `gh release list`), so derive it from the releases/latest API.


### PR DESCRIPTION
Second half of the release flow; needs moxygen#412 first. Two commits.

- **One `version` dispatch releases both repos.** validate resolves `MOXYGEN_REV` as before. If no `v*` moxygen release sits at the pin, it dispatches moxygen's version release with the same version at `rev = MOXYGEN_REV`, watches that run to completion, and re-resolves. A moxygen failure fails this run at once with a link to the moxygen run. If a moxygen release already exists at the pin, nothing is dispatched (the common case). The `moxygen_release` input is dropped: it could only restate what the pin determined, or fail.
- **moqx's own release is published atomically** (second commit, same fixes as moxygen#412): draft until finalize, stale drafts removed first, and portable-build builds the resolved commit instead of the branch tip.

The sync bot's app install already has `actions: write` on moxygen (the upstream sync uses it there). YAML parses; `gh run list --created` and `gh run watch --exit-status` were checked against real moxygen runs. The dispatch path itself can only be exercised live, on the next version release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/692)
<!-- Reviewable:end -->
