### PR TITLE
ci: cut artifact retention from 90 days to 7

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -419,12 +419,15 @@ jobs:
           tar czf "$ARTIFACT" -C install .
           echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
 
+      # Handoff to the release job within this run; the release then holds the
+      # same tarball on free storage. The week is re-run headroom: a failed
+      # release job can be retried without rebuilding, over a weekend included.
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.package.outputs.artifact }}
           path: ${{ steps.package.outputs.artifact }}
-          retention-days: 90
+          retention-days: 7
 
   # ════════════════════════════════════════════════════════════════════════════
   # Manifest: stitch per-arch images into multiplatform tags

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -43,9 +43,11 @@ jobs:
           ls -la "$ARTIFACT"
           echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
 
+      # No release backs this, so it keeps a working window — but a dev build is
+      # reproducible, and 90 days of them dominated the storage bill.
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.package.outputs.artifact }}
           path: ${{ steps.package.outputs.artifact }}
-          retention-days: 90
+          retention-days: 7

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -43,11 +43,11 @@ jobs:
           ls -la "$ARTIFACT"
           echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
 
-      # No release backs this, so it keeps a working window — but a dev build is
-      # reproducible, and 90 days of them dominated the storage bill.
+      # Longer than the ci-main lanes: no release carries this, so the artifact
+      # is the only copy. Dev builds are rare enough that the storage is noise.
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.package.outputs.artifact }}
           path: ${{ steps.package.outputs.artifact }}
-          retention-days: 7
+          retention-days: 30


### PR DESCRIPTION
moqx half of openmoq/moxygen#426. The org's Actions storage is now billing rather than being discounted, and it is the only line item that is: September shows storage at $80.44 gross and $80.44 net, while every compute SKU is still fully discounted to $0.

The lanes get different windows, because they are backed differently.

`ci main`: 90 days to 7. The artifact exists only to hand the tarball from the publish jobs to the release job inside the same run, and the release then carries the same tarball on free unlimited storage. What 7 days costs is narrow: re-running a failed release job without a rebuild, and a week covers a Friday failure re-run on Monday.

`dev build`: 90 days to 30. No release backs it, so the artifact is the only copy, and dev builds are rare enough that the storage is noise.

`perf test` stays at 30 days; it is small, and the dashboard pulls its rolling window from published Pages rather than from the artifact.

Nothing about what gets published changes.

Retention applies at upload time, so this only bends the curve forward. The existing backlog was cleared separately: every artifact 10 days or older in this repo and moxygen was deleted, 2376 artifacts and 748 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moqx/706)
<!-- Reviewable:end -->
