### PR TITLE
fix: stop treating a partial re-delivered object as a payload mismatch

### DIFF
--- a/src/MoqxCache.cpp
+++ b/src/MoqxCache.cpp
@@ -334,7 +334,7 @@ folly::Expected<folly::Unit, MoQPublishError> MoqxCache::CacheGroup::cacheObject
           MoQPublishError(MoQPublishError::MALFORMED_TRACK, "Invalid status change")
       );
     }
-    if (status == ObjectStatus::NORMAL && cachedObject->complete &&
+    if (status == ObjectStatus::NORMAL && complete && cachedObject->complete &&
         ((!payload && cachedObject->payload) || (payload && !cachedObject->payload) ||
          (payload && cachedObject->payload && newPayloadSize != cachedObject->payloadSize))) {
       XLOG(ERR) << "Payload mismatch; objID=" << objectID;
@@ -347,6 +347,13 @@ folly::Expected<folly::Unit, MoQPublishError> MoqxCache::CacheGroup::cacheObject
       return folly::makeUnexpected(
           MoQPublishError(MoQPublishError::MALFORMED_TRACK, "forwardingPreference mismatch")
       );
+    }
+
+    if (cachedObject->complete && !complete) {
+      // The first chunk of a re-delivery replaces a whole object. Stop
+      // advertising the location until it is whole again: a fetch would
+      // neither serve it nor skip past it.
+      track.cachedContent.remove({groupID, objectID}, {groupID, objectID});
     }
 
     // TODO: Consider removing status from CacheEntry. For fetch streams, we

--- a/test/MoqxCacheTest.cpp
+++ b/test/MoqxCacheTest.cpp
@@ -1249,6 +1249,52 @@ CO_TEST_F(MoqxCacheTest, TestPopulateObjectUsingBeginObjectAndObjectPayload) {
   EXPECT_EQ(res.value()->fetchOk().endLocation, (AbsoluteLocation{0, 1}));
 }
 
+// An object large enough to span reads is re-delivered a chunk at a time, so
+// the first chunk is shorter than the copy already in cache.  That is not a
+// payload mismatch, and treating it as one resets the upstream subgroup.
+CO_TEST_F(MoqxCacheTest, TestRecacheStreamedObjectWithPartialFirstChunk) {
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  writeback->objectStream(ObjectHeader(0, 0, 0, 0, 200), makeBuf(200));
+  writeback.reset();
+
+  writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  auto subgroupConsumer = writeback->beginSubgroup(0, 0, 0).value();
+  auto res = subgroupConsumer->beginObject(0, 200, makeBuf(50));
+  EXPECT_FALSE(res.hasError());
+  auto status = subgroupConsumer->objectPayload(makeBuf(150), false);
+  EXPECT_FALSE(status.hasError());
+  writeback.reset();
+
+  // The re-delivered object is whole again, not truncated to the first chunk.
+  EXPECT_CALL(*consumer_, object(0, 0, 0, HasChainDataLengthOf(200), _, _, _))
+      .WillOnce(Return(folly::unit));
+  auto fetchRes = co_await cache_.fetch(getFetch({0, 0}, {0, 1}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(fetchRes.hasValue());
+  co_await folly::coro::co_reschedule_on_current_executor;
+}
+
+// Re-delivery leaves the cached copy incomplete until its last chunk lands.
+// A fetch in that window has to treat the object as a miss and move past it;
+// cachedContent still advertising the location stalls the fetch loop.
+CO_TEST_F(MoqxCacheTest, TestFetchWhileCachedObjectIsBeingRecached) {
+  auto writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  writeback->objectStream(ObjectHeader(0, 0, 0, 0, 200), makeBuf(200));
+  writeback.reset();
+
+  // Start re-delivering the same object and stop before the last chunk.
+  writeback = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  auto subgroupConsumer = writeback->beginSubgroup(0, 0, 0).value();
+  EXPECT_FALSE(subgroupConsumer->beginObject(0, 200, makeBuf(50)).hasError());
+
+  // Reaching upstream at all is the point: the object is a miss, and the
+  // fetch has to get past it to the end of the range.
+  expectUpstreamFetch(FetchError{0, FetchErrorCode::DOES_NOT_EXIST, "gone"});
+  EXPECT_CALL(*consumer_, reset(_));
+  auto res = co_await cache_.fetch(getFetch({0, 0}, {0, 1}), trackingConsumer_, upstream_);
+  EXPECT_TRUE(res.hasValue());
+  co_await folly::coro::co_reschedule_on_current_executor;
+}
+
 CO_TEST_F(MoqxCacheTest, TestUpstreamFetchUsingBeginObjectAndObjectPayload) {
   // Test case for upstream fetch using beginObject and objectPayload
 
@@ -3917,12 +3963,13 @@ TEST_F(MoqxCacheTest, SubgroupWritebackCacheErrorResetsInnerConsumer) {
 
 // Same test but for beginObject path (multi-part object delivery).
 TEST_F(MoqxCacheTest, SubgroupWritebackBeginObjectCacheErrorResetsInner) {
-  // Pre-populate cache with a complete object
+  // Record object 0 as non-existent, so beginObject for it is a cache error.
+  // A short first chunk is not one: the object arrives over several reads.
   auto writeback1 = cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
   auto sgRes1 = writeback1->beginSubgroup(0, 0, 0);
   ASSERT_TRUE(sgRes1.hasValue());
   auto sg1 = std::move(sgRes1.value());
-  auto objRes = sg1->object(0, makeBuf(50), noExtensions(), false);
+  auto objRes = sg1->object(1, makeBuf(50), makeObjectGapExtensions(1), false);
   ASSERT_TRUE(objRes.hasValue());
   sg1->endOfSubgroup();
   writeback1.reset();
@@ -3939,7 +3986,7 @@ TEST_F(MoqxCacheTest, SubgroupWritebackBeginObjectCacheErrorResetsInner) {
   ASSERT_TRUE(sgRes2.hasValue());
   auto sg2 = std::move(sgRes2.value());
 
-  // beginObject with different payload size triggers "Payload mismatch"
+  // beginObject into a known gap triggers "Object in known gap"
   EXPECT_CALL(*innerSg, reset(_)).Times(1);
 
   auto beginRes = sg2->beginObject(0, 100, makeBuf(100), Extensions());


### PR DESCRIPTION
An object large enough to span multiple reads arrives at the relay a chunk at a time. When the cache already held a complete copy, it compared the first chunk's length against the whole object and called it a payload mismatch, resetting the subgroup and tearing down the subscription. The mismatch check now only fires once the re-delivered object is complete again. Replacing a complete cached object with its first chunk also clears the cachedContent marker for that location, so a fetch arriving mid- replacement treats it as a miss and moves past it instead of stalling.

Ported from a fix already merged upstream in facebookexperimental/moxygen that hadn't yet reached moqx's pinned moxygen revision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/699)
<!-- Reviewable:end -->
