### PR TITLE
ci: route build lanes by the build label, relay jobs by relay

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -77,7 +77,7 @@ jobs:
             # takes the uninstrumented one. Without it configure.sh refuses.
             uninstrumented_deps: true
             leak_check: true
-            runner: [self-hosted, linode]
+            runner: [self-hosted, build]
             # Sized by memory, not cores. See ci-pr.yml for the measurements.
             build_jobs: 10
     name: ${{ matrix.name }}
@@ -552,7 +552,7 @@ jobs:
   deploy:
     if: github.ref_name == 'main'
     needs: [manifest, release]
-    runs-on: [self-hosted, linode]
+    runs-on: [self-hosted, relay]
     env:
       DOMAIN: moqx-main.ci.openmoq.org
       RELAY_PORT: 4433

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -68,9 +68,9 @@ jobs:
             # takes the uninstrumented one. Without it configure.sh refuses.
             uninstrumented_deps: true
             leak_check: true
-            runner: [self-hosted, linode]
-            # Sized by memory, not cores. The linode box is 16c/31GB with no
-            # swap; the heaviest test TUs peak near 2.3 GB of cc1plus RSS each
+            runner: [self-hosted, build]
+            # Sized by memory, not cores. The self-hosted boxes are 16c/31GB;
+            # the heaviest test TUs peak near 2.3 GB of cc1plus RSS each
             # under Debug+ASan. Worst-case concurrent footprint is 38 GB at
             # -j16 and 34 GB at -j14, both of which OOM-kill the compiler.
             # -j10 lands at ~25 GB, leaving headroom for the co-resident relay.

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, linode]
+    runs-on: [self-hosted, relay]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -90,7 +90,7 @@ permissions:
 jobs:
   perf:
     name: perf-test
-    runs-on: [self-hosted, linode]
+    runs-on: [self-hosted, relay]
     # Headroom for the from-source moxygen fallback on top of the perf runs.
     timeout-minutes: 240
     outputs:

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -137,7 +137,7 @@ Promotes `snapshot-latest` artifacts to a versioned `vX.Y.Z` release (no rebuild
 |-----|--------|---------|
 | check-format | ubuntu-latest (trixie) | clang-format-19 check; ruff lint + format check (via uv) |
 | linux | ubuntu-22.04 | Build + test (prebuilt tarball, from-source fallback) |
-| asan debug | self-hosted (linode) | ASan/UBSan on moqx TUs, build + test |
+| asan debug | self-hosted (build) | ASan/UBSan on moqx TUs, build + test |
 
 Format check must pass before build runs. The asan lane sanitizes moqx's own
 TUs over the uninstrumented prebuilt deps; instrumenting the full stack needs
@@ -174,7 +174,7 @@ Merges the sync PR if CI passed. Deletes the branch after merge.
 
 ### 5. `deploy relay` — Manual deployment
 
-**Trigger:** manual `workflow_dispatch` | **Runner:** self-hosted (linode)
+**Trigger:** manual `workflow_dispatch` | **Runner:** self-hosted (relay)
 
 Deploys a specific image tag to a named instance. Handles TLS cert
 provisioning/renewal via Route53, health check verification, Slack notification.


### PR DESCRIPTION
moqx half of openmoq/moxygen#415. A second self-hosted runner (`linode-ubuntu-amd64-001`, moqx-001) is registered with labels `amd64, build` and no `linode` label. The existing runner now carries `build` and `relay` as well.

- asan debug (ci-pr, ci-main) runs on `[self-hosted, build]`, so either box can take it.
- The ci-main deploy job, deploy-relay, and perf-test run on `[self-hosted, relay]`. Only the box hosting the relay carries that label, so a deploy can never land on the build-only box.
- The asan memory-sizing comment now describes both boxes; the "no swap" claim was stale.
- docs/ci-architecture.md updated.

After this and #415 merge, nothing selects on `linode` and it becomes a plain tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/704)
<!-- Reviewable:end -->
