### PR TITLE
relay: (d18+)Reject unsupported Mandatory Track Properties (draft-18 …

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -9,6 +9,7 @@
 
 #include "MoqxCache.h"
 #include "relay/NullConsumers.h"
+#include "relay/TrackProperties.h"
 #include <folly/logging/xlog.h>
 #include <moxygen/MoQTrackProperties.h>
 
@@ -1697,6 +1698,16 @@ folly::coro::Task<Publisher::FetchResult> MoqxCache::fetchUpstream(
 
   XLOG(DBG1) << "upstream success";
   track->extensions = res.value()->fetchOk().extensions;
+
+  if (hasUnsupportedMandatoryProperty(track->extensions)) {
+    consumer->reset(ResetStreamErrorCode::INTERNAL_ERROR);
+    co_return folly::makeUnexpected(FetchError{
+        fetch.requestID,
+        FetchErrorCode::UNSUPPORTED_EXTENSION,
+        "unsupported mandatory track property"
+    });
+  }
+
   if (lastObject) {
     if (!fetchHandle) {
       XLOG(DBG1) << "no fetchHandle and last object";

--- a/src/MoqxRelay.cpp
+++ b/src/MoqxRelay.cpp
@@ -17,6 +17,7 @@
 #include "relay/PublisherCrossExecFilter.h"
 #include "relay/SubscriberCrossExecFilter.h"
 #include "relay/TrackEventCallback.h"
+#include "relay/TrackProperties.h"
 #include "relay/TrackStatsFilter.h"
 #include "relay/WeakRelayForwarderCallback.h"
 #include <folly/Random.h>
@@ -649,6 +650,14 @@ Subscriber::PublishResult MoqxRelay::publishFromPublisherExec(
     return folly::makeUnexpected(std::move(*err));
   }
 
+  if (hasUnsupportedMandatoryProperty(pub.extensions)) {
+    return folly::makeUnexpected(PublishError{
+        pub.requestID,
+        RequestErrorCode::UNSUPPORTED_EXTENSION,
+        "unsupported mandatory track property"
+    });
+  }
+
   auto localPubFwd = std::make_shared<MoQForwarder>(pub.fullTrackName);
   // Install the new forwarder and return the identity of the one that was displaced, if any.
   // Either a publisher or a subscriber forwarder could be displaced. Either way, the relay exec
@@ -740,6 +749,13 @@ MoqxRelay::publish(PublishRequest pub, std::shared_ptr<Publisher::SubscriptionHa
   auto session = MoQSession::getRequestSession();
   if (auto err = validatePublishNamespace(pub.fullTrackName, pub.requestID)) {
     return folly::makeUnexpected(std::move(*err));
+  }
+  if (hasUnsupportedMandatoryProperty(pub.extensions)) {
+    return folly::makeUnexpected(PublishError{
+        pub.requestID,
+        RequestErrorCode::UNSUPPORTED_EXTENSION,
+        "unsupported mandatory track property"
+    });
   }
   XCHECK(mode() != Mode::LocalForwarder) << "publish() bypassed by LocalPublishFilter in LF mode";
 
@@ -2045,6 +2061,13 @@ MoqxRelay::subscribeUpstreamAndApplyOk(
   }
   // Apply the OK to the forwarder; the NGR rides the outgoing SUBSCRIBE (record, don't fire).
   const auto& ok = subRes.value()->subscribeOk();
+  if (hasUnsupportedMandatoryProperty(ok.extensions)) {
+    co_return folly::makeUnexpected(SubscribeError{
+        clientRequestID,
+        SubscribeErrorCode::UNSUPPORTED_EXTENSION,
+        "upstream SUBSCRIBE returned unsupported mandatory property"
+    });
+  }
   InitialTrackState{ok.largest, ok.extensions}.applyTo(*publisherFwd);
   publisherFwd->tryProcessNewGroupRequest(params, /*fire=*/false);
   // Moving the handle shared_ptr keeps the pointee (and `ok`) alive, so reading ok.*

--- a/src/relay/TrackProperties.h
+++ b/src/relay/TrackProperties.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <moxygen/MoQTypes.h>
+
+namespace openmoq::moqx {
+
+// draft-18 §2.5.1: types 0x4000-0x7FFF are Mandatory Track Properties; moqx
+// currently understands none, so any type in range is unsupported.
+inline bool hasUnsupportedMandatoryProperty(const moxygen::Extensions& ext) {
+  auto isMandatory = [](const moxygen::Extension& e) {
+    return e.type >= 0x4000 && e.type <= 0x7FFF;
+  };
+  for (auto& e : ext.getMutableExtensions()) {
+    if (isMandatory(e)) {
+      return true;
+    }
+  }
+  for (auto& e : ext.getImmutableExtensions()) {
+    if (isMandatory(e)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace openmoq::moqx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -311,6 +311,11 @@ moqx_add_gtest(moqx_initial_track_state_test
   LIBS moqx_core moqx_test_main GTest::gmock
 )
 
+moqx_add_gtest(moqx_track_properties_test
+  SRCS TrackPropertiesTest.cpp
+  LIBS moqx_core moqx_test_main GTest::gmock
+)
+
 moqx_add_gtest(moqx_local_forwarder_registry_test
   SRCS LocalForwarderRegistryTest.cpp
   LIBS moqx_core moqx_test_main GTest::gmock

--- a/test/MoqxCacheTest.cpp
+++ b/test/MoqxCacheTest.cpp
@@ -581,6 +581,57 @@ CO_TEST_F(MoqxCacheTest, TestFetchMissTailUpstreamError) {
   EXPECT_TRUE(res.hasError());
 }
 
+// An upstream FETCH_OK carrying an unsupported Mandatory
+// Track Property must be rejected with UNSUPPORTED_EXTENSION, and — since no
+// FETCH_OK has reached the downstream fetcher yet on this path — the
+// not-yet-established stream must be reset.
+CO_TEST_F(MoqxCacheTest, TestFetchTailUpstreamMandatoryPropertyRejected) {
+  populateCacheRange({0, 0}, {0, 1});
+  Extensions mandatoryExt;
+  mandatoryExt.insertMutableExtension(Extension{0x4000, 1});
+  EXPECT_CALL(*upstream_, fetch(_, _))
+      .WillOnce([&](Fetch, std::shared_ptr<FetchConsumer> consumer) {
+        upstreamFetchConsumer_ = std::move(consumer);
+        upstreamFetchHandle_ = std::make_shared<moxygen::MockFetchHandle>(
+            FetchOk{0, GroupOrder::OldestFirst, 0, AbsoluteLocation{1, 0}, mandatoryExt}
+        );
+        return folly::coro::makeTask<Publisher::FetchResult>(upstreamFetchHandle_);
+      });
+  expectFetchObjects({0, 0}, {0, 1}, false);
+  EXPECT_CALL(*consumer_, reset(ResetStreamErrorCode::INTERNAL_ERROR));
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 10}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasError());
+  EXPECT_EQ(res.error().errorCode, FetchErrorCode::UNSUPPORTED_EXTENSION);
+}
+
+// Regression: when track state already lets fetch() take the fast path
+// (FETCH_OK returned synchronously, live track/known past data), fetchImpl
+// keeps running as a *detached* background task. A FetchError returned from
+// fetchUpstream() there would otherwise be silently discarded — the downstream
+// must instead learn about it via an explicit stream reset.
+CO_TEST_F(MoqxCacheTest, TestFetchLiveTrackDetachedUpstreamMandatoryPropertyRejected) {
+  populateCacheRange({0, 5}, {0, 6});
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+
+  Extensions mandatoryExt;
+  mandatoryExt.insertMutableExtension(Extension{0x4000, 1});
+  EXPECT_CALL(*upstream_, fetch(_, _))
+      .WillOnce([&](Fetch, std::shared_ptr<FetchConsumer> consumer) {
+        upstreamFetchConsumer_ = std::move(consumer);
+        upstreamFetchHandle_ = std::make_shared<moxygen::MockFetchHandle>(
+            FetchOk{0, GroupOrder::OldestFirst, 0, AbsoluteLocation{1, 0}, mandatoryExt}
+        );
+        return folly::coro::makeTask<Publisher::FetchResult>(upstreamFetchHandle_);
+      });
+  EXPECT_CALL(*consumer_, reset(ResetStreamErrorCode::INTERNAL_ERROR));
+
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 10}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasValue()
+  ) << "fast path returns FETCH_OK synchronously before the background task runs";
+
+  co_await folly::coro::co_reschedule_on_current_executor;
+}
+
 CO_TEST_F(MoqxCacheTest, TestFetchMissNoTrackUpstreamCompleteHit) {
   // Test case for fetch when no track is present, full range served by upstream
   expectUpstreamFetch({0, 0}, {0, 10}, 0, AbsoluteLocation{1, 0});

--- a/test/MoqxRelayPublishTests.cpp
+++ b/test/MoqxRelayPublishTests.cpp
@@ -39,6 +39,31 @@ TEST_P(MoQRelayTest, PublishSuccess) {
   removeSession(publisherSession);
 }
 
+// A PUBLISH carrying a Mandatory Track Property moqx
+// does not understand must be rejected with UNSUPPORTED_EXTENSION.
+TEST_P(MoQRelayTest, PublishRejectsUnsupportedMandatoryProperty) {
+  auto publisherSession = createMockSession();
+
+  PublishRequest pub;
+  pub.fullTrackName = kTestTrackName;
+  pub.extensions.insertMutableExtension(Extension{0x4000, 1});
+
+  withSessionContext(publisherSession, [&]() {
+    auto res = subscriberInterface()->publish(std::move(pub), createMockSubscriptionHandle());
+    if (res.hasError()) {
+      EXPECT_EQ(res.error().errorCode, RequestErrorCode::UNSUPPORTED_EXTENSION);
+      return;
+    }
+    ASSERT_TRUE(res.hasValue());
+    auto replyRes = folly::coro::blockingWait(std::move(res->reply), exec_.get());
+    ASSERT_TRUE(replyRes.hasError());
+    EXPECT_EQ(replyRes.error().errorCode, RequestErrorCode::UNSUPPORTED_EXTENSION);
+  });
+
+  removeSession(publisherSession);
+  driveIfMultiThread();
+}
+
 // Namespace tree tests (Prune*, MixedContent*, ActiveChildCount, PublishKeepsNode)
 // are in NamespaceTreeTest.cpp.
 // MoQForwarder unit tests (draining, tombstoning, hard errors, etc.)

--- a/test/MoqxRelaySubscribeTests.cpp
+++ b/test/MoqxRelaySubscribeTests.cpp
@@ -205,6 +205,43 @@ TEST_P(MoQRelayTest, FirstSubscriberViaUpstreamSubscribeReceivesData) {
   driveIfMultiThread();
 }
 
+// UNSUPPORTED_EXTENSION, cancelling the downstream subscription.
+TEST_P(MoQRelayTest, SubscribeRejectsUpstreamUnsupportedMandatoryProperty) {
+  auto publisherSession = createMockSession();
+  auto subSession = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(1);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+  upstreamOk.extensions.insertMutableExtension(Extension{0x4000, 1});
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce([upstreamOk](const SubscribeRequest&, std::shared_ptr<TrackConsumer>) {
+        auto handle = std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+        return folly::coro::makeTask<Publisher::SubscribeResult>(
+            folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(handle)
+        );
+      });
+
+  auto consumer = createMockConsumer();
+  auto handle = subscribeToTrack(
+      subSession,
+      kTestTrackName,
+      consumer,
+      RequestID(0),
+      /*addToState=*/false,
+      SubscribeErrorCode::UNSUPPORTED_EXTENSION
+  );
+  EXPECT_EQ(handle, nullptr);
+
+  removeSession(publisherSession);
+  removeSession(subSession);
+  driveIfMultiThread();
+}
+
 // Regression: a second subscriber that arrives while a first subscriber's upstream
 // SUBSCRIBE is still in flight must observe the upstream-seeded largest. In
 // LocalForwarderMT the second takes the acquireLocalForwarder isNew=false fast path

--- a/test/TrackPropertiesTest.cpp
+++ b/test/TrackPropertiesTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) OpenMOQ contributors.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "relay/TrackProperties.h"
+
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+
+using namespace moxygen;
+using openmoq::moqx::hasUnsupportedMandatoryProperty;
+
+namespace {
+
+constexpr uint64_t kMandatoryRangeStart = 0x4000;
+constexpr uint64_t kMandatoryRangeEnd = 0x7FFF;
+
+} // namespace
+
+TEST(TrackPropertiesTest, NoExtensionsIsSupported) {
+  Extensions ext;
+  EXPECT_FALSE(hasUnsupportedMandatoryProperty(ext));
+}
+
+TEST(TrackPropertiesTest, MutableExtensionOutsideRangeIsSupported) {
+  Extensions ext;
+  ext.insertMutableExtension(Extension{kMandatoryRangeStart - 1, 1});
+  ext.insertMutableExtension(Extension{kMandatoryRangeEnd + 1, 1});
+  EXPECT_FALSE(hasUnsupportedMandatoryProperty(ext));
+}
+
+TEST(TrackPropertiesTest, MutableExtensionAtRangeStartIsUnsupported) {
+  Extensions ext;
+  ext.insertMutableExtension(Extension{kMandatoryRangeStart, 1});
+  EXPECT_TRUE(hasUnsupportedMandatoryProperty(ext));
+}
+
+TEST(TrackPropertiesTest, MutableExtensionAtRangeEndIsUnsupported) {
+  Extensions ext;
+  ext.insertMutableExtension(Extension{kMandatoryRangeEnd, 1});
+  EXPECT_TRUE(hasUnsupportedMandatoryProperty(ext));
+}
+
+// Mutability is a wire-framing choice independent of the type value, so an
+// unsupported mandatory property sent as an immutable extension must be
+// caught too.
+TEST(TrackPropertiesTest, ImmutableExtensionInRangeIsUnsupported) {
+  Extensions ext;
+  ext.insertImmutableExtension(Extension{kMandatoryRangeStart, 1});
+  EXPECT_TRUE(hasUnsupportedMandatoryProperty(ext));
+}
+
+TEST(TrackPropertiesTest, ImmutableExtensionOutsideRangeIsSupported) {
+  Extensions ext;
+  ext.insertImmutableExtension(Extension{kMandatoryRangeStart - 1, 1});
+  EXPECT_FALSE(hasUnsupportedMandatoryProperty(ext));
+}
+
+TEST(TrackPropertiesTest, SupportedExtensionAlongsideOthersIsStillSupported) {
+  Extensions ext;
+  ext.insertMutableExtension(Extension{0x1, 1});
+  ext.insertImmutableExtension(Extension{0x2, 2});
+  EXPECT_FALSE(hasUnsupportedMandatoryProperty(ext));
+}


### PR DESCRIPTION
…§2.5.1)

Add hasUnsupportedMandatoryProperty() (src/relay/TrackProperties.h), a shared helper that flags any extension in the 0x4000-0x7FFF Mandatory Track Property range across both the mutable and immutable extension lists — moqx currently understands none of them.

Wire the check into the three places a peer can hand the relay a mandatory property it can't honor:
- PUBLISH: publish() and publishFromPublisherExec() reject the request with UNSUPPORTED_EXTENSION before installing a forwarder.
- SUBSCRIBE_OK: subscribeUpstreamAndApplyOk() rejects the downstream subscribe if the upstream's OK carries one, instead of applying it to the forwarder.
- FETCH_OK: MoqxCache::fetchUpstream() rejects the fetch and resets the consumer's stream if the upstream's FetchOk carries one, including on the detached background-task path taken when the fast path (live track / known past data) already returned FETCH_OK synchronously.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/697)
<!-- Reviewable:end -->
